### PR TITLE
Fix missing enum casts

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -156,10 +156,10 @@ module ibex_controller (
 
     csr_save_cause_o       = 1'b0;
 
-    exc_cause_o            = '0;
+    exc_cause_o            = exc_cause_e'('0);
     exc_pc_mux_o           = EXC_PC_IRQ;
 
-    csr_cause_o            = '0;
+    csr_cause_o            = exc_cause_e'('0);
 
     pc_mux_o               = PC_BOOT;
     pc_set_o               = 1'b0;

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -129,10 +129,10 @@ module ibex_core #(
 
   // CSR control
   logic        csr_access_ex;
-  logic  [1:0] csr_op_ex;
+  csr_op_e     csr_op_ex;
 
   logic        csr_access;
-  logic  [1:0] csr_op;
+  csr_op_e     csr_op;
   csr_num_e    csr_addr;
   logic [31:0] csr_rdata;
   logic [31:0] csr_wdata;

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -371,9 +371,11 @@ module ibex_cs_registers #(
       mcause_q   <= '0;
 
       depc_q      <= '0;
-      dcsr_q      <= '{
-        prv:     PRIV_LVL_M,
-        default: '0
+      dcsr_q     <= '{
+        xdebugver: x_debug_ver_e'('0),
+        cause:     dbg_cause_e'('0),
+        prv:       PRIV_LVL_M,
+        default:   '0
       };
       dscratch0_q <= '0;
       dscratch1_q <= '0;

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -86,7 +86,7 @@ module ibex_id_stage #(
 
     // CSR
     output logic                      csr_access_ex_o,
-    output logic [1:0]                csr_op_ex_o,
+    output ibex_defines::csr_op_e     csr_op_ex_o,
     output ibex_defines::exc_cause_e  csr_cause_o,
     output logic                      csr_save_if_o,
     output logic                      csr_save_id_o,
@@ -220,7 +220,7 @@ module ibex_id_stage #(
 
   // CSR control
   logic        csr_access;
-  logic [1:0]  csr_op;
+  csr_op_e     csr_op;
   logic        csr_status;
 
   // Forwarding


### PR DESCRIPTION
This PR fixes to remaining issues related to the recent introduction of enum types for previously hard-coded parameters:

1. Before assigning literals to enum types, Vivado expects an explicit type cast and otherwise throws an error. (#33)
2. There were instances of `csr_op` signals in `id_stage` which still were using the previous logic types leading to illegal signal assignments (#34).

The changes have been tested using Verilator and Vivado (synthesis and implementation ran through without issues).