### PR TITLE
Temporarily switch to custom sphinx

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
 setuptools_scm
-sphinx>=1.8
+git+https://github.com/wallento/sphinx@fix-latex-figure-in-admonition#egg=sphinx
 sphinx_rtd_theme
 git+https://github.com/wallento/sphinx-wavedrom


### PR DESCRIPTION
Using figures in admonitions did not work so far. A patch was created
and merge is pending. As long as it is not merged, use custom sphinx.

Fixes #24