### PR TITLE
Code cleanup

### DIFF
--- a/rtl/ibex_alu.sv
+++ b/rtl/ibex_alu.sv
@@ -118,8 +118,10 @@ module ibex_alu (
   assign shift_op_a_32 = {shift_arithmetic & shift_op_a[31], shift_op_a};
 
   logic signed [32:0] shift_right_result_signed;
+  logic        [32:0] shift_right_result_ext;
   assign shift_right_result_signed = $signed(shift_op_a_32) >>> shift_amt[4:0];
-  assign shift_right_result        = shift_right_result_signed[31:0];
+  assign shift_right_result_ext    = $unsigned(shift_right_result_signed);
+  assign shift_right_result        = shift_right_result_ext[31:0];
 
   // bit reverse the shift_right_result for left shifts
   for (genvar j = 0; j < 32; j++) begin : gen_rev_shift_right_result

--- a/rtl/ibex_alu.sv
+++ b/rtl/ibex_alu.sv
@@ -114,9 +114,10 @@ module ibex_alu (
 
   // right shifts, we let the synthesizer optimize this
   logic [32:0] shift_op_a_32;
-
   assign shift_op_a_32 = {shift_arithmetic & shift_op_a[31], shift_op_a};
 
+  // The MSB of shift_right_result_ext can safely be ignored. We just extend the input to always
+  // do arithmetic shifts.
   logic signed [32:0] shift_right_result_signed;
   logic        [32:0] shift_right_result_ext;
   assign shift_right_result_signed = $signed(shift_op_a_32) >>> shift_amt[4:0];

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -156,10 +156,10 @@ module ibex_controller (
 
     csr_save_cause_o       = 1'b0;
 
-    exc_cause_o            = exc_cause_e'('0);
+    exc_cause_o            = exc_cause_e'({$bits(exc_cause_e){1'b0}});
     exc_pc_mux_o           = EXC_PC_IRQ;
 
-    csr_cause_o            = exc_cause_e'('0);
+    csr_cause_o            = exc_cause_e'({$bits(exc_cause_e){1'b0}});
 
     pc_mux_o               = PC_BOOT;
     pc_set_o               = 1'b0;

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -371,8 +371,8 @@ module ibex_cs_registers #(
 
       depc_q      <= '0;
       dcsr_q     <= '{
-        xdebugver: x_debug_ver_e'('0),
-        cause:     dbg_cause_e'('0),
+        xdebugver: x_debug_ver_e'({$bits(x_debug_ver_e){1'b0}}),
+        cause:     dbg_cause_e'({$bits(dbg_cause_e){1'b0}}),
         prv:       PRIV_LVL_M,
         default:   '0
       };

--- a/rtl/ibex_multdiv_fast.sv
+++ b/rtl/ibex_multdiv_fast.sv
@@ -56,7 +56,8 @@ module ibex_multdiv_fast (
   } div_fsm_e;
   div_fsm_e divcurr_state_q, divcurr_state_n;
 
-  logic signed [34:0] mac_res_ext;
+  logic signed [34:0] mac_res_signed;
+  logic        [34:0] mac_res_ext;
 
   logic [33:0] mac_res_q, mac_res_n, mac_res, op_reminder_n;
   logic [15:0] mult_op_a;
@@ -117,8 +118,9 @@ module ibex_multdiv_fast (
 
   assign multdiv_result_o = div_en_i ? mac_res_q[31:0] : mac_res_n[31:0];
 
-  assign mac_res_ext = $signed({sign_a, mult_op_a})*$signed({sign_b, mult_op_b}) + $signed(accum);
-  assign mac_res     = mac_res_ext[33:0];
+  assign mac_res_signed = $signed({sign_a, mult_op_a})*$signed({sign_b, mult_op_b}) + $signed(accum);
+  assign mac_res_ext    = $unsigned(mac_res_signed);
+  assign mac_res        = mac_res_ext[33:0];
 
   assign res_adder_h   = alu_adder_ext_i[33:1];
 

--- a/rtl/ibex_multdiv_fast.sv
+++ b/rtl/ibex_multdiv_fast.sv
@@ -97,9 +97,9 @@ module ibex_multdiv_fast (
 
       if (div_en_i) begin
         div_counter_q     <= div_counter_n;
-        op_denominator_q  <= op_denominator_n  ;
-        op_numerator_q    <= op_numerator_n    ;
-        op_quotient_q     <= op_quotient_n     ;
+        op_denominator_q  <= op_denominator_n;
+        op_numerator_q    <= op_numerator_n;
+        op_quotient_q     <= op_quotient_n;
         divcurr_state_q   <= divcurr_state_n;
       end
 
@@ -134,12 +134,9 @@ module ibex_multdiv_fast (
 
   assign one_shift     = {31'b0, 1'b1} << div_counter_q;
 
-  /*
-     The adder in the ALU computes alu_operand_a_o + alu_operand_b_o which means
-     Reminder - Divisor. If Reminder - Divisor >= 0, is_greater_equal is equal to 1,
-     the next Reminder is Reminder - Divisor contained in res_adder_h and the
-  */
-
+  // The adder in the ALU computes alu_operand_a_o + alu_operand_b_o which means
+  // Reminder - Divisor. If Reminder - Divisor >= 0, is_greater_equal is equal to 1,
+  // the next Reminder is Reminder - Divisor contained in res_adder_h and the
   always_comb begin
     if ((mac_res_q[31] ^ op_denominator_q[31]) == 1'b0) begin
       is_greater_equal = (res_adder_h[31] == 1'b0);
@@ -167,42 +164,42 @@ module ibex_multdiv_fast (
     unique case(divcurr_state_q)
       MD_IDLE: begin
         if (operator_i == MD_OP_DIV) begin
-          //Check if the Denominator is 0
-          //quotient for division by 0
+          // Check if the Denominator is 0
+          // quotient for division by 0
           op_reminder_n    = '1;
           divcurr_state_n  = equal_to_zero ? MD_FINISH : MD_ABS_A;
         end else begin
-          //Check if the Denominator is 0
-          //reminder for division by 0
+          // Check if the Denominator is 0
+          // reminder for division by 0
           op_reminder_n     = {2'b0, op_a_i};
           divcurr_state_n    = equal_to_zero ? MD_FINISH : MD_ABS_A;
         end
-        //0 - B = 0 iff B == 0
+        // 0 - B = 0 iff B == 0
         alu_operand_a_o     = {32'h0  , 1'b1};
         alu_operand_b_o     = {~op_b_i, 1'b1};
         div_counter_n        = 5'd31;
       end
 
       MD_ABS_A: begin
-        //quotient
+        // quotient
         op_quotient_n     = '0;
-        //A abs value
+        // A abs value
         op_numerator_n    = div_sign_a ? alu_adder_i : op_a_i;
         divcurr_state_n   = MD_ABS_B;
         div_counter_n     = 5'd31;
-        //ABS(A) = 0 - A
+        // ABS(A) = 0 - A
         alu_operand_a_o   = {32'h0  , 1'b1};
         alu_operand_b_o   = {~op_a_i, 1'b1};
       end
 
       MD_ABS_B: begin
-        //reminder
+        // reminder
         op_reminder_n     = { 33'h0, op_numerator_q[31]};
-        //B abs value
+        // B abs value
         op_denominator_n  = div_sign_b ? alu_adder_i : op_b_i;
         divcurr_state_n   = MD_COMP;
         div_counter_n     = 5'd31;
-        //ABS(B) = 0 - B
+        // ABS(B) = 0 - B
         alu_operand_a_o   = {32'h0  , 1'b1};
         alu_operand_b_o   = {~op_b_i, 1'b1};
       end
@@ -211,8 +208,8 @@ module ibex_multdiv_fast (
         op_reminder_n     = {1'b0, next_reminder[31:0], op_numerator_q[div_counter_n]};
         op_quotient_n     = next_quotient[31:0];
         divcurr_state_n   = (div_counter_q == 5'd1) ? MD_LAST : MD_COMP;
-        //Division
-        alu_operand_a_o   = {mac_res_q[31:0], 1'b1}; //it contains the reminder
+        // Division
+        alu_operand_a_o   = {mac_res_q[31:0], 1'b1};         // it contains the reminder
         alu_operand_b_o   = {~op_denominator_q[31:0], 1'b1}; // -denominator two's compliment
       end
 
@@ -222,11 +219,11 @@ module ibex_multdiv_fast (
           // we do not need anymore the reminder
           op_reminder_n   = {1'b0, next_quotient};
         end else begin
-          //this time we do not save the quotient anymore since we need only the reminder
+          // this time we do not save the quotient anymore since we need only the reminder
           op_reminder_n  = {2'b0, next_reminder[31:0]};
         end
-        //Division
-        alu_operand_a_o     = {mac_res_q[31:0], 1'b1}; // it contains the reminder
+        // Division
+        alu_operand_a_o     = {mac_res_q[31:0], 1'b1};         // it contains the reminder
         alu_operand_b_o     = {~op_denominator_q[31:0], 1'b1}; // -denominator two's compliment
 
         divcurr_state_n = MD_CHANGE_SIGN;
@@ -239,7 +236,7 @@ module ibex_multdiv_fast (
         end else begin
           op_reminder_n = (rem_change_sign) ? {2'h0,alu_adder_i} : mac_res_q;
         end
-        //ABS(Quotient) = 0 - Quotient (or Reminder)
+        // ABS(Quotient) = 0 - Quotient (or Reminder)
         alu_operand_a_o     = {32'h0  , 1'b1};
         alu_operand_b_o     = {~mac_res_q[31:0], 1'b1};
       end
@@ -267,7 +264,7 @@ module ibex_multdiv_fast (
     unique case (mult_state_q)
 
       ALBL: begin
-        //al*bl
+        // al*bl
         mult_op_a = op_a_i[`OP_L];
         mult_op_b = op_b_i[`OP_L];
         sign_a    = 1'b0;
@@ -278,24 +275,24 @@ module ibex_multdiv_fast (
       end
 
       ALBH: begin
-        //al*bh<<16
+        // al*bh<<16
         mult_op_a = op_a_i[`OP_L];
         mult_op_b = op_b_i[`OP_H];
         sign_a    = 1'b0;
         sign_b    = signed_mode_i[1] & op_b_i[31];
-        //result of AL*BL (in mac_res_q) always unsigned with no carry, so carries_q always 00
+        // result of AL*BL (in mac_res_q) always unsigned with no carry, so carries_q always 00
         accum     = {18'b0,mac_res_q[31:16]};
         if (operator_i == MD_OP_MULL) begin
           mac_res_n = {2'b0,mac_res[`OP_L],mac_res_q[`OP_L]};
         end else begin
-          //MD_OP_MULH
+          // MD_OP_MULH
           mac_res_n = mac_res;
         end
         mult_state_n = AHBL;
       end
 
       AHBL: begin
-        //ah*bl<<16
+        // ah*bl<<16
         mult_op_a = op_a_i[`OP_H];
         mult_op_b = op_b_i[`OP_L];
         sign_a    = signed_mode_i[0] & op_a_i[31];
@@ -313,23 +310,21 @@ module ibex_multdiv_fast (
       end
 
       AHBH: begin
-        //only MD_OP_MULH here
-        //ah*bh
+        // only MD_OP_MULH here
+        // ah*bh
         mult_op_a = op_a_i[`OP_H];
         mult_op_b = op_b_i[`OP_H];
         sign_a    = signed_mode_i[0] & op_a_i[31];
         sign_b    = signed_mode_i[1] & op_b_i[31];
         accum[17: 0]  = mac_res_q[33:16];
         accum[33:18]  = {16{signed_mult & mac_res_q[33]}};
-        //result of AH*BL is not signed only if signed_mode_i == 2'b00
+        // result of AH*BL is not signed only if signed_mode_i == 2'b00
         mac_res_n    = mac_res;
         mult_state_n = ALBL;
         mult_is_ready = 1'b1;
-
       end
       default:;
     endcase // mult_state_q
   end
-
 
 endmodule // ibex_mult

--- a/rtl/ibex_multdiv_fast.sv
+++ b/rtl/ibex_multdiv_fast.sv
@@ -118,6 +118,10 @@ module ibex_multdiv_fast (
 
   assign multdiv_result_o = div_en_i ? mac_res_q[31:0] : mac_res_n[31:0];
 
+  // The 2 MSBs of mac_res_ext (mac_res_ext[34:33]) are always equal since:
+  // 1. The 2 MSBs of the multiplicants are always equal, and
+  // 2. The 16 MSBs of the addend (accum[33:18]) are always equal.
+  // Thus, it is safe to ignore mac_res_ext[34].
   assign mac_res_signed = $signed({sign_a, mult_op_a})*$signed({sign_b, mult_op_b}) + $signed(accum);
   assign mac_res_ext    = $unsigned(mac_res_signed);
   assign mac_res        = mac_res_ext[33:0];


### PR DESCRIPTION
This PR contains a couple of fixes related to linting errors. First of all, the width of literals later cast to enums is specified. Second, before doing a part select, signed signals are converted to unsigned signals. Also, this PR clarifies that some MSBs in the ALU and the multiplier can safely be ignored (some linting tools also produce errors because of these MSBs being ignored).
