### PR TITLE
Code cleanup

### DIFF
--- a/doc/exception_interrupts.rst
+++ b/doc/exception_interrupts.rst
@@ -15,6 +15,8 @@ Ibex supports interrupts, exceptions on illegal instructions.
 +------------+-----------------------------+
 | **0x84**   | Illegal Instruction         |
 +------------+-----------------------------+
+| **0x8C**   | LSU Error                   |
++------------+-----------------------------+
 | **0x88**   | ECALL Instruction Executed  |
 +------------+-----------------------------+
 
@@ -32,7 +34,7 @@ Multiple interrupts requests are assumed to be handled by event/interrupt contro
 Exceptions
 ----------
 
-The illegal instruction exception and ecall instruction exceptions cannot be disabled and are always active.
+The illegal instruction exception, LSU error exceptions and ecall instruction exceptions cannot be disabled and are always active.
 
 
 Handling

--- a/doc/load_store_unit.rst
+++ b/doc/load_store_unit.rst
@@ -24,14 +24,19 @@ Signals that are used by the LSU:
 | ``data_wdata_o[31:0]``  | output    | Data to be written to memory, sent together   |
 |                         |           | with ``data_req_o``                           |
 +-------------------------+-----------+-----------------------------------------------+
-| ``data_rdata_i[31:0]``  | input     | Data read from memory                         |
-+-------------------------+-----------+-----------------------------------------------+
-| ``data_rvalid_i``       | input     | ``data_rdata_is`` holds valid data when       |
-|                         |           | ``data_rvalid_i`` is high. This signal will   |
-|                         |           | be high for exactly one cycle per request.    |
-+-------------------------+-----------+-----------------------------------------------+
 | ``data_gnt_i``          | input     | The other side accepted the request.          |
-|                         |           | ``data_addr_o`` may change in the next cycle  |
+|                         |           | Outputs may change in the next cycle.         |
++-------------------------+-----------+-----------------------------------------------+
+| ``data_rvalid_i``       | input     | ``data_err_i`` and ``data_rdata_i`` hold      |
+|                         |           | valid data when ``data_rvalid_i`` is high.    |
+|                         |           | This signal will be high for exactly one      |
+|                         |           | cycle per request.                            |
++-------------------------+-----------+-----------------------------------------------+
+| ``data_err_i``          | input     | Error response from the bus or the memory:    |
+|                         |           | request cannot be handled. High in case of an |
+|                         |           | error.                                        |
++-------------------------+-----------+-----------------------------------------------+
+| ``data_rdata_i[31:0]``  | input     | Data read from memory                         |
 +-------------------------+-----------+-----------------------------------------------+
 
 
@@ -47,7 +52,11 @@ Protocol
 
 The protocol that is used by the LSU to communicate with a memory works as follows:
 
-The LSU provides a valid address in ``data_addr_o`` and sets ``data_req_o`` high. The memory then answers with a ``data_gnt_i`` set high as soon as it is ready to serve the request. This may happen in the same cycle as the request was sent or any number of cycles later. After a grant was received, the address may be changed in the next cycle by the LSU. In addition, the ``data_wdata_o``, ``data_we_o`` and ``data_be_o`` signals may be changed as it is assumed that the memory has already processed and stored that information. After receiving a grant, the memory answers with a ``data_rvalid_i`` set high if ``data_rdata_i`` is valid. This may happen one or more cycles after the grant has been received. Note that ``data_rvalid_i`` must also be set when a write was performed, although the ``data_rdata_i`` has no meaning in this case.
+1. The LSU provides a valid address in ``data_addr_o`` and sets ``data_req_o`` high. In the case of a store, the LSU also sets ``data_we_o`` high and configures ``data_be_o`` and ``data_wdata_o``. The memory then answers with a ``data_gnt_i`` set high as soon as it is ready to serve the request. This may happen in the same cycle as the request was sent or any number of cycles later.
+
+2. After receiving a grant, the address may be changed in the next cycle by the LSU. In addition, the ``data_wdata_o``, ``data_we_o`` and ``data_be_o`` signals may be changed as it is assumed that the memory has already processed and stored that information.
+
+3. The memory answers with a ``data_rvalid_i`` set high for exactly one cycle to signal the response from the bus or the memory using ``data_err_i`` and ``data_rdata_i`` (during the very same cycle). This may happen one or more cycles after the grant has been received. If ``data_err_i`` is low, the request could successfully be handled at the destination and in the case of a load, ``data_rdata_i`` contains valid data. If ``data_err_i`` is high, an error occured in the memory system and the core will raise an exception.
 
 :numref:`timing1`, :numref:`timing2` and :numref:`timing3` show example-timing diagrams of the protocol.
 
@@ -58,19 +67,20 @@ The LSU provides a valid address in ``data_addr_o`` and sets ``data_req_o`` high
    {"signal":
      [
        {"name": "clk", "wave": "p......"},
-       {"name": "data_addr_o", "wave": "x=.xxxx", "data": ["Address"]},
-       {"name": "data_wdata_o", "wave": "x=.xxxx", "data": ["WData"]},
        {"name": "data_req_o", "wave": "01.0..."},
+       {"name": "data_addr_o", "wave": "x=.xxxx", "data": ["Address"]},
+       {"name": "data_we_o", "wave": "x=.xxxx", "data": ["WE"]},
+       {"name": "data_be_o", "wave": "x=.xxxx", "data": ["BE"]},
+       {"name": "data_wdata_o", "wave": "x=.xxxx", "data": ["WData"]},
        {"name": "data_gnt_i", "wave": "0.10..."}, 
        {"name": "data_rvalid_i", "wave": "0..10.."},
-       {"name": "data_wdata_o", "wave": "xxx=xxx", "data": ["RData"]},
-       {"name": "data_we_o", "wave": "x=.xxxx", "data": ["WE"]},
-       {"name": "data_be_o", "wave": "x=.xxxx", "data": ["BE"]}
+       {"name": "data_err_i", "wave": "xxx=xxx", "data": ["Err"]},
+       {"name": "data_rdata_i", "wave": "xxx=xxx", "data": ["RData"]}
+
      ],
      "config": { "hscale": 2 }
     }
 
-   
 .. wavedrom::
    :name: timing2
    :caption: Back-to-back Memory Transaction
@@ -78,18 +88,18 @@ The LSU provides a valid address in ``data_addr_o`` and sets ``data_req_o`` high
    {"signal":
      [
        {"name": "clk", "wave": "p......"},
-       {"name": "data_addr_o", "wave": "x==xxxx", "data": ["Addr1", "Addr2"]},
-       {"name": "data_wdata_o", "wave": "x==xxxx", "data": ["WData1", "Wdata2"]},
        {"name": "data_req_o", "wave": "01.0..."},
-       {"name": "data_gnt_i", "wave": "01.0..."}, 
-       {"name": "data_rvalid_i", "wave": "0.1.0.."},
-       {"name": "data_wdata_o", "wave": "xx==xxx", "data": ["RData1", "RData2"]},
+       {"name": "data_addr_o", "wave": "x==xxxx", "data": ["Addr1", "Addr2"]},
        {"name": "data_we_o", "wave": "x==xxxx", "data": ["WE1", "WE2"]},
-       {"name": "data_be_o", "wave": "x==xxxx", "data": ["BE1", "BE2"]}
+       {"name": "data_be_o", "wave": "x==xxxx", "data": ["BE1", "BE2"]},
+       {"name": "data_wdata_o", "wave": "x==xxxx", "data": ["WData1", "Wdata2"]},
+       {"name": "data_gnt_i", "wave": "01.0..."},
+       {"name": "data_rvalid_i", "wave": "0.1.0.."},
+       {"name": "data_err_i", "wave": "xx==xxx", "data": ["Err1", "Err2"]},
+       {"name": "data_rdata_i", "wave": "xx==xxx", "data": ["RData1", "RData2"]}
      ],
      "config": { "hscale": 2 }
    }
-
    
 .. wavedrom::
    :name: timing3
@@ -98,14 +108,15 @@ The LSU provides a valid address in ``data_addr_o`` and sets ``data_req_o`` high
    {"signal":
      [
        {"name": "clk", "wave": "p......"},
-       {"name": "data_addr_o", "wave": "x=..xxx", "data": ["Address"]},
-       {"name": "data_wdata_o", "wave": "x=..xxx", "data": ["WData"]},
        {"name": "data_req_o", "wave": "01..0.."},
+       {"name": "data_addr_o", "wave": "x=..xxx", "data": ["Address"]},
+       {"name": "data_we_o", "wave": "x=..xxx", "data": ["WE"]},
+       {"name": "data_be_o", "wave": "x=..xxx", "data": ["BE"]},
+       {"name": "data_wdata_o", "wave": "x=..xxx", "data": ["WData"]},
        {"name": "data_gnt_i", "wave": "0..10.."}, 
        {"name": "data_rvalid_i", "wave": "0....10"},
-       {"name": "data_wdata_o", "wave": "xxxxx=x", "data": ["RData"]},
-       {"name": "data_we_o", "wave": "x=..xxx", "data": ["WE"]},
-       {"name": "data_be_o", "wave": "x=..xxx", "data": ["BE"]}
+       {"name": "data_err_i", "wave": "xxxxx=x", "data": ["Err"]},
+       {"name": "data_rdata_i", "wave": "xxxxx=x", "data": ["RData"]}
      ],
      "config": { "hscale": 2 }
    }

--- a/rtl/ibex_alu.sv
+++ b/rtl/ibex_alu.sv
@@ -72,7 +72,7 @@ module ibex_alu (
       ALU_SLT,  ALU_SLTU,
       ALU_SLET, ALU_SLETU: adder_op_b_negate = 1'b1;
 
-      default: ;
+      default:;
     endcase
   end
 
@@ -200,7 +200,7 @@ module ibex_alu (
       ALU_SLETU,
       ALU_LE,  ALU_LEU:  cmp_result = ~is_greater_equal | is_equal;
 
-      default: ;
+      default:;
     endcase
   end
 
@@ -237,7 +237,7 @@ module ibex_alu (
       ALU_SLT,  ALU_SLTU,
       ALU_SLET, ALU_SLETU: result_o = {31'h0,cmp_result};
 
-      default: ; // default case to suppress unique warning
+      default:;
     endcase
   end
 

--- a/rtl/ibex_compressed_decoder.sv
+++ b/rtl/ibex_compressed_decoder.sv
@@ -36,7 +36,7 @@ module ibex_compressed_decoder (
 
   always_comb begin
     illegal_instr_o = 1'b0;
-    instr_o         = '0;
+    instr_o         = 'X;
 
     unique case (instr_i[1:0])
       // C0
@@ -160,7 +160,15 @@ module ibex_compressed_decoder (
                     // 101: c.addw
                     illegal_instr_o = 1'b1;
                   end
+
+                  default: begin
+                    illegal_instr_o = 1'bX;
+                  end
                 endcase
+              end
+
+              default: begin
+                illegal_instr_o = 1'bX;
               end
             endcase
           end
@@ -174,7 +182,7 @@ module ibex_compressed_decoder (
           end
 
           default: begin
-            // illegal_instr_o = 1'b1;         // not reachable, dead code, commenting out
+            illegal_instr_o = 1'bX;
           end
         endcase
       end
@@ -226,8 +234,15 @@ module ibex_compressed_decoder (
                        instr_i[11:9], 2'b00, {OPCODE_STORE}};
           end
 
-          default: begin
+          3'b001,
+          3'b011,
+          3'b101,
+          3'b111: begin
             illegal_instr_o = 1'b1;
+          end
+
+          default: begin
+            illegal_instr_o = 1'bX;
           end
         endcase
       end

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -510,7 +510,7 @@ module ibex_controller (
 
       default: begin
         instr_req_o = 1'b0;
-        ctrl_fsm_ns = RESET;
+        ctrl_fsm_ns = ctrl_fsm_e'({$bits(ctrl_fsm_e){1'bX}});
       end
     endcase
   end

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -58,6 +58,8 @@ module ibex_controller (
 
     // LSU
     input  logic                      data_misaligned_i,
+    input  logic                      load_err_i,
+    input  logic                      store_err_i,
 
     // jump/branch signals
     input  logic                      branch_in_id_i,        // branch in id
@@ -121,6 +123,8 @@ module ibex_controller (
   logic irq_enable_int;
 
   logic debug_mode_q, debug_mode_n;
+  logic load_err_q, load_err_n;
+  logic store_err_q, store_err_n;
 
 `ifndef SYNTHESIS
   // synopsys translate_off
@@ -179,6 +183,9 @@ module ibex_controller (
     debug_csr_save_o       = 1'b0;
     debug_cause_o          = DBG_CAUSE_EBREAK;
     debug_mode_n           = debug_mode_q;
+
+    load_err_n             = 1'b0;
+    store_err_n            = 1'b0;
 
     perf_tbranch_o         = 1'b0;
     perf_jump_o            = 1'b0;
@@ -290,10 +297,13 @@ module ibex_controller (
                 perf_tbranch_o = branch_set_i;
                 perf_jump_o    = jump_set_i;
               end else if (mret_insn_i || dret_insn_i || ecall_insn_i || pipe_flush_i ||
-                           ebrk_insn_i || illegal_insn_i || csr_status_i) begin
+                           ebrk_insn_i || illegal_insn_i || csr_status_i ||
+                           store_err_i || load_err_i) begin
                 ctrl_fsm_ns = FLUSH;
                 halt_if_o   = 1'b1;
                 halt_id_o   = 1'b1;
+                load_err_n  = load_err_i;
+                store_err_n = store_err_i;
               end
             end
           end
@@ -475,6 +485,25 @@ module ibex_controller (
               csr_cause_o           = EXC_CAUSE_BREAKPOINT;
             end
           end
+          load_err_q: begin
+            pc_mux_o         = PC_EXCEPTION;
+            pc_set_o         = 1'b1;
+            csr_save_id_o    = 1'b1;
+            csr_save_cause_o = 1'b1;
+            exc_pc_mux_o     = EXC_PC_LOAD;
+            exc_cause_o      = EXC_CAUSE_LOAD_ACCESS_FAULT;
+            csr_cause_o      = EXC_CAUSE_LOAD_ACCESS_FAULT;
+          end
+          store_err_q: begin
+            pc_mux_o         = PC_EXCEPTION;
+            pc_set_o         = 1'b1;
+            csr_save_id_o    = 1'b1;
+            csr_save_cause_o = 1'b1;
+            exc_pc_mux_o     = EXC_PC_STORE;
+            exc_cause_o      = EXC_CAUSE_STORE_ACCESS_FAULT;
+            csr_cause_o      = EXC_CAUSE_STORE_ACCESS_FAULT;
+          end
+
           default:;
         endcase
       end
@@ -502,9 +531,13 @@ module ibex_controller (
     if (!rst_ni) begin
       ctrl_fsm_cs  <= RESET;
       debug_mode_q <= 1'b0;
+      load_err_q   <= 1'b0;
+      store_err_q  <= 1'b0;
     end else begin
       ctrl_fsm_cs  <= ctrl_fsm_ns;
       debug_mode_q <= debug_mode_n;
+      load_err_q   <= load_err_n;
+      store_err_q  <= store_err_n;
     end
   end
 

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -352,15 +352,15 @@ module ibex_core #(
       .data_misaligned_i            ( data_misaligned      ),
       .misaligned_addr_i            ( misaligned_addr      ),
 
+      .lsu_load_err_i               ( lsu_load_err         ),
+      .lsu_store_err_i              ( lsu_store_err        ),
+
       // Interrupt Signals
       .irq_i                        ( irq_i                ), // incoming interrupts
       .irq_id_i                     ( irq_id_i             ),
       .m_irq_enable_i               ( m_irq_enable         ),
       .irq_ack_o                    ( irq_ack_o            ),
       .irq_id_o                     ( irq_id_o             ),
-
-      .lsu_load_err_i               ( lsu_load_err         ),
-      .lsu_store_err_i              ( lsu_store_err        ),
 
       // Debug Signal
       .debug_cause_o                ( debug_cause          ),

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -310,7 +310,7 @@ module ibex_cs_registers #(
           mstatus_n.mpie = mstatus_q.mie;
           mstatus_n.mie  = 1'b0;
           mstatus_n.mpp  = PRIV_LVL_M;
-          mepc_n = exception_pc;
+          mepc_n         = exception_pc;
           mcause_n       = csr_cause_i;
         end
       end //csr_save_cause_i

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -190,8 +190,7 @@ module ibex_cs_registers #(
   // read logic
   always_comb begin
     csr_rdata_int = '0;
-    case (csr_addr_i)
-
+    unique case (csr_addr_i)
       // mstatus: always M-mode, contains IE bit
       CSR_MSTATUS: csr_rdata_int = {
                                   19'b0,
@@ -219,10 +218,9 @@ module ibex_cs_registers #(
       CSR_DPC: csr_rdata_int = depc_q;
       CSR_DSCRATCH0: csr_rdata_int = dscratch0_q;
       CSR_DSCRATCH1: csr_rdata_int = dscratch1_q;
-      default: ;
+      default:;
     endcase
   end
-
 
   // write logic
   always_comb begin
@@ -235,7 +233,7 @@ module ibex_cs_registers #(
     mcause_n     = mcause_q;
     exception_pc = pc_id_i;
 
-    case (csr_addr_i)
+    unique case (csr_addr_i)
       // mstatus: IE bit
       CSR_MSTATUS: if (csr_we_int) begin
         mstatus_n = '{
@@ -283,7 +281,7 @@ module ibex_cs_registers #(
         begin
           dscratch1_n = csr_wdata_int;
         end
-      default: ;
+      default:;
     endcase
 
     // exception controller gets priority over other writes
@@ -332,7 +330,6 @@ module ibex_cs_registers #(
 
   // CSR operation logic
   always_comb begin
-    csr_wdata_int = csr_wdata_i;
     csr_we_int    = 1'b1;
 
     unique case (csr_op_i)
@@ -343,7 +340,10 @@ module ibex_cs_registers #(
         csr_wdata_int = csr_wdata_i;
         csr_we_int    = 1'b0;
       end
-      default:;
+      default: begin
+        csr_wdata_int = 'X;
+        csr_we_int    = 1'bX;
+      end
     endcase
   end
 
@@ -481,7 +481,7 @@ module ibex_cs_registers #(
         CSR_OP_WRITE:  PCCR_n[0] = csr_wdata_i;
         CSR_OP_SET:    PCCR_n[0] = csr_wdata_i | PCCR_q[0];
         CSR_OP_CLEAR:  PCCR_n[0] = csr_wdata_i & ~(PCCR_q[0]);
-        default:       ;
+        default:       PCCR_n[0] = 'X;
       endcase
     end
   end
@@ -502,7 +502,7 @@ module ibex_cs_registers #(
           CSR_OP_WRITE:  PCCR_n[c] = csr_wdata_i;
           CSR_OP_SET:    PCCR_n[c] = csr_wdata_i | PCCR_q[c];
           CSR_OP_CLEAR:  PCCR_n[c] = csr_wdata_i & ~(PCCR_q[c]);
-          default:       ;
+          default:       PCCR_n[c] = 'X;
         endcase
       end
     end
@@ -520,7 +520,7 @@ module ibex_cs_registers #(
         CSR_OP_WRITE:  PCMR_n = csr_wdata_i[1:0];
         CSR_OP_SET:    PCMR_n = csr_wdata_i[1:0] | PCMR_q;
         CSR_OP_CLEAR:  PCMR_n = csr_wdata_i[1:0] & ~(PCMR_q);
-        default:       ;
+        default:       PCMR_n = 'X;
       endcase
     end
 
@@ -530,7 +530,7 @@ module ibex_cs_registers #(
         CSR_OP_WRITE:  PCER_n = csr_wdata_i[N_PERF_COUNTERS-1:0];
         CSR_OP_SET:    PCER_n = csr_wdata_i[N_PERF_COUNTERS-1:0] | PCER_q;
         CSR_OP_CLEAR:  PCER_n = csr_wdata_i[N_PERF_COUNTERS-1:0] & ~(PCER_q);
-        default:       ;
+        default:       PCER_n = 'X;
       endcase
     end
   end

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -481,6 +481,7 @@ module ibex_cs_registers #(
         CSR_OP_WRITE:  PCCR_n[0] = csr_wdata_i;
         CSR_OP_SET:    PCCR_n[0] = csr_wdata_i | PCCR_q[0];
         CSR_OP_CLEAR:  PCCR_n[0] = csr_wdata_i & ~(PCCR_q[0]);
+        default:       ;
       endcase
     end
   end
@@ -501,6 +502,7 @@ module ibex_cs_registers #(
           CSR_OP_WRITE:  PCCR_n[c] = csr_wdata_i;
           CSR_OP_SET:    PCCR_n[c] = csr_wdata_i | PCCR_q[c];
           CSR_OP_CLEAR:  PCCR_n[c] = csr_wdata_i & ~(PCCR_q[c]);
+          default:       ;
         endcase
       end
     end
@@ -518,6 +520,7 @@ module ibex_cs_registers #(
         CSR_OP_WRITE:  PCMR_n = csr_wdata_i[1:0];
         CSR_OP_SET:    PCMR_n = csr_wdata_i[1:0] | PCMR_q;
         CSR_OP_CLEAR:  PCMR_n = csr_wdata_i[1:0] & ~(PCMR_q);
+        default:       ;
       endcase
     end
 
@@ -527,6 +530,7 @@ module ibex_cs_registers #(
         CSR_OP_WRITE:  PCER_n = csr_wdata_i[N_PERF_COUNTERS-1:0];
         CSR_OP_SET:    PCER_n = csr_wdata_i[N_PERF_COUNTERS-1:0] | PCER_q;
         CSR_OP_CLEAR:  PCER_n = csr_wdata_i[N_PERF_COUNTERS-1:0] & ~(PCER_q);
+        default:       ;
       endcase
     end
   end

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -340,7 +340,10 @@ module ibex_decoder #(
               illegal_insn_o = 1'b1;
             end
           end
-          default:;
+
+          default: begin
+            alu_operator_o = alu_op_e'({$bits(alu_op_e){1'bX}});
+          end
         endcase
       end
 

--- a/rtl/ibex_defines.sv
+++ b/rtl/ibex_defines.sv
@@ -185,9 +185,11 @@ typedef enum logic [2:0] {
 
 // Exception cause
 typedef enum logic [5:0] {
-  EXC_CAUSE_ILLEGAL_INSN = 6'h02,
-  EXC_CAUSE_BREAKPOINT   = 6'h03,
-  EXC_CAUSE_ECALL_MMODE  = 6'h0B
+  EXC_CAUSE_ILLEGAL_INSN       = 6'h02,
+  EXC_CAUSE_BREAKPOINT         = 6'h03,
+  EXC_CAUSE_LOAD_ACCESS_FAULT  = 6'h05,
+  EXC_CAUSE_STORE_ACCESS_FAULT = 6'h07,
+  EXC_CAUSE_ECALL_MMODE        = 6'h0B
 } exc_cause_e;
 
 // Exceptions offsets
@@ -201,6 +203,7 @@ typedef enum logic [7:0] {
   EXC_OFF_RST        = 8'h80,
   EXC_OFF_ILLINSN    = 8'h84,
   EXC_OFF_ECALL      = 8'h88,
+  EXC_OFF_LSUERR     = 8'h8c,
   EXC_OFF_BREAKPOINT = 8'h90
 } exc_off_e;
 

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -272,12 +272,12 @@ module ibex_id_stage #(
 
   // ALU_Op_a Mux
   always_comb begin : alu_operand_a_mux
-    case (alu_op_a_mux_sel)
+    unique case (alu_op_a_mux_sel)
       OP_A_REGA_OR_FWD:  alu_operand_a = operand_a_fw_id;
       OP_A_CURRPC:       alu_operand_a = pc_id_i;
       OP_A_IMM:          alu_operand_a = imm_a;
-      default:           alu_operand_a = operand_a_fw_id;
-    endcase // case (alu_op_a_mux_sel)
+      default:           alu_operand_a = 'X;
+    endcase
   end
 
   assign imm_a = (imm_a_mux_sel == IMM_A_Z) ? zimm_rs1_type : '0;

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -440,6 +440,8 @@ module ibex_id_stage #(
 
       // LSU
       .data_misaligned_i              ( data_misaligned_i      ),
+      .load_err_i                     ( lsu_load_err_i         ),
+      .store_err_i                    ( lsu_store_err_i        ),
 
       // jump/branch control
       .branch_in_id_i                 ( branch_in_id           ),

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -104,8 +104,8 @@ module ibex_if_stage #(
       EXC_PC_STORE:      exc_pc = { boot_addr_i[31:8], {EXC_OFF_LSUERR} };
       EXC_PC_BREAKPOINT: exc_pc = { boot_addr_i[31:8], {EXC_OFF_BREAKPOINT} };
       EXC_PC_IRQ:        exc_pc = { boot_addr_i[31:8], {exc_vec_pc_mux_i}, 2'b0 };
-      EXC_PC_DBD:        exc_pc = { DmHaltAddr };
-      EXC_PC_DBGEXC:     exc_pc = { DmExceptionAddr };
+      EXC_PC_DBD:        exc_pc = DmHaltAddr;
+      EXC_PC_DBGEXC:     exc_pc = DmExceptionAddr;
       default:           exc_pc = 'X;
     endcase
   end

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -94,8 +94,6 @@ module ibex_if_stage #(
 
   // exception PC selection mux
   always_comb begin : exc_pc_mux
-    exc_pc = '0;
-
     // TODO: The behavior below follows an outdated (pre-1.10) RISC-V Privileged
     // Spec to implement a "free-form" vectored trap handler.
     // We need to update this code and crt0.S to follow the new mtvec spec.
@@ -108,14 +106,12 @@ module ibex_if_stage #(
       EXC_PC_IRQ:        exc_pc = { boot_addr_i[31:8], {exc_vec_pc_mux_i}, 2'b0 };
       EXC_PC_DBD:        exc_pc = { DmHaltAddr };
       EXC_PC_DBGEXC:     exc_pc = { DmExceptionAddr };
-      default:;
+      default:           exc_pc = 'X;
     endcase
   end
 
   // fetch address selection mux
   always_comb begin : fetch_addr_mux
-    fetch_addr_n = '0;
-
     unique case (pc_mux_i)
       PC_BOOT:      fetch_addr_n = {boot_addr_i[31:8], {EXC_OFF_RST}};
       PC_JUMP:      fetch_addr_n = jump_target_ex_i;
@@ -123,8 +119,7 @@ module ibex_if_stage #(
       PC_ERET:      fetch_addr_n = exception_pc_reg_i; // PC is restored when returning
                                                        // from IRQ/exception
       PC_DRET:      fetch_addr_n = depc_i;
-
-      default:;
+      default:      fetch_addr_n = 'X;
     endcase
   end
 

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -102,11 +102,12 @@ module ibex_if_stage #(
     unique case (exc_pc_mux_i)
       EXC_PC_ILLINSN:    exc_pc = { boot_addr_i[31:8], {EXC_OFF_ILLINSN} };
       EXC_PC_ECALL:      exc_pc = { boot_addr_i[31:8], {EXC_OFF_ECALL} };
+      EXC_PC_LOAD:       exc_pc = { boot_addr_i[31:8], {EXC_OFF_LSUERR} };
+      EXC_PC_STORE:      exc_pc = { boot_addr_i[31:8], {EXC_OFF_LSUERR} };
       EXC_PC_BREAKPOINT: exc_pc = { boot_addr_i[31:8], {EXC_OFF_BREAKPOINT} };
       EXC_PC_IRQ:        exc_pc = { boot_addr_i[31:8], {exc_vec_pc_mux_i}, 2'b0 };
       EXC_PC_DBD:        exc_pc = { DmHaltAddr };
       EXC_PC_DBGEXC:     exc_pc = { DmExceptionAddr };
-      // TODO: Add case for EXC_PC_STORE and EXC_PC_LOAD as soon as they are supported
       default:;
     endcase
   end

--- a/rtl/ibex_int_controller.sv
+++ b/rtl/ibex_int_controller.sv
@@ -85,6 +85,10 @@ module ibex_int_controller (
       IRQ_DONE: begin
         exc_ctrl_ns = IDLE;
       end
+
+      default: begin
+        exc_ctrl_ns = exc_ctrl_e'({$bits(exc_ctrl_e){1'bX}});
+      end
     endcase
   end
 

--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -102,17 +102,19 @@ module ibex_load_store_unit (
       2'b00: begin // Writing a word
         if (!misaligned_st) begin // non-misaligned case
           unique case (data_addr_int[1:0])
-            2'b00: data_be = 4'b1111;
-            2'b01: data_be = 4'b1110;
-            2'b10: data_be = 4'b1100;
-            2'b11: data_be = 4'b1000;
+            2'b00:   data_be = 4'b1111;
+            2'b01:   data_be = 4'b1110;
+            2'b10:   data_be = 4'b1100;
+            2'b11:   data_be = 4'b1000;
+            default: data_be = 'X;
           endcase // case (data_addr_int[1:0])
         end else begin // misaligned case
           unique case (data_addr_int[1:0])
-            2'b00: data_be = 4'b0000; // this is not used, but included for completeness
-            2'b01: data_be = 4'b0001;
-            2'b10: data_be = 4'b0011;
-            2'b11: data_be = 4'b0111;
+            2'b00:   data_be = 4'b0000; // this is not used, but included for completeness
+            2'b01:   data_be = 4'b0001;
+            2'b10:   data_be = 4'b0011;
+            2'b11:   data_be = 4'b0111;
+            default: data_be = 'X;
           endcase // case (data_addr_int[1:0])
         end
       end
@@ -120,10 +122,11 @@ module ibex_load_store_unit (
       2'b01: begin // Writing a half word
         if (!misaligned_st) begin // non-misaligned case
           unique case (data_addr_int[1:0])
-            2'b00: data_be = 4'b0011;
-            2'b01: data_be = 4'b0110;
-            2'b10: data_be = 4'b1100;
-            2'b11: data_be = 4'b1000;
+            2'b00:   data_be = 4'b0011;
+            2'b01:   data_be = 4'b0110;
+            2'b10:   data_be = 4'b1100;
+            2'b11:   data_be = 4'b1000;
+            default: data_be = 'X;
           endcase // case (data_addr_int[1:0])
         end else begin // misaligned case
           data_be = 4'b0001;
@@ -133,10 +136,11 @@ module ibex_load_store_unit (
       2'b10,
       2'b11: begin // Writing a byte
         unique case (data_addr_int[1:0])
-          2'b00: data_be = 4'b0001;
-          2'b01: data_be = 4'b0010;
-          2'b10: data_be = 4'b0100;
-          2'b11: data_be = 4'b1000;
+          2'b00:   data_be = 4'b0001;
+          2'b01:   data_be = 4'b0010;
+          2'b10:   data_be = 4'b0100;
+          2'b11:   data_be = 4'b1000;
+          default: data_be = 'X;
         endcase // case (data_addr_int[1:0])
       end
     endcase // case (data_type_ex_i)
@@ -148,10 +152,11 @@ module ibex_load_store_unit (
   assign wdata_offset = data_addr_int[1:0] - data_reg_offset_ex_i[1:0];
   always_comb begin
     unique case (wdata_offset)
-      2'b00: data_wdata = data_wdata_ex_i[31:0];
-      2'b01: data_wdata = {data_wdata_ex_i[23:0], data_wdata_ex_i[31:24]};
-      2'b10: data_wdata = {data_wdata_ex_i[15:0], data_wdata_ex_i[31:16]};
-      2'b11: data_wdata = {data_wdata_ex_i[ 7:0], data_wdata_ex_i[31: 8]};
+      2'b00:   data_wdata =  data_wdata_ex_i[31:0];
+      2'b01:   data_wdata = {data_wdata_ex_i[23:0], data_wdata_ex_i[31:24]};
+      2'b10:   data_wdata = {data_wdata_ex_i[15:0], data_wdata_ex_i[31:16]};
+      2'b11:   data_wdata = {data_wdata_ex_i[ 7:0], data_wdata_ex_i[31: 8]};
+      default: data_wdata = 'X;
     endcase // case (wdata_offset)
   end
 

--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -98,7 +98,7 @@ module ibex_load_store_unit (
   // BE generation //
   ///////////////////
   always_comb begin
-    case (data_type_ex_i) // Data type 00 Word, 01 Half word, 11,10 byte
+    unique case (data_type_ex_i) // Data type 00 Word, 01 Half word, 11,10 byte
       2'b00: begin // Writing a word
         if (!misaligned_st) begin // non-misaligned case
           unique case (data_addr_int[1:0])
@@ -143,6 +143,8 @@ module ibex_load_store_unit (
           default: data_be = 'X;
         endcase // case (data_addr_int[1:0])
       end
+
+      default:     data_be = 'X;
     endcase // case (data_type_ex_i)
   end
 
@@ -189,17 +191,18 @@ module ibex_load_store_unit (
 
   // take care of misaligned words
   always_comb begin
-    case (rdata_offset_q)
-      2'b00: rdata_w_ext = data_rdata_i[31:0];
-      2'b01: rdata_w_ext = {data_rdata_i[ 7:0], rdata_q[31:8]};
-      2'b10: rdata_w_ext = {data_rdata_i[15:0], rdata_q[31:16]};
-      2'b11: rdata_w_ext = {data_rdata_i[23:0], rdata_q[31:24]};
+    unique case (rdata_offset_q)
+      2'b00:   rdata_w_ext =  data_rdata_i[31:0];
+      2'b01:   rdata_w_ext = {data_rdata_i[ 7:0], rdata_q[31:8]};
+      2'b10:   rdata_w_ext = {data_rdata_i[15:0], rdata_q[31:16]};
+      2'b11:   rdata_w_ext = {data_rdata_i[23:0], rdata_q[31:24]};
+      default: rdata_w_ext = 'X;
     endcase
   end
 
   // sign extension for half words
   always_comb begin
-    case (rdata_offset_q)
+    unique case (rdata_offset_q)
       2'b00: begin
         if (!data_sign_ext_q) begin
           rdata_h_ext = {16'h0000, data_rdata_i[15:0]};
@@ -231,12 +234,14 @@ module ibex_load_store_unit (
           rdata_h_ext = {{16{data_rdata_i[7]}}, data_rdata_i[7:0], rdata_q[31:24]};
         end
       end
+
+      default: rdata_h_ext = 'X;
     endcase // case (rdata_offset_q)
   end
 
   // sign extension for bytes
   always_comb begin
-    case (rdata_offset_q)
+    unique case (rdata_offset_q)
       2'b00: begin
         if (!data_sign_ext_q) begin
           rdata_b_ext = {24'h00_0000, data_rdata_i[7:0]};
@@ -268,15 +273,18 @@ module ibex_load_store_unit (
           rdata_b_ext = {{24{data_rdata_i[31]}}, data_rdata_i[31:24]};
         end
       end
+
+      default: rdata_b_ext = 'X;
     endcase // case (rdata_offset_q)
   end
 
   // select word, half word or byte sign extended version
   always_comb begin
-    case (data_type_q)
+    unique case (data_type_q)
       2'b00:       data_rdata_ext = rdata_w_ext;
       2'b01:       data_rdata_ext = rdata_h_ext;
       2'b10,2'b11: data_rdata_ext = rdata_b_ext;
+      default:     data_rdata_ext = 'X;
     endcase //~case(rdata_type_q)
   end
 
@@ -340,7 +348,7 @@ module ibex_load_store_unit (
     increase_address = 1'b0;
     data_misaligned_o = 1'b0;
 
-    case(CS)
+    unique case(CS)
       // starts from not active and stays in IDLE until request was granted
       IDLE: begin
         if (data_req_ex_i) begin
@@ -416,9 +424,8 @@ module ibex_load_store_unit (
         end
       end //~ WAIT_RVALID
 
-
       default: begin
-        NS = IDLE;
+        NS = ls_fsm_e'({$bits(ls_fsm_e){1'bX}});
       end
     endcase
   end
@@ -430,18 +437,23 @@ module ibex_load_store_unit (
     data_misaligned = 1'b0;
 
     if (data_req_ex_i && !data_misaligned_q) begin
-      case (data_type_ex_i)
+      unique case (data_type_ex_i)
         2'b00: begin // word
           if (data_addr_int[1:0] != 2'b00) begin
             data_misaligned = 1'b1;
           end
         end
+
         2'b01: begin // half word
           if (data_addr_int[1:0] == 2'b11) begin
             data_misaligned = 1'b1;
           end
         end
-      default: ;
+
+        2'b10,
+        2'b11:;
+
+        default: data_misaligned = 1'bX;
       endcase // case (data_type_ex_i)
     end
   end

--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -318,8 +318,10 @@ module ibex_load_store_unit (
 
   assign misaligned_st = data_misaligned_q;
 
-  assign load_err_o    = 1'b0;
-  assign store_err_o   = 1'b0;
+  // to know what kind of error to signal, we need to know the type of the transaction to which
+  // the outsanding rvalid belongs.
+  assign load_err_o    = data_err_i & data_rvalid_i & ~data_we_q;
+  assign store_err_o   = data_err_i & data_rvalid_i &  data_we_q;
 
   // FSM
   always_comb begin

--- a/rtl/ibex_multdiv_fast.sv
+++ b/rtl/ibex_multdiv_fast.sv
@@ -245,7 +245,9 @@ module ibex_multdiv_fast (
         divcurr_state_n = MD_IDLE;
       end
 
-      default:;
+      default: begin
+        divcurr_state_n = div_fsm_e'({$bits(div_fsm_e){1'bX}});
+      end
     endcase // divcurr_state_q
   end
 
@@ -323,7 +325,9 @@ module ibex_multdiv_fast (
         mult_state_n = ALBL;
         mult_is_ready = 1'b1;
       end
-      default:;
+      default: begin
+        mult_state_n = mult_fsm_e'({$bits(mult_fsm_e){1'bX}});
+      end
     endcase // mult_state_q
   end
 

--- a/rtl/ibex_multdiv_slow.sv
+++ b/rtl/ibex_multdiv_slow.sv
@@ -283,7 +283,9 @@ module ibex_multdiv_slow (
             curr_state_d = MD_IDLE;
         end
 
-        default:;
+        default: begin
+          curr_state_d = div_fsm_e'({$bits(div_fsm_e){1'bX}});
+        end
         endcase // curr_state_q
       end
   end

--- a/rtl/ibex_prefetch_buffer.sv
+++ b/rtl/ibex_prefetch_buffer.sv
@@ -200,8 +200,7 @@ module ibex_prefetch_buffer (
       end
 
       default: begin
-        // NS          = IDLE;      // unreachable, removing dead code
-        // instr_req_o = 1'b0;      // unreachable, removing dead code
+        NS = prefetch_fsm_e'({$bits(prefetch_fsm_e){1'bX}});
       end
     endcase
   end


### PR DESCRIPTION
This PR implements a couple of changes (to list the most important ones):
- Add capability to detect and react on load/store errors
- Add missing `default` in `unique case`, progagate `'X' in FSM states
- Replace non-unique `case` constructs by `unique case` -> resolves #43 
- Remove unnessary `{}` to avoid linting errors
- Update doc to add `data_err_i` and LSU exceptions -> resolves #44 

The changes are tested in simulation using Verilator. The FPGA bitstream build is completing without errors.