### PR TITLE
Code cleanup

### DIFF
--- a/doc/exception_interrupts.rst
+++ b/doc/exception_interrupts.rst
@@ -15,9 +15,9 @@ Ibex supports interrupts, exceptions on illegal instructions.
 +------------+-----------------------------+
 | **0x84**   | Illegal Instruction         |
 +------------+-----------------------------+
-| **0x8C**   | LSU Error                   |
-+------------+-----------------------------+
 | **0x88**   | ECALL Instruction Executed  |
++------------+-----------------------------+
+| **0x8C**   | LSU Error                   |
 +------------+-----------------------------+
 
 The base address of the interrupt vector table is given by the boot address (must be aligned to 256 bytes, i.e., its least significant byte must be 0x00). The most significant  3 bytes of the boot address given to the core are used for the first instruction fetch of the core and as the basis of the interrupt vector table. The core starts fetching at the address made by concatenating the most significant 3 bytes of the boot address and the reset value (0x80) as the least significant byte. The boot address can be changed after the first instruction was fetched to change the interrupt vector table address. It is assumed that the boot address is supplied via a register to avoid long paths to the instruction fetch unit.

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -252,10 +252,10 @@ module ibex_tracer #(
 
         if (instr_i[14:12] != 3'b111) begin
           // regular load
-            regs_read.push_back('{rs1, rs1_value_i});
-            str = $sformatf("%-16s x%0d, %0d(x%0d)", mnemonic, rd, $signed(imm_i_type_i), rs1);
+          regs_read.push_back('{rs1, rs1_value_i});
+          str = $sformatf("%-16s x%0d, %0d(x%0d)", mnemonic, rd, $signed(imm_i_type_i), rs1);
         end else begin
-            printMnemonic("INVALID");
+          printMnemonic("INVALID");
         end
       end
     endfunction
@@ -276,11 +276,11 @@ module ibex_tracer #(
 
         if (!instr_i[14]) begin
           // regular store
-            regs_read.push_back('{rs2, rs2_value_i});
-            regs_read.push_back('{rs1, rs1_value_i});
-            str = $sformatf("%-16s x%0d, %0d(x%0d)", mnemonic, rs2, $signed(imm_s_type_i), rs1);
+          regs_read.push_back('{rs2, rs2_value_i});
+          regs_read.push_back('{rs1, rs1_value_i});
+          str = $sformatf("%-16s x%0d, %0d(x%0d)", mnemonic, rs2, $signed(imm_s_type_i), rs1);
         end else begin
-            printMnemonic("INVALID");
+          printMnemonic("INVALID");
         end
       end
     endfunction // printSInstr
@@ -335,7 +335,7 @@ module ibex_tracer #(
       // use casex instead of case inside due to ModelSim bug
       casex (instr_i)
         // Aliases
-        32'h00_00_00_13:   trace.printMnemonic("nop");
+        32'h00_00_00_13:  trace.printMnemonic("nop");
         // Regular opcodes
         INSTR_LUI:        trace.printUInstr("lui");
         INSTR_AUIPC:      trace.printUInstr("auipc");
@@ -391,9 +391,10 @@ module ibex_tracer #(
         INSTR_DIVU:       trace.printRInstr("divu");
         INSTR_REM:        trace.printRInstr("rem");
         INSTR_REMU:       trace.printRInstr("remu");
-        {25'b?, {OPCODE_LOAD}}:     trace.printLoadInstr();
-        {25'b?, {OPCODE_STORE}}:    trace.printStoreInstr();
-        default:           trace.printMnemonic("INVALID");
+        // LOAD & STORE
+        INSTR_LOAD:       trace.printLoadInstr();
+        INSTR_STORE:      trace.printStoreInstr();
+        default:          trace.printMnemonic("INVALID");
       endcase // unique case (instr_i)
 
       // replace register written back

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -234,7 +234,7 @@ module ibex_tracer #(
           size = instr_i[30:28];
         end
 
-        case (size)
+        unique case (size)
           3'b000: mnemonic = "lb";
           3'b001: mnemonic = "lh";
           3'b010: mnemonic = "lw";
@@ -243,6 +243,10 @@ module ibex_tracer #(
           3'b110: mnemonic = "p.elw";
           3'b011,
           3'b111: begin
+            printMnemonic("INVALID");
+            return;
+          end
+          default: begin
             printMnemonic("INVALID");
             return;
           end
@@ -264,11 +268,15 @@ module ibex_tracer #(
       string mnemonic;
       begin
 
-        case (instr_i[13:12])
+        unique case (instr_i[13:12])
           2'b00:  mnemonic = "sb";
           2'b01:  mnemonic = "sh";
           2'b10:  mnemonic = "sw";
           2'b11: begin
+            printMnemonic("INVALID");
+            return;
+          end
+          default: begin
             printMnemonic("INVALID");
             return;
           end
@@ -333,7 +341,7 @@ module ibex_tracer #(
       trace.instr      = instr_i;
 
       // use casex instead of case inside due to ModelSim bug
-      casex (instr_i)
+      unique casex (instr_i)
         // Aliases
         32'h00_00_00_13:  trace.printMnemonic("nop");
         // Regular opcodes

--- a/rtl/ibex_tracer_defines.sv
+++ b/rtl/ibex_tracer_defines.sv
@@ -7,61 +7,61 @@ package ibex_tracer_defines;
 import ibex_defines::*;
 
 // instruction masks (for tracer)
-parameter int unsigned INSTR_LUI     = { 25'b?,                           {OPCODE_LUI  } };
-parameter int unsigned INSTR_AUIPC   = { 25'b?,                           {OPCODE_AUIPC} };
-parameter int unsigned INSTR_JAL     = { 25'b?,                           {OPCODE_JAL  } };
-parameter int unsigned INSTR_JALR    = { 17'b?,             3'b000, 5'b?, {OPCODE_JALR } };
+parameter logic [31:0] INSTR_LUI     = { 25'b?,                           {OPCODE_LUI  } };
+parameter logic [31:0] INSTR_AUIPC   = { 25'b?,                           {OPCODE_AUIPC} };
+parameter logic [31:0] INSTR_JAL     = { 25'b?,                           {OPCODE_JAL  } };
+parameter logic [31:0] INSTR_JALR    = { 17'b?,             3'b000, 5'b?, {OPCODE_JALR } };
 // BRANCH
-parameter int unsigned INSTR_BEQ     = { 17'b?,             3'b000, 5'b?, {OPCODE_BRANCH} };
-parameter int unsigned INSTR_BNE     = { 17'b?,             3'b001, 5'b?, {OPCODE_BRANCH} };
-parameter int unsigned INSTR_BLT     = { 17'b?,             3'b100, 5'b?, {OPCODE_BRANCH} };
-parameter int unsigned INSTR_BGE     = { 17'b?,             3'b101, 5'b?, {OPCODE_BRANCH} };
-parameter int unsigned INSTR_BLTU    = { 17'b?,             3'b110, 5'b?, {OPCODE_BRANCH} };
-parameter int unsigned INSTR_BGEU    = { 17'b?,             3'b111, 5'b?, {OPCODE_BRANCH} };
-parameter int unsigned INSTR_BALL    = { 17'b?,             3'b010, 5'b?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSTR_BEQ     = { 17'b?,             3'b000, 5'b?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSTR_BNE     = { 17'b?,             3'b001, 5'b?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSTR_BLT     = { 17'b?,             3'b100, 5'b?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSTR_BGE     = { 17'b?,             3'b101, 5'b?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSTR_BLTU    = { 17'b?,             3'b110, 5'b?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSTR_BGEU    = { 17'b?,             3'b111, 5'b?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSTR_BALL    = { 17'b?,             3'b010, 5'b?, {OPCODE_BRANCH} };
 // OPIMM
-parameter int unsigned INSTR_ADDI    = { 17'b?,             3'b000, 5'b?, {OPCODE_OPIMM} };
-parameter int unsigned INSTR_SLTI    = { 17'b?,             3'b010, 5'b?, {OPCODE_OPIMM} };
-parameter int unsigned INSTR_SLTIU   = { 17'b?,             3'b011, 5'b?, {OPCODE_OPIMM} };
-parameter int unsigned INSTR_XORI    = { 17'b?,             3'b100, 5'b?, {OPCODE_OPIMM} };
-parameter int unsigned INSTR_ORI     = { 17'b?,             3'b110, 5'b?, {OPCODE_OPIMM} };
-parameter int unsigned INSTR_ANDI    = { 17'b?,             3'b111, 5'b?, {OPCODE_OPIMM} };
-parameter int unsigned INSTR_SLLI    = { 7'b0000000, 10'b?, 3'b001, 5'b?, {OPCODE_OPIMM} };
-parameter int unsigned INSTR_SRLI    = { 7'b0000000, 10'b?, 3'b101, 5'b?, {OPCODE_OPIMM} };
-parameter int unsigned INSTR_SRAI    = { 7'b0100000, 10'b?, 3'b101, 5'b?, {OPCODE_OPIMM} };
+parameter logic [31:0] INSTR_ADDI    = { 17'b?,             3'b000, 5'b?, {OPCODE_OPIMM} };
+parameter logic [31:0] INSTR_SLTI    = { 17'b?,             3'b010, 5'b?, {OPCODE_OPIMM} };
+parameter logic [31:0] INSTR_SLTIU   = { 17'b?,             3'b011, 5'b?, {OPCODE_OPIMM} };
+parameter logic [31:0] INSTR_XORI    = { 17'b?,             3'b100, 5'b?, {OPCODE_OPIMM} };
+parameter logic [31:0] INSTR_ORI     = { 17'b?,             3'b110, 5'b?, {OPCODE_OPIMM} };
+parameter logic [31:0] INSTR_ANDI    = { 17'b?,             3'b111, 5'b?, {OPCODE_OPIMM} };
+parameter logic [31:0] INSTR_SLLI    = { 7'b0000000, 10'b?, 3'b001, 5'b?, {OPCODE_OPIMM} };
+parameter logic [31:0] INSTR_SRLI    = { 7'b0000000, 10'b?, 3'b101, 5'b?, {OPCODE_OPIMM} };
+parameter logic [31:0] INSTR_SRAI    = { 7'b0100000, 10'b?, 3'b101, 5'b?, {OPCODE_OPIMM} };
 // OP
-parameter int unsigned INSTR_ADD     = { 7'b0000000, 10'b?, 3'b000, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_SUB     = { 7'b0100000, 10'b?, 3'b000, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_SLL     = { 7'b0000000, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_SLT     = { 7'b0000000, 10'b?, 3'b010, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_SLTU    = { 7'b0000000, 10'b?, 3'b011, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_XOR     = { 7'b0000000, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_SRL     = { 7'b0000000, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_SRA     = { 7'b0100000, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_OR      = { 7'b0000000, 10'b?, 3'b110, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_AND     = { 7'b0000000, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_ADD     = { 7'b0000000, 10'b?, 3'b000, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_SUB     = { 7'b0100000, 10'b?, 3'b000, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_SLL     = { 7'b0000000, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_SLT     = { 7'b0000000, 10'b?, 3'b010, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_SLTU    = { 7'b0000000, 10'b?, 3'b011, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_XOR     = { 7'b0000000, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_SRL     = { 7'b0000000, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_SRA     = { 7'b0100000, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_OR      = { 7'b0000000, 10'b?, 3'b110, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_AND     = { 7'b0000000, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
 
 // SYSTEM
-parameter int unsigned INSTR_CSRRW   = { 17'b?,             3'b001, 5'b?, {OPCODE_SYSTEM} };
-parameter int unsigned INSTR_CSRRS   = { 17'b?,             3'b010, 5'b?, {OPCODE_SYSTEM} };
-parameter int unsigned INSTR_CSRRC   = { 17'b?,             3'b011, 5'b?, {OPCODE_SYSTEM} };
-parameter int unsigned INSTR_CSRRWI  = { 17'b?,             3'b101, 5'b?, {OPCODE_SYSTEM} };
-parameter int unsigned INSTR_CSRRSI  = { 17'b?,             3'b110, 5'b?, {OPCODE_SYSTEM} };
-parameter int unsigned INSTR_CSRRCI  = { 17'b?,             3'b111, 5'b?, {OPCODE_SYSTEM} };
-parameter int unsigned INSTR_ECALL   = { 12'b000000000000,         13'b0, {OPCODE_SYSTEM} };
-parameter int unsigned INSTR_EBREAK  = { 12'b000000000001,         13'b0, {OPCODE_SYSTEM} };
-parameter int unsigned INSTR_MRET    = { 12'b001100000010,         13'b0, {OPCODE_SYSTEM} };
-parameter int unsigned INSTR_DRET    = { 12'b011110110010,         13'b0, {OPCODE_SYSTEM} };
-parameter int unsigned INSTR_WFI     = { 12'b000100000101,         13'b0, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSTR_CSRRW   = { 17'b?,             3'b001, 5'b?, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSTR_CSRRS   = { 17'b?,             3'b010, 5'b?, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSTR_CSRRC   = { 17'b?,             3'b011, 5'b?, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSTR_CSRRWI  = { 17'b?,             3'b101, 5'b?, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSTR_CSRRSI  = { 17'b?,             3'b110, 5'b?, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSTR_CSRRCI  = { 17'b?,             3'b111, 5'b?, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSTR_ECALL   = { 12'b000000000000,         13'b0, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSTR_EBREAK  = { 12'b000000000001,         13'b0, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSTR_MRET    = { 12'b001100000010,         13'b0, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSTR_DRET    = { 12'b011110110010,         13'b0, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSTR_WFI     = { 12'b000100000101,         13'b0, {OPCODE_SYSTEM} };
 
 // RV32M
-parameter int unsigned INSTR_DIV     = { 7'b0000001, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_DIVU    = { 7'b0000001, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_REM     = { 7'b0000001, 10'b?, 3'b110, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_REMU    = { 7'b0000001, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_PMUL    = { 7'b0000001, 10'b?, 3'b000, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_PMUH    = { 7'b0000001, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_PMULHSU = { 7'b0000001, 10'b?, 3'b010, 5'b?, {OPCODE_OP} };
-parameter int unsigned INSTR_PMULHU  = { 7'b0000001, 10'b?, 3'b011, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_DIV     = { 7'b0000001, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_DIVU    = { 7'b0000001, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_REM     = { 7'b0000001, 10'b?, 3'b110, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_REMU    = { 7'b0000001, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_PMUL    = { 7'b0000001, 10'b?, 3'b000, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_PMUH    = { 7'b0000001, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_PMULHSU = { 7'b0000001, 10'b?, 3'b010, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSTR_PMULHU  = { 7'b0000001, 10'b?, 3'b011, 5'b?, {OPCODE_OP} };
 
 endpackage

--- a/rtl/ibex_tracer_defines.sv
+++ b/rtl/ibex_tracer_defines.sv
@@ -64,4 +64,8 @@ parameter logic [31:0] INSTR_PMUH    = { 7'b0000001, 10'b?, 3'b001, 5'b?, {OPCOD
 parameter logic [31:0] INSTR_PMULHSU = { 7'b0000001, 10'b?, 3'b010, 5'b?, {OPCODE_OP} };
 parameter logic [31:0] INSTR_PMULHU  = { 7'b0000001, 10'b?, 3'b011, 5'b?, {OPCODE_OP} };
 
+// LOAD & STORE
+parameter logic [31:0] INSTR_LOAD    = {25'b?,                            {OPCODE_LOAD } };
+parameter logic [31:0] INSTR_STORE   = {25'b?,                            {OPCODE_STORE} };
+
 endpackage


### PR DESCRIPTION
This PR contains:
- a cosmetic fix to the documentation (exceptions were not ordered correctly)
- fixes to the tracer (switch from unsigned to logic for instruction mask parameters, replace non-unique `case` by `unique case` + `default`)
