### PR TITLE
Code cleanup

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -163,10 +163,10 @@ module ibex_controller (
 
     csr_save_cause_o       = 1'b0;
 
-    exc_cause_o            = exc_cause_e'({$bits(exc_cause_e){1'b0}});
+    exc_cause_o            = EXC_CAUSE_INSN_ADDR_MISA; // = 6'h00
     exc_pc_mux_o           = EXC_PC_IRQ;
 
-    csr_cause_o            = exc_cause_e'({$bits(exc_cause_e){1'b0}});
+    csr_cause_o            = EXC_CAUSE_INSN_ADDR_MISA; // = 6'h00
 
     pc_mux_o               = PC_BOOT;
     pc_set_o               = 1'b0;
@@ -513,7 +513,7 @@ module ibex_controller (
 
       default: begin
         instr_req_o = 1'b0;
-        ctrl_fsm_ns = ctrl_fsm_e'({$bits(ctrl_fsm_e){1'bX}});
+        ctrl_fsm_ns = ctrl_fsm_e'(1'bX);
       end
     endcase
   end

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -27,34 +27,35 @@ module ibex_controller (
     input  logic                      clk_i,
     input  logic                      rst_ni,
 
-    input  logic                      fetch_enable_i,        // Start the decoding
-    output logic                      ctrl_busy_o,           // Core is busy processing instructions
-    output logic                      first_fetch_o,         // Core is at the FIRST FETCH stage
-    output logic                      is_decoding_o,         // Core is in decoding state
+    input  logic                      fetch_enable_i,        // start decoding
+    output logic                      ctrl_busy_o,           // core is busy processing instrs
+    output logic                      first_fetch_o,         // core is at the FIRST FETCH stage
+    output logic                      is_decoding_o,         // core is in decoding state
 
     // decoder related signals
-    output logic                      deassert_we_o,         // deassert write enable for next instruction
+    output logic                      deassert_we_o,         // deassert write enable for next
+                                                             // instr
 
-    input  logic                      illegal_insn_i,        // decoder encountered an invalid instruction
-    input  logic                      ecall_insn_i,          // ecall encountered an mret instruction
-    input  logic                      mret_insn_i,           // decoder encountered an mret instruction
-    input  logic                      dret_insn_i,           // decoder encountered an dret instruction
+    input  logic                      illegal_insn_i,        // decoder has an invalid instr
+    input  logic                      ecall_insn_i,          // decoder has ECALL instr
+    input  logic                      mret_insn_i,           // decoder has MRET instr
+    input  logic                      dret_insn_i,           // decoder has DRET instr
     input  logic                      pipe_flush_i,          // decoder wants to do a pipe flush
-    input  logic                      ebrk_insn_i,           // decoder encountered an ebreak instruction
-    input  logic                      csr_status_i,          // decoder encountered an csr status instruction
+    input  logic                      ebrk_insn_i,           // decoder has EBREAK instr
+    input  logic                      csr_status_i,          // decoder has CSR status instr
 
     // from IF/ID pipeline
-    input  logic                      instr_valid_i,         // instruction coming from IF/ID pipeline is
-                                                             // valid
+    input  logic                      instr_valid_i,         // instruction coming from IF/ID stage
+                                                             // is valid
 
     // from prefetcher
-    output logic                      instr_req_o,           // Start fetching instructions
+    output logic                      instr_req_o,           // start fetching instructions
 
     // to prefetcher
     output logic                      pc_set_o,              // jump to address set by pc_mux
-    output ibex_defines::pc_sel_e     pc_mux_o,              // Selector in the Fetch stage to select the
-                                                             // right PC (normal, jump ...)
-    output ibex_defines::exc_pc_sel_e exc_pc_mux_o,          // Selects target PC for exception
+    output ibex_defines::pc_sel_e     pc_mux_o,              // IF stage fetch address selector
+                                                             // (boot, normal, exception...)
+    output ibex_defines::exc_pc_sel_e exc_pc_mux_o,          // IF stage selector for exception PC
 
     // LSU
     input  logic                      data_misaligned_i,
@@ -73,7 +74,8 @@ module ibex_controller (
     // Interrupt Controller Signals
     input  logic                      irq_req_ctrl_i,
     input  logic [4:0]                irq_id_ctrl_i,
-    input  logic                      m_IE_i,                // interrupt enable bit from CSR (M mode)
+    input  logic                      m_IE_i,                // interrupt enable bit from CSR
+                                                             // (M mode)
 
     output logic                      irq_ack_o,
     output logic [4:0]                irq_id_o,
@@ -97,7 +99,7 @@ module ibex_controller (
     output logic                      csr_save_cause_o,
 
     // forwarding signals
-    output ibex_defines::op_fw_sel_e  operand_a_fw_mux_sel_o, // regfile ra data selector form ID stage
+    output ibex_defines::op_fw_sel_e  operand_a_fw_mux_sel_o, // regfile ra selector for ID stage
 
     // stall signals
     output logic                      halt_if_o,
@@ -106,9 +108,10 @@ module ibex_controller (
     input  logic                      id_ready_i,             // ID stage is ready
 
     // Performance Counters
-    output logic                      perf_jump_o,            // we are executing a jump instruction
-                                                              // (j, jr, jal, jalr)
-    output logic                      perf_tbranch_o          // we are executing a taken branch instruction
+    output logic                      perf_jump_o,            // we are executing a jump
+                                                              // instruction (j, jr, jal, jalr)
+    output logic                      perf_tbranch_o          // we are executing a taken branch
+                                                              // instruction
 );
   import ibex_defines::*;
 

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -532,7 +532,7 @@ module ibex_core #(
 `ifndef VERILATOR
 `ifdef TRACE_EXECUTION
   ibex_tracer ibex_tracer_i (
-      .clk_i            ( clk_i                                ), // always-running clock for tracing
+      .clk_i            ( clk_i                                ), // always-on clk for tracer
       .rst_ni           ( rst_ni                               ),
 
       .fetch_enable_i   ( fetch_enable_i                       ),

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -70,15 +70,15 @@ module ibex_cs_registers #(
     input  logic                      csr_save_cause_i,
 
     // Performance Counters
-    input  logic                      if_valid_i,        // IF stage gives a new instruction
+    input  logic                      if_valid_i,        // IF stage gives a new instr
     input  logic                      id_valid_i,        // ID stage is done
-    input  logic                      is_compressed_i,   // compressed instruction in ID
+    input  logic                      is_compressed_i,   // compressed instr in ID
     input  logic                      is_decoding_i,     // controller is in DECODE state
 
-    input  logic                      imiss_i,           // instruction fetch
+    input  logic                      imiss_i,           // instr fetch
     input  logic                      pc_set_i,          // pc was set to a new value
-    input  logic                      jump_i,            // jump instruction seen   (j, jr, jal, jalr)
-    input  logic                      branch_i,          // branch instruction seen (bf, bnf)
+    input  logic                      jump_i,            // jump instr seen (j, jr, jal, jalr)
+    input  logic                      branch_i,          // branch instr seen (bf, bnf)
     input  logic                      branch_taken_i,    // branch was taken
     input  logic                      mem_load_i,        // load from memory in this cycle
     input  logic                      mem_store_i,       // store to memory in this cycle

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -239,7 +239,7 @@ module ibex_cs_registers #(
         mstatus_n = '{
           mie:  csr_wdata_int[`MSTATUS_MIE_BITS],
           mpie: csr_wdata_int[`MSTATUS_MPIE_BITS],
-          mpp:  priv_lvl_e'(PRIV_LVL_M)
+          mpp:  PRIV_LVL_M
         };
       end
       // mepc: exception program counter
@@ -371,8 +371,8 @@ module ibex_cs_registers #(
 
       depc_q      <= '0;
       dcsr_q     <= '{
-        xdebugver: x_debug_ver_e'({$bits(x_debug_ver_e){1'b0}}),
-        cause:     dbg_cause_e'({$bits(dbg_cause_e){1'b0}}),
+        xdebugver: XDEBUGVER_NO,   // 4'h0
+        cause:     DBG_CAUSE_NONE, // 3'h0
         prv:       PRIV_LVL_M,
         default:   '0
       };

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -28,36 +28,41 @@ module ibex_decoder #(
     parameter bit RV32M  = 1
 ) (
     // singals running to/from controller
-    input  logic                     deassert_we_i,         // deassert we, we are stalled or not active
-    input  logic                     data_misaligned_i,     // misaligned data load/store in progress
+    input  logic                     deassert_we_i,         // deassert we, we are stalled or
+                                                            // not active
+    input  logic                     data_misaligned_i,     // misaligned data load/store in
+                                                            // progress
     input  logic                     branch_mux_i,
     input  logic                     jump_mux_i,
-    output logic                     illegal_insn_o,        // illegal instruction encountered
-    output logic                     ebrk_insn_o,           // trap instruction encountered
-    output logic                     mret_insn_o,           // return from exception instruction encountered
-    output logic                     dret_insn_o,           // return from debug (M)
-    output logic                     ecall_insn_o,          // environment call (syscall)
-                                                            // instruction encountered
+    output logic                     illegal_insn_o,        // illegal instr encountered
+    output logic                     ebrk_insn_o,           // trap instr encountered
+    output logic                     mret_insn_o,           // return from exception instr
+                                                            // encountered
+    output logic                     dret_insn_o,           // return from debug instr encountered
+    output logic                     ecall_insn_o,          // syscall instr encountered
     output logic                     pipe_flush_o,          // pipeline flush is requested
 
     // from IF/ID pipeline
-    input  logic [31:0]              instr_rdata_i,         // instruction read from instr memory/cache
+    input  logic [31:0]              instr_rdata_i,         // instruction read from memory/cache
     input  logic                     illegal_c_insn_i,      // compressed instruction decode failed
 
     // ALU signals
     output ibex_defines::alu_op_e    alu_operator_o,        // ALU operation selection
     output ibex_defines::op_a_sel_e  alu_op_a_mux_sel_o,    // operand a selection: reg value, PC,
                                                             // immediate or zero
-    output ibex_defines::op_b_sel_e  alu_op_b_mux_sel_o,    // operand b selection: reg value or immediate
+    output ibex_defines::op_b_sel_e  alu_op_b_mux_sel_o,    // operand b selection: reg value or
+                                                            // immediate
 
     output ibex_defines::imm_a_sel_e imm_a_mux_sel_o,       // immediate selection for operand a
     output ibex_defines::imm_b_sel_e imm_b_mux_sel_o,       // immediate selection for operand b
 
     // MUL, DIV related control signals
     output logic                     mult_int_en_o,         // perform integer multiplication
-    output logic                     div_int_en_o,          // perform integer division or reminder
+    output logic                     div_int_en_o,          // perform integer division or
+                                                            // remainder
     output ibex_defines::md_op_e     multdiv_operator_o,
     output logic [1:0]               multdiv_signed_mode_o,
+
     // register file related signals
     output logic                     regfile_we_o,          // write enable for regfile
 
@@ -66,13 +71,14 @@ module ibex_decoder #(
     output ibex_defines::csr_op_e    csr_op_o,              // operation to perform on CSR
     output logic                     csr_status_o,          // access to xstatus CSR
 
-    // LD/ST unit signals
+    // LSU signals
     output logic                     data_req_o,            // start transaction to data memory
-    output logic                     data_we_o,             // data memory write enable
-    output logic [1:0]               data_type_o,           // data type on data memory: byte,
-                                                            // half word or word
-    output logic                     data_sign_extension_o, // sign extension on read data from data memory
-    output logic [1:0]               data_reg_offset_o,     // offset in byte inside register for stores
+    output logic                     data_we_o,             // write enable
+    output logic [1:0]               data_type_o,           // size of transaction: byte, half
+                                                            // word or word
+    output logic                     data_sign_extension_o, // sign extension for data read from
+                                                            // memory
+    output logic [1:0]               data_reg_offset_o,     // register byte offset for stores
 
     // jump/branches
     output logic                     jump_in_id_o,          // jump is being calculated in ALU

--- a/rtl/ibex_defines.sv
+++ b/rtl/ibex_defines.sv
@@ -112,8 +112,8 @@ typedef enum logic[1:0] {
 
 // Constants for the dcsr.xdebugver fields
 typedef enum logic[3:0] {
-   XDEBUGVER_NO  = 4'd0, // no external debug support
-   XDEBUGVER_STD = 4'd4, // external debug according to RISC-V debug spec
+   XDEBUGVER_NO     = 4'd0, // no external debug support
+   XDEBUGVER_STD    = 4'd4, // external debug according to RISC-V debug spec
    XDEBUGVER_NONSTD = 4'd15 // debug not conforming to RISC-V debug spec
 } x_debug_ver_e;
 
@@ -185,6 +185,7 @@ typedef enum logic [2:0] {
 
 // Exception cause
 typedef enum logic [5:0] {
+  EXC_CAUSE_INSN_ADDR_MISA     = 6'h00,
   EXC_CAUSE_ILLEGAL_INSN       = 6'h02,
   EXC_CAUSE_BREAKPOINT         = 6'h03,
   EXC_CAUSE_LOAD_ACCESS_FAULT  = 6'h05,
@@ -209,6 +210,7 @@ typedef enum logic [7:0] {
 
 // Debug cause
 typedef enum logic [2:0] {
+  DBG_CAUSE_NONE    = 3'h0,
   DBG_CAUSE_EBREAK  = 3'h1,
   DBG_CAUSE_TRIGGER = 3'h2,
   DBG_CAUSE_HALTREQ = 3'h3,

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -129,9 +129,9 @@ module ibex_id_stage #(
     input  logic [31:0]               csr_rdata_i,
 
     // Performance Counters
-    output logic                      perf_jump_o,    // we are executing a jump instruction
-    output logic                      perf_branch_o,  // we are executing a branch instruction
-    output logic                      perf_tbranch_o  // we are executing a taken branch instruction
+    output logic                      perf_jump_o,    // executing a jump instr
+    output logic                      perf_branch_o,  // executing a branch instr
+    output logic                      perf_tbranch_o  // executing a taken branch instr
 );
 
   import ibex_defines::*;
@@ -648,12 +648,13 @@ module ibex_id_stage #(
 `ifndef VERILATOR
   // make sure that branch decision is valid when jumping
   assert property (
-    @(posedge clk_i) (branch_decision_i !== 1'bx || branch_in_id == 1'b0) ) else begin
-      $display("Branch decision is X"); end
+    @(posedge clk_i) (branch_decision_i !== 1'bx || branch_in_id == 1'b0) ) else
+      $display("Branch decision is X");
 
 `ifdef CHECK_MISALIGNED
   assert property (
-    @(posedge clk_i) (~data_misaligned_i) ) else $display("Misaligned memory access at %x",pc_id_i);
+    @(posedge clk_i) (~data_misaligned_i) ) else
+      $display("Misaligned memory access at %x",pc_id_i);
 `endif
 
   // the instruction delivered to the ID stage should always be valid

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -43,22 +43,23 @@ module ibex_if_stage #(
     input  logic                      instr_rvalid_i,
     input  logic [31:0]               instr_rdata_i,
     // Output of IF Pipeline stage
-    output logic                      instr_valid_id_o,      // instruction in IF/ID pipeline is valid
-    output logic [31:0]               instr_rdata_id_o,      // read instruction is sampled and sent
+    output logic                      instr_valid_id_o,      // instr in IF/ID is valid
+    output logic [31:0]               instr_rdata_id_o,      // read instr is sampled and sent
                                                              // to ID stage for decoding
-    output logic                      is_compressed_id_o,    // compressed decoder thinks this is a
-                                                             // compressed instruction
-    output logic                      illegal_c_insn_id_o,   // compressed decoder thinks this is an
-                                                             // invalid instruction
+    output logic                      is_compressed_id_o,    // compressed decoder thinks this is
+                                                             // a compressed instr
+    output logic                      illegal_c_insn_id_o,   // compressed decoder thinks this is
+                                                             // an invalid instr
     output logic [31:0]               pc_if_o,
     output logic [31:0]               pc_id_o,
     // Forwarding ports - control signals
-    input  logic                      clear_instr_valid_i,   // clear instruction valid bit in IF/ID pipe
-    input  logic                      pc_set_i,              // set the program counter to a new value
-    input  logic [31:0]               exception_pc_reg_i,    // address used to restore PC when the
-                                                             // interrupt/exception is served
-    input  logic [31:0]               depc_i,                // address used to restore PC when the debug is served
-    input  ibex_defines::pc_sel_e     pc_mux_i,              // sel for pc multiplexer
+    input  logic                      clear_instr_valid_i,   // clear instr valid bit in IF/ID
+    input  logic                      pc_set_i,              // set the PC to a new value
+    input  logic [31:0]               exception_pc_reg_i,    // address used to restore PC when
+                                                             // the interrupt/exception is served
+    input  logic [31:0]               depc_i,                // address used to restore PC when
+                                                             // the debug request is served
+    input  ibex_defines::pc_sel_e     pc_mux_i,              // selector for PC multiplexer
     input  ibex_defines::exc_pc_sel_e exc_pc_mux_i,          // selects ISR address
     input  ibex_defines::exc_cause_e  exc_vec_pc_mux_i,      // selects ISR address for vectorized
                                                              // interrupt lines
@@ -71,8 +72,8 @@ module ibex_if_stage #(
     input  logic                      id_ready_i,
     output logic                      if_valid_o,
     // misc signals
-    output logic                      if_busy_o,             // is the IF stage busy fetching instructions?
-    output logic                      perf_imiss_o           // Instruction Fetch Miss
+    output logic                      if_busy_o,             // IF stage is busy fetching instr
+    output logic                      perf_imiss_o           // instr fetch miss
 );
 
   import ibex_defines::*;

--- a/rtl/ibex_int_controller.sv
+++ b/rtl/ibex_int_controller.sv
@@ -87,7 +87,7 @@ module ibex_int_controller (
       end
 
       default: begin
-        exc_ctrl_ns = exc_ctrl_e'({$bits(exc_ctrl_e){1'bX}});
+        exc_ctrl_ns = exc_ctrl_e'(1'bX);
       end
     endcase
   end

--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -423,7 +423,7 @@ module ibex_load_store_unit (
       end //~ WAIT_RVALID
 
       default: begin
-        ls_fsm_ns = ls_fsm_e'({$bits(ls_fsm_e){1'bX}});
+        ls_fsm_ns = ls_fsm_e'(1'bX);
       end
     endcase
   end

--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -43,18 +43,18 @@ module ibex_load_store_unit (
     input  logic [31:0]  data_rdata_i,
 
     // signals from ex stage
-    input  logic         data_we_ex_i,         // write enable                      -> from ex stage
-    input  logic [1:0]   data_type_ex_i,       // Data type word, halfword, byte    -> from ex stage
-    input  logic [31:0]  data_wdata_ex_i,      // data to write to memory           -> from ex stage
-    input  logic [1:0]   data_reg_offset_ex_i, // offset inside register for stores -> from ex stage
-    input  logic         data_sign_ext_ex_i,   // sign extension                    -> from ex stage
+    input  logic         data_we_ex_i,         // write enable                     -> from EX
+    input  logic [1:0]   data_type_ex_i,       // data type: word, half word, byte -> from EX
+    input  logic [31:0]  data_wdata_ex_i,      // data to write to memory          -> from EX
+    input  logic [1:0]   data_reg_offset_ex_i, // register byte offset for stores  -> from EX
+    input  logic         data_sign_ext_ex_i,   // sign extension                   -> from EX
 
-    output logic [31:0]  data_rdata_ex_o,      // requested data                    -> to ex stage
-    input  logic         data_req_ex_i,        // data request                      -> from ex stage
+    output logic [31:0]  data_rdata_ex_o,      // requested data                   -> to EX
+    input  logic         data_req_ex_i,        // data request                     -> from EX
 
     input  logic [31:0]  adder_result_ex_i,
 
-    output logic         data_misaligned_o,    // misaligned access was detected    -> to controller
+    output logic         data_misaligned_o,    // misaligned access detected       -> to controller
     output logic [31:0]  misaligned_addr_o,
 
     // exception signals

--- a/rtl/ibex_multdiv_fast.sv
+++ b/rtl/ibex_multdiv_fast.sv
@@ -122,7 +122,8 @@ module ibex_multdiv_fast (
   // 1. The 2 MSBs of the multiplicants are always equal, and
   // 2. The 16 MSBs of the addend (accum[33:18]) are always equal.
   // Thus, it is safe to ignore mac_res_ext[34].
-  assign mac_res_signed = $signed({sign_a, mult_op_a})*$signed({sign_b, mult_op_b}) + $signed(accum);
+  assign mac_res_signed =
+      $signed({sign_a, mult_op_a}) * $signed({sign_b, mult_op_b}) + $signed(accum);
   assign mac_res_ext    = $unsigned(mac_res_signed);
   assign mac_res        = mac_res_ext[33:0];
 

--- a/rtl/ibex_multdiv_fast.sv
+++ b/rtl/ibex_multdiv_fast.sv
@@ -247,7 +247,7 @@ module ibex_multdiv_fast (
       end
 
       default: begin
-        divcurr_state_n = div_fsm_e'({$bits(div_fsm_e){1'bX}});
+        divcurr_state_n = div_fsm_e'(1'bX);
       end
     endcase // divcurr_state_q
   end
@@ -327,7 +327,7 @@ module ibex_multdiv_fast (
         mult_is_ready = 1'b1;
       end
       default: begin
-        mult_state_n = mult_fsm_e'({$bits(mult_fsm_e){1'bX}});
+        mult_state_n = mult_fsm_e'(1'bX);
       end
     endcase // mult_state_q
   end

--- a/rtl/ibex_multdiv_slow.sv
+++ b/rtl/ibex_multdiv_slow.sv
@@ -284,7 +284,7 @@ module ibex_multdiv_slow (
         end
 
         default: begin
-          curr_state_d = div_fsm_e'({$bits(div_fsm_e){1'bX}});
+          curr_state_d = div_fsm_e'(1'bX);
         end
         endcase // curr_state_q
       end

--- a/rtl/ibex_prefetch_buffer.sv
+++ b/rtl/ibex_prefetch_buffer.sv
@@ -200,7 +200,7 @@ module ibex_prefetch_buffer (
       end
 
       default: begin
-        NS = prefetch_fsm_e'({$bits(prefetch_fsm_e){1'bX}});
+        NS = prefetch_fsm_e'(1'bX);
       end
     endcase
   end

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -331,8 +331,8 @@ module ibex_tracer #(
     instr_trace_t trace;
     mem_acc_t     mem_acc;
     // special case for WFI because we don't wait for unstalling there
-    if ( (id_valid_i || mret_insn_i || ecall_insn_i || pipe_flush_i || ebrk_insn_i || dret_insn_i ||
-          csr_status_i || ex_data_req_i) && is_decoding_i) begin
+    if ((id_valid_i || mret_insn_i || ecall_insn_i || pipe_flush_i || ebrk_insn_i ||
+         dret_insn_i || csr_status_i || ex_data_req_i) && is_decoding_i) begin
       trace = new ();
 
       trace.simtime    = $time;


### PR DESCRIPTION
This PR implements three main changes:
- Enforce line wrapping after 100 characters. This is required by our style guide and avoids lint warnings.
- Simplify default assignments of `'X` and `'0` to enum types.
- Make state signal names for the prefetch buffer FSM lowercase.

Successfully tested in Verilator and Vivado. 