### PR TITLE
Doc: Switch back to upstream Sphinx

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 setuptools_scm
-git+https://github.com/wallento/sphinx@fix-latex-figure-in-admonition#egg=sphinx
+sphinx>=2.1.0
 sphinx_rtd_theme
 sphinxcontrib-wavedrom
 wavedrom>=1.9.0rc1


### PR DESCRIPTION
Upstream has now released a new version which includes Stefan's patch to
correctly build the PDFs.

Fixes #41