### PR TITLE
Align data and instruction address output

### DIFF
--- a/doc/instruction_fetch.rst
+++ b/doc/instruction_fetch.rst
@@ -4,10 +4,7 @@ Instruction Fetch
 =================
 
 The Instruction-Fetch (IF) stage of the core is able to supply one instruction to the Instruction-Decode (ID) stage per cycle if the instruction cache or the instruction memory is able to serve one instruction per cycle.
-The instruction address must be half-word-aligned due to the support of compressed instructions.
-It is not possible to jump to instruction addresses that have the LSB bit set.
-
-For optimal performance and timing closure reasons, a prefetcher is used which fetches instruction from the instruction memory, or instruction cache.
+For optimal performance and timing closure reasons, a prefetcher is used which fetches instructions from the instruction memory, or instruction cache.
 
 The following table describes the signals that are used to fetch instructions.
 This interface is a simplified version of the interface used on the data interface as described in :ref:`load-store-unit`.
@@ -21,7 +18,7 @@ The main difference is that the instruction interface does not allow for writes 
 | ``instr_req_o``         | output    | Request valid, must stay high until           |
 |                         |           | ``instr_gnt_i`` is high for one cycle         |
 +-------------------------+-----------+-----------------------------------------------+
-| ``instr_addr_o[31:0]``  | output    | Address                                       |
+| ``instr_addr_o[31:0]``  | output    | Address, word aligned                         |
 +-------------------------+-----------+-----------------------------------------------+
 | ``instr_gnt_i``         | input     | The other side accepted the request.          |
 |                         |           | ``instr_req_o`` may be deasserted in the next |
@@ -33,6 +30,15 @@ The main difference is that the instruction interface does not allow for writes 
 +-------------------------+-----------+-----------------------------------------------+
 | ``instr_rdata_i[31:0]`` | input     | Data read from memory                         |
 +-------------------------+-----------+-----------------------------------------------+
+
+
+Misaligned Accesses
+-------------------
+
+Externally, the IF interface performs word-aligned instruction fetches only.
+Misaligned instruction fetches are handled by performing two separate word-aligned instruction fetches.
+Internally, the core can deal with both word- and half-word-aligned instruction addresses to support compressed instructions.
+The LSB of the instruction address is ignored internally.
 
 
 Protocol

--- a/doc/load_store_unit.rst
+++ b/doc/load_store_unit.rst
@@ -14,7 +14,7 @@ Signals that are used by the LSU:
 | ``data_req_o``          | output    | Request valid, must stay high until           |
 |                         |           | ``data_gnt_i`` is high for one cycle          |
 +-------------------------+-----------+-----------------------------------------------+
-| ``data_addr_o[31:0]``   | output    | Address                                       |
+| ``data_addr_o[31:0]``   | output    | Address, word aligned                         |
 +-------------------------+-----------+-----------------------------------------------+
 | ``data_we_o``           | output    | Write Enable, high for writes, low for        |
 |                         |           | reads. Sent together with ``data_req_o``      |
@@ -44,8 +44,8 @@ Signals that are used by the LSU:
 Misaligned Accesses
 -------------------
 
-The LSU is able to perform misaligned accesses, meaning accesses that are not aligned on natural word boundaries.
-However, it needs to perform two separate word-aligned accesses internally.
+The LSU is able to handle misaligned memory accesses, meaning accesses that are not aligned on natural word boundaries.
+However, it does so by performing two separate word-aligned accesses.
 This means that at least two cycles are needed for misaligned loads and stores.
 
 .. _lsu-protocol:

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -266,6 +266,11 @@ module ibex_if_stage #(
   assert property (
     @(posedge clk_i) (instr_gnt_i) |-> (instr_req_o) )
   else $warning("There was a grant without a request");
+
+  // assert that the address is word aligned when request is sent
+  assert property (
+    @(posedge clk_i) (instr_req_o) |-> (instr_addr_o[1:0] == 2'b00) ) else
+      $display("Instruction address not word aligned");
 `endif
 
 endmodule

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -259,13 +259,13 @@ module ibex_if_stage #(
 `ifndef VERILATOR
   // the boot address needs to be aligned to 256 bytes
   assert property (
-    @(posedge clk_i) (boot_addr_i[7:0] == 8'h00) )
-  else $error("The provided boot address is not aligned to 256 bytes");
+    @(posedge clk_i) (boot_addr_i[7:0] == 8'h00) ) else
+      $error("The provided boot address is not aligned to 256 bytes");
 
   // there should never be a grant when there is no request
   assert property (
-    @(posedge clk_i) (instr_gnt_i) |-> (instr_req_o) )
-  else $warning("There was a grant without a request");
+    @(posedge clk_i) (instr_gnt_i) |-> (instr_req_o) ) else
+      $warning("There was a grant without a request");
 
   // assert that the address is word aligned when request is sent
   assert property (

--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -477,8 +477,10 @@ module ibex_load_store_unit (
   // there should be no rvalid when we are in IDLE
   assert property ( @(posedge clk_i) (ls_fsm_cs == IDLE) |-> (data_rvalid_i == 1'b0) );
 
-  // assert that errors are only sent at the same time as grant
-  assert property ( @(posedge clk_i) (data_err_i) |-> (data_gnt_i) );
+  // assert that errors are only sent at the same time as rvalid
+  assert property (
+    @(posedge clk_i) (data_err_i) |-> (data_rvalid_i) ) else
+      $display("Data error not sent with rvalid");
 
   // assert that the address does not contain X when request is sent
   assert property ( @(posedge clk_i) (data_req_o) |-> (!$isunknown(data_addr_o)) );

--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -482,5 +482,10 @@ module ibex_load_store_unit (
 
   // assert that the address does not contain X when request is sent
   assert property ( @(posedge clk_i) (data_req_o) |-> (!$isunknown(data_addr_o)) );
+
+  // assert that the address is word aligned when request is sent
+  assert property (
+    @(posedge clk_i) (data_req_o) |-> (data_addr_o[1:0] == 2'b00) ) else
+      $display("Data address not word aligned");
 `endif
 endmodule

--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -471,11 +471,15 @@ module ibex_load_store_unit (
   // make sure there is no new request when the old one is not yet completely done
   // i.e. it should not be possible to get a grant without an rvalid for the
   // last request
-  assert property ( @(posedge clk_i)
-      ((ls_fsm_cs == WAIT_RVALID) && (data_gnt_i == 1'b1)) |-> (data_rvalid_i == 1'b1) );
+  assert property (
+    @(posedge clk_i)
+      ((ls_fsm_cs == WAIT_RVALID) && (data_gnt_i == 1'b1)) |-> (data_rvalid_i == 1'b1) ) else
+        $display("Data grant set while LSU keeps waiting for rvalid");
 
   // there should be no rvalid when we are in IDLE
-  assert property ( @(posedge clk_i) (ls_fsm_cs == IDLE) |-> (data_rvalid_i == 1'b0) );
+  assert property (
+    @(posedge clk_i) (ls_fsm_cs == IDLE) |-> (data_rvalid_i == 1'b0) ) else
+      $display("Data rvalid set while LSU idle");
 
   // assert that errors are only sent at the same time as rvalid
   assert property (
@@ -483,7 +487,9 @@ module ibex_load_store_unit (
       $display("Data error not sent with rvalid");
 
   // assert that the address does not contain X when request is sent
-  assert property ( @(posedge clk_i) (data_req_o) |-> (!$isunknown(data_addr_o)) );
+  assert property (
+    @(posedge clk_i) (data_req_o) |-> (!$isunknown(data_addr_o)) ) else
+      $display("Data address not valid");
 
   // assert that the address is word aligned when request is sent
   assert property (


### PR DESCRIPTION
This PR adds two commits to ensure the data and instruction address output by the core is always word aligned.

The core handles unaligned accesses by issuing two separate, aligned accesses. However, without these commits, the core still outputs unaligned addresses for the two accesses and relies on the memory to ignore the address LSBs.

Tested with Verilator and Vivado.