### PR TITLE
Expand word widths to keep Verilator lint checks happy

### DIFF
--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -97,15 +97,15 @@ module ibex_cs_registers #(
       (0     <<  0)  // A - Atomic Instructions extension
     | (1     <<  2)  // C - Compressed extension
     | (0     <<  3)  // D - Double precision floating-point extension
-    | (RV32E <<  4)  // E - RV32E base ISA
+    | {27'b0,RV32E,4'b0}  // E - RV32E base ISA
     | (0     <<  5)  // F - Single precision floating-point extension
     | (1     <<  8)  // I - RV32I/64I/128I base ISA
-    | (RV32M << 12)  // M - Integer Multiply/Divide extension
+    | {19'b0,RV32M,12'b0}  // M - Integer Multiply/Divide extension
     | (0     << 13)  // N - User level interrupts supported
     | (0     << 18)  // S - Supervisor mode implemented
     | (0     << 20)  // U - User mode implemented
     | (0     << 23)  // X - Non-standard extensions present
-    | (MXL   << 30); // M-XLEN
+    | {MXL,30'b0}; // M-XLEN
 
   `define MSTATUS_UIE_BITS        0
   `define MSTATUS_SIE_BITS        1

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -93,20 +93,37 @@ module ibex_cs_registers #(
 
   // misa
   localparam logic [1:0] MXL = 2'd1; // M-XLEN: XLEN in M-Mode for RV32
+  localparam logic MISA_X = 0,
+  MISA_W = 0,
+  MISA_V = 0,
+  MISA_U = 0,
+  MISA_T = 0,
+  MISA_S = 0,
+  MISA_R = 0,
+  MISA_Q = 0,
+  MISA_P = 0,
+  MISA_O = 0,
+  MISA_N = 0,
+  MISA_L = 0,
+  MISA_K = 0,
+  MISA_J = 0,
+  MISA_I = 0,
+  MISA_H = 0,
+  MISA_G = 0,
+  MISA_F = 0,
+  MISA_D = 0,
+  MISA_C = 1,
+  MISA_B = 0,
+  MISA_A = 0;
   localparam logic [31:0] MISA_VALUE =
-      (0     <<  0)  // A - Atomic Instructions extension
-    | (1     <<  2)  // C - Compressed extension
-    | (0     <<  3)  // D - Double precision floating-point extension
-    | {27'b0,RV32E,4'b0}  // E - RV32E base ISA
-    | (0     <<  5)  // F - Single precision floating-point extension
-    | (1     <<  8)  // I - RV32I/64I/128I base ISA
-    | {19'b0,RV32M,12'b0}  // M - Integer Multiply/Divide extension
-    | (0     << 13)  // N - User level interrupts supported
-    | (0     << 18)  // S - Supervisor mode implemented
-    | (0     << 20)  // U - User mode implemented
-    | (0     << 23)  // X - Non-standard extensions present
-    | {MXL,30'b0}; // M-XLEN
-
+    {MXL,6'b0,
+     MISA_X,MISA_W,MISA_V,MISA_U,
+     MISA_T,MISA_S,MISA_R,MISA_Q,
+     MISA_P,MISA_O,MISA_N,RV32M,
+     MISA_L,MISA_K,MISA_J,MISA_I,
+     MISA_H,MISA_G,MISA_F,RV32E,
+     MISA_D,MISA_C,MISA_B,MISA_A}; // M-XLEN
+ 
   `define MSTATUS_UIE_BITS        0
   `define MSTATUS_SIE_BITS        1
   `define MSTATUS_MIE_BITS        3

--- a/rtl/ibex_register_file_ff.sv
+++ b/rtl/ibex_register_file_ff.sv
@@ -52,15 +52,15 @@ module ibex_register_file #(
 );
 
   localparam int unsigned ADDR_WIDTH = RV32E ? 4 : 5;
-  localparam int unsigned NUM_WORDS  = 2**ADDR_WIDTH;
+  localparam logic [ADDR_WIDTH:0] NUM_WORDS  = 2**ADDR_WIDTH;
 
   logic [NUM_WORDS-1:0][DataWidth-1:0] rf_reg;
   logic [NUM_WORDS-1:1][DataWidth-1:0] rf_reg_tmp;
   logic [NUM_WORDS-1:1]                we_a_dec;
 
   always_comb begin : we_a_decoder
-    for (int i = 1; i < NUM_WORDS; i++) begin
-      we_a_dec[i] = ({27'b0,waddr_a_i} == i) ?  we_a_i : 1'b0;
+    for (logic [ADDR_WIDTH:0] i = 1; i < NUM_WORDS; i++) begin
+      we_a_dec[i] = {1'b0,waddr_a_i} == i ?  we_a_i : 1'b0;
     end
   end
 
@@ -69,7 +69,7 @@ module ibex_register_file #(
     if (!rst_ni) begin
       rf_reg_tmp <= '{default:'0};
     end else begin
-      for (int r = 1; r < NUM_WORDS; r++) begin
+      for (logic [ADDR_WIDTH:0] r = 1; r < NUM_WORDS; r++) begin
         if (we_a_dec[r]) rf_reg_tmp[r] <= wdata_a_i;
       end
     end

--- a/rtl/ibex_register_file_ff.sv
+++ b/rtl/ibex_register_file_ff.sv
@@ -60,7 +60,7 @@ module ibex_register_file #(
 
   always_comb begin : we_a_decoder
     for (int i = 1; i < NUM_WORDS; i++) begin
-      we_a_dec[i] = (waddr_a_i == i) ?  we_a_i : 1'b0;
+      we_a_dec[i] = ({27'b0,waddr_a_i} == i) ?  we_a_i : 1'b0;
     end
   end
 

--- a/rtl/ibex_register_file_ff.sv
+++ b/rtl/ibex_register_file_ff.sv
@@ -60,7 +60,7 @@ module ibex_register_file #(
 
   always_comb begin : we_a_decoder
     for (logic [ADDR_WIDTH:0] i = 1; i < NUM_WORDS; i++) begin
-      we_a_dec[i] = {1'b0,waddr_a_i} == i ?  we_a_i : 1'b0;
+      we_a_dec[i] = waddr_a_i == i[4:0] ?  we_a_i : 1'b0;
     end
   end
 


### PR DESCRIPTION
Verilator bombs out by default unless all the widths match (and -Wno-width is not specified). This patch expands widths where necessary to overcome this problem. However it may not be the most elegant solution.
