### PR TITLE
Avoid WIDTH lint warnings in Verilator

### DIFF
--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -94,18 +94,18 @@ module ibex_cs_registers #(
   // misa
   localparam logic [1:0] MXL = 2'd1; // M-XLEN: XLEN in M-Mode for RV32
   localparam logic [31:0] MISA_VALUE =
-      (0     <<  0)  // A - Atomic Instructions extension
-    | (1     <<  2)  // C - Compressed extension
-    | (0     <<  3)  // D - Double precision floating-point extension
-    | (RV32E <<  4)  // E - RV32E base ISA
-    | (0     <<  5)  // F - Single precision floating-point extension
-    | (1     <<  8)  // I - RV32I/64I/128I base ISA
-    | (RV32M << 12)  // M - Integer Multiply/Divide extension
-    | (0     << 13)  // N - User level interrupts supported
-    | (0     << 18)  // S - Supervisor mode implemented
-    | (0     << 20)  // U - User mode implemented
-    | (0     << 23)  // X - Non-standard extensions present
-    | (MXL   << 30); // M-XLEN
+      (0          <<  0)  // A - Atomic Instructions extension
+    | (1          <<  2)  // C - Compressed extension
+    | (0          <<  3)  // D - Double precision floating-point extension
+    | (32'(RV32E) <<  4)  // E - RV32E base ISA
+    | (0          <<  5)  // F - Single precision floating-point extension
+    | (1          <<  8)  // I - RV32I/64I/128I base ISA
+    | (32'(RV32M) << 12)  // M - Integer Multiply/Divide extension
+    | (0          << 13)  // N - User level interrupts supported
+    | (0          << 18)  // S - Supervisor mode implemented
+    | (0          << 20)  // U - User mode implemented
+    | (0          << 23)  // X - Non-standard extensions present
+    | (32'(MXL)   << 30); // M-XLEN
 
   `define MSTATUS_UIE_BITS        0
   `define MSTATUS_SIE_BITS        1

--- a/rtl/ibex_register_file_ff.sv
+++ b/rtl/ibex_register_file_ff.sv
@@ -60,7 +60,7 @@ module ibex_register_file #(
 
   always_comb begin : we_a_decoder
     for (int i = 1; i < NUM_WORDS; i++) begin
-      we_a_dec[i] = (waddr_a_i == i) ?  we_a_i : 1'b0;
+      we_a_dec[i] = (waddr_a_i == 5'(i)) ?  we_a_i : 1'b0;
     end
   end
 


### PR DESCRIPTION
Verilator displays the following lint warnings:

```
%Warning-WIDTH: ../src/lowrisc_ibex_ibex_0.1/rtl/ibex_cs_registers.sv:100: Operator SHIFTL expects 32 bits on the LHS, but LHS's VARREF 'RV32E' generates 1 bits.
                ... Use "/* verilator lint_off WIDTH */" and lint_on around source to disable this message.
%Warning-WIDTH: ../src/lowrisc_ibex_ibex_0.1/rtl/ibex_cs_registers.sv:103: Operator SHIFTL expects 32 bits on the LHS, but LHS's VARREF 'RV32M' generates 1 bits.
%Warning-WIDTH: ../src/lowrisc_ibex_ibex_0.1/rtl/ibex_cs_registers.sv:108: Operator SHIFTL expects 32 bits on the LHS, but LHS's VARREF 'MXL' generates 2 bits.
%Warning-WIDTH: ../src/lowrisc_ibex_ibex_0.1/rtl/ibex_register_file_ff.sv:63: Operator EQ expects 32 bits on the LHS, but LHS's VARREF 'waddr_a_i' generates 5 bits.
```

It's not quite clear (to me) from reading the SV spec if this is a bug
in Verilator lint, or if this is actually a code bug.

Alternative proposal for #92