### PR TITLE
Switch to new signal name in tracer instantiation

### DIFF
--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -763,7 +763,7 @@ module ibex_core #(
 
       .pc_i             ( id_stage_i.pc_id_i                   ),
       .instr_i          ( id_stage_i.instr                     ),
-      .compressed_i     ( id_stage_i.is_compressed_i           ),
+      .compressed_i     ( id_stage_i.instr_is_compressed_i     ),
       .id_valid_i       ( id_stage_i.id_valid_o                ),
       .is_decoding_i    ( id_stage_i.is_decoding_o             ),
       .is_branch_i      ( id_stage_i.branch_in_id              ),


### PR DESCRIPTION
This got forgotten when renaming the signal inside ID stage in
commit  b22a6a10defc7bad31dda7d8a33c7145d1a79a3b.

This fixes #112 .