### PR TITLE
Cleanup ID stage and decoder

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -106,7 +106,7 @@ module ibex_controller (
     input  logic                      stall_multdiv_i,
     input  logic                      stall_jump_i,
     input  logic                      stall_branch_i,
-    input  logic                      instr_multicyle_i,     // multicycle instructions active
+    input  logic                      instr_multicycle_i,    // multicycle instructions active
 
     output logic                      id_valid_o,
 
@@ -268,7 +268,7 @@ module ibex_controller (
 
         /*
          * TODO: What should happen on
-         * instr_valid_i && (instr_multicyle_i || branch_in_id_i)?
+         * instr_valid_i && (instr_multicycle_i || branch_in_id_i)?
          * Let the instruction finish executing before serving debug or
          * interrupt requests?
          */
@@ -289,7 +289,7 @@ module ibex_controller (
           end
 
           default: begin
-            exc_kill_o    = irq_req_ctrl_i & ~instr_multicyle_i & ~branch_in_id_i;
+            exc_kill_o    = irq_req_ctrl_i & ~instr_multicycle_i & ~branch_in_id_i;
 
             if (instr_valid_i) begin
               // analyze the current instruction in the ID stage

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -514,8 +514,9 @@ module ibex_controller (
   // Stall control //
   ///////////////////
 
-  // deassert WE when the core is not decoding instructions
-  // or in case of illegal instruction
+  // deassert write enable when the core is not decoding instructions, i.e., current instruction
+  // in ID stage done, but waiting for next instruction from IF stage, or in case of illegal
+  // instruction
   assign deassert_we_o = ~is_decoding_o | illegal_insn_i;
 
   // update registers

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -184,7 +184,7 @@ module ibex_core #(
   // stall control
   logic        halt_if;
   logic        id_ready;
-  logic        ex_ready;
+  logic        ex_valid;
 
   logic        if_valid;
   logic        id_valid;
@@ -390,7 +390,8 @@ module ibex_core #(
       .halt_if_o                    ( halt_if                ),
 
       .id_ready_o                   ( id_ready               ),
-      .ex_ready_i                   ( ex_ready               ),
+      .ex_valid_i                   ( ex_valid               ),
+      .lsu_valid_i                  ( data_valid_lsu         ),
 
       .id_valid_o                   ( id_valid               ),
 
@@ -469,31 +470,30 @@ module ibex_core #(
   ibex_ex_block #(
       .RV32M ( RV32M )
   ) ex_block_i (
-      .clk_i                      ( clk                   ),
-      .rst_ni                     ( rst_ni                ),
-      // Alu signals from ID stage
-      //TODO: hot encoding
-      .alu_operator_i             ( alu_operator_ex       ),
-      .multdiv_operator_i         ( multdiv_operator_ex   ),
-      .alu_operand_a_i            ( alu_operand_a_ex      ),
-      .alu_operand_b_i            ( alu_operand_b_ex      ),
+      .clk_i                      ( clk                    ),
+      .rst_ni                     ( rst_ni                 ),
 
-      // Multipler
-      .mult_en_i                  ( mult_en_ex            ),
-      .div_en_i                   ( div_en_ex             ),
-      .multdiv_signed_mode_i      ( multdiv_signed_mode_ex),
-      .multdiv_operand_a_i        ( multdiv_operand_a_ex  ),
-      .multdiv_operand_b_i        ( multdiv_operand_b_ex  ),
-      .alu_adder_result_ex_o      ( alu_adder_result_ex   ), // from ALU to LSU
-      .regfile_wdata_ex_o         ( regfile_wdata_ex      ),
+      // ALU signal from ID stage
+      .alu_operator_i             ( alu_operator_ex        ),
+      .alu_operand_a_i            ( alu_operand_a_ex       ),
+      .alu_operand_b_i            ( alu_operand_b_ex       ),
 
-      // To IF: Jump and branch target and decision
-      .jump_target_o              ( jump_target_ex        ),
-      .branch_decision_o          ( branch_decision       ),
+      // Multipler/Divider signal from ID stage
+      .multdiv_operator_i         ( multdiv_operator_ex    ),
+      .mult_en_i                  ( mult_en_ex             ),
+      .div_en_i                   ( div_en_ex              ),
+      .multdiv_signed_mode_i      ( multdiv_signed_mode_ex ),
+      .multdiv_operand_a_i        ( multdiv_operand_a_ex   ),
+      .multdiv_operand_b_i        ( multdiv_operand_b_ex   ),
 
-      .lsu_en_i                   ( data_req_ex           ),
-      .lsu_ready_ex_i             ( data_valid_lsu        ),
-      .ex_ready_o                 ( ex_ready              )
+      // Outputs
+      .alu_adder_result_ex_o      ( alu_adder_result_ex    ), // to LSU
+      .regfile_wdata_ex_o         ( regfile_wdata_ex       ), // to ID
+
+      .jump_target_o              ( jump_target_ex         ), // to IF
+      .branch_decision_o          ( branch_decision        ), // to ID
+
+      .ex_valid_o                 ( ex_valid               )
   );
 
   /////////////////////

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -161,9 +161,6 @@ module ibex_core #(
   logic [31:0] multdiv_operand_b_ex;
 
   // CSR control
-  logic        csr_access_ex;
-  csr_op_e     csr_op_ex;
-
   logic        csr_access;
   csr_op_e     csr_op;
   csr_num_e    csr_addr;
@@ -410,8 +407,8 @@ module ibex_core #(
       .multdiv_operand_b_ex_o       ( multdiv_operand_b_ex   ),
 
       // CSR ID/EX
-      .csr_access_ex_o              ( csr_access_ex          ),
-      .csr_op_ex_o                  ( csr_op_ex              ),
+      .csr_access_o                 ( csr_access             ),
+      .csr_op_o                     ( csr_op                 ),
       .csr_save_if_o                ( csr_save_if            ), // control signal to save pc
       .csr_save_id_o                ( csr_save_id            ), // control signal to save pc
       .csr_restore_mret_id_o        ( csr_restore_mret_id    ), // control signal to restore pc
@@ -549,10 +546,8 @@ module ibex_core #(
   // CSRs (Control and Status Registers) //
   /////////////////////////////////////////
 
-  assign csr_access = csr_access_ex;
   assign csr_wdata  = alu_operand_a_ex;
-  assign csr_op     = csr_op_ex;
-  assign csr_addr   = csr_num_e'(csr_access_ex ? alu_operand_b_ex[11:0] : 12'b0);
+  assign csr_addr   = csr_num_e'(csr_access ? alu_operand_b_ex[11:0] : 12'b0);
 
   assign perf_load  = data_req_o & data_gnt_i & (~data_we_o);
   assign perf_store = data_req_o & data_gnt_i & data_we_o;

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -109,6 +109,7 @@ module ibex_core #(
 
   // IF/ID signals
   logic        instr_valid_id;
+  logic        instr_new_id;
   logic [31:0] instr_rdata_id;         // Instruction sampled inside IF stage
   logic [15:0] instr_rdata_c_id;       // Compressed instruction sampled inside IF stage
   logic        instr_is_compressed_id;
@@ -313,6 +314,7 @@ module ibex_core #(
 
       // outputs to ID stage
       .instr_valid_id_o         ( instr_valid_id         ),
+      .instr_new_id_o           ( instr_new_id           ),
       .instr_rdata_id_o         ( instr_rdata_id         ),
       .instr_rdata_c_id_o       ( instr_rdata_c_id       ),
       .instr_is_compressed_id_o ( instr_is_compressed_id ),
@@ -365,18 +367,19 @@ module ibex_core #(
       .is_decoding_o                ( is_decoding            ),
       .illegal_insn_o               ( illegal_insn_id        ),
 
-      // Interface to instruction memory
+      // from/to IF-ID pipeline register
       .instr_valid_i                ( instr_valid_id         ),
+      .instr_new_i                  ( instr_new_id           ),
       .instr_rdata_i                ( instr_rdata_id         ),
       .instr_rdata_c_i              ( instr_rdata_c_id       ),
       .instr_is_compressed_i        ( instr_is_compressed_id ),
-      .instr_req_o                  ( instr_req_int          ),
 
       // Jumps and branches
       .branch_decision_i            ( branch_decision        ),
 
       // IF and ID control signals
       .instr_valid_clear_o          ( instr_valid_clear      ),
+      .instr_req_o                  ( instr_req_int          ),
       .pc_set_o                     ( pc_set                 ),
       .pc_mux_o                     ( pc_mux_id              ),
       .exc_pc_mux_o                 ( exc_pc_mux_id          ),

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -765,7 +765,7 @@ module ibex_core #(
       .cluster_id_i     ( cluster_id_i                         ),
 
       .pc_i             ( id_stage_i.pc_id_i                   ),
-      .instr_i          ( id_stage_i.instr                     ),
+      .instr_i          ( id_stage_i.instr_rdata_i             ),
       .compressed_i     ( id_stage_i.instr_is_compressed_i     ),
       .id_valid_i       ( id_stage_i.id_valid_o                ),
       .is_decoding_i    ( id_stage_i.is_decoding_o             ),
@@ -782,9 +782,9 @@ module ibex_core #(
 
       .lsu_value_i      ( data_wdata_ex                        ),
 
-      .ex_reg_addr_i    ( id_stage_i.regfile_waddr_id          ),
+      .ex_reg_addr_i    ( id_stage_i.regfile_waddr             ),
       .ex_reg_we_i      ( id_stage_i.regfile_we                ),
-      .ex_reg_wdata_i   ( id_stage_i.regfile_wdata_id          ),
+      .ex_reg_wdata_i   ( id_stage_i.regfile_wdata             ),
       .data_valid_lsu_i ( data_valid_lsu                       ),
       .ex_data_addr_i   ( data_addr_o                          ),
       .ex_data_req_i    ( data_req_o                           ),

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -782,9 +782,9 @@ module ibex_core #(
 
       .lsu_value_i      ( data_wdata_ex                        ),
 
-      .ex_reg_addr_i    ( id_stage_i.regfile_waddr_mux         ),
-      .ex_reg_we_i      ( id_stage_i.regfile_we_mux            ),
-      .ex_reg_wdata_i   ( id_stage_i.regfile_wdata_mux         ),
+      .ex_reg_addr_i    ( id_stage_i.regfile_waddr_id          ),
+      .ex_reg_we_i      ( id_stage_i.regfile_we                ),
+      .ex_reg_wdata_i   ( id_stage_i.regfile_wdata_id          ),
       .data_valid_lsu_i ( data_valid_lsu                       ),
       .ex_data_addr_i   ( data_addr_o                          ),
       .ex_data_req_i    ( data_req_o                           ),

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -117,7 +117,7 @@ module ibex_core #(
   logic [31:0] pc_if;                  // Program counter in IF stage
   logic [31:0] pc_id;                  // Program counter in ID stage
 
-  logic        clear_instr_valid;
+  logic        instr_valid_clear;
   logic        pc_set;
   pc_sel_e     pc_mux_id;              // Mux selector for next PC
   exc_pc_sel_e exc_pc_mux_id;          // Mux selector for exception PC
@@ -321,7 +321,7 @@ module ibex_core #(
       .pc_id_o                  ( pc_id                  ),
 
       // control signals
-      .clear_instr_valid_i      ( clear_instr_valid      ),
+      .instr_valid_clear_i      ( instr_valid_clear      ),
       .pc_set_i                 ( pc_set                 ),
       .pc_mux_i                 ( pc_mux_id              ),
       .exc_pc_mux_i             ( exc_pc_mux_id          ),
@@ -376,7 +376,7 @@ module ibex_core #(
       .branch_decision_i            ( branch_decision        ),
 
       // IF and ID control signals
-      .clear_instr_valid_o          ( clear_instr_valid      ),
+      .instr_valid_clear_o          ( instr_valid_clear      ),
       .pc_set_o                     ( pc_set                 ),
       .pc_mux_o                     ( pc_mux_id              ),
       .exc_pc_mux_o                 ( exc_pc_mux_id          ),

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -60,6 +60,7 @@ module ibex_decoder #(
     output logic [1:0]               multdiv_signed_mode_o,
 
     // register file related signals
+    output ibex_defines::rf_wd_sel_e regfile_wdata_sel_o,   // RF write data selection
     output logic                     regfile_we_o,          // write enable for regfile
 
     // CSR manipulation
@@ -107,6 +108,7 @@ module ibex_decoder #(
     multdiv_operator_o          = MD_OP_MULL;
     multdiv_signed_mode_o       = 2'b00;
 
+    regfile_wdata_sel_o         = RF_WD_EX;
     regfile_we_o                = 1'b0;
 
     csr_access_o                = 1'b0;
@@ -229,9 +231,10 @@ module ibex_decoder #(
       end
 
       OPCODE_LOAD: begin
-        data_req_o      = 1'b1;
-        regfile_we_o    = 1'b1;
-        data_type_o     = 2'b00;
+        data_req_o          = 1'b1;
+        regfile_wdata_sel_o = RF_WD_LSU;
+        regfile_we_o        = 1'b1;
+        data_type_o         = 2'b00;
 
         // offset from immediate
         alu_operator_o      = ALU_ADD;
@@ -463,6 +466,7 @@ module ibex_decoder #(
         end else begin
           // instruction to read/modify CSR
           csr_access_o        = 1'b1;
+          regfile_wdata_sel_o = RF_WD_CSR;
           regfile_we_o        = 1'b1;
           alu_op_b_mux_sel_o  = OP_B_IMM;
           imm_a_mux_sel_o     = IMM_A_Z;

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -35,6 +35,7 @@ module ibex_decoder #(
     output logic                     dret_insn_o,           // return from debug instr encountered
     output logic                     ecall_insn_o,          // syscall instr encountered
     output logic                     pipe_flush_o,          // pipeline flush is requested
+    output logic                     jump_set_o,            // jump taken set signal
 
     // from IF/ID pipeline
     input  logic                     instr_new_i,           // instruction read is new
@@ -92,6 +93,7 @@ module ibex_decoder #(
 
   always_comb begin
     jump_in_dec_o               = 1'b0;
+    jump_set_o                  = 1'b0;
     branch_in_dec_o             = 1'b0;
     alu_operator_o              = ALU_SLTU;
     alu_op_a_mux_sel_o          = OP_A_REG_A;
@@ -142,6 +144,7 @@ module ibex_decoder #(
           imm_b_mux_sel_o     = IMM_B_J;
           alu_operator_o      = ALU_ADD;
           regfile_we_o        = 1'b0;
+          jump_set_o          = 1'b1;
         end else begin
           // Calculate and store PC+4
           alu_op_a_mux_sel_o  = OP_A_CURRPC;

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -28,8 +28,6 @@ module ibex_decoder #(
     parameter bit RV32M  = 1
 ) (
     // singals running to/from controller
-    input  logic                     branch_mux_i,
-    input  logic                     jump_mux_i,
     output logic                     illegal_insn_o,        // illegal instr encountered
     output logic                     ebrk_insn_o,           // trap instr encountered
     output logic                     mret_insn_o,           // return from exception instr
@@ -39,6 +37,7 @@ module ibex_decoder #(
     output logic                     pipe_flush_o,          // pipeline flush is requested
 
     // from IF/ID pipeline
+    input  logic                     instr_new_i,           // instruction read is new
     input  logic [31:0]              instr_rdata_i,         // instruction read from memory/cache
     input  logic                     illegal_c_insn_i,      // compressed instruction decode failed
 
@@ -136,7 +135,7 @@ module ibex_decoder #(
 
       OPCODE_JAL: begin   // Jump and Link
         jump_in_dec_o         = 1'b1;
-        if (jump_mux_i) begin
+        if (instr_new_i) begin
           // Calculate jump target
           alu_op_a_mux_sel_o  = OP_A_CURRPC;
           alu_op_b_mux_sel_o  = OP_B_IMM;
@@ -155,7 +154,7 @@ module ibex_decoder #(
 
       OPCODE_JALR: begin  // Jump and Link Register
         jump_in_dec_o         = 1'b1;
-        if (jump_mux_i) begin
+        if (instr_new_i) begin
           // Calculate jump target
           alu_op_a_mux_sel_o  = OP_A_REG_A;
           alu_op_b_mux_sel_o  = OP_B_IMM;
@@ -177,7 +176,7 @@ module ibex_decoder #(
 
       OPCODE_BRANCH: begin // Branch
         branch_in_dec_o       = 1'b1;
-        if (branch_mux_i) begin
+        if (instr_new_i) begin
           unique case (instr_rdata_i[14:12])
             3'b000:  alu_operator_o = ALU_EQ;
             3'b001:  alu_operator_o = ALU_NE;

--- a/rtl/ibex_defines.sv
+++ b/rtl/ibex_defines.sv
@@ -153,6 +153,12 @@ typedef enum logic [2:0] {
   IMM_B_INCR_ADDR
 } imm_b_sel_e;
 
+// Regfile write data selection
+typedef enum logic [1:0] {
+  RF_WD_LSU,
+  RF_WD_EX,
+  RF_WD_CSR
+} rf_wd_sel_e;
 
 //////////////
 // IF stage //

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -53,6 +53,7 @@ module ibex_id_stage #(
 
     // Interface to IF stage
     input  logic                      instr_valid_i,
+    input  logic                      instr_new_i,
     input  logic [31:0]               instr_rdata_i,         // from IF-ID pipeline registers
     input  logic [15:0]               instr_rdata_c_i,       // from IF-ID pipeline registers
     input  logic                      instr_is_compressed_i,
@@ -169,9 +170,7 @@ module ibex_id_stage #(
 
   logic        branch_in_id, branch_in_dec;
   logic        branch_set_n, branch_set_q;
-  logic        branch_mux_dec;
   logic        jump_set;
-  logic        jump_mux_dec;
   logic        jump_in_id, jump_in_dec;
 
   logic        instr_multicycle;
@@ -388,9 +387,6 @@ module ibex_id_stage #(
 
   ibex_decoder #( .RV32M ( RV32M ) ) decoder_i (
       // controller related signals
-      .branch_mux_i                    ( branch_mux_dec            ),
-      .jump_mux_i                      ( jump_mux_dec              ),
-
       .illegal_insn_o                  ( illegal_insn_dec          ),
       .ebrk_insn_o                     ( ebrk_insn                 ),
       .mret_insn_o                     ( mret_insn_dec             ),
@@ -399,6 +395,7 @@ module ibex_id_stage #(
       .pipe_flush_o                    ( pipe_flush_dec            ),
 
       // from IF/ID pipeline
+      .instr_new_i                     ( instr_new_i               ),
       .instr_rdata_i                   ( instr                     ),
       .illegal_c_insn_i                ( illegal_c_insn_i          ),
 
@@ -635,16 +632,12 @@ module ibex_id_stage #(
     select_data_rf   = RF_EX;
     instr_multicycle = 1'b0;
     branch_set_n     = 1'b0;
-    branch_mux_dec   = 1'b0;
     jump_set         = 1'b0;
-    jump_mux_dec     = 1'b0;
     perf_branch_o    = 1'b0;
 
     unique case (id_wb_fsm_cs)
 
       IDLE: begin
-        jump_mux_dec         = 1'b1;
-        branch_mux_dec       = 1'b1;
         unique case (1'b1)
           data_req_id: begin
             //LSU operation

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -173,7 +173,7 @@ module ibex_id_stage #(
   logic        jump_mux_dec;
   logic        jump_in_id, jump_in_dec;
 
-  logic        instr_multicyle;
+  logic        instr_multicycle;
   logic        stall_lsu;
   logic        stall_multdiv;
   logic        stall_branch;
@@ -503,7 +503,7 @@ module ibex_id_stage #(
       .branch_set_i                   ( branch_set_q           ),
       .jump_set_i                     ( jump_set               ),
 
-      .instr_multicyle_i              ( instr_multicyle        ),
+      .instr_multicycle_i             ( instr_multicycle       ),
 
       .irq_i                          ( irq_i                  ),
       // Interrupt Controller Signals
@@ -625,55 +625,55 @@ module ibex_id_stage #(
   assign multdiv_en_id  = mult_en_id | div_en_id;
 
   always_comb begin : id_wb_fsm
-    id_wb_fsm_ns    = id_wb_fsm_cs;
-    regfile_we      = regfile_we_id;
-    stall_lsu       = 1'b0;
-    stall_multdiv   = 1'b0;
-    stall_jump      = 1'b0;
-    stall_branch    = 1'b0;
-    select_data_rf  = RF_EX;
-    instr_multicyle = 1'b0;
-    branch_set_n    = 1'b0;
-    branch_mux_dec  = 1'b0;
-    jump_set        = 1'b0;
-    jump_mux_dec    = 1'b0;
-    perf_branch_o   = 1'b0;
+    id_wb_fsm_ns     = id_wb_fsm_cs;
+    regfile_we       = regfile_we_id;
+    stall_lsu        = 1'b0;
+    stall_multdiv    = 1'b0;
+    stall_jump       = 1'b0;
+    stall_branch     = 1'b0;
+    select_data_rf   = RF_EX;
+    instr_multicycle = 1'b0;
+    branch_set_n     = 1'b0;
+    branch_mux_dec   = 1'b0;
+    jump_set         = 1'b0;
+    jump_mux_dec     = 1'b0;
+    perf_branch_o    = 1'b0;
 
     unique case (id_wb_fsm_cs)
 
       IDLE: begin
-        jump_mux_dec   = 1'b1;
-        branch_mux_dec = 1'b1;
+        jump_mux_dec         = 1'b1;
+        branch_mux_dec       = 1'b1;
         unique case (1'b1)
           data_req_id: begin
             //LSU operation
-            regfile_we      = 1'b0;
-            id_wb_fsm_ns    = WAIT_MULTICYCLE;
-            stall_lsu       = 1'b1;
-            instr_multicyle = 1'b1;
+            regfile_we       = 1'b0;
+            id_wb_fsm_ns     = WAIT_MULTICYCLE;
+            stall_lsu        = 1'b1;
+            instr_multicycle = 1'b1;
           end
           branch_in_id: begin
             //Cond Branch operation
-            id_wb_fsm_ns    = branch_decision_i ? WAIT_MULTICYCLE : IDLE;
-            stall_branch    = branch_decision_i;
-            instr_multicyle = branch_decision_i;
-            branch_set_n    = branch_decision_i;
-            perf_branch_o   = 1'b1;
+            id_wb_fsm_ns     = branch_decision_i ? WAIT_MULTICYCLE : IDLE;
+            stall_branch     = branch_decision_i;
+            instr_multicycle = branch_decision_i;
+            branch_set_n     = branch_decision_i;
+            perf_branch_o    = 1'b1;
           end
           multdiv_en_id: begin
             //MUL or DIV operation
-            regfile_we      = 1'b0;
-            id_wb_fsm_ns    = WAIT_MULTICYCLE;
-            stall_multdiv   = 1'b1;
-            instr_multicyle = 1'b1;
+            regfile_we       = 1'b0;
+            id_wb_fsm_ns     = WAIT_MULTICYCLE;
+            stall_multdiv    = 1'b1;
+            instr_multicycle = 1'b1;
           end
           jump_in_id: begin
             //UnCond Branch operation
-            regfile_we      = 1'b0;
-            id_wb_fsm_ns    = WAIT_MULTICYCLE;
-            stall_jump      = 1'b1;
-            instr_multicyle = 1'b1;
-            jump_set        = 1'b1;
+            regfile_we       = 1'b0;
+            id_wb_fsm_ns     = WAIT_MULTICYCLE;
+            stall_jump       = 1'b1;
+            instr_multicycle = 1'b1;
+            jump_set         = 1'b1;
           end
           default:;
         endcase
@@ -681,14 +681,14 @@ module ibex_id_stage #(
 
       WAIT_MULTICYCLE: begin
         if (ex_ready_i) begin
-          regfile_we     = regfile_we_id;
-          id_wb_fsm_ns   = IDLE;
-          stall_lsu      = 1'b0;
-          stall_multdiv  = 1'b0;
-          select_data_rf = data_req_id ? RF_LSU : RF_EX;
+          regfile_we        = regfile_we_id;
+          id_wb_fsm_ns      = IDLE;
+          stall_lsu         = 1'b0;
+          stall_multdiv     = 1'b0;
+          select_data_rf    = data_req_id ? RF_LSU : RF_EX;
         end else begin
-          regfile_we      = 1'b0;
-          instr_multicyle = 1'b1;
+          regfile_we        = 1'b0;
+          instr_multicycle  = 1'b1;
           unique case (1'b1)
             data_req_id:
               stall_lsu     = 1'b1;

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -74,7 +74,8 @@ module ibex_id_stage #(
     input  logic [31:0]               pc_id_i,
 
     // Stalls
-    input  logic                      ex_ready_i,
+    input  logic                      ex_valid_i,  // EX stage has valid output
+    input  logic                      lsu_valid_i, // LSU has valid output, or is done
     output logic                      id_valid_o, // ID stage is done
 
     // ALU
@@ -680,7 +681,7 @@ module ibex_id_stage #(
       end
 
       WAIT_MULTICYCLE: begin
-        if (ex_ready_i) begin
+        if ( (data_req_id & lsu_valid_i) | (~data_req_id & ex_valid_i) ) begin
           regfile_we        = regfile_we_id;
           id_wb_fsm_ns      = IDLE;
           stall_lsu         = 1'b0;

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -393,6 +393,7 @@ module ibex_id_stage #(
       .dret_insn_o                     ( dret_insn_dec             ),
       .ecall_insn_o                    ( ecall_insn_dec            ),
       .pipe_flush_o                    ( pipe_flush_dec            ),
+      .jump_set_o                      ( jump_set                  ),
 
       // from IF/ID pipeline
       .instr_new_i                     ( instr_new_i               ),
@@ -632,7 +633,6 @@ module ibex_id_stage #(
     select_data_rf   = RF_EX;
     instr_multicycle = 1'b0;
     branch_set_n     = 1'b0;
-    jump_set         = 1'b0;
     perf_branch_o    = 1'b0;
 
     unique case (id_wb_fsm_cs)
@@ -667,7 +667,6 @@ module ibex_id_stage #(
             id_wb_fsm_ns     = WAIT_MULTICYCLE;
             stall_jump       = 1'b1;
             instr_multicycle = 1'b1;
-            jump_set         = 1'b1;
           end
           default:;
         endcase

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -88,8 +88,8 @@ module ibex_id_stage #(
     output logic [31:0]               multdiv_operand_b_ex_o,
 
     // CSR
-    output logic                      csr_access_ex_o,
-    output ibex_defines::csr_op_e     csr_op_ex_o,
+    output logic                      csr_access_o,
+    output ibex_defines::csr_op_e     csr_op_o,
     output logic                      csr_save_if_o,
     output logic                      csr_save_id_o,
     output logic                      csr_restore_mret_id_o,
@@ -226,8 +226,6 @@ module ibex_id_stage #(
   logic        data_req_id, data_req_dec;
 
   // CSR control
-  logic        csr_access;
-  csr_op_e     csr_op;
   logic        csr_status;
 
   // For tracer
@@ -394,8 +392,8 @@ module ibex_id_stage #(
       .multdiv_signed_mode_o           ( multdiv_signed_mode  ),
 
       // CSRs
-      .csr_access_o                    ( csr_access           ),
-      .csr_op_o                        ( csr_op               ),
+      .csr_access_o                    ( csr_access_o         ),
+      .csr_op_o                        ( csr_op_o             ),
       .csr_status_o                    ( csr_status           ),
 
       // LSU
@@ -556,9 +554,6 @@ module ibex_id_stage #(
   assign alu_operator_ex_o           = alu_operator;
   assign alu_operand_a_ex_o          = alu_operand_a;
   assign alu_operand_b_ex_o          = alu_operand_b;
-
-  assign csr_access_ex_o             = csr_access;
-  assign csr_op_ex_o                 = csr_op;
 
   assign mult_en_ex_o                = mult_en_id;
   assign div_en_ex_o                 = div_en_id;

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -61,7 +61,7 @@ module ibex_if_stage #(
     output logic [31:0]               pc_id_o,
 
     // Forwarding ports - control signals
-    input  logic                      clear_instr_valid_i,      // clear instr valid bit in IF-ID
+    input  logic                      instr_valid_clear_i,      // clear instr valid bit in IF-ID
     input  logic                      pc_set_i,                 // set the PC to a new value
     input  logic [31:0]               csr_mepc_i,               // PC to restore after handling
                                                                 // the interrupt/exception
@@ -246,7 +246,7 @@ module ibex_if_stage #(
         instr_is_compressed_id_o <= instr_is_compressed_int;
         illegal_c_insn_id_o      <= illegal_c_insn;
         pc_id_o                  <= pc_if_o;
-      end else if (clear_instr_valid_i) begin
+      end else if (instr_valid_clear_i) begin
         instr_valid_id_o         <= 1'b0;
       end
     end

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -49,6 +49,7 @@ module ibex_if_stage #(
 
     // Output of IF Pipeline stage
     output logic                      instr_valid_id_o,         // instr in IF-ID is valid
+    output logic                      instr_new_id_o,           // instr in IF-ID is new
     output logic [31:0]               instr_rdata_id_o,         // instr for ID stage
     output logic [15:0]               instr_rdata_c_id_o,       // compressed instr for ID stage
                                                                 // (mtval), meaningful only if
@@ -232,6 +233,7 @@ module ibex_if_stage #(
   // IF-ID pipeline registers, frozen when the ID stage is stalled
   always_ff @(posedge clk_i or negedge rst_ni) begin : if_id_pipeline_regs
     if (!rst_ni) begin
+      instr_new_id_o             <= 1'b0;
       instr_valid_id_o           <= 1'b0;
       instr_rdata_id_o           <= '0;
       instr_rdata_c_id_o         <= '0;
@@ -239,6 +241,7 @@ module ibex_if_stage #(
       illegal_c_insn_id_o        <= 1'b0;
       pc_id_o                    <= '0;
     end else begin
+      instr_new_id_o             <= if_valid_o;
       if (if_valid_o) begin
         instr_valid_id_o         <= 1'b1;
         instr_rdata_id_o         <= instr_decompressed;

--- a/rtl/ibex_multdiv_slow.sv
+++ b/rtl/ibex_multdiv_slow.sv
@@ -37,7 +37,7 @@ module ibex_multdiv_slow (
     output logic [32:0]          alu_operand_b_o,
     output logic [31:0]          multdiv_result_o,
 
-    output logic                 ready_o
+    output logic                 valid_o
 );
 
   import ibex_defines::*;
@@ -290,7 +290,7 @@ module ibex_multdiv_slow (
       end
   end
 
-  assign ready_o = (curr_state_q == MD_FINISH) |
+  assign valid_o = (curr_state_q == MD_FINISH) |
                    (curr_state_q == MD_LAST &
                      (operator_i == MD_OP_MULL |
                       operator_i == MD_OP_MULH));


### PR DESCRIPTION
This PR contains a major cleanup of the ID stage and the decoder. Control logic (e.g. for stalls) that depends not on the decoder exclusively, is moved out of the decoder. Similarly, logic inside the ID stage that is strictly related to instruction decoding (immediate & register file address generation and checking) is moved into the decoder. 

As a result, the ID stage now instantiates the modules of the controller, decoder and registers, and contains the the main muxes, the write-back (WB) FSM to handle multicycle instructions and minimal glue logic, only.
This will ease future work on any of these parts. 

Finally, the WB FSM inside the ID stage is cleaned up to remove circular dependencies between FSM and decoder. This resolves #103 .