### PR TITLE
Check `rs1` & `rd` for non-CSR system instructions

### DIFF
--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -530,6 +530,11 @@ module ibex_decoder #(
             default:
               illegal_insn_o = 1'b1;
           endcase
+
+          // rs1 and rd must be 0
+          if (instr[`REG_S1] || instr[`REG_D]) begin
+            illegal_insn_o = 1'b1;
+          end
         end else begin
           // instruction to read/modify CSR
           csr_access_o        = 1'b1;


### PR DESCRIPTION
According to the spec, these two fields must be 0 for `ecall`, `ebreak`, `mret`, `dret` and `wfi` instructions.
This PR adds a commit to generate an illegal instruction exception if they are not zero.
