### PR TITLE
Improve documentation for misa and mtvec CSRs

### DIFF
--- a/doc/cs_registers.rst
+++ b/doc/cs_registers.rst
@@ -85,6 +85,15 @@ When the MRET instruction is executed, the value of MPIE will be stored back to 
 If you want to enable interrupt handling in your exception handler, set ``mstatus``.MIE to 1'b1 inside your handler code.
 
 
+Machine ISA Register (misa)
+---------------------------
+
+CSR Address: ``0x301``
+
+``misa`` is a WARL register which describes the ISA supported by the hart.
+One Ibex, ``misa`` is hard-wired, i.e. it will remain unchanged after any write.
+
+
 Machine Trap-Vector Base Address (mtvec)
 ----------------------------------------
 

--- a/doc/cs_registers.rst
+++ b/doc/cs_registers.rst
@@ -12,7 +12,7 @@ Ibex implements all the Control and Status Registers (CSRs) listed in the follow
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x301  | ``misa``           | WARL   | Machine ISA and Extensions                    |
 +---------+--------------------+--------+-----------------------------------------------+
-|  0x305  | ``mtvec``          | R      | Machine Trap-Vector Base Address              |
+|  0x305  | ``mtvec``          | WARL   | Machine Trap-Vector Base Address              |
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x320  | ``mcountinhibit``  | RW     | Machine Counter-Inhibit Register              |
 +---------+--------------------+--------+-----------------------------------------------+
@@ -100,7 +100,8 @@ Machine Trap-Vector Base Address (mtvec)
 CSR Address: ``0x305``
 
 When an exception is encountered, the core jumps to the corresponding handler using the content of ``mtvec`` as base address.
-It is a read-only register which contains the boot address.
+It is a WARL register which contains the boot address.
+It contains a hard-wired value, so will remain unchanged after any writes.
 ``mtvec``.MODE is set to 2'b01 to indicate vectored interrupt handling.
 
 


### PR DESCRIPTION
misa is WARL, but hard-wired. mtvec is WARL rather than read-only (but is also hard wired). The patches in this PR adjust the documentation to reflect this.