### PR TITLE
Trivial doc cleanups

### DIFF
--- a/doc/cs_registers.rst
+++ b/doc/cs_registers.rst
@@ -61,6 +61,8 @@ Ibex implements all the Control and Status Registers (CSRs) listed in the follow
 |  0xF14  | ``mhartid``        | R      | Hardware Thread ID                            |
 +---------+--------------------+--------+-----------------------------------------------+
 
+See the :ref:`performance-counters` documentation for a description of the counter registers.
+
 
 Machine Status (mstatus)
 ------------------------

--- a/doc/cs_registers.rst
+++ b/doc/cs_registers.rst
@@ -91,7 +91,7 @@ Machine ISA Register (misa)
 CSR Address: ``0x301``
 
 ``misa`` is a WARL register which describes the ISA supported by the hart.
-One Ibex, ``misa`` is hard-wired, i.e. it will remain unchanged after any write.
+On Ibex, ``misa`` is hard-wired, i.e. it will remain unchanged after any write.
 
 
 Machine Trap-Vector Base Address (mtvec)


### PR DESCRIPTION
Fixes a doc typo introduced in #128. As penance for this mistake, I added another minor improvement - the CSR page now links to the performance counters page for documentation on those registers.