### PR TITLE
Cleanup main processor controller

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -33,9 +33,6 @@ module ibex_controller (
     output logic                      is_decoding_o,         // core is in decoding state
 
     // decoder related signals
-    output logic                      deassert_we_o,         // deassert write enable for next
-                                                             // instr
-
     input  logic                      illegal_insn_i,        // decoder has an invalid instr
     input  logic                      ecall_insn_i,          // decoder has ECALL instr
     input  logic                      mret_insn_i,           // decoder has MRET instr
@@ -510,11 +507,6 @@ module ibex_controller (
   // if low, current instr finishes in current cycle
   // multicycle instructions have this set except during the last cycle
   assign stall = stall_lsu_i | stall_multdiv_i | stall_jump_i | stall_branch_i;
-
-  // deassert write enable when the core is not decoding instructions, i.e., current instruction
-  // in ID stage done, but waiting for next instruction from IF stage, or in case of illegal
-  // instruction
-  assign deassert_we_o = ~is_decoding_o | illegal_insn_i;
 
   // signal to IF stage that ID stage is ready for next instruction
   assign id_ready_o = ~stall;

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -53,7 +53,7 @@ module ibex_controller (
     // to IF-ID pipeline stage
     output logic                      instr_valid_clear_o,   // kill instr in IF-ID reg
     output logic                      id_ready_o,            // ID stage is ready for new instr
-    output logic                      halt_if_o,             // request halt of IF stage
+    output logic                      halt_if_o,             // IF stage must not forward new instr
 
     // to prefetcher
     output logic                      instr_req_o,           // start fetching instructions
@@ -126,13 +126,14 @@ module ibex_controller (
 
   ctrl_fsm_e ctrl_fsm_cs, ctrl_fsm_ns;
 
-  logic irq_enable_int;
-
   logic debug_mode_q, debug_mode_n;
   logic load_err_q, load_err_n;
   logic store_err_q, store_err_n;
 
+  logic stall;
   logic halt_id;
+  logic irq;
+  logic special_req;
 
 `ifndef SYNTHESIS
   // synopsys translate_off
@@ -148,6 +149,12 @@ module ibex_controller (
   // synopsys translate_on
 `endif
 
+  assign irq         = irq_req_ctrl_i & m_IE_i;
+  assign exc_kill_o  = 1'b0;
+
+  // special requests: special instructions, exceptions, pipeline flushes...
+  assign special_req = mret_insn_i | dret_insn_i | ecall_insn_i | ebrk_insn_i | wfi_insn_i |
+                      illegal_insn_i | store_err_i | load_err_i | csr_status_i;
 
   /////////////////////
   // Core controller //
@@ -158,7 +165,6 @@ module ibex_controller (
     instr_req_o            = 1'b1;
 
     exc_ack_o              = 1'b0;
-    exc_kill_o             = 1'b0;
 
     csr_save_if_o          = 1'b0;
     csr_save_id_o          = 1'b0;
@@ -183,7 +189,6 @@ module ibex_controller (
     halt_id                = 1'b0;
     irq_ack_o              = 1'b0;
     irq_id_o               = irq_id_ctrl_i;
-    irq_enable_int         = m_IE_i;
 
     debug_csr_save_o       = 1'b0;
     debug_cause_o          = DBG_CAUSE_EBREAK;
@@ -247,7 +252,7 @@ module ibex_controller (
         end
 
         // handle interrupts
-        if (irq_req_ctrl_i && irq_enable_int) begin
+        if (irq) begin
           // This assumes that the pipeline is always flushed before
           // going to sleep.
           ctrl_fsm_ns = IRQ_TAKEN;
@@ -264,60 +269,57 @@ module ibex_controller (
       end
 
       DECODE: begin
-        is_decoding_o = 1'b0;
+        // normal operating mode of the ID stage, in case of debug and interrupt requests,
+        // priorities are as follows (lower number == higher priority)
+        // 1. currently running (multicycle) instructions and exceptions caused by these
+        // 2. debug requests
+        // 3. interrupt requests
 
-        /*
-         * TODO: What should happen on
-         * instr_valid_i && (instr_multicycle_i || branch_in_id_i)?
-         * Let the instruction finish executing before serving debug or
-         * interrupt requests?
-         */
+        if (instr_valid_i) begin
+          // analyze current instruction in ID stage
+          is_decoding_o = 1'b1;
 
-        unique case (1'b1)
-          debug_req_i && !debug_mode_q: begin
-            // Enter debug mode from external request
-            ctrl_fsm_ns   = DBG_TAKEN_ID;
-            halt_if_o     = 1'b1;
-            halt_id       = 1'b1;
-          end
+          // set PC in IF stage to branch or jump target
+          if (branch_set_i || jump_set_i) begin
+            pc_mux_o       = PC_JUMP;
+            pc_set_o       = 1'b1;
 
-          irq_req_ctrl_i && irq_enable_int && !debug_req_i && !debug_mode_q: begin
-            // Serve an interrupt (not in debug mode)
-            ctrl_fsm_ns = IRQ_TAKEN;
+            perf_tbranch_o = branch_set_i;
+            perf_jump_o    = jump_set_i;
+
+          // get ready for special instructions, exceptions, pipeline flushes
+          end else if (special_req) begin
+            ctrl_fsm_ns = FLUSH;
             halt_if_o   = 1'b1;
             halt_id     = 1'b1;
+            load_err_n  = load_err_i;
+            store_err_n = store_err_i;
           end
 
-          default: begin
-            exc_kill_o    = irq_req_ctrl_i & ~instr_multicycle_i & ~branch_in_id_i;
-
-            if (instr_valid_i) begin
-              // analyze the current instruction in the ID stage
-              is_decoding_o = 1'b1;
-
-              if (branch_set_i || jump_set_i) begin
-                pc_mux_o       = PC_JUMP;
-                pc_set_o       = 1'b1;
-
-                perf_tbranch_o = branch_set_i;
-                perf_jump_o    = jump_set_i;
-              end else if (mret_insn_i || dret_insn_i || ecall_insn_i || wfi_insn_i ||
-                           ebrk_insn_i || illegal_insn_i || csr_status_i ||
-                           store_err_i || load_err_i) begin
-                ctrl_fsm_ns = FLUSH;
-                halt_if_o   = 1'b1;
-                halt_id     = 1'b1;
-                load_err_n  = load_err_i;
-                store_err_n = store_err_i;
-              end
-            end
+          // stall IF stage to not starve debug and interrupt requests, these just
+          // need to wait until after the current (multicycle) instruction
+          if ((debug_req_i || irq) && stall && !debug_mode_q) begin
+            halt_if_o   = 1'b1;
           end
-        endcase
+        end
+
+        if  (debug_req_i && !stall && !special_req && !debug_mode_q) begin
+          // enter debug mode
+          ctrl_fsm_ns = DBG_TAKEN_ID;
+          halt_if_o   = 1'b1;
+          halt_id     = 1'b1;
+
+        end else if (irq && !stall && !special_req && !debug_mode_q) begin
+          // handle interrupt (not in debug mode)
+          ctrl_fsm_ns = IRQ_TAKEN;
+          halt_if_o   = 1'b1;
+          halt_id     = 1'b1;
+        end
 
         // Single stepping
         // prevent any more instructions from executing
         if (debug_single_step_i && !debug_mode_q) begin
-          halt_if_o = 1'b1;
+          halt_if_o   = 1'b1;
           ctrl_fsm_ns = DBG_TAKEN_IF;
         end
       end
@@ -520,13 +522,17 @@ module ibex_controller (
   // Stall control //
   ///////////////////
 
+  // current instr needs at least one more cycle to finsih after the current cycle
+  // if low, current instr finsihes in current cycle
+  assign stall = stall_lsu_i | stall_multdiv_i | stall_jump_i | stall_branch_i;
+
   // deassert write enable when the core is not decoding instructions, i.e., current instruction
   // in ID stage done, but waiting for next instruction from IF stage, or in case of illegal
   // instruction
   assign deassert_we_o = ~is_decoding_o | illegal_insn_i;
 
   // signal to IF stage that ID stage is ready for next instruction
-  assign id_ready_o = ~stall_lsu_i & ~stall_multdiv_i & ~stall_jump_i & ~stall_branch_i;
+  assign id_ready_o = ~stall;
 
   // kill instruction in IF-ID reg for instructions that are done
   assign instr_valid_clear_o = id_ready_o | halt_id;

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -68,7 +68,6 @@ module ibex_controller (
     input  logic                      store_err_i,
 
     // jump/branch signals
-    input  logic                      branch_in_id_i,        // branch in id
     input  logic                      branch_set_i,          // branch taken set signal
     input  logic                      jump_set_i,            // jump taken set signal
 
@@ -106,7 +105,6 @@ module ibex_controller (
     input  logic                      stall_multdiv_i,
     input  logic                      stall_jump_i,
     input  logic                      stall_branch_i,
-    input  logic                      instr_multicycle_i,    // multicycle instructions active
 
     output logic                      id_valid_o,
 

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -40,7 +40,7 @@ module ibex_controller (
     input  logic                      ecall_insn_i,          // decoder has ECALL instr
     input  logic                      mret_insn_i,           // decoder has MRET instr
     input  logic                      dret_insn_i,           // decoder has DRET instr
-    input  logic                      pipe_flush_i,          // decoder wants to do a pipe flush
+    input  logic                      wfi_insn_i,            // decoder has WFI instr
     input  logic                      ebrk_insn_i,           // decoder has EBREAK instr
     input  logic                      csr_status_i,          // decoder has CSR status instr
 
@@ -301,7 +301,7 @@ module ibex_controller (
 
                 perf_tbranch_o = branch_set_i;
                 perf_jump_o    = jump_set_i;
-              end else if (mret_insn_i || dret_insn_i || ecall_insn_i || pipe_flush_i ||
+              end else if (mret_insn_i || dret_insn_i || ecall_insn_i || wfi_insn_i ||
                            ebrk_insn_i || illegal_insn_i || csr_status_i ||
                            store_err_i || load_err_i) begin
                 ctrl_fsm_ns = FLUSH;
@@ -407,7 +407,7 @@ module ibex_controller (
         halt_if_o = 1'b1;
         halt_id   = 1'b1;
 
-        if (!pipe_flush_i) begin
+        if (!wfi_insn_i) begin
           ctrl_fsm_ns = DECODE;
         end else begin
           ctrl_fsm_ns = WAIT_SLEEP;

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -128,6 +128,7 @@ module ibex_controller (
   logic halt_id;
   logic irq;
   logic exc_req;
+  logic exc_req_lsu;
   logic special_req;
 
 `ifndef SYNTHESIS
@@ -151,10 +152,14 @@ module ibex_controller (
   assign exc_kill_o  = 1'b0;
 
   // exception requests
-  assign exc_req     = ecall_insn_i | ebrk_insn_i | illegal_insn_i | store_err_i | load_err_i;
+  assign exc_req     = ecall_insn_i | ebrk_insn_i | illegal_insn_i;
+
+  // LSU exception requests
+  assign exc_req_lsu = store_err_i | load_err_i;
 
   // special requests: special instructions, pipeline flushes, exceptions...
-  assign special_req = mret_insn_i | dret_insn_i | wfi_insn_i | csr_status_i | exc_req;
+  assign special_req = mret_insn_i | dret_insn_i | wfi_insn_i | csr_status_i |
+      exc_req | exc_req_lsu;
 
   /////////////////////
   // Core controller //
@@ -404,6 +409,7 @@ module ibex_controller (
         ctrl_fsm_ns = DECODE;
 
         // exceptions: set exception PC, save PC and exception cause
+        // exc_req_lsu is high for one clock cycle only (in DECODE)
         if (exc_req || store_err_q || load_err_q) begin
           pc_set_o         = 1'b1;
           pc_mux_o         = PC_EXC;

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -497,6 +497,7 @@ module ibex_controller (
         // single stepping
         // set exception registers, but do not jump into handler (debug-spec p.44).
         if (debug_single_step_i && !debug_mode_q) begin
+          pc_set_o    = 1'b0;
           ctrl_fsm_ns = DBG_TAKEN_IF;
         end
       end // FLUSH

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -133,6 +133,7 @@ module ibex_controller (
   logic stall;
   logic halt_id;
   logic irq;
+  logic exc_req;
   logic special_req;
 
 `ifndef SYNTHESIS
@@ -152,9 +153,11 @@ module ibex_controller (
   assign irq         = irq_req_ctrl_i & m_IE_i;
   assign exc_kill_o  = 1'b0;
 
-  // special requests: special instructions, exceptions, pipeline flushes...
-  assign special_req = mret_insn_i | dret_insn_i | ecall_insn_i | ebrk_insn_i | wfi_insn_i |
-                      illegal_insn_i | store_err_i | load_err_i | csr_status_i;
+  // exception requests
+  assign exc_req     = ecall_insn_i | ebrk_insn_i | illegal_insn_i | store_err_i | load_err_i;
+
+  // special requests: special instructions, pipeline flushes, exceptions...
+  assign special_req = mret_insn_i | dret_insn_i | wfi_insn_i | csr_status_i | exc_req;
 
   /////////////////////
   // Core controller //
@@ -301,7 +304,18 @@ module ibex_controller (
           if ((debug_req_i || irq) && stall && !debug_mode_q) begin
             halt_if_o   = 1'b1;
           end
-        end
+
+          // single stepping:
+          // execute a single instruction and then enter debug mode, in case of exceptions,
+          // set registers but do not jump into handler (debug-spec p.44).
+          if (debug_single_step_i && !debug_mode_q) begin
+            halt_if_o   = 1'b1;
+
+            if (!special_req && !stall) begin
+              ctrl_fsm_ns = DBG_TAKEN_IF;
+            end
+          end
+        end // instr_valid_i
 
         if  (debug_req_i && !stall && !special_req && !debug_mode_q) begin
           // enter debug mode
@@ -316,13 +330,7 @@ module ibex_controller (
           halt_id     = 1'b1;
         end
 
-        // Single stepping
-        // prevent any more instructions from executing
-        if (debug_single_step_i && !debug_mode_q) begin
-          halt_if_o   = 1'b1;
-          ctrl_fsm_ns = DBG_TAKEN_IF;
-        end
-      end
+      end // DECODE
 
       IRQ_TAKEN: begin
         pc_mux_o          = PC_EXC;
@@ -509,7 +517,13 @@ module ibex_controller (
 
           default:;
         endcase
-      end
+
+        // single stepping
+        // set exception registers, but do not jump into handler (debug-spec p.44).
+        if (debug_single_step_i && !debug_mode_q) begin
+          ctrl_fsm_ns = DBG_TAKEN_IF;
+        end
+      end // FLUSH
 
       default: begin
         instr_req_o = 1'b0;

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -74,7 +74,7 @@ module ibex_cs_registers #(
                                                              // missing write permissions
     // Performance Counters
     input  logic                      insn_ret_i,            // instr retired in ID/EX stage
-    input  logic                      id_valid_i,            // ID stage is done
+    input  logic                      id_out_valid_i,        // ID stage is done
     input  logic                      instr_is_compressed_i, // compressed instr in ID
     input  logic                      is_decoding_i,         // controller is in DECODE state
 
@@ -551,7 +551,7 @@ module ibex_cs_registers #(
     mhpmcounter_incr[8]  = branch_i;            // num of branches (conditional)
     mhpmcounter_incr[9]  = branch_taken_i;      // num of taken branches (conditional)
     mhpmcounter_incr[10] = is_decoding_i        // num of compressed instr
-        & id_valid_i & instr_is_compressed_i;
+        & id_out_valid_i & instr_is_compressed_i;
 
     // inactive counters
     for (int unsigned i=3+MHPMCounterNum; i<32; i++) begin : gen_mhpmcounter_incr_inactive

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -40,7 +40,7 @@ module ibex_decoder #(
                                                             // encountered
     output logic                     dret_insn_o,           // return from debug instr encountered
     output logic                     ecall_insn_o,          // syscall instr encountered
-    output logic                     pipe_flush_o,          // pipeline flush is requested
+    output logic                     wfi_insn_o,            // wait for interrupt instr encountered
     output logic                     jump_set_o,            // jump taken set signal
 
     // from IF-ID pipeline register
@@ -198,7 +198,7 @@ module ibex_decoder #(
     mret_insn_o                 = 1'b0;
     dret_insn_o                 = 1'b0;
     ecall_insn_o                = 1'b0;
-    pipe_flush_o                = 1'b0;
+    wfi_insn_o                  = 1'b0;
 
     opcode                      = opcode_e'(instr[6:0]);
 
@@ -542,8 +542,7 @@ module ibex_decoder #(
               dret_insn_o = 1'b1;
 
             12'h105:  // wfi
-              // flush pipeline
-              pipe_flush_o = 1'b1;
+              wfi_insn_o = 1'b1;
 
             default:
               illegal_insn = 1'b1;

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -43,7 +43,6 @@ module ibex_id_stage #(
     input  logic                      fetch_enable_i,
     output logic                      ctrl_busy_o,
     output logic                      core_ctrl_firstfetch_o,
-    output logic                      is_decoding_o,
     output logic                      illegal_insn_o,
 
     // Interface to IF stage
@@ -407,7 +406,6 @@ module ibex_id_stage #(
       .fetch_enable_i                 ( fetch_enable_i         ),
       .ctrl_busy_o                    ( ctrl_busy_o            ),
       .first_fetch_o                  ( core_ctrl_firstfetch_o ),
-      .is_decoding_o                  ( is_decoding_o          ),
 
       // decoder related signals
       .illegal_insn_i                 ( illegal_insn_o         ),

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -54,8 +54,7 @@ module ibex_id_stage #(
     input  logic                      instr_is_compressed_i,
     output logic                      instr_req_o,
     output logic                      instr_valid_clear_o,   // kill instr in IF-ID reg
-    output logic                      id_ready_o,            // ID stage is ready for next instr
-    output logic                      halt_if_o,             // ID stage requests IF stage to halt
+    output logic                      id_in_ready_o,         // ID stage is ready for next instr
 
     // Jumps and branches
     input  logic                      branch_decision_i,
@@ -70,9 +69,9 @@ module ibex_id_stage #(
     input  logic [31:0]               pc_id_i,
 
     // Stalls
-    input  logic                      ex_valid_i,  // EX stage has valid output
-    input  logic                      lsu_valid_i, // LSU has valid output, or is done
-    output logic                      id_valid_o,  // ID stage is done
+    input  logic                      ex_valid_i,     // EX stage has valid output
+    input  logic                      lsu_valid_i,    // LSU has valid output, or is done
+    output logic                      id_out_valid_o, // ID stage is done
 
     // ALU
     output ibex_defines::alu_op_e     alu_operator_ex_o,
@@ -427,8 +426,7 @@ module ibex_id_stage #(
 
       // to IF-ID pipeline
       .instr_valid_clear_o            ( instr_valid_clear_o    ),
-      .id_ready_o                     ( id_ready_o             ),
-      .halt_if_o                      ( halt_if_o              ),
+      .id_in_ready_o                  ( id_in_ready_o          ),
 
       // from prefetcher
       .instr_req_o                    ( instr_req_o            ),
@@ -481,7 +479,7 @@ module ibex_id_stage #(
       .stall_jump_i                   ( stall_jump             ),
       .stall_branch_i                 ( stall_branch           ),
 
-      .id_valid_o                     ( id_valid_o             ),
+      .id_out_valid_o                 ( id_out_valid_o         ),
 
       // Performance Counters
       .perf_jump_o                    ( perf_jump_o            ),

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -157,7 +157,6 @@ module ibex_id_stage #(
   logic        wfi_insn_dec;
 
   logic        branch_in_dec;
-  logic        branch_in_id, unused_branch_in_id;
   logic        branch_set_n, branch_set_q;
   logic        jump_in_dec;
   logic        jump_set;
@@ -521,10 +520,6 @@ module ibex_id_stage #(
   assign mult_en_id      = instr_executing ? mult_en_dec   : 1'b0;
   assign div_en_id       = instr_executing ? div_en_dec    : 1'b0;
 
-  // For tracer
-  assign branch_in_id        = instr_executing ? branch_in_dec : 1'b0;
-  assign unused_branch_in_id = branch_in_id;
-
   ///////////
   // ID-EX //
   ///////////
@@ -647,7 +642,7 @@ module ibex_id_stage #(
 `ifndef VERILATOR
   // make sure that branch decision is valid when jumping
   assert property (
-    @(posedge clk_i) (branch_decision_i !== 1'bx || branch_in_id == 1'b0) ) else
+    @(posedge clk_i) (branch_decision_i !== 1'bx || branch_in_dec == 1'b0) ) else
       $display("Branch decision is X");
 
 `ifdef CHECK_MISALIGNED

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -158,7 +158,7 @@ module ibex_id_stage #(
   logic        mret_insn_dec;
   logic        dret_insn_dec;
   logic        ecall_insn_dec;
-  logic        pipe_flush_dec;
+  logic        wfi_insn_dec;
 
   logic        branch_in_id, branch_in_dec;
   logic        branch_set_n, branch_set_q;
@@ -342,7 +342,7 @@ module ibex_id_stage #(
       .mret_insn_o                     ( mret_insn_dec        ),
       .dret_insn_o                     ( dret_insn_dec        ),
       .ecall_insn_o                    ( ecall_insn_dec       ),
-      .pipe_flush_o                    ( pipe_flush_dec       ),
+      .wfi_insn_o                      ( wfi_insn_dec         ),
       .jump_set_o                      ( jump_set             ),
 
       // from IF-ID pipeline register
@@ -418,7 +418,7 @@ module ibex_id_stage #(
       .ecall_insn_i                   ( ecall_insn_dec         ),
       .mret_insn_i                    ( mret_insn_dec          ),
       .dret_insn_i                    ( dret_insn_dec          ),
-      .pipe_flush_i                   ( pipe_flush_dec         ),
+      .wfi_insn_i                     ( wfi_insn_dec           ),
       .ebrk_insn_i                    ( ebrk_insn              ),
       .csr_status_i                   ( csr_status             ),
 

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -636,6 +636,7 @@ module ibex_id_stage #(
       WAIT_MULTICYCLE: begin
         if ((data_req_dec & lsu_valid_i) | (~data_req_dec & ex_valid_i)) begin
           id_wb_fsm_ns            = IDLE;
+          instr_multicycle        = 1'b1;
           instr_multicycle_done_n = 1'b1;
         end else begin
           regfile_we              = 1'b0;


### PR DESCRIPTION
This PR contains a series commits to cleanup the main processor controller inside `ibex_controller.sv` and solve related issues.

The main changes are:
- Interrupt and debug requests no longer interrupt/abort multicycle instructions such as loads, stores, jumps, branches etc. Instead such instructions are first finished and if they cause an exception, the core jumps into the handler before serving the debug or interrupt requests. This fixes issues #108 and #121 .
- Exceptions are prioritized according to the spec inside the controller FSM.
- Obsolete signals between ID stage, IF stage and controller have been removed which simplifies the design.
- The interplay of IF stage and controller has been streamlined.