### PR TITLE
Tracer based on RVFI

### DIFF
--- a/examples/sim/tb/ibex_tracer_tb.sv
+++ b/examples/sim/tb/ibex_tracer_tb.sv
@@ -6,10 +6,12 @@
 // The `nop` instruction is the only input
 
 module ibex_tracer_tb;
-  logic         clk         = 1'b0;
-  logic         rst_n       = 1'b0;
-  logic [31:0]  instr_rdata = 32'h00000013;
-  logic [31:0]  data_rdata  = 32'h00000000;
+  logic         clk          = 1'b0;
+  logic         rst_n        = 1'b0;
+  logic [31:0]  instr_rdata  = 32'h00000013;
+  logic [31:0]  data_rdata   = 32'h00000000;
+  logic         instr_gnt    = 1'b0;
+  logic         instr_rvalid = 1'b0;
 
   initial begin: clock_gen
     forever begin
@@ -25,26 +27,47 @@ module ibex_tracer_tb;
   end
 
   initial begin: instr_gen
-    #200ns instr_rdata = 32'h00000013;
-    #10ns instr_rdata = 32'h00000093;
-    #10ns instr_rdata = 32'h00400113;
-    #10ns instr_rdata = 32'hff810113;
-    #10ns instr_rdata = 32'h13410d13;
-    #10ns instr_rdata = 32'he1070713;
-    #10ns instr_rdata = 32'hfff7c793;
-    #10ns instr_rdata = 32'h00000013;
-    #10ns instr_rdata = 32'h002d2c23;
-    #10ns instr_rdata = 32'h00000013;
-    #10ns instr_rdata = 32'h000d2083;
-          data_rdata  = 32'h22222222;
-    #10ns instr_rdata = 32'h60008113;
-    #10ns instr_rdata = 32'h00000013;
-    #10ns instr_rdata = 32'h00000113;
-    #30ns instr_rdata = 32'h00000013;
-    #10ns instr_rdata = 32'h0000000f;
-    #10ns instr_rdata = 32'h00000013;
-    #10ns instr_rdata = 32'h00000013;
-    #10ns instr_rdata = 32'h0000000f;
+    #200ns instr_rdata  = 32'h81868106;
+           instr_rvalid = 1'b0;
+           instr_gnt    = 1'b1;
+    #10ns  instr_rvalid = 1'b1;
+           instr_gnt    = 1'b0;
+    #10ns  instr_rvalid = 1'b0;
+    #30ns  instr_rdata  = 32'h00400113;
+           instr_rvalid = 1'b0;
+           instr_gnt    = 1'b1;
+    #10ns  instr_rvalid = 1'b1;
+           instr_gnt    = 1'b0;
+    #10ns  instr_rvalid = 1'b0;
+           instr_rdata  = 32'hff810113;
+           instr_gnt    = 1'b1;
+    #10ns  instr_rvalid = 1'b1;
+           instr_gnt    = 1'b0;
+    #10ns  instr_rvalid = 1'b0;
+           instr_rdata  = 32'h4000006f;
+           instr_gnt    = 1'b1;
+    #10ns  instr_rvalid = 1'b1;
+           instr_gnt    = 1'b0;
+    #10ns  instr_rvalid = 1'b0;
+    #10ns  instr_rdata  = 32'h039597b3;
+           instr_gnt    = 1'b1;
+    #10ns  instr_rvalid = 1'b1;
+           instr_gnt    = 1'b1;
+    #10ns  instr_rdata  = 32'h13410d13;
+    #10ns  instr_rdata  = 32'he1070713;
+    #10ns  instr_rdata  = 32'hfff7c793;
+    #10ns  instr_rdata  = 32'h00000013;
+    #10ns  instr_rdata  = 32'h002d2c23;
+    #10ns  instr_rdata  = 32'h00000013;
+    #10ns  instr_rdata  = 32'h000d2083;
+           data_rdata   = 32'h12345678;
+    #10ns  instr_rdata  = 32'h60008113;
+    #10ns  instr_rdata  = 32'h00000013;
+    #10ns  instr_rdata  = 32'h002d2023;
+    #20ns  instr_rdata  = 32'h0000000f;
+    #10ns  instr_rdata  = 32'h00000113;
+    #30ns  instr_rdata  = 32'h00000013;
+    #10ns  instr_rdata  = 32'h0000000f;
   end
 
   ibex_core_tracer ibex_i (

--- a/examples/sim/tb/ibex_tracer_tb.sv
+++ b/examples/sim/tb/ibex_tracer_tb.sv
@@ -48,67 +48,68 @@ module ibex_tracer_tb;
   end
 
   ibex_core_tracer ibex_i (
-    .clk_i              (clk),
-    .rst_ni             (rst_n),
+    .clk_i                  (clk),
+    .rst_ni                 (rst_n),
 
-    .test_en_i          (1'b0),
+    .test_en_i              (1'b0),
 
     // Core ID, Cluster ID and boot address are considered more or less static
-    .core_id_i          (4'b0),
-    .cluster_id_i       (6'b0),
-    .boot_addr_i        (32'b0),
+    .core_id_i              (4'b0),
+    .cluster_id_i           (6'b0),
+    .boot_addr_i            (32'b0),
 
     // Instruction memory interface
-    .instr_req_o        (),
-    .instr_gnt_i        (1'b1),
-    .instr_rvalid_i     (1'b1),
-    .instr_addr_o       (),
-    .instr_rdata_i      (instr_rdata),
+    .instr_req_o            (),
+    .instr_gnt_i            (instr_gnt),
+    .instr_rvalid_i         (instr_rvalid),
+    .instr_addr_o           (),
+    .instr_rdata_i          (instr_rdata),
 
     // Data memory interface
-    .data_req_o         (),
-    .data_gnt_i         (1'b1),
-    .data_rvalid_i      (1'b1),
-    .data_we_o          (),
-    .data_be_o          (),
-    .data_addr_o        (),
-    .data_wdata_o       (),
-    .data_rdata_i       (data_rdata),
-    .data_err_i         (1'b0),
+    .data_req_o             (),
+    .data_gnt_i             (1'b1),
+    .data_rvalid_i          (1'b1),
+    .data_we_o              (),
+    .data_be_o              (),
+    .data_addr_o            (),
+    .data_wdata_o           (),
+    .data_rdata_i           (data_rdata),
+    .data_err_i             (1'b0),
 
     // Interrupt inputs
-    .irq_i              (1'b0),
-    .irq_id_i           (5'b0),
-    .irq_ack_o          (),
-    .irq_id_o           (),
+    .irq_i                  (1'b0),
+    .irq_id_i               (5'b0),
+    .irq_ack_o              (),
+    .irq_id_o               (),
 
     // Debug Interface
-    .debug_req_i        (1'b0),
+    .debug_req_i            (1'b0),
 
     // RISC-V Formal Interface
-    .rvfi_valid         (),
-    .rvfi_order         (),
-    .rvfi_insn          (),
-    .rvfi_trap          (),
-    .rvfi_halt          (),
-    .rvfi_intr          (),
-    .rvfi_mode          (),
-    .rvfi_rs1_addr      (),
-    .rvfi_rs2_addr      (),
-    .rvfi_rs1_rdata     (),
-    .rvfi_rs2_rdata     (),
-    .rvfi_rd_addr       (),
-    .rvfi_rd_wdata      (),
-    .rvfi_pc_rdata      (),
-    .rvfi_pc_wdata      (),
-    .rvfi_mem_addr      (),
-    .rvfi_mem_rmask     (),
-    .rvfi_mem_wmask     (),
-    .rvfi_mem_rdata     (),
-    .rvfi_mem_wdata     (),
+    .rvfi_valid             (),
+    .rvfi_order             (),
+    .rvfi_insn              (),
+    .rvfi_insn_uncompressed (),
+    .rvfi_trap              (),
+    .rvfi_halt              (),
+    .rvfi_intr              (),
+    .rvfi_mode              (),
+    .rvfi_rs1_addr          (),
+    .rvfi_rs2_addr          (),
+    .rvfi_rs1_rdata         (),
+    .rvfi_rs2_rdata         (),
+    .rvfi_rd_addr           (),
+    .rvfi_rd_wdata          (),
+    .rvfi_pc_rdata          (),
+    .rvfi_pc_wdata          (),
+    .rvfi_mem_addr          (),
+    .rvfi_mem_rmask         (),
+    .rvfi_mem_wmask         (),
+    .rvfi_mem_rdata         (),
+    .rvfi_mem_wdata         (),
 
     // CPU Control Signals
-    .fetch_enable_i     (1'b1)
+    .fetch_enable_i         (1'b1)
   );
 
 endmodule

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -101,8 +101,6 @@ module ibex_controller (
     input  logic                      stall_jump_i,
     input  logic                      stall_branch_i,
 
-    output logic                      id_out_valid_o,        // ID stage has valid output
-
     // performance monitors
     output logic                      perf_jump_o,           // we are executing a jump
                                                              // instruction (j, jr, jal, jalr)
@@ -532,9 +530,6 @@ module ibex_controller (
   // kill instr in IF-ID pipeline reg that are done, or if a
   // multicycle instr causes an exception for example
   assign instr_valid_clear_o = ~stall |  halt_id;
-
-  // signal that ID stage has valid output
-  assign id_out_valid_o      = ~stall & instr_valid_i & ~special_req;
 
   // update registers
   always_ff @(posedge clk_i or negedge rst_ni) begin : update_regs

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -180,8 +180,6 @@ module ibex_core #(
   logic        id_in_ready;
   logic        ex_valid;
 
-  logic        if_id_pipe_reg_we;
-
   logic        lsu_data_valid;
 
   // Signals between instruction core interface and pipe (if and id stages)
@@ -216,13 +214,11 @@ module ibex_core #(
   logic        perf_store;
 
   // for RVFI
-  logic        id_out_valid, unused_id_out_valid;       // ID stage has valid output data
   logic        illegal_insn_id, unused_illegal_insn_id; // ID stage sees an illegal instruction
 
   // RISC-V Formal Interface signals
 `ifdef RVFI
-  logic [31:0] rvfi_insn_opcode;
-  logic        rvfi_valid_int;
+  logic [31:0] rvfi_insn_id;
   logic [4:0]  rvfi_rs1_addr_id;
   logic [4:0]  rvfi_rs2_addr_id;
   logic [31:0] rvfi_rs1_data_d;
@@ -240,11 +236,6 @@ module ibex_core #(
   logic        rvfi_rd_we_id;
   logic        rvfi_insn_new_d;
   logic        rvfi_insn_new_q;
-  logic        rvfi_insn_clear_d;
-  logic        rvfi_insn_clear_q;
-  logic        rvfi_changed_insn;
-  logic        rvfi_changed_pc;
-  logic [31:0] rvfi_pc_id_q;
   logic [3:0]  rvfi_mem_mask_int;
   logic [31:0] rvfi_mem_rdata_d;
   logic [31:0] rvfi_mem_rdata_q;
@@ -336,7 +327,6 @@ module ibex_core #(
 
       // pipeline stalls
       .id_in_ready_i            ( id_in_ready            ),
-      .if_id_pipe_reg_we_o      ( if_id_pipe_reg_we      ),
 
       .if_busy_o                ( if_busy                ),
       .perf_imiss_o             ( perf_imiss             )
@@ -388,8 +378,6 @@ module ibex_core #(
       // Stalls
       .ex_valid_i                   ( ex_valid               ),
       .lsu_valid_i                  ( lsu_data_valid         ),
-
-      .id_out_valid_o               ( id_out_valid           ),
 
       .alu_operator_ex_o            ( alu_operator_ex        ),
       .alu_operand_a_ex_o           ( alu_operand_a_ex       ),
@@ -465,7 +453,6 @@ module ibex_core #(
   );
 
   // for RVFI only
-  assign unused_id_out_valid    = id_out_valid;
   assign unused_illegal_insn_id = illegal_insn_id;
 
   ibex_ex_block #(
@@ -611,33 +598,55 @@ module ibex_core #(
   );
 
 `ifdef RVFI
-  always_ff @(posedge clk) begin
-    rvfi_halt      <= '0;
-    rvfi_trap      <= '0;
-    rvfi_intr      <= irq_ack_o;
-    rvfi_order     <= rst_ni ? rvfi_order + rvfi_valid : '0;
-    rvfi_insn      <= rvfi_insn_opcode;
-    rvfi_mode      <= PRIV_LVL_M;
-    rvfi_rs1_addr  <= rvfi_rs1_addr_id;
-    rvfi_rs2_addr  <= rvfi_rs2_addr_id;
-    rvfi_pc_rdata  <= pc_id;
-    rvfi_mem_rmask <= rvfi_mem_mask_int;
-    rvfi_mem_wmask <= data_we_o ? rvfi_mem_mask_int : 4'b0000;
-    rvfi_valid     <= rvfi_valid_int;
-    rvfi_rs1_rdata <= rvfi_rs1_data_d;
-    rvfi_rs2_rdata <= rvfi_rs2_data_d;
+  always_ff @(posedge clk or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rvfi_halt      <= '0;
+      rvfi_trap      <= '0;
+      rvfi_intr      <= '0;
+      rvfi_order     <= '0;
+      rvfi_insn      <= '0;
+      rvfi_mode      <= '0;
+      rvfi_rs1_addr  <= '0;
+      rvfi_rs2_addr  <= '0;
+      rvfi_pc_rdata  <= '0;
+      rvfi_pc_wdata  <= '0;
+      rvfi_mem_rmask <= '0;
+      rvfi_mem_wmask <= '0;
+      rvfi_valid     <= '0;
+      rvfi_rs1_rdata <= '0;
+      rvfi_rs2_rdata <= '0;
+      rvfi_rd_wdata  <= '0;
+      rvfi_rd_addr   <= '0;
+      rvfi_mem_rdata <= '0;
+      rvfi_mem_wdata <= '0;
+      rvfi_mem_addr  <= '0;
+    end else begin
+      rvfi_halt      <= '0;
+      rvfi_trap      <= illegal_insn_id;
+      rvfi_intr      <= irq_ack_o;
+      rvfi_order     <= rvfi_order + rvfi_valid;
+      rvfi_insn      <= rvfi_insn_id;
+      rvfi_mode      <= PRIV_LVL_M; // TODO: Update for user mode support
+      rvfi_rs1_addr  <= rvfi_rs1_addr_id;
+      rvfi_rs2_addr  <= rvfi_rs2_addr_id;
+      rvfi_pc_rdata  <= pc_id;
+      rvfi_pc_wdata  <= pc_if;
+      rvfi_mem_rmask <= rvfi_mem_mask_int;
+      rvfi_mem_wmask <= data_we_o ? rvfi_mem_mask_int : 4'b0000;
+      rvfi_valid     <= instr_ret;
+      rvfi_rs1_rdata <= rvfi_rs1_data_d;
+      rvfi_rs2_rdata <= rvfi_rs2_data_d;
+      rvfi_rd_wdata  <= rvfi_rd_wdata_d;
+      rvfi_rd_addr   <= rvfi_rd_addr_d;
+      rvfi_mem_rdata <= rvfi_mem_rdata_d;
+      rvfi_mem_wdata <= rvfi_mem_wdata_d;
+      rvfi_mem_addr  <= rvfi_mem_addr_d;
+    end
   end
-
-  assign rvfi_pc_wdata  = pc_id;
-  assign rvfi_rd_wdata  = rvfi_rd_wdata_q;
-  assign rvfi_rd_addr   = rvfi_rd_addr_q;
-  assign rvfi_mem_rdata = rvfi_mem_rdata_q;
-  assign rvfi_mem_wdata = rvfi_mem_wdata_q;
-  assign rvfi_mem_addr  = rvfi_mem_addr_q;
 
   // Keep the mem data stable for each instruction cycle
   always_comb begin
-    if (rvfi_insn_new_d) begin
+    if (rvfi_insn_new_d && lsu_data_valid) begin
       rvfi_mem_addr_d  = alu_adder_result_ex;
       rvfi_mem_rdata_d = regfile_wdata_lsu;
       rvfi_mem_wdata_d = data_wdata_ex;
@@ -647,10 +656,16 @@ module ibex_core #(
       rvfi_mem_wdata_d = rvfi_mem_wdata_q;
     end
   end
-  always_ff @(posedge clk) begin
-    rvfi_mem_addr_q  <= rvfi_mem_addr_d;
-    rvfi_mem_rdata_q <= rvfi_mem_rdata_d;
-    rvfi_mem_wdata_q <= rvfi_mem_wdata_d;
+  always_ff @(posedge clk or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rvfi_mem_addr_q  <= '0;
+      rvfi_mem_rdata_q <= '0;
+      rvfi_mem_wdata_q <= '0;
+    end else begin
+      rvfi_mem_addr_q  <= rvfi_mem_addr_d;
+      rvfi_mem_rdata_q <= rvfi_mem_rdata_d;
+      rvfi_mem_wdata_q <= rvfi_mem_wdata_d;
+    end
   end
   // Byte enable based on data type
   always_comb begin
@@ -662,19 +677,17 @@ module ibex_core #(
     endcase
   end
 
-  assign rvfi_valid_int = id_out_valid && if_id_pipe_reg_we && !illegal_c_insn_id;
-
   always_comb begin
     if (instr_is_compressed_id) begin
-      rvfi_insn_opcode = {16'b0, instr_rdata_c_id};
+      rvfi_insn_id = {16'b0, instr_rdata_c_id};
     end else begin
-      rvfi_insn_opcode = instr_rdata_id;
+      rvfi_insn_id = instr_rdata_id;
     end
   end
 
   // Source register data are kept stable for each instruction cycle
   always_comb begin
-    if (rvfi_insn_new_d) begin
+    if (instr_new_id) begin
       rvfi_rs1_data_d = rvfi_rs1_data_id;
       rvfi_rs2_data_d = rvfi_rs2_data_id;
     end else begin
@@ -682,9 +695,14 @@ module ibex_core #(
       rvfi_rs2_data_d = rvfi_rs2_data_q;
     end
   end
-  always_ff @(posedge clk) begin
-    rvfi_rs1_data_q <= rvfi_rs1_data_d;
-    rvfi_rs2_data_q <= rvfi_rs2_data_d;
+  always_ff @(posedge clk or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rvfi_rs1_data_q <= '0;
+      rvfi_rs2_data_q <= '0;
+    end else begin
+      rvfi_rs1_data_q <= rvfi_rs1_data_d;
+      rvfi_rs2_data_q <= rvfi_rs2_data_d;
+    end
   end
 
   // RD write register is refreshed only once per cycle and
@@ -694,7 +712,6 @@ module ibex_core #(
       if (!rvfi_rd_we_id) begin
         rvfi_rd_addr_d    = '0;
         rvfi_rd_wdata_d   = '0;
-        rvfi_insn_clear_d = 1'b0;
       end else begin
         rvfi_rd_addr_d = rvfi_rd_addr_id;
         if (!rvfi_rd_addr_id) begin
@@ -702,43 +719,41 @@ module ibex_core #(
         end else begin
           rvfi_rd_wdata_d = rvfi_rd_wdata_id;
         end
-        rvfi_insn_clear_d = 1'b1;
       end
     end else begin
       rvfi_rd_addr_d    = rvfi_rd_addr_q;
       rvfi_rd_wdata_d   = rvfi_rd_wdata_q;
-      rvfi_insn_clear_d = 1'b0;
     end
   end
-  always_ff @(posedge clk) begin
-    rvfi_insn_clear_q <= rvfi_insn_clear_d;
-    rvfi_rd_addr_q    <= rvfi_rd_addr_d;
-    rvfi_rd_wdata_q   <= rvfi_rd_wdata_d;
+  always_ff @(posedge clk or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rvfi_rd_addr_q    <= '0;
+      rvfi_rd_wdata_q   <= '0;
+    end else begin
+      rvfi_rd_addr_q    <= rvfi_rd_addr_d;
+      rvfi_rd_wdata_q   <= rvfi_rd_wdata_d;
+    end
   end
 
-  // New instruction signalling based on changes of
-  // instruction data, program counter and valid signal
   always_comb begin
-    if (rvfi_changed_insn || rvfi_changed_pc || rvfi_valid ) begin
+    if (instr_new_id) begin
       rvfi_insn_new_d = 1'b1;
-    end else if (rvfi_insn_clear_q) begin
-      rvfi_insn_new_d = 1'b0;
     end else begin
       rvfi_insn_new_d = rvfi_insn_new_q;
     end
   end
-  always_ff @(posedge clk) begin
-    rvfi_insn_new_q <= rvfi_insn_new_d;
+  always_ff @(posedge clk or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rvfi_insn_new_q <= 1'b0;
+    end else begin
+      if (instr_ret) begin
+        rvfi_insn_new_q <= 1'b0;
+      end else begin
+        rvfi_insn_new_q <= rvfi_insn_new_d;
+      end
+    end
   end
 
-  // Change in instruction code
-  assign rvfi_changed_insn = rvfi_insn != rvfi_insn_opcode;
-
-  // Change in program counter
-  always_ff @(posedge clk) begin
-    rvfi_pc_id_q <= pc_id;
-  end
-  assign rvfi_changed_pc = rvfi_pc_id_q != pc_id;
 `endif
 
 endmodule

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -81,6 +81,7 @@ module ibex_core #(
     output logic        rvfi_valid,
     output logic [63:0] rvfi_order,
     output logic [31:0] rvfi_insn,
+    output logic [31:0] rvfi_insn_uncompressed,
     output logic        rvfi_trap,
     output logic        rvfi_halt,
     output logic        rvfi_intr,
@@ -600,47 +601,49 @@ module ibex_core #(
 `ifdef RVFI
   always_ff @(posedge clk or negedge rst_ni) begin
     if (!rst_ni) begin
-      rvfi_halt      <= '0;
-      rvfi_trap      <= '0;
-      rvfi_intr      <= '0;
-      rvfi_order     <= '0;
-      rvfi_insn      <= '0;
-      rvfi_mode      <= '0;
-      rvfi_rs1_addr  <= '0;
-      rvfi_rs2_addr  <= '0;
-      rvfi_pc_rdata  <= '0;
-      rvfi_pc_wdata  <= '0;
-      rvfi_mem_rmask <= '0;
-      rvfi_mem_wmask <= '0;
-      rvfi_valid     <= '0;
-      rvfi_rs1_rdata <= '0;
-      rvfi_rs2_rdata <= '0;
-      rvfi_rd_wdata  <= '0;
-      rvfi_rd_addr   <= '0;
-      rvfi_mem_rdata <= '0;
-      rvfi_mem_wdata <= '0;
-      rvfi_mem_addr  <= '0;
+      rvfi_halt              <= '0;
+      rvfi_trap              <= '0;
+      rvfi_intr              <= '0;
+      rvfi_order             <= '0;
+      rvfi_insn              <= '0;
+      rvfi_insn_uncompressed <= '0;
+      rvfi_mode              <= '0;
+      rvfi_rs1_addr          <= '0;
+      rvfi_rs2_addr          <= '0;
+      rvfi_pc_rdata          <= '0;
+      rvfi_pc_wdata          <= '0;
+      rvfi_mem_rmask         <= '0;
+      rvfi_mem_wmask         <= '0;
+      rvfi_valid             <= '0;
+      rvfi_rs1_rdata         <= '0;
+      rvfi_rs2_rdata         <= '0;
+      rvfi_rd_wdata          <= '0;
+      rvfi_rd_addr           <= '0;
+      rvfi_mem_rdata         <= '0;
+      rvfi_mem_wdata         <= '0;
+      rvfi_mem_addr          <= '0;
     end else begin
-      rvfi_halt      <= '0;
-      rvfi_trap      <= illegal_insn_id;
-      rvfi_intr      <= irq_ack_o;
-      rvfi_order     <= rvfi_order + rvfi_valid;
-      rvfi_insn      <= rvfi_insn_id;
-      rvfi_mode      <= PRIV_LVL_M; // TODO: Update for user mode support
-      rvfi_rs1_addr  <= rvfi_rs1_addr_id;
-      rvfi_rs2_addr  <= rvfi_rs2_addr_id;
-      rvfi_pc_rdata  <= pc_id;
-      rvfi_pc_wdata  <= pc_if;
-      rvfi_mem_rmask <= rvfi_mem_mask_int;
-      rvfi_mem_wmask <= data_we_o ? rvfi_mem_mask_int : 4'b0000;
-      rvfi_valid     <= instr_ret;
-      rvfi_rs1_rdata <= rvfi_rs1_data_d;
-      rvfi_rs2_rdata <= rvfi_rs2_data_d;
-      rvfi_rd_wdata  <= rvfi_rd_wdata_d;
-      rvfi_rd_addr   <= rvfi_rd_addr_d;
-      rvfi_mem_rdata <= rvfi_mem_rdata_d;
-      rvfi_mem_wdata <= rvfi_mem_wdata_d;
-      rvfi_mem_addr  <= rvfi_mem_addr_d;
+      rvfi_halt              <= '0;
+      rvfi_trap              <= illegal_insn_id;
+      rvfi_intr              <= irq_ack_o;
+      rvfi_order             <= rvfi_order + rvfi_valid;
+      rvfi_insn              <= rvfi_insn_id;
+      rvfi_insn_uncompressed <= instr_rdata_id;
+      rvfi_mode              <= PRIV_LVL_M; // TODO: Update for user mode support
+      rvfi_rs1_addr          <= rvfi_rs1_addr_id;
+      rvfi_rs2_addr          <= rvfi_rs2_addr_id;
+      rvfi_pc_rdata          <= pc_id;
+      rvfi_pc_wdata          <= pc_if;
+      rvfi_mem_rmask         <= rvfi_mem_mask_int;
+      rvfi_mem_wmask         <= data_we_o ? rvfi_mem_mask_int : 4'b0000;
+      rvfi_valid             <= instr_ret;
+      rvfi_rs1_rdata         <= rvfi_rs1_data_d;
+      rvfi_rs2_rdata         <= rvfi_rs2_data_d;
+      rvfi_rd_wdata          <= rvfi_rd_wdata_d;
+      rvfi_rd_addr           <= rvfi_rd_addr_d;
+      rvfi_mem_rdata         <= rvfi_mem_rdata_d;
+      rvfi_mem_wdata         <= rvfi_mem_wdata_d;
+      rvfi_mem_addr          <= rvfi_mem_addr_d;
     end
   end
 

--- a/rtl/ibex_core_tracer.sv
+++ b/rtl/ibex_core_tracer.sv
@@ -62,6 +62,7 @@ module ibex_core_tracer #(
     output logic        rvfi_valid,
     output logic [63:0] rvfi_order,
     output logic [31:0] rvfi_insn,
+    output logic [31:0] rvfi_insn_uncompressed,
     output logic        rvfi_trap,
     output logic        rvfi_halt,
     output logic        rvfi_intr,
@@ -132,6 +133,7 @@ module ibex_core_tracer #(
     .rvfi_valid,
     .rvfi_order,
     .rvfi_insn,
+    .rvfi_insn_uncompressed,
     .rvfi_trap,
     .rvfi_halt,
     .rvfi_intr,
@@ -157,23 +159,23 @@ module ibex_core_tracer #(
 
 `ifndef VERILATOR
   ibex_tracer ibex_tracer_i (
-      .clk_i            ( clk_i          ),
-      .rst_ni           ( rst_ni         ),
+      .clk_i            ( clk_i                  ),
+      .rst_ni           ( rst_ni                 ),
 
-      .fetch_enable_i   ( fetch_enable_i ),
-      .core_id_i        ( core_id_i      ),
-      .cluster_id_i     ( cluster_id_i   ),
+      .fetch_enable_i   ( fetch_enable_i         ),
+      .core_id_i        ( core_id_i              ),
+      .cluster_id_i     ( cluster_id_i           ),
 
-      .valid_i          ( rvfi_valid     ),
-      .pc_i             ( rvfi_pc_rdata  ),
-      .instr_i          ( rvfi_insn      ),
-      .rs1_value_i      ( rvfi_rs1_rdata ),
-      .rs2_value_i      ( rvfi_rs2_rdata ),
-      .ex_reg_addr_i    ( rvfi_rd_addr   ),
-      .ex_reg_wdata_i   ( rvfi_rd_wdata  ),
-      .ex_data_addr_i   ( rvfi_mem_addr  ),
-      .ex_data_wdata_i  ( rvfi_mem_wdata ),
-      .ex_data_rdata_i  ( rvfi_mem_rdata )
+      .valid_i          ( rvfi_valid             ),
+      .pc_i             ( rvfi_pc_rdata          ),
+      .instr_i          ( rvfi_insn_uncompressed ),
+      .rs1_value_i      ( rvfi_rs1_rdata         ),
+      .rs2_value_i      ( rvfi_rs2_rdata         ),
+      .ex_reg_addr_i    ( rvfi_rd_addr           ),
+      .ex_reg_wdata_i   ( rvfi_rd_wdata          ),
+      .ex_data_addr_i   ( rvfi_mem_addr          ),
+      .ex_data_wdata_i  ( rvfi_mem_wdata         ),
+      .ex_data_rdata_i  ( rvfi_mem_rdata         )
   );
 `endif // VERILATOR
 

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -70,8 +70,6 @@ module ibex_id_stage #(
     // Stalls
     input  logic                      ex_valid_i,     // EX stage has valid output
     input  logic                      lsu_valid_i,    // LSU has valid output, or is done
-    output logic                      id_out_valid_o, // ID stage is done
-
     // ALU
     output ibex_defines::alu_op_e     alu_operator_ex_o,
     output logic [31:0]               alu_operand_a_ex_o,
@@ -479,8 +477,6 @@ module ibex_id_stage #(
       .stall_multdiv_i                ( stall_multdiv          ),
       .stall_jump_i                   ( stall_jump             ),
       .stall_branch_i                 ( stall_branch           ),
-
-      .id_out_valid_o                 ( id_out_valid_o         ),
 
       // Performance Counters
       .perf_jump_o                    ( perf_jump_o            ),

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -77,7 +77,6 @@ module ibex_if_stage #(
 
     // pipeline stall
     input  logic                      id_in_ready_i,            // ID stage is ready for new instr
-    output logic                      if_id_pipe_reg_we_o,      // IF-ID pipeline reg write enable
 
     // misc signals
     output logic                      if_busy_o,                // IF stage is busy fetching instr
@@ -103,6 +102,8 @@ module ibex_if_stage #(
 
   logic        [5:0] irq_id;
   logic              unused_irq_bit;
+
+  logic              if_id_pipe_reg_we; // IF-ID pipeline reg write enable
 
   logic        [7:0] unused_boot_addr;
 
@@ -193,7 +194,7 @@ module ibex_if_stage #(
       if (fetch_valid) begin
         have_instr = 1'b1;
 
-        if (req_i && if_id_pipe_reg_we_o) begin
+        if (req_i && if_id_pipe_reg_we) begin
           fetch_ready      = 1'b1;
           offset_in_init_d = 1'b0;
         end
@@ -231,7 +232,7 @@ module ibex_if_stage #(
   );
 
   // IF-ID pipeline registers, frozen when the ID stage is stalled
-  assign if_id_pipe_reg_we_o = have_instr & id_in_ready_i;
+  assign if_id_pipe_reg_we = have_instr & id_in_ready_i;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : if_id_pipeline_regs
     if (!rst_ni) begin
@@ -243,8 +244,8 @@ module ibex_if_stage #(
       illegal_c_insn_id_o        <= 1'b0;
       pc_id_o                    <= '0;
     end else begin
-      instr_new_id_o             <= if_id_pipe_reg_we_o;
-      if (if_id_pipe_reg_we_o) begin
+      instr_new_id_o             <= if_id_pipe_reg_we;
+      if (if_id_pipe_reg_we) begin
         instr_valid_id_o         <= 1'b1;
         instr_rdata_id_o         <= instr_decompressed;
         instr_rdata_c_id_o       <= fetch_rdata[15:0];

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -20,10 +20,6 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-`ifdef RISCV_FORMAL
-  `define RVFI
-`endif
-
 /**
  * Instruction Fetch Stage
  *


### PR DESCRIPTION
This PR changes how RVFI signals are generated (https://github.com/lowRISC/ibex/issues/151, fixes https://github.com/lowRISC/ibex/issues/147).
It also forwards the uncompressed instruction to the tracer (https://github.com/lowRISC/ibex/issues/154).

As those commits are all closely coupled I think it is easier to do it in one PR.
@taoliug could you please test this before it is merged? 