### PR TITLE
Update google_riscv-dv to 2e5a401

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: 084fa3a4debb682b34c9b7f9b17342bb06619a3b
+    rev: 2e5a40145a367ac3b04f78fee02c5011022719fd
   }
 }

--- a/vendor/google_riscv-dv/setting/riscv_core_setting.sv
+++ b/vendor/google_riscv-dv/setting/riscv_core_setting.sv
@@ -32,6 +32,9 @@ riscv_instr_name_t unsupported_instr[];
 // ISA supported by the processor
 riscv_instr_group_t supported_isa[$] = {RV32I, RV32M, RV64I, RV64M, RV32C, RV64C};
 
+// Debug mode support
+bit support_debug_mode = 0;
+
 // Support delegate trap to user mode
 bit support_umode_trap = 0;
 

--- a/vendor/google_riscv-dv/src/riscv_asm_program_gen.sv
+++ b/vendor/google_riscv-dv/src/riscv_asm_program_gen.sv
@@ -174,6 +174,9 @@ class riscv_asm_program_gen extends uvm_object;
     gen_privileged_mode_switch_routine();
     // Program end
     gen_program_end();
+    // Generate debug mode section
+    gen_debug_mode_section();
+    // Starting point of data section
     gen_data_page_begin();
     // Generate the sub program in binary format
     gen_bin_program();
@@ -891,5 +894,16 @@ class riscv_asm_program_gen extends uvm_object;
     end
   endfunction
 
+  // Generate the program in the debug ROM
+  // Processor will fetch instruction from here upon receiving debug request from debug module
+  virtual function gen_debug_mode_section();
+    string instr[];
+    if (riscv_instr_pkg::support_debug_mode) begin
+      instr = {"dret"};
+      gen_section("debug_rom", instr);
+      instr = {"dret"};
+      gen_section("debug_exception", instr);
+    end
+  endfunction
 
 endclass


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision 2e5a40145a367ac3b04f78fee02c5011022719fd

* Merge pull request #36 from google/dev (taoliug)
* Add basic debug mode support (Tao Liu)