### PR TITLE
ID/EX stage: do not write to register file upon load errors

### DIFF
--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -622,7 +622,7 @@ module ibex_id_stage #(
         if ((data_req_dec & lsu_valid_i) | (~data_req_dec & ex_valid_i)) begin
           id_wb_fsm_ns            = IDLE;
           instr_multicycle_done_n = 1'b1;
-          regfile_we_wb           = regfile_we_dec;
+          regfile_we_wb           = regfile_we_dec & ~lsu_load_err_i;
           instr_ret_o             = 1'b1;
         end else begin
           stall_lsu               = data_req_dec;


### PR DESCRIPTION
This commit fixes the write back FSM to not store values returned from
memory to the register file when the LSU is reporting a load error.

This bug was reported by @ivanmgribeiro. This commit resolves #162.