### PR TITLE
Remove unneeded tracer define

### DIFF
--- a/ibex.core
+++ b/ibex.core
@@ -8,7 +8,6 @@ filesets:
   files_rtl:
     files:
       - rtl/ibex_defines.sv
-      - rtl/ibex_tracer_defines.sv
       - rtl/ibex_alu.sv
       - rtl/ibex_compressed_decoder.sv
       - rtl/ibex_controller.sv


### PR DESCRIPTION
The tracer defines are not used by ibex on its own.