### PR TITLE
Rename packages

### DIFF
--- a/ibex_core.core
+++ b/ibex_core.core
@@ -7,7 +7,7 @@ description: "CPU core with 2 stage pipeline implementing the RV32IMC_Zicsr ISA"
 filesets:
   files_rtl:
     files:
-      - rtl/ibex_defines.sv
+      - rtl/ibex_pkg.sv
       - rtl/ibex_alu.sv
       - rtl/ibex_compressed_decoder.sv
       - rtl/ibex_controller.sv

--- a/ibex_tracer.core
+++ b/ibex_tracer.core
@@ -9,7 +9,7 @@ filesets:
     depend:
       - lowrisc:ibex:ibex
     files:
-      - rtl/ibex_tracer_defines.sv
+      - rtl/ibex_tracer_pkg.sv
       - rtl/ibex_tracer.sv
       - rtl/ibex_core_tracer.sv
     file_type: systemVerilogSource

--- a/rtl/ibex_alu.sv
+++ b/rtl/ibex_alu.sv
@@ -22,23 +22,23 @@
  * Arithmetic logic unit
  */
 module ibex_alu (
-    input  ibex_defines::alu_op_e operator_i,
-    input  logic [31:0]           operand_a_i,
-    input  logic [31:0]           operand_b_i,
+    input  ibex_pkg::alu_op_e operator_i,
+    input  logic [31:0]       operand_a_i,
+    input  logic [31:0]       operand_b_i,
 
-    input  logic [32:0]           multdiv_operand_a_i,
-    input  logic [32:0]           multdiv_operand_b_i,
+    input  logic [32:0]       multdiv_operand_a_i,
+    input  logic [32:0]       multdiv_operand_b_i,
 
-    input  logic                  multdiv_en_i,
+    input  logic              multdiv_en_i,
 
-    output logic [31:0]           adder_result_o,
-    output logic [33:0]           adder_result_ext_o,
+    output logic [31:0]       adder_result_o,
+    output logic [33:0]       adder_result_ext_o,
 
-    output logic [31:0]           result_o,
-    output logic                  comparison_result_o,
-    output logic                  is_equal_result_o
+    output logic [31:0]       result_o,
+    output logic              comparison_result_o,
+    output logic              is_equal_result_o
 );
-  import ibex_defines::*;
+  import ibex_pkg::*;
 
   logic [31:0] operand_a_rev;
   logic [32:0] operand_b_neg;

--- a/rtl/ibex_compressed_decoder.sv
+++ b/rtl/ibex_compressed_decoder.sv
@@ -28,7 +28,7 @@ module ibex_compressed_decoder (
     output logic        is_compressed_o,
     output logic        illegal_instr_o
 );
-  import ibex_defines::*;
+  import ibex_pkg::*;
 
   ////////////////////////
   // Compressed decoder //

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -24,90 +24,90 @@
  * Main controller of the processor
  */
 module ibex_controller (
-    input  logic                      clk_i,
-    input  logic                      rst_ni,
+    input  logic                  clk_i,
+    input  logic                  rst_ni,
 
-    input  logic                      fetch_enable_i,        // start decoding
-    output logic                      ctrl_busy_o,           // core is busy processing instrs
-    output logic                      first_fetch_o,         // core is at the FIRST FETCH stage
+    input  logic                  fetch_enable_i,        // start decoding
+    output logic                  ctrl_busy_o,           // core is busy processing instrs
+    output logic                  first_fetch_o,         // core is at the FIRST FETCH stage
 
     // decoder related signals
-    input  logic                      illegal_insn_i,        // decoder has an invalid instr
-    input  logic                      ecall_insn_i,          // decoder has ECALL instr
-    input  logic                      mret_insn_i,           // decoder has MRET instr
-    input  logic                      dret_insn_i,           // decoder has DRET instr
-    input  logic                      wfi_insn_i,            // decoder has WFI instr
-    input  logic                      ebrk_insn_i,           // decoder has EBREAK instr
-    input  logic                      csr_status_i,          // decoder has CSR status instr
+    input  logic                  illegal_insn_i,        // decoder has an invalid instr
+    input  logic                  ecall_insn_i,          // decoder has ECALL instr
+    input  logic                  mret_insn_i,           // decoder has MRET instr
+    input  logic                  dret_insn_i,           // decoder has DRET instr
+    input  logic                  wfi_insn_i,            // decoder has WFI instr
+    input  logic                  ebrk_insn_i,           // decoder has EBREAK instr
+    input  logic                  csr_status_i,          // decoder has CSR status instr
 
     // from IF-ID pipeline stage
-    input  logic                      instr_valid_i,         // instr from IF-ID reg is valid
-    input  logic [31:0]               instr_i,               // instr from IF-ID reg, for mtval
-    input  logic [15:0]               instr_compressed_i,    // instr from IF-ID reg, for mtval
-    input  logic                      instr_is_compressed_i, // instr from IF-ID reg is compressed
+    input  logic                  instr_valid_i,         // instr from IF-ID reg is valid
+    input  logic [31:0]           instr_i,               // instr from IF-ID reg, for mtval
+    input  logic [15:0]           instr_compressed_i,    // instr from IF-ID reg, for mtval
+    input  logic                  instr_is_compressed_i, // instr from IF-ID reg is compressed
 
     // to IF-ID pipeline stage
-    output logic                      instr_valid_clear_o,   // kill instr in IF-ID reg
-    output logic                      id_in_ready_o,         // ID stage is ready for new instr
+    output logic                  instr_valid_clear_o,   // kill instr in IF-ID reg
+    output logic                  id_in_ready_o,         // ID stage is ready for new instr
 
     // to prefetcher
-    output logic                      instr_req_o,           // start fetching instructions
-    output logic                      pc_set_o,              // jump to address set by pc_mux
-    output ibex_defines::pc_sel_e     pc_mux_o,              // IF stage fetch address selector
-                                                             // (boot, normal, exception...)
-    output ibex_defines::exc_pc_sel_e exc_pc_mux_o,          // IF stage selector for exception PC
+    output logic                  instr_req_o,           // start fetching instructions
+    output logic                  pc_set_o,              // jump to address set by pc_mux
+    output ibex_pkg::pc_sel_e     pc_mux_o,              // IF stage fetch address selector
+                                                         // (boot, normal, exception...)
+    output ibex_pkg::exc_pc_sel_e exc_pc_mux_o,          // IF stage selector for exception PC
 
     // LSU
-    input  logic [31:0]               lsu_addr_last_i,       // for mtval
-    input  logic                      load_err_i,
-    input  logic                      store_err_i,
+    input  logic [31:0]           lsu_addr_last_i,       // for mtval
+    input  logic                  load_err_i,
+    input  logic                  store_err_i,
 
     // jump/branch signals
-    input  logic                      branch_set_i,          // branch taken set signal
-    input  logic                      jump_set_i,            // jump taken set signal
+    input  logic                  branch_set_i,          // branch taken set signal
+    input  logic                  jump_set_i,            // jump taken set signal
 
     // External Interrupt Req Signals, used to wake up from wfi even if the interrupt is not taken
-    input  logic                      irq_i,
+    input  logic                  irq_i,
     // Interrupt Controller Signals
-    input  logic                      irq_req_ctrl_i,
-    input  logic [4:0]                irq_id_ctrl_i,
-    input  logic                      m_IE_i,                // interrupt enable bit from CSR
-                                                             // (M mode)
+    input  logic                  irq_req_ctrl_i,
+    input  logic [4:0]            irq_id_ctrl_i,
+    input  logic                  m_IE_i,                // interrupt enable bit from CSR
+                                                         // (M mode)
 
-    output logic                      irq_ack_o,
-    output logic [4:0]                irq_id_o,
+    output logic                  irq_ack_o,
+    output logic [4:0]            irq_id_o,
 
-    output ibex_defines::exc_cause_e  exc_cause_o,
-    output logic                      exc_ack_o,
-    output logic                      exc_kill_o,
+    output ibex_pkg::exc_cause_e  exc_cause_o,
+    output logic                  exc_ack_o,
+    output logic                  exc_kill_o,
 
     // debug signals
-    input  logic                      debug_req_i,
-    output ibex_defines::dbg_cause_e  debug_cause_o,
-    output logic                      debug_csr_save_o,
-    input  logic                      debug_single_step_i,
-    input  logic                      debug_ebreakm_i,
+    input  logic                  debug_req_i,
+    output ibex_pkg::dbg_cause_e  debug_cause_o,
+    output logic                  debug_csr_save_o,
+    input  logic                  debug_single_step_i,
+    input  logic                  debug_ebreakm_i,
 
-    output logic                      csr_save_if_o,
-    output logic                      csr_save_id_o,
-    output logic                      csr_restore_mret_id_o,
-    output logic                      csr_restore_dret_id_o,
-    output logic                      csr_save_cause_o,
-    output logic [31:0]               csr_mtval_o,
+    output logic                  csr_save_if_o,
+    output logic                  csr_save_id_o,
+    output logic                  csr_restore_mret_id_o,
+    output logic                  csr_restore_dret_id_o,
+    output logic                  csr_save_cause_o,
+    output logic [31:0]           csr_mtval_o,
 
     // stall signals
-    input  logic                      stall_lsu_i,
-    input  logic                      stall_multdiv_i,
-    input  logic                      stall_jump_i,
-    input  logic                      stall_branch_i,
+    input  logic                  stall_lsu_i,
+    input  logic                  stall_multdiv_i,
+    input  logic                  stall_jump_i,
+    input  logic                  stall_branch_i,
 
     // performance monitors
-    output logic                      perf_jump_o,           // we are executing a jump
-                                                             // instruction (j, jr, jal, jalr)
-    output logic                      perf_tbranch_o         // we are executing a taken branch
-                                                             // instruction
+    output logic                  perf_jump_o,           // we are executing a jump
+                                                         // instruction (j, jr, jal, jalr)
+    output logic                  perf_tbranch_o         // we are executing a taken branch
+                                                         // instruction
 );
-  import ibex_defines::*;
+  import ibex_pkg::*;
 
   // FSM state encoding
   typedef enum logic [3:0] {

--- a/rtl/ibex_core.f
+++ b/rtl/ibex_core.f
@@ -1,5 +1,4 @@
 ibex_defines.sv
-ibex_tracer_defines.sv
 ibex_alu.sv
 ibex_compressed_decoder.sv
 ibex_controller.sv

--- a/rtl/ibex_core.f
+++ b/rtl/ibex_core.f
@@ -1,4 +1,4 @@
-ibex_defines.sv
+ibex_pkg.sv
 ibex_alu.sv
 ibex_compressed_decoder.sv
 ibex_controller.sv

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -106,7 +106,7 @@ module ibex_core #(
 
 );
 
-  import ibex_defines::*;
+  import ibex_pkg::*;
 
   // IF/ID signals
   logic        instr_valid_id;

--- a/rtl/ibex_core_tracer.sv
+++ b/rtl/ibex_core_tracer.sv
@@ -87,7 +87,7 @@ module ibex_core_tracer #(
 
 );
 
-  import ibex_defines::*;
+  import ibex_pkg::*;
 
   ibex_core #(
     .MHPMCounterNum(MHPMCounterNum),

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -32,61 +32,61 @@ module ibex_cs_registers #(
     parameter bit RV32M                     = 0
 ) (
     // Clock and Reset
-    input  logic                     clk_i,
-    input  logic                     rst_ni,
+    input  logic                 clk_i,
+    input  logic                 rst_ni,
 
     // Core and Cluster ID
-    input  logic  [3:0]              core_id_i,
-    input  logic  [5:0]              cluster_id_i,
+    input  logic  [3:0]          core_id_i,
+    input  logic  [5:0]          cluster_id_i,
 
     // Interface to registers (SRAM like)
-    input  logic                     csr_access_i,
-    input  ibex_defines::csr_num_e   csr_addr_i,
-    input  logic [31:0]              csr_wdata_i,
-    input  ibex_defines::csr_op_e    csr_op_i,
-    output logic [31:0]              csr_rdata_o,
+    input  logic                 csr_access_i,
+    input  ibex_pkg::csr_num_e   csr_addr_i,
+    input  logic [31:0]          csr_wdata_i,
+    input  ibex_pkg::csr_op_e    csr_op_i,
+    output logic [31:0]          csr_rdata_o,
 
     // Interrupts
-    output logic                     m_irq_enable_o,
-    output logic [31:0]              csr_mepc_o,
+    output logic                 m_irq_enable_o,
+    output logic [31:0]          csr_mepc_o,
 
     // debug
-    input  ibex_defines::dbg_cause_e debug_cause_i,
-    input  logic                     debug_csr_save_i,
-    output logic [31:0]              csr_depc_o,
-    output logic                     debug_single_step_o,
-    output logic                     debug_ebreakm_o,
+    input  ibex_pkg::dbg_cause_e debug_cause_i,
+    input  logic                 debug_csr_save_i,
+    output logic [31:0]          csr_depc_o,
+    output logic                 debug_single_step_o,
+    output logic                 debug_ebreakm_o,
 
-    input  logic [31:0]              pc_if_i,
-    input  logic [31:0]              pc_id_i,
+    input  logic [31:0]          pc_if_i,
+    input  logic [31:0]          pc_id_i,
 
-    input  logic                     csr_save_if_i,
-    input  logic                     csr_save_id_i,
-    input  logic                     csr_restore_mret_i,
-    input  logic                     csr_restore_dret_i,
-    input  logic                     csr_save_cause_i,
-    input  logic [31:0]              csr_mtvec_i,
-    input  ibex_defines::exc_cause_e csr_mcause_i,
-    input  logic [31:0]              csr_mtval_i,
-    output logic                     illegal_csr_insn_o,     // access to non-existent CSR,
-                                                             // with wrong priviledge level, or
-                                                             // missing write permissions
-    input  logic                     instr_new_id_i,         // ID stage sees a new instr
+    input  logic                 csr_save_if_i,
+    input  logic                 csr_save_id_i,
+    input  logic                 csr_restore_mret_i,
+    input  logic                 csr_restore_dret_i,
+    input  logic                 csr_save_cause_i,
+    input  logic [31:0]          csr_mtvec_i,
+    input  ibex_pkg::exc_cause_e csr_mcause_i,
+    input  logic [31:0]          csr_mtval_i,
+    output logic                 illegal_csr_insn_o,     // access to non-existent CSR,
+                                                         // with wrong priviledge level, or
+                                                         // missing write permissions
+    input  logic                 instr_new_id_i,         // ID stage sees a new instr
 
     // Performance Counters
-    input  logic                     instr_ret_i,            // instr retired in ID/EX stage
-    input  logic                     instr_ret_compressed_i, // compressed instr retired
-    input  logic                     imiss_i,                // instr fetch
-    input  logic                     pc_set_i,               // PC was set to a new value
-    input  logic                     jump_i,                 // jump instr seen (j, jr, jal, jalr)
-    input  logic                     branch_i,               // branch instr seen (bf, bnf)
-    input  logic                     branch_taken_i,         // branch was taken
-    input  logic                     mem_load_i,             // load from memory in this cycle
-    input  logic                     mem_store_i,            // store to memory in this cycle
-    input  logic                     lsu_busy_i
+    input  logic                 instr_ret_i,            // instr retired in ID/EX stage
+    input  logic                 instr_ret_compressed_i, // compressed instr retired
+    input  logic                 imiss_i,                // instr fetch
+    input  logic                 pc_set_i,               // PC was set to a new value
+    input  logic                 jump_i,                 // jump instr seen (j, jr, jal, jalr)
+    input  logic                 branch_i,               // branch instr seen (bf, bnf)
+    input  logic                 branch_taken_i,         // branch was taken
+    input  logic                 mem_load_i,             // load from memory in this cycle
+    input  logic                 mem_store_i,            // store to memory in this cycle
+    input  logic                 lsu_busy_i
 );
 
-  import ibex_defines::*;
+  import ibex_pkg::*;
 
   // misa
   localparam logic [1:0] MXL = 2'd1; // M-XLEN: XLEN in M-Mode for RV32

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -34,71 +34,71 @@ module ibex_decoder #(
     parameter bit RV32M = 1
 ) (
     // to/from controller
-    output logic                     illegal_insn_o,        // illegal instr encountered
-    output logic                     ebrk_insn_o,           // trap instr encountered
-    output logic                     mret_insn_o,           // return from exception instr
-                                                            // encountered
-    output logic                     dret_insn_o,           // return from debug instr encountered
-    output logic                     ecall_insn_o,          // syscall instr encountered
-    output logic                     wfi_insn_o,            // wait for interrupt instr encountered
-    output logic                     jump_set_o,            // jump taken set signal
+    output logic                 illegal_insn_o,        // illegal instr encountered
+    output logic                 ebrk_insn_o,           // trap instr encountered
+    output logic                 mret_insn_o,           // return from exception instr
+                                                        // encountered
+    output logic                 dret_insn_o,           // return from debug instr encountered
+    output logic                 ecall_insn_o,          // syscall instr encountered
+    output logic                 wfi_insn_o,            // wait for interrupt instr encountered
+    output logic                 jump_set_o,            // jump taken set signal
 
     // from IF-ID pipeline register
-    input  logic                     instr_new_i,           // instruction read is new
-    input  logic [31:0]              instr_rdata_i,         // instruction read from memory/cache
-    input  logic                     illegal_c_insn_i,      // compressed instruction decode failed
+    input  logic                 instr_new_i,           // instruction read is new
+    input  logic [31:0]          instr_rdata_i,         // instruction read from memory/cache
+    input  logic                 illegal_c_insn_i,      // compressed instruction decode failed
 
     // immediates
-    output ibex_defines::imm_a_sel_e imm_a_mux_sel_o,       // immediate selection for operand a
-    output ibex_defines::imm_b_sel_e imm_b_mux_sel_o,       // immediate selection for operand b
-    output logic [31:0]              imm_i_type_o,
-    output logic [31:0]              imm_s_type_o,
-    output logic [31:0]              imm_b_type_o,
-    output logic [31:0]              imm_u_type_o,
-    output logic [31:0]              imm_j_type_o,
-    output logic [31:0]              zimm_rs1_type_o,
+    output ibex_pkg::imm_a_sel_e imm_a_mux_sel_o,       // immediate selection for operand a
+    output ibex_pkg::imm_b_sel_e imm_b_mux_sel_o,       // immediate selection for operand b
+    output logic [31:0]          imm_i_type_o,
+    output logic [31:0]          imm_s_type_o,
+    output logic [31:0]          imm_b_type_o,
+    output logic [31:0]          imm_u_type_o,
+    output logic [31:0]          imm_j_type_o,
+    output logic [31:0]          zimm_rs1_type_o,
 
     // register file
-    output ibex_defines::rf_wd_sel_e regfile_wdata_sel_o,   // RF write data selection
-    output logic                     regfile_we_o,          // write enable for regfile
-    output logic [4:0]               regfile_raddr_a_o,
-    output logic [4:0]               regfile_raddr_b_o,
-    output logic [4:0]               regfile_waddr_o,
+    output ibex_pkg::rf_wd_sel_e regfile_wdata_sel_o,   // RF write data selection
+    output logic                 regfile_we_o,          // write enable for regfile
+    output logic [4:0]           regfile_raddr_a_o,
+    output logic [4:0]           regfile_raddr_b_o,
+    output logic [4:0]           regfile_waddr_o,
 
     // ALU
-    output ibex_defines::alu_op_e    alu_operator_o,        // ALU operation selection
-    output ibex_defines::op_a_sel_e  alu_op_a_mux_sel_o,    // operand a selection: reg value, PC,
-                                                            // immediate or zero
-    output ibex_defines::op_b_sel_e  alu_op_b_mux_sel_o,    // operand b selection: reg value or
-                                                            // immediate
+    output ibex_pkg::alu_op_e    alu_operator_o,        // ALU operation selection
+    output ibex_pkg::op_a_sel_e  alu_op_a_mux_sel_o,    // operand a selection: reg value, PC,
+                                                        // immediate or zero
+    output ibex_pkg::op_b_sel_e  alu_op_b_mux_sel_o,    // operand b selection: reg value or
+                                                        // immediate
 
     // MULT & DIV
-    output logic                     mult_en_o,             // perform integer multiplication
-    output logic                     div_en_o,              // perform integer division or
-                                                            // remainder
-    output ibex_defines::md_op_e     multdiv_operator_o,
-    output logic [1:0]               multdiv_signed_mode_o,
+    output logic                 mult_en_o,             // perform integer multiplication
+    output logic                 div_en_o,              // perform integer division or
+                                                        // remainder
+    output ibex_pkg::md_op_e     multdiv_operator_o,
+    output logic [1:0]           multdiv_signed_mode_o,
 
     // CSRs
-    output logic                     csr_access_o,          // access to CSR
-    output ibex_defines::csr_op_e    csr_op_o,              // operation to perform on CSR
-    output logic                     csr_status_o,          // access to xstatus CSR
+    output logic                 csr_access_o,          // access to CSR
+    output ibex_pkg::csr_op_e    csr_op_o,              // operation to perform on CSR
+    output logic                 csr_status_o,          // access to xstatus CSR
 
     // LSU
-    output logic                     data_req_o,            // start transaction to data memory
-    output logic                     data_we_o,             // write enable
-    output logic [1:0]               data_type_o,           // size of transaction: byte, half
-                                                            // word or word
-    output logic                     data_sign_extension_o, // sign extension for data read from
-                                                            // memory
-    output logic [1:0]               data_reg_offset_o,     // register byte offset for stores
+    output logic                 data_req_o,            // start transaction to data memory
+    output logic                 data_we_o,             // write enable
+    output logic [1:0]           data_type_o,           // size of transaction: byte, half
+                                                        // word or word
+    output logic                 data_sign_extension_o, // sign extension for data read from
+                                                        // memory
+    output logic [1:0]           data_reg_offset_o,     // register byte offset for stores
 
     // jump/branches
-    output logic                     jump_in_dec_o,         // jump is being calculated in ALU
-    output logic                     branch_in_dec_o
+    output logic                 jump_in_dec_o,         // jump is being calculated in ALU
+    output logic                 branch_in_dec_o
 );
 
-  import ibex_defines::*;
+  import ibex_pkg::*;
 
   logic        illegal_insn;
   logic        illegal_reg_rv32e;

--- a/rtl/ibex_ex_block.sv
+++ b/rtl/ibex_ex_block.sv
@@ -29,32 +29,32 @@
 module ibex_ex_block #(
     parameter bit RV32M = 1
 ) (
-    input  logic                  clk_i,
-    input  logic                  rst_ni,
+    input  logic              clk_i,
+    input  logic              rst_ni,
 
     // ALU
-    input  ibex_defines::alu_op_e alu_operator_i,
-    input  logic [31:0]           alu_operand_a_i,
-    input  logic [31:0]           alu_operand_b_i,
+    input  ibex_pkg::alu_op_e alu_operator_i,
+    input  logic [31:0]       alu_operand_a_i,
+    input  logic [31:0]       alu_operand_b_i,
 
     // Multiplier/Divider
-    input  ibex_defines::md_op_e  multdiv_operator_i,
-    input  logic                  mult_en_i,
-    input  logic                  div_en_i,
-    input  logic  [1:0]           multdiv_signed_mode_i,
-    input  logic [31:0]           multdiv_operand_a_i,
-    input  logic [31:0]           multdiv_operand_b_i,
+    input  ibex_pkg::md_op_e  multdiv_operator_i,
+    input  logic              mult_en_i,
+    input  logic              div_en_i,
+    input  logic  [1:0]       multdiv_signed_mode_i,
+    input  logic [31:0]       multdiv_operand_a_i,
+    input  logic [31:0]       multdiv_operand_b_i,
 
     // Outputs
-    output logic [31:0]           alu_adder_result_ex_o, // to LSU
-    output logic [31:0]           regfile_wdata_ex_o,
-    output logic [31:0]           jump_target_o,         // to IF
-    output logic                  branch_decision_o,     // to ID
+    output logic [31:0]       alu_adder_result_ex_o, // to LSU
+    output logic [31:0]       regfile_wdata_ex_o,
+    output logic [31:0]       jump_target_o,         // to IF
+    output logic              branch_decision_o,     // to ID
 
-    output logic                  ex_valid_o             // EX has valid output
+    output logic              ex_valid_o             // EX has valid output
 );
 
-  import ibex_defines::*;
+  import ibex_pkg::*;
 
   localparam bit MULT_TYPE = 1; // 0 -> SLOW, 1 -> FAST
 

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -35,118 +35,118 @@ module ibex_id_stage #(
     parameter bit RV32E = 0,
     parameter bit RV32M = 1
 ) (
-    input  logic                      clk_i,
-    input  logic                      rst_ni,
+    input  logic                  clk_i,
+    input  logic                  rst_ni,
 
-    input  logic                      test_en_i,
+    input  logic                  test_en_i,
 
-    input  logic                      fetch_enable_i,
-    output logic                      ctrl_busy_o,
-    output logic                      core_ctrl_firstfetch_o,
-    output logic                      illegal_insn_o,
+    input  logic                  fetch_enable_i,
+    output logic                  ctrl_busy_o,
+    output logic                  core_ctrl_firstfetch_o,
+    output logic                  illegal_insn_o,
 
     // Interface to IF stage
-    input  logic                      instr_valid_i,
-    input  logic                      instr_new_i,
-    input  logic [31:0]               instr_rdata_i,         // from IF-ID pipeline registers
-    input  logic [15:0]               instr_rdata_c_i,       // from IF-ID pipeline registers
-    input  logic                      instr_is_compressed_i,
-    output logic                      instr_req_o,
-    output logic                      instr_valid_clear_o,   // kill instr in IF-ID reg
-    output logic                      id_in_ready_o,         // ID stage is ready for next instr
+    input  logic                  instr_valid_i,
+    input  logic                  instr_new_i,
+    input  logic [31:0]           instr_rdata_i,         // from IF-ID pipeline registers
+    input  logic [15:0]           instr_rdata_c_i,       // from IF-ID pipeline registers
+    input  logic                  instr_is_compressed_i,
+    output logic                  instr_req_o,
+    output logic                  instr_valid_clear_o,   // kill instr in IF-ID reg
+    output logic                  id_in_ready_o,         // ID stage is ready for next instr
 
     // Jumps and branches
-    input  logic                      branch_decision_i,
+    input  logic                  branch_decision_i,
 
     // IF and ID stage signals
-    output logic                      pc_set_o,
-    output ibex_defines::pc_sel_e     pc_mux_o,
-    output ibex_defines::exc_pc_sel_e exc_pc_mux_o,
+    output logic                  pc_set_o,
+    output ibex_pkg::pc_sel_e     pc_mux_o,
+    output ibex_pkg::exc_pc_sel_e exc_pc_mux_o,
 
-    input  logic                      illegal_c_insn_i,
+    input  logic                  illegal_c_insn_i,
 
-    input  logic [31:0]               pc_id_i,
+    input  logic [31:0]           pc_id_i,
 
     // Stalls
-    input  logic                      ex_valid_i,     // EX stage has valid output
-    input  logic                      lsu_valid_i,    // LSU has valid output, or is done
+    input  logic                  ex_valid_i,     // EX stage has valid output
+    input  logic                  lsu_valid_i,    // LSU has valid output, or is done
     // ALU
-    output ibex_defines::alu_op_e     alu_operator_ex_o,
-    output logic [31:0]               alu_operand_a_ex_o,
-    output logic [31:0]               alu_operand_b_ex_o,
+    output ibex_pkg::alu_op_e     alu_operator_ex_o,
+    output logic [31:0]           alu_operand_a_ex_o,
+    output logic [31:0]           alu_operand_b_ex_o,
 
     // MUL, DIV
-    output logic                      mult_en_ex_o,
-    output logic                      div_en_ex_o,
-    output ibex_defines::md_op_e      multdiv_operator_ex_o,
-    output logic  [1:0]               multdiv_signed_mode_ex_o,
-    output logic [31:0]               multdiv_operand_a_ex_o,
-    output logic [31:0]               multdiv_operand_b_ex_o,
+    output logic                  mult_en_ex_o,
+    output logic                  div_en_ex_o,
+    output ibex_pkg::md_op_e      multdiv_operator_ex_o,
+    output logic  [1:0]           multdiv_signed_mode_ex_o,
+    output logic [31:0]           multdiv_operand_a_ex_o,
+    output logic [31:0]           multdiv_operand_b_ex_o,
 
     // CSR
-    output logic                      csr_access_o,
-    output ibex_defines::csr_op_e     csr_op_o,
-    output logic                      csr_save_if_o,
-    output logic                      csr_save_id_o,
-    output logic                      csr_restore_mret_id_o,
-    output logic                      csr_restore_dret_id_o,
-    output logic                      csr_save_cause_o,
-    output logic [31:0]               csr_mtval_o,
-    input  logic                      illegal_csr_insn_i,
+    output logic                  csr_access_o,
+    output ibex_pkg::csr_op_e     csr_op_o,
+    output logic                  csr_save_if_o,
+    output logic                  csr_save_id_o,
+    output logic                  csr_restore_mret_id_o,
+    output logic                  csr_restore_dret_id_o,
+    output logic                  csr_save_cause_o,
+    output logic [31:0]           csr_mtval_o,
+    input  logic                  illegal_csr_insn_i,
 
     // Interface to load store unit
-    output logic                      data_req_ex_o,
-    output logic                      data_we_ex_o,
-    output logic [1:0]                data_type_ex_o,
-    output logic                      data_sign_ext_ex_o,
-    output logic [1:0]                data_reg_offset_ex_o,
-    output logic [31:0]               data_wdata_ex_o,
+    output logic                  data_req_ex_o,
+    output logic                  data_we_ex_o,
+    output logic [1:0]            data_type_ex_o,
+    output logic                  data_sign_ext_ex_o,
+    output logic [1:0]            data_reg_offset_ex_o,
+    output logic [31:0]           data_wdata_ex_o,
 
-    input  logic                      lsu_addr_incr_req_i,
-    input  logic [31:0]               lsu_addr_last_i,
+    input  logic                  lsu_addr_incr_req_i,
+    input  logic [31:0]           lsu_addr_last_i,
 
     // Interrupt signals
-    input  logic                      irq_i,
-    input  logic [4:0]                irq_id_i,
-    input  logic                      m_irq_enable_i,
-    output logic                      irq_ack_o,
-    output logic [4:0]                irq_id_o,
-    output ibex_defines::exc_cause_e  exc_cause_o,
+    input  logic                  irq_i,
+    input  logic [4:0]            irq_id_i,
+    input  logic                  m_irq_enable_i,
+    output logic                  irq_ack_o,
+    output logic [4:0]            irq_id_o,
+    output ibex_pkg::exc_cause_e  exc_cause_o,
 
-    input  logic                      lsu_load_err_i,
-    input  logic                      lsu_store_err_i,
+    input  logic                  lsu_load_err_i,
+    input  logic                  lsu_store_err_i,
 
     // Debug Signal
-    output ibex_defines::dbg_cause_e  debug_cause_o,
-    output logic                      debug_csr_save_o,
-    input  logic                      debug_req_i,
-    input  logic                      debug_single_step_i,
-    input  logic                      debug_ebreakm_i,
+    output ibex_pkg::dbg_cause_e  debug_cause_o,
+    output logic                  debug_csr_save_o,
+    input  logic                  debug_req_i,
+    input  logic                  debug_single_step_i,
+    input  logic                  debug_ebreakm_i,
 
     // Write back signal
-    input  logic [31:0]               regfile_wdata_lsu_i,
-    input  logic [31:0]               regfile_wdata_ex_i,
-    input  logic [31:0]               csr_rdata_i,
+    input  logic [31:0]           regfile_wdata_lsu_i,
+    input  logic [31:0]           regfile_wdata_ex_i,
+    input  logic [31:0]           csr_rdata_i,
 
 `ifdef RVFI
-    output logic [4:0]                rfvi_reg_raddr_ra_o,
-    output logic [31:0]               rfvi_reg_rdata_ra_o,
-    output logic [4:0]                rfvi_reg_raddr_rb_o,
-    output logic [31:0]               rfvi_reg_rdata_rb_o,
-    output logic [4:0]                rfvi_reg_waddr_rd_o,
-    output logic [31:0]               rfvi_reg_wdata_rd_o,
-    output logic                      rfvi_reg_we_o,
+    output logic [4:0]            rfvi_reg_raddr_ra_o,
+    output logic [31:0]           rfvi_reg_rdata_ra_o,
+    output logic [4:0]            rfvi_reg_raddr_rb_o,
+    output logic [31:0]           rfvi_reg_rdata_rb_o,
+    output logic [4:0]            rfvi_reg_waddr_rd_o,
+    output logic [31:0]           rfvi_reg_wdata_rd_o,
+    output logic                  rfvi_reg_we_o,
 `endif
 
     // Performance Counters
-    output logic                      perf_jump_o,    // executing a jump instr
-    output logic                      perf_branch_o,  // executing a branch instr
-    output logic                      perf_tbranch_o, // executing a taken branch instr
-    output logic                      instr_ret_o,
-    output logic                      instr_ret_compressed_o
+    output logic                  perf_jump_o,    // executing a jump instr
+    output logic                  perf_branch_o,  // executing a branch instr
+    output logic                  perf_tbranch_o, // executing a taken branch instr
+    output logic                  instr_ret_o,
+    output logic                  instr_ret_compressed_o
 );
 
-  import ibex_defines::*;
+  import ibex_pkg::*;
 
   // Decoder/Controller, ID stage internal signals
   logic        illegal_insn_dec;

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -30,60 +30,60 @@ module ibex_if_stage #(
     parameter int unsigned DmHaltAddr      = 32'h1A110800,
     parameter int unsigned DmExceptionAddr = 32'h1A110808
 ) (
-    input  logic                      clk_i,
-    input  logic                      rst_ni,
+    input  logic                   clk_i,
+    input  logic                   rst_ni,
 
-    input  logic [31:0]               boot_addr_i,              // also used for mtvec
-    input  logic                      req_i,                    // instruction request control
+    input  logic [31:0]            boot_addr_i,              // also used for mtvec
+    input  logic                   req_i,                    // instruction request control
 
     // instruction cache interface
-    output logic                      instr_req_o,
-    output logic [31:0]               instr_addr_o,
-    input  logic                      instr_gnt_i,
-    input  logic                      instr_rvalid_i,
-    input  logic [31:0]               instr_rdata_i,
+    output logic                  instr_req_o,
+    output logic [31:0]           instr_addr_o,
+    input  logic                  instr_gnt_i,
+    input  logic                  instr_rvalid_i,
+    input  logic [31:0]           instr_rdata_i,
 
     // Output of IF Pipeline stage
-    output logic                      instr_valid_id_o,         // instr in IF-ID is valid
-    output logic                      instr_new_id_o,           // instr in IF-ID is new
-    output logic [31:0]               instr_rdata_id_o,         // instr for ID stage
-    output logic [15:0]               instr_rdata_c_id_o,       // compressed instr for ID stage
-                                                                // (mtval), meaningful only if
-                                                                // instr_is_compressed_id_o = 1'b1
-    output logic                      instr_is_compressed_id_o, // compressed decoder thinks this
-                                                                // is a compressed instr
-    output logic                      illegal_c_insn_id_o,      // compressed decoder thinks this
-                                                                // is an invalid instr
-    output logic [31:0]               pc_if_o,
-    output logic [31:0]               pc_id_o,
+    output logic                  instr_valid_id_o,         // instr in IF-ID is valid
+    output logic                  instr_new_id_o,           // instr in IF-ID is new
+    output logic [31:0]           instr_rdata_id_o,         // instr for ID stage
+    output logic [15:0]           instr_rdata_c_id_o,       // compressed instr for ID stage
+                                                            // (mtval), meaningful only if
+                                                            // instr_is_compressed_id_o = 1'b1
+    output logic                  instr_is_compressed_id_o, // compressed decoder thinks this
+                                                            // is a compressed instr
+    output logic                  illegal_c_insn_id_o,      // compressed decoder thinks this
+                                                            // is an invalid instr
+    output logic [31:0]           pc_if_o,
+    output logic [31:0]           pc_id_o,
 
     // Forwarding ports - control signals
-    input  logic                      instr_valid_clear_i,      // clear instr valid bit in IF-ID
-    input  logic                      pc_set_i,                 // set the PC to a new value
-    input  logic [31:0]               csr_mepc_i,               // PC to restore after handling
-                                                                // the interrupt/exception
-    input  logic [31:0]               csr_depc_i,               // PC to restore after handling
-                                                                // the debug request
-    input  ibex_defines::pc_sel_e     pc_mux_i,                 // selector for PC multiplexer
-    input  ibex_defines::exc_pc_sel_e exc_pc_mux_i,             // selects ISR address
-    input  ibex_defines::exc_cause_e  exc_cause,                // selects ISR address for
+    input  logic                  instr_valid_clear_i,      // clear instr valid bit in IF-ID
+    input  logic                  pc_set_i,                 // set the PC to a new value
+    input  logic [31:0]           csr_mepc_i,               // PC to restore after handling
+                                                            // the interrupt/exception
+    input  logic [31:0]           csr_depc_i,               // PC to restore after handling
+                                                            // the debug request
+    input  ibex_pkg::pc_sel_e     pc_mux_i,                 // selector for PC multiplexer
+    input  ibex_pkg::exc_pc_sel_e exc_pc_mux_i,             // selects ISR address
+    input  ibex_pkg::exc_cause_e  exc_cause,                // selects ISR address for
                                                                 // vectorized interrupt lines
 
     // jump and branch target and decision
-    input  logic [31:0]               jump_target_ex_i,         // jump target address
+    input  logic [31:0]           jump_target_ex_i,         // jump target address
 
     // CSRs
-    output logic [31:0]               csr_mtvec_o,
+    output logic [31:0]           csr_mtvec_o,
 
     // pipeline stall
-    input  logic                      id_in_ready_i,            // ID stage is ready for new instr
+    input  logic                  id_in_ready_i,            // ID stage is ready for new instr
 
     // misc signals
-    output logic                      if_busy_o,                // IF stage is busy fetching instr
-    output logic                      perf_imiss_o              // instr fetch miss
+    output logic                  if_busy_o,                // IF stage is busy fetching instr
+    output logic                  perf_imiss_o              // instr fetch miss
 );
 
-  import ibex_defines::*;
+  import ibex_pkg::*;
 
   logic              offset_in_init_d, offset_in_init_q;
   logic              have_instr;

--- a/rtl/ibex_int_controller.sv
+++ b/rtl/ibex_int_controller.sv
@@ -38,7 +38,7 @@ module ibex_int_controller (
     input  logic        m_IE_i          // interrupt enable bit from CSR (M mode)
 );
 
-  import ibex_defines::*;
+  import ibex_pkg::*;
 
   typedef enum logic [1:0] { IDLE, IRQ_PENDING, IRQ_DONE} exc_ctrl_e;
   exc_ctrl_e exc_ctrl_ns, exc_ctrl_cs;

--- a/rtl/ibex_multdiv_fast.sv
+++ b/rtl/ibex_multdiv_fast.sv
@@ -24,26 +24,26 @@
  * 16x16 kernel multiplier and Long Division
  */
 module ibex_multdiv_fast (
-    input  logic                 clk_i,
-    input  logic                 rst_ni,
-    input  logic                 mult_en_i,
-    input  logic                 div_en_i,
-    input  ibex_defines::md_op_e operator_i,
-    input  logic  [1:0]          signed_mode_i,
-    input  logic [31:0]          op_a_i,
-    input  logic [31:0]          op_b_i,
-    input  logic [33:0]          alu_adder_ext_i,
-    input  logic [31:0]          alu_adder_i,
-    input  logic                 equal_to_zero,
+    input  logic             clk_i,
+    input  logic             rst_ni,
+    input  logic             mult_en_i,
+    input  logic             div_en_i,
+    input  ibex_pkg::md_op_e operator_i,
+    input  logic  [1:0]      signed_mode_i,
+    input  logic [31:0]      op_a_i,
+    input  logic [31:0]      op_b_i,
+    input  logic [33:0]      alu_adder_ext_i,
+    input  logic [31:0]      alu_adder_i,
+    input  logic             equal_to_zero,
 
-    output logic [32:0]          alu_operand_a_o,
-    output logic [32:0]          alu_operand_b_o,
+    output logic [32:0]      alu_operand_a_o,
+    output logic [32:0]      alu_operand_b_o,
 
-    output logic [31:0]          multdiv_result_o,
-    output logic                 valid_o
+    output logic [31:0]      multdiv_result_o,
+    output logic             valid_o
 );
 
-  import ibex_defines::*;
+  import ibex_pkg::*;
 
   logic [ 4:0] div_counter_q, div_counter_n;
   typedef enum logic [1:0] {

--- a/rtl/ibex_multdiv_slow.sv
+++ b/rtl/ibex_multdiv_slow.sv
@@ -21,26 +21,26 @@
  * Baugh-Wooley multiplier and Long Division
  */
 module ibex_multdiv_slow (
-    input  logic                 clk_i,
-    input  logic                 rst_ni,
-    input  logic                 mult_en_i,
-    input  logic                 div_en_i,
-    input  ibex_defines::md_op_e operator_i,
-    input  logic  [1:0]          signed_mode_i,
-    input  logic [31:0]          op_a_i,
-    input  logic [31:0]          op_b_i,
-    input  logic [33:0]          alu_adder_ext_i,
-    input  logic [31:0]          alu_adder_i,
-    input  logic                 equal_to_zero,
+    input  logic             clk_i,
+    input  logic             rst_ni,
+    input  logic             mult_en_i,
+    input  logic             div_en_i,
+    input  ibex_pkg::md_op_e operator_i,
+    input  logic  [1:0]      signed_mode_i,
+    input  logic [31:0]      op_a_i,
+    input  logic [31:0]      op_b_i,
+    input  logic [33:0]      alu_adder_ext_i,
+    input  logic [31:0]      alu_adder_i,
+    input  logic             equal_to_zero,
 
-    output logic [32:0]          alu_operand_a_o,
-    output logic [32:0]          alu_operand_b_o,
-    output logic [31:0]          multdiv_result_o,
+    output logic [32:0]      alu_operand_a_o,
+    output logic [32:0]      alu_operand_b_o,
+    output logic [31:0]      multdiv_result_o,
 
-    output logic                 valid_o
+    output logic             valid_o
 );
 
-  import ibex_defines::*;
+  import ibex_pkg::*;
 
   logic [ 4:0] multdiv_state_q, multdiv_state_d, multdiv_state_m1;
   typedef enum logic [2:0] {

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -19,9 +19,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
- * Defines for various constants used by the processor core
+ * Package with constants used by Ibex
  */
-package ibex_defines;
+package ibex_pkg;
 
 
 /////////////

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -19,8 +19,8 @@
 
 `ifndef VERILATOR
 
-import ibex_defines::*;
-import ibex_tracer_defines::*;
+import ibex_pkg::*;
+import ibex_tracer_pkg::*;
 
 // Source/Destination register instruction index
 `define REG_S1 19:15

--- a/rtl/ibex_tracer_pkg.sv
+++ b/rtl/ibex_tracer_pkg.sv
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-package ibex_tracer_defines;
-import ibex_defines::*;
+package ibex_tracer_pkg;
+import ibex_pkg::*;
 
 // instruction masks (for tracer)
 parameter logic [31:0] INSTR_LUI     = { 25'b?,                           {OPCODE_LUI  } };

--- a/src_files.yml
+++ b/src_files.yml
@@ -3,7 +3,6 @@ ibex:
   ]
   files: [
     ibex_defines.sv,
-    ibex_tracer_defines.sv,
     ibex_alu.sv,
     ibex_compressed_decoder.sv,
     ibex_controller.sv,

--- a/src_files.yml
+++ b/src_files.yml
@@ -2,7 +2,7 @@ ibex:
   incdirs: [
   ]
   files: [
-    ibex_defines.sv,
+    ibex_pkg.sv,
     ibex_alu.sv,
     ibex_compressed_decoder.sv,
     ibex_controller.sv,
@@ -27,8 +27,8 @@ ibex_vip_rtl:
   incdirs: [
   ]
   files: [
-    ibex_defines.sv,
-    ibex_tracer_defines.sv,
+    ibex_pkg.sv,
+    ibex_tracer_pkg.sv,
     ibex_tracer.sv,
   ]
 ibex_regfile_rtl:


### PR DESCRIPTION
Rename _defines.sv to _pkg.sv. Patch best viewed without whitespace changes.