### PR TITLE
Rename cores for fusesoc, mainly tracer

### DIFF
--- a/doc/tracer.rst
+++ b/doc/tracer.rst
@@ -4,7 +4,7 @@ Tracer
 ======
 
 The module ``ibex_tracer`` can be used to create a log of the executed instructions.
-It is used by ``ibex_core_tracer`` which forwards the signals added by :ref:`rvfi` as an input for the tracer.
+It is used by ``ibex_core_tracing`` which forwards the signals added by :ref:`rvfi` as an input for the tracer.
 
 .. note::
 

--- a/dv/uvm/ibex_dv.f
+++ b/dv/uvm/ibex_dv.f
@@ -25,7 +25,7 @@ ${PRJ_DIR}/ibex/rtl/ibex_prefetch_buffer.sv
 ${PRJ_DIR}/ibex/rtl/ibex_fetch_fifo.sv
 ${PRJ_DIR}/ibex/rtl/ibex_register_file_ff.sv
 ${PRJ_DIR}/ibex/rtl/ibex_core.sv
-${PRJ_DIR}/ibex/rtl/ibex_core_tracer.sv
+${PRJ_DIR}/ibex/rtl/ibex_core_tracing.sv
 
 // Core DV files
 +incdir+${PRJ_DIR}/ibex/dv/uvm/env

--- a/dv/uvm/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/tb/core_ibex_tb_top.sv
@@ -14,8 +14,8 @@ module core_ibex_tb_top;
   clk_if ibex_clk_if(.clk(clk));
 
   // TODO(taliu) Resolve the tied-off ports
-  ibex_core_tracer #(.DmHaltAddr(`BOOT_ADDR + 'h40),
-                     .DmExceptionAddr(`BOOT_ADDR + 'h44)
+  ibex_core_tracing #(.DmHaltAddr(`BOOT_ADDR + 'h40),
+                      .DmExceptionAddr(`BOOT_ADDR + 'h44)
   ) dut (
     .clk_i(clk),
     .rst_ni(rst_n),

--- a/examples/fpga/artya7-100/top_artya7_100.core
+++ b/examples/fpga/artya7-100/top_artya7_100.core
@@ -7,7 +7,7 @@ description: "Ibex example toplevel for the Arty A7-100 board"
 filesets:
   files_rtl_artya7:
     depend:
-      - lowrisc:ibex:ibex
+      - lowrisc:ibex:ibex_core
     files:
       - rtl/top_artya7_100.sv
       - rtl/ram_1p.sv

--- a/examples/sim/README.md
+++ b/examples/sim/README.md
@@ -1,8 +1,8 @@
-# Ibex tracer simulation example
+# Example: Ibex with enabled instruction tracing for simulation
 
 ## Overview
 
-This examples shows the usage of the module `ibex_core_tracer` which forwards
+This examples shows the usage of the module `ibex_core_tracing` which forwards
 all port signals to the `ibex_core` and a subset of signals to `ibex_tracer`.
 The tracer will create a file with a stream of executed instructions.
 
@@ -20,7 +20,7 @@ export MODEL_TECH=/path/to/modelsim/bin
 Run the following command in the top level directory.
 
 ```
-fusesoc --cores-root=. run --target=sim lowrisc:ibex:top_tracer_sim
+fusesoc --cores-root=. run --target=sim lowrisc:ibex:top_tracing_sim
 ```
 
-The trace output can be found in `build/lowrisc_ibex_top_tracer_sim_0.1/sim-modelsim/trace_core_00_0.log`.
+The trace output can be found in `build/lowrisc_ibex_top_tracing_sim_0.1/sim-modelsim/trace_core_00_0.log`.

--- a/examples/sim/tb/ibex_tracing_tb.sv
+++ b/examples/sim/tb/ibex_tracing_tb.sv
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Sample testbench for Ibex tracer
+// Sample testbench for Ibex with tracing enabled
 // The `nop` instruction is the only input
 
-module ibex_tracer_tb;
+module ibex_tracing_tb;
   logic         clk          = 1'b0;
   logic         rst_n        = 1'b0;
   logic [31:0]  instr_rdata  = 32'h00000013;
@@ -70,7 +70,7 @@ module ibex_tracer_tb;
     #10ns  instr_rdata  = 32'h0000000f;
   end
 
-  ibex_core_tracer ibex_i (
+  ibex_core_tracing ibex_i (
     .clk_i                  (clk),
     .rst_ni                 (rst_n),
 
@@ -107,29 +107,6 @@ module ibex_tracer_tb;
 
     // Debug Interface
     .debug_req_i            (1'b0),
-
-    // RISC-V Formal Interface
-    .rvfi_valid             (),
-    .rvfi_order             (),
-    .rvfi_insn              (),
-    .rvfi_insn_uncompressed (),
-    .rvfi_trap              (),
-    .rvfi_halt              (),
-    .rvfi_intr              (),
-    .rvfi_mode              (),
-    .rvfi_rs1_addr          (),
-    .rvfi_rs2_addr          (),
-    .rvfi_rs1_rdata         (),
-    .rvfi_rs2_rdata         (),
-    .rvfi_rd_addr           (),
-    .rvfi_rd_wdata          (),
-    .rvfi_pc_rdata          (),
-    .rvfi_pc_wdata          (),
-    .rvfi_mem_addr          (),
-    .rvfi_mem_rmask         (),
-    .rvfi_mem_wmask         (),
-    .rvfi_mem_rdata         (),
-    .rvfi_mem_wdata         (),
 
     // CPU Control Signals
     .fetch_enable_i         (1'b1)

--- a/examples/sim/top_tracing_sim.core
+++ b/examples/sim/top_tracing_sim.core
@@ -2,15 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:ibex:top_tracer_sim:0.1"
-description: "Ibex tracer example for modelsim"
+name: "lowrisc:ibex:top_tracing_sim:0.1"
+description: "Ibex with tracing enabled (ModelSim only right now)"
 filesets:
   files_tb:
     depend:
-      - lowrisc:ibex:tracer
+      - lowrisc:ibex:ibex_core_tracing
     files:
       - rtl/prim_clock_gating.sv
-      - tb/ibex_tracer_tb.sv
+      - tb/ibex_tracing_tb.sv
     file_type: systemVerilogSource
 
 targets:
@@ -19,7 +19,7 @@ targets:
     filesets:
       - files_tb
     toplevel:
-      - ibex_tracer_tb
+      - ibex_tracing_tb
     tools:
       modelsim:
         vlog_options: [-timescale=1ns/1ns]

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:ibex:ibex:0.1"
+name: "lowrisc:ibex:ibex_core:0.1"
 description: "CPU core with 2 stage pipeline implementing the RV32IMC_Zicsr ISA"
 filesets:
   files_rtl:
@@ -28,6 +28,11 @@ filesets:
       - rtl/ibex_register_file_ff.sv # FPGA
       - rtl/ibex_core.sv
     file_type: systemVerilogSource
+
+parameters:
+  RVFI:
+    datatype: bool
+    paramtype: vlogdefine
 
 targets:
   default:

--- a/ibex_core_tracing.core
+++ b/ibex_core_tracing.core
@@ -1,0 +1,28 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ibex:ibex_core_tracing:0.1"
+description: "Ibex CPU core with tracing enabled"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:ibex:ibex_core
+      - lowrisc:ibex:ibex_tracer
+    files:
+      - rtl/ibex_core_tracing.sv
+    file_type: systemVerilogSource
+
+parameters:
+  # The tracer uses the RISC-V Formal Interface (RVFI) to collect trace signals.
+  RVFI:
+    datatype: bool
+    paramtype: vlogdefine
+    default: true
+
+targets:
+  default:
+    filesets:
+      - files_rtl
+    parameters:
+      - RVFI=true

--- a/ibex_tracer.core
+++ b/ibex_tracer.core
@@ -2,27 +2,16 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:ibex:tracer:0.1"
-description: "core_ibex_tracer"
+name: "lowrisc:ibex:ibex_tracer:0.1"
+description: "Tracer for use with Ibex using the RVFI interface"
 filesets:
   files_rtl:
-    depend:
-      - lowrisc:ibex:ibex
     files:
       - rtl/ibex_tracer_pkg.sv
       - rtl/ibex_tracer.sv
-      - rtl/ibex_core_tracer.sv
     file_type: systemVerilogSource
-
-parameters:
-  RVFI:
-    datatype: bool
-    paramtype: vlogdefine
-    description: Enable RVFI signals for tracing
 
 targets:
   default:
     filesets:
       - files_rtl
-    parameters:
-      - RVFI=true

--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -3,13 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-// ibex_tracer relies on the signals from the RISC-V Formal Interface
-`define RVFI
-
 /**
  * Top level module of the ibex RISC-V core with tracing enabled
  */
-module ibex_core_tracer #(
+module ibex_core_tracing #(
     parameter int unsigned MHPMCounterNum   = 8,
     parameter int unsigned MHPMCounterWidth = 40,
     parameter bit RV32E                     = 0,
@@ -55,39 +52,39 @@ module ibex_core_tracer #(
     // Debug Interface
     input  logic        debug_req_i,
 
-    // RISC-V Formal Interface
-    // Does not comply with the coding standards of _i/_o suffixes, but follows
-    // the convention of RISC-V Formal Interface Specification.
-`ifdef RVFI
-    output logic        rvfi_valid,
-    output logic [63:0] rvfi_order,
-    output logic [31:0] rvfi_insn,
-    output logic [31:0] rvfi_insn_uncompressed,
-    output logic        rvfi_trap,
-    output logic        rvfi_halt,
-    output logic        rvfi_intr,
-    output logic [ 1:0] rvfi_mode,
-    output logic [ 4:0] rvfi_rs1_addr,
-    output logic [ 4:0] rvfi_rs2_addr,
-    output logic [31:0] rvfi_rs1_rdata,
-    output logic [31:0] rvfi_rs2_rdata,
-    output logic [ 4:0] rvfi_rd_addr,
-    output logic [31:0] rvfi_rd_wdata,
-    output logic [31:0] rvfi_pc_rdata,
-    output logic [31:0] rvfi_pc_wdata,
-    output logic [31:0] rvfi_mem_addr,
-    output logic [ 3:0] rvfi_mem_rmask,
-    output logic [ 3:0] rvfi_mem_wmask,
-    output logic [31:0] rvfi_mem_rdata,
-    output logic [31:0] rvfi_mem_wdata,
-`endif
-
     // CPU Control Signals
     input  logic        fetch_enable_i
 
 );
 
   import ibex_pkg::*;
+
+  // ibex_tracer relies on the signals from the RISC-V Formal Interface
+  `ifndef RVFI
+    Fatal error: RVFI needs to be defined globally.
+  `endif
+
+  logic        rvfi_valid;
+  logic [63:0] rvfi_order;
+  logic [31:0] rvfi_insn;
+  logic [31:0] rvfi_insn_uncompressed;
+  logic        rvfi_trap;
+  logic        rvfi_halt;
+  logic        rvfi_intr;
+  logic [ 1:0] rvfi_mode;
+  logic [ 4:0] rvfi_rs1_addr;
+  logic [ 4:0] rvfi_rs2_addr;
+  logic [31:0] rvfi_rs1_rdata;
+  logic [31:0] rvfi_rs2_rdata;
+  logic [ 4:0] rvfi_rd_addr;
+  logic [31:0] rvfi_rd_wdata;
+  logic [31:0] rvfi_pc_rdata;
+  logic [31:0] rvfi_pc_wdata;
+  logic [31:0] rvfi_mem_addr;
+  logic [ 3:0] rvfi_mem_rmask;
+  logic [ 3:0] rvfi_mem_wmask;
+  logic [31:0] rvfi_mem_rdata;
+  logic [31:0] rvfi_mem_wdata;
 
   ibex_core #(
     .MHPMCounterNum(MHPMCounterNum),
@@ -129,7 +126,6 @@ module ibex_core_tracer #(
 
     .debug_req_i,
 
-`ifdef RVFI
     .rvfi_valid,
     .rvfi_order,
     .rvfi_insn,
@@ -151,14 +147,13 @@ module ibex_core_tracer #(
     .rvfi_mem_wmask,
     .rvfi_mem_rdata,
     .rvfi_mem_wdata,
-`endif
 
     .fetch_enable_i
   );
 
 
 `ifndef VERILATOR
-  ibex_tracer ibex_tracer_i (
+  ibex_tracer u_ibex_tracer (
       .clk_i            ( clk_i                  ),
       .rst_ni           ( rst_ni                 ),
 
@@ -177,6 +172,8 @@ module ibex_core_tracer #(
       .ex_data_wdata_i  ( rvfi_mem_wdata         ),
       .ex_data_rdata_i  ( rvfi_mem_rdata         )
   );
-`endif // VERILATOR
+`else
+    // ibex_tracer uses language constructs which Verilator doesn't understand.
+`endif
 
 endmodule

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -17,7 +17,6 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-`ifndef VERILATOR
 
 import ibex_pkg::*;
 import ibex_tracer_pkg::*;
@@ -30,6 +29,9 @@ import ibex_tracer_pkg::*;
 
 /**
  * Traces the executed instructions
+ *
+ * Note: Verilator does not support the language constructs used in this
+ * module!
  */
 module ibex_tracer #(
     parameter int unsigned RegAddrWidth = 5
@@ -418,5 +420,3 @@ endmodule
 `undef REG_S2
 `undef REG_S3
 `undef REG_D
-
-`endif

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -17,10 +17,6 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-
-import ibex_pkg::*;
-import ibex_tracer_pkg::*;
-
 // Source/Destination register instruction index
 `define REG_S1 19:15
 `define REG_S2 24:20
@@ -55,6 +51,9 @@ module ibex_tracer #(
     input  logic [31:0]               ex_data_wdata_i,
     input  logic [31:0]               ex_data_rdata_i
 );
+
+  import ibex_pkg::*;
+  import ibex_tracer_pkg::*;
 
   integer      f;
   string       fn;


### PR DESCRIPTION
Painful, but needed for symmetry and to reduce confusion: rename the cores in the fusesoc core files.

This PR requires RVFI to be defined globally if the ibex_core_tracing.sv is used to avoid potential design bugs caused by differing tool behavior. It's better to be explicit here.

If RVFI is not set and the ibex_core_tracing.sv file is used a compile error will be thrown as the file includes invalid syntax. I'm not yet sure that this is the right way to go, but it seems that there's no universally understood way to convince a Verilog parser to issue a compile-time fatal error.