### PR TITLE
Update google_riscv-dv to 4e0d063

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: 2e5a40145a367ac3b04f78fee02c5011022719fd
+    rev: 4e0d063fea574cfae55c5bb627771b69d9899899
   }
 }

--- a/vendor/google_riscv-dv/run
+++ b/vendor/google_riscv-dv/run
@@ -147,7 +147,7 @@ if [[ "$SIMULATOR" == "vcs" ]]; then
                    -Mdir=$OUT/vcs_simv.csrc \
                    -o $OUT/vcs_simv ${CMP_OPTS}"
 
-  SIM_CMD="$OUT/vcs_simv +UVM_TESTNAME="
+  SIM_CMD="$OUT/vcs_simv +vcs+lic+wait +UVM_TESTNAME="
 
 elif [[ "$SIMULATOR" == "irun" ]]; then
 

--- a/vendor/google_riscv-dv/src/riscv_instr_pkg.sv
+++ b/vendor/google_riscv-dv/src/riscv_instr_pkg.sv
@@ -22,7 +22,7 @@ package riscv_instr_pkg;
   `include "dv_defines.svh"
   `include "riscv_defines.svh"
 
-  `define include_file(f) `include "``f``"
+  `define include_file(f) `include `"f`"
 
   typedef enum bit [3:0] {
     BARE = 4'b0000,


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision 4e0d063fea574cfae55c5bb627771b69d9899899

* Merge pull request #38 from google/dev (taoliug)
* Fix illegal instruction test issue Fix Xcelium compile failure #37
  (Tao Liu)