### PR TITLE
Update google_riscv-dv to 112dcc2

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: 4e0d063fea574cfae55c5bb627771b69d9899899
+    rev: 112dcc2e669f124dfe48c35a09477603c3ccb180
   }
 }

--- a/vendor/google_riscv-dv/src/riscv_instr_gen_config.sv
+++ b/vendor/google_riscv-dv/src/riscv_instr_gen_config.sv
@@ -59,7 +59,7 @@ class riscv_instr_gen_config extends uvm_object;
   // Options for privileged mode CSR checking
   // Below checking can be made optional as the ISS implementation could be different with the
   // processor.
-  bit                    check_misa_init_val = 1'b1;
+  bit                    check_misa_init_val = 1'b0;
   bit                    check_xstatus = 1'b1;
 
   //-----------------------------------------------------------------------------
@@ -75,7 +75,7 @@ class riscv_instr_gen_config extends uvm_object;
   // Options to turn off some specific types of instructions
   bit                    no_branch_jump;   // No branch/jump instruction
   bit                    no_load_store;    // No load/store instruction
-  bit                    no_csr_instr = 1; // No csr instruction
+  bit                    no_csr_instr;     // No csr instruction
   bit                    no_ebreak = 1;    // No ebreak instruction
   bit                    no_fence;         // No fence instruction
   bit                    no_wfi = 1;       // No WFI instruction
@@ -90,6 +90,10 @@ class riscv_instr_gen_config extends uvm_object;
   string                 asm_test_suffix;
   // Enable interrupt bit in MSTATUS (MIE, SIE, UIE)
   int                    enable_interrupt;
+  // Enable accessing illegal CSR instruction
+  // - Accessing non-existence CSR
+  // - Accessing CSR with wrong privileged mode
+  bit                    enable_illegal_csr_instruction;
   // sfence support
   bit                    allow_sfence_exception = 0;
   // Interrupt/Exception Delegation
@@ -237,6 +241,7 @@ class riscv_instr_gen_config extends uvm_object;
     get_bool_arg_value("+no_branch_jump=", no_branch_jump);
     get_bool_arg_value("+no_load_store=", no_load_store);
     get_bool_arg_value("+no_csr_instr=", no_csr_instr);
+    get_bool_arg_value("+enable_illegal_csr_instruction=", enable_illegal_csr_instruction);
     get_bool_arg_value("+allow_sfence_exception=", allow_sfence_exception);
     get_bool_arg_value("+no_data_page=", no_data_page);
     get_bool_arg_value("+no_directed_instr=", no_directed_instr);

--- a/vendor/google_riscv-dv/src/riscv_rand_instr.sv
+++ b/vendor/google_riscv-dv/src/riscv_rand_instr.sv
@@ -72,9 +72,6 @@ class riscv_rand_instr extends riscv_instr_base;
   }
 
   constraint constraint_cfg_knob_c {
-    if(cfg.no_csr_instr == 1) {
-      category != CSR;
-    }
     if(cfg.no_ebreak) {
       instr_name != EBREAK;
       instr_name != C_EBREAK;
@@ -90,6 +87,25 @@ class riscv_rand_instr extends riscv_instr_base;
     }
     if(cfg.no_branch_jump) {
       category != BRANCH;
+    }
+  }
+
+  constraint csr_instr_c {
+    if(cfg.no_csr_instr == 1) {
+      category != CSR;
+    } else {
+      if (cfg.enable_illegal_csr_instruction) {
+        !(csr inside {implemented_csr});
+      } else {
+        // Use scratch register to avoid the side effect of modifying other privileged mode CSR.
+        if (cfg.init_privileged_mode == MACHINE_MODE) {
+          csr == MSCRATCH;
+        } else if (cfg.init_privileged_mode == SUPERVISOR_MODE) {
+          csr == SSCRATCH;
+        } else {
+          csr == USCRATCH;
+        }
+      }
     }
   }
 

--- a/vendor/google_riscv-dv/test/riscv_instr_test_lib.sv
+++ b/vendor/google_riscv-dv/test/riscv_instr_test_lib.sv
@@ -57,8 +57,11 @@
 // riscv_wfi_test:
 //  - Randomly inject wfi instruction, verify core can be halted and resumed properly(by interrupt)
 //
-// riscv_privileged_csr_test:
-//  - To be released soon
+// riscv_csr_test:
+//  - Random instructions with CSR intruction enabled
+//
+// riscv_illegal_csr_test:
+//  - Accessing non-existence CSR or CSR with the wrong privileged mode
 //
 //================================================================================================
 
@@ -274,6 +277,18 @@ class riscv_wfi_test extends riscv_rand_instr_test;
 
   virtual function void randomize_cfg();
     cfg.no_wfi = 1'b0;
+    super.randomize_cfg();
+  endfunction
+
+endclass
+
+class riscv_illegal_csr_test extends riscv_rand_instr_test;
+
+  `uvm_component_utils(riscv_illegal_csr_test)
+  `uvm_component_new
+
+  virtual function void randomize_cfg();
+    cfg.enable_illegal_csr_instruction = 1'b1;
     super.randomize_cfg();
   endfunction
 


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision 112dcc2e669f124dfe48c35a09477603c3ccb180

* Merge pull request #39 from google/dev (taoliug)
* CSR instruction update (Tao Liu)