### PR TITLE
Cleanup CSRs

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -86,7 +86,6 @@ module ibex_controller (
     output logic                  csr_save_if_o,
     output logic                  csr_save_id_o,
     output logic                  csr_restore_mret_id_o,
-    output logic                  csr_restore_dret_id_o,
     output logic                  csr_save_cause_o,
     output logic [31:0]           csr_mtval_o,
 
@@ -203,7 +202,6 @@ module ibex_controller (
     csr_save_if_o         = 1'b0;
     csr_save_id_o         = 1'b0;
     csr_restore_mret_id_o = 1'b0;
-    csr_restore_dret_id_o = 1'b0;
     csr_save_cause_o      = 1'b0;
     csr_mtval_o           = '0;
 
@@ -519,7 +517,6 @@ module ibex_controller (
           end else if (dret_insn_i) begin
             pc_mux_o              = PC_DRET;
             pc_set_o              = 1'b1;
-            csr_restore_dret_id_o = 1'b1;
             debug_mode_d          = 1'b0;
           end else if (wfi_insn_i) begin
             ctrl_fsm_ns           = WAIT_SLEEP;

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -199,7 +199,6 @@ module ibex_core #(
   logic        csr_save_if;
   logic        csr_save_id;
   logic        csr_restore_mret_id;
-  logic        csr_restore_dret_id;
   logic        csr_save_cause;
   logic [31:0] csr_mtvec;
   logic [31:0] csr_mtval;
@@ -400,10 +399,9 @@ module ibex_core #(
       // CSR ID/EX
       .csr_access_o                 ( csr_access             ),
       .csr_op_o                     ( csr_op                 ),
-      .csr_save_if_o                ( csr_save_if            ), // control signal to save pc
-      .csr_save_id_o                ( csr_save_id            ), // control signal to save pc
-      .csr_restore_mret_id_o        ( csr_restore_mret_id    ), // control signal to restore pc
-      .csr_restore_dret_id_o        ( csr_restore_dret_id    ), // control signal to restore pc
+      .csr_save_if_o                ( csr_save_if            ), // control signal to save PC
+      .csr_save_id_o                ( csr_save_id            ), // control signal to save PC
+      .csr_restore_mret_id_o        ( csr_restore_mret_id    ), // restore mstatus upon MRET
       .csr_save_cause_o             ( csr_save_cause         ),
       .csr_mtval_o                  ( csr_mtval              ),
       .illegal_csr_insn_i           ( illegal_csr_insn_id    ),
@@ -593,7 +591,6 @@ module ibex_core #(
       .csr_save_if_i           ( csr_save_if            ),
       .csr_save_id_i           ( csr_save_id            ),
       .csr_restore_mret_i      ( csr_restore_mret_id    ),
-      .csr_restore_dret_i      ( csr_restore_dret_id    ),
       .csr_save_cause_i        ( csr_save_cause         ),
       .csr_mtvec_i             ( csr_mtvec              ),
       .csr_mcause_i            ( exc_cause              ),

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -113,26 +113,9 @@ module ibex_cs_registers #(
     | (0          << 23)  // X - Non-standard extensions present
     | (32'(MXL)   << 30); // M-XLEN
 
-  `define MSTATUS_UIE_BITS        0
-  `define MSTATUS_SIE_BITS        1
-  `define MSTATUS_MIE_BITS        3
-  `define MSTATUS_UPIE_BITS       4
-  `define MSTATUS_SPIE_BITS       5
-  `define MSTATUS_MPIE_BITS       7
-  `define MSTATUS_SPP_BITS        8
-  `define MSTATUS_MPP_BITS    12:11
-
   typedef struct packed {
-    //logic uie;       - unimplemented, hardwired to '0
-    // logic sie;      - unimplemented, hardwired to '0
-    // logic hie;      - unimplemented, hardwired to '0
-    logic mie;
-    //logic upie;     - unimplemented, hardwired to '0
-    // logic spie;     - unimplemented, hardwired to '0
-    // logic hpie;     - unimplemented, hardwired to '0
-    logic mpie;
-    // logic spp;      - unimplemented, hardwired to '0
-    // logic[1:0] hpp; - unimplemented, hardwired to '0
+    logic      mie;
+    logic      mpie;
     priv_lvl_e mpp;
   } Status_t;
 
@@ -238,15 +221,10 @@ module ibex_cs_registers #(
 
       // mstatus: always M-mode, contains IE bit
       CSR_MSTATUS: begin
-        csr_rdata_int = {
-            19'b0,
-            mstatus_q.mpp,
-            3'b0,
-            mstatus_q.mpie,
-            3'h0,
-            mstatus_q.mie,
-            3'h0
-        };
+        csr_rdata_int                                                   = '0;
+        csr_rdata_int[CSR_MSTATUS_MIE_BIT]                              = mstatus_q.mie;
+        csr_rdata_int[CSR_MSTATUS_MPIE_BIT]                             = mstatus_q.mpie;
+        csr_rdata_int[CSR_MSTATUS_MPP_BIT_HIGH:CSR_MSTATUS_MPP_BIT_LOW] = mstatus_q.mpp;
       end
 
       // misa
@@ -358,8 +336,8 @@ module ibex_cs_registers #(
       CSR_MSTATUS: begin
         if (csr_we_int) begin
           mstatus_d = '{
-              mie:  csr_wdata_int[`MSTATUS_MIE_BITS],
-              mpie: csr_wdata_int[`MSTATUS_MPIE_BITS],
+              mie:  csr_wdata_int[CSR_MSTATUS_MIE_BIT],
+              mpie: csr_wdata_int[CSR_MSTATUS_MPIE_BIT],
               mpp:  PRIV_LVL_M
           };
         end

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -72,7 +72,6 @@ module ibex_cs_registers #(
     input  logic                 csr_save_if_i,
     input  logic                 csr_save_id_i,
     input  logic                 csr_restore_mret_i,
-    input  logic                 csr_restore_dret_i,
     input  logic                 csr_save_cause_i,
     input  logic [31:0]          csr_mtvec_i,
     input  ibex_pkg::exc_cause_e csr_mcause_i,
@@ -488,11 +487,6 @@ module ibex_cs_registers #(
         mepc_d         = mstack_epc_q;
         mcause_d       = mstack_cause_q;
       end // csr_restore_mret_i
-
-      csr_restore_dret_i: begin // DRET
-        mstatus_d.mie  = mstatus_q.mpie;
-        mstatus_d.mpie = 1'b1;
-      end // csr_restore_dret_i
 
       default:;
     endcase

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -90,7 +90,6 @@ module ibex_id_stage #(
     output logic                  csr_save_if_o,
     output logic                  csr_save_id_o,
     output logic                  csr_restore_mret_id_o,
-    output logic                  csr_restore_dret_id_o,
     output logic                  csr_save_cause_o,
     output logic [31:0]           csr_mtval_o,
     input  logic                  illegal_csr_insn_i,
@@ -453,7 +452,6 @@ module ibex_id_stage #(
       .csr_save_if_o                  ( csr_save_if_o          ),
       .csr_save_id_o                  ( csr_save_id_o          ),
       .csr_restore_mret_id_o          ( csr_restore_mret_id_o  ),
-      .csr_restore_dret_id_o          ( csr_restore_dret_id_o  ),
       .csr_save_cause_o               ( csr_save_cause_o       ),
       .csr_mtval_o                    ( csr_mtval_o            ),
 

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -246,6 +246,12 @@ parameter logic [11:0] CSR_OFF_MCOUNTER       = 12'hB00; // mcounter       @ 12'
 parameter logic [11:0] CSR_OFF_MCOUNTERH      = 12'hB80; // mcounterh      @ 12'hB83 - 12'hB9F
 parameter logic [11:0] CSR_MASK_MCOUNTER      = 12'hFE0;
 
+// CSR status bits
+parameter int unsigned CSR_MSTATUS_MIE_BIT      = 3;
+parameter int unsigned CSR_MSTATUS_MPIE_BIT     = 7;
+parameter int unsigned CSR_MSTATUS_MPP_BIT_LOW  = 11;
+parameter int unsigned CSR_MSTATUS_MPP_BIT_HIGH = 12;
+
 // CSR interrupt pending/enable bits
 parameter int unsigned CSR_MSIX_BIT      = 3;
 parameter int unsigned CSR_MTIX_BIT      = 7;


### PR DESCRIPTION
This PR contains two cleanup commits affecting the CSRs:
1. Remove define for `mstatus` CSR by bit index parameters in `ibex_pkg.sv`.
2. Remove `csr_restore_dret_id_o` signal. This signal was used to restore the `mstatus` CSR when exiting debug mode. This is not needed as the `mstatus` CSR is not modified when entering debug mode.
 