### PR TITLE
Adapt interrupt interface for Arty example, tracer and TB

### DIFF
--- a/examples/fpga/artya7-100/rtl/top_artya7_100.sv
+++ b/examples/fpga/artya7-100/rtl/top_artya7_100.sv
@@ -70,10 +70,11 @@ module top_artya7_100 (
      .data_rdata_i          (data_rdata),
      .data_err_i            ('b0),
 
-     .irq_i                 ('b0),
-     .irq_id_i              ('b0),
-     .irq_ack_o             (),
-     .irq_id_o              (),
+     .irq_software_i        (1'b0),
+     .irq_timer_i           (1'b0),
+     .irq_external_i        (1'b0),
+     .irq_fast_i            (15'b0),
+     .irq_nm_i              (1'b0),
 
      .debug_req_i           ('b0),
 

--- a/examples/sim/tb/ibex_tracing_tb.sv
+++ b/examples/sim/tb/ibex_tracing_tb.sv
@@ -100,10 +100,11 @@ module ibex_tracing_tb;
     .data_err_i             (1'b0),
 
     // Interrupt inputs
-    .irq_i                  (1'b0),
-    .irq_id_i               (5'b0),
-    .irq_ack_o              (),
-    .irq_id_o               (),
+    .irq_software_i         (1'b0),
+    .irq_timer_i            (1'b0),
+    .irq_external_i         (1'b0),
+    .irq_fast_i             (15'b0),
+    .irq_nm_i               (1'b0),
 
     // Debug Interface
     .debug_req_i            (1'b0),

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -85,7 +85,6 @@ module ibex_core #(
     output logic [31:0] rvfi_insn_uncompressed,
     output logic        rvfi_trap,
     output logic        rvfi_halt,
-    output logic        rvfi_intr,
     output logic [ 1:0] rvfi_mode,
     output logic [ 4:0] rvfi_rs1_addr,
     output logic [ 4:0] rvfi_rs2_addr,
@@ -620,7 +619,6 @@ module ibex_core #(
     if (!rst_ni) begin
       rvfi_halt              <= '0;
       rvfi_trap              <= '0;
-      rvfi_intr              <= '0;
       rvfi_order             <= '0;
       rvfi_insn              <= '0;
       rvfi_insn_uncompressed <= '0;
@@ -642,7 +640,6 @@ module ibex_core #(
     end else begin
       rvfi_halt              <= '0;
       rvfi_trap              <= illegal_insn_id;
-      rvfi_intr              <= irq_ack_o;
       rvfi_order             <= rvfi_order + rvfi_valid;
       rvfi_insn              <= rvfi_insn_id;
       rvfi_insn_uncompressed <= instr_rdata_id;

--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -44,10 +44,11 @@ module ibex_core_tracing #(
     input  logic        data_err_i,
 
     // Interrupt inputs
-    input  logic        irq_i,                 // level sensitive IR lines
-    input  logic [4:0]  irq_id_i,
-    output logic        irq_ack_o,             // irq ack
-    output logic [4:0]  irq_id_o,
+    input  logic        irq_software_i,
+    input  logic        irq_timer_i,
+    input  logic        irq_external_i,
+    input  logic [14:0] irq_fast_i,
+    input  logic        irq_nm_i,       // non-maskeable interrupt
 
     // Debug Interface
     input  logic        debug_req_i,
@@ -70,7 +71,6 @@ module ibex_core_tracing #(
   logic [31:0] rvfi_insn_uncompressed;
   logic        rvfi_trap;
   logic        rvfi_halt;
-  logic        rvfi_intr;
   logic [ 1:0] rvfi_mode;
   logic [ 4:0] rvfi_rs1_addr;
   logic [ 4:0] rvfi_rs2_addr;
@@ -119,10 +119,11 @@ module ibex_core_tracing #(
     .data_rdata_i,
     .data_err_i,
 
-    .irq_i,
-    .irq_id_i,
-    .irq_ack_o,
-    .irq_id_o,
+    .irq_software_i,
+    .irq_timer_i,
+    .irq_external_i,
+    .irq_fast_i,
+    .irq_nm_i,
 
     .debug_req_i,
 
@@ -132,7 +133,6 @@ module ibex_core_tracing #(
     .rvfi_insn_uncompressed,
     .rvfi_trap,
     .rvfi_halt,
-    .rvfi_intr,
     .rvfi_mode,
     .rvfi_rs1_addr,
     .rvfi_rs2_addr,


### PR DESCRIPTION
This PR also adapts the interrupt interface in the Arty example, the tracer and the tracer TB.

A follow-up PR will contain the required changes for the UVM infrastructure.

This PR is related to #187 .