### PR TITLE
RVFI: re-add accidentally removed `rvfi_intr` signal

### DIFF
--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -71,6 +71,7 @@ module ibex_core_tracing #(
   logic [31:0] rvfi_insn_uncompressed;
   logic        rvfi_trap;
   logic        rvfi_halt;
+  logic        rvfi_intr;
   logic [ 1:0] rvfi_mode;
   logic [ 4:0] rvfi_rs1_addr;
   logic [ 4:0] rvfi_rs2_addr;
@@ -133,6 +134,7 @@ module ibex_core_tracing #(
     .rvfi_insn_uncompressed,
     .rvfi_trap,
     .rvfi_halt,
+    .rvfi_intr,
     .rvfi_mode,
     .rvfi_rs1_addr,
     .rvfi_rs2_addr,


### PR DESCRIPTION
This PR re-adds the signal `rvfi_intr` part of the RVFI after it got accidentally removed in PR #188.

This signal is now set during the first instruction after the PC has been set to enter a trap handler.