### PR TITLE
Change mtvec implementation and boot address

### DIFF
--- a/doc/cs_registers.rst
+++ b/doc/cs_registers.rst
@@ -129,9 +129,14 @@ Machine Trap-Vector Base Address (mtvec)
 
 CSR Address: ``0x305``
 
+Reset Value: ``0x0000_0001``
+
 When an exception is encountered, the core jumps to the corresponding handler using the content of ``mtvec`` as base address.
-It is a WARL register which contains the boot address.
-It contains a hard-wired value, so will remain unchanged after any writes.
+``mtvec`` is a WARL register.
+Its value can be changed using the instructions added by the Zicsr extension.
+The value written to and read from the register will always be 256-byte aligned, and only vectored mode is supported.
+This means the bottom 8 bits of the write input are ignored, and instead ``0x01`` is written in the bottom 8 bits of the register.
+``mtvec``.BASE is initialized to the 256-byte aligned boot address on booting the core.
 ``mtvec``.MODE is set to 2'b01 to indicate vectored interrupt handling.
 
 

--- a/doc/exception_interrupts.rst
+++ b/doc/exception_interrupts.rst
@@ -8,10 +8,10 @@ Ibex implements trap handling for interrupts and exceptions according to the RIS
 All exceptions cause the core to jump to the base address of the vector table in the ``mtvec`` CSR.
 Interrupts are handled in vectored mode, i.e., the core jumps to the base address plus four times the interrupt ID.
 
-The base address of the vector table is given by the boot address (must be aligned to 256 bytes, i.e., its least significant byte must be 0x00).
-The most significant 3 bytes of the boot address given to the core are used for the first instruction fetch of the core and as the basis of the interrupt vector table.
+The base address of the vector table is initialized on booting the core.
+The most significant 3 bytes of the boot address given to the core are used for the first instruction fetch of the core and to initialize the base of the interrupt vector table when the core is booted.
 The core starts fetching at the address made by concatenating the most significant 3 bytes of the boot address and the reset value (0x80) as the least significant byte.
-The boot address can be changed after the first instruction was fetched to change the interrupt vector table address.
+It is possible to change the base address after booting using the instructions added by the Zicsr extension.
 It is assumed that the boot address is supplied via a register to avoid long paths to the instruction fetch unit.
 
 

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -124,6 +124,7 @@ module ibex_core #(
   pc_sel_e     pc_mux_id;              // Mux selector for next PC
   exc_pc_sel_e exc_pc_mux_id;          // Mux selector for exception PC
   exc_cause_e  exc_cause;              // Exception cause
+  logic        csr_mtvec_init;
 
   logic        lsu_load_err;
   logic        lsu_store_err;
@@ -325,6 +326,7 @@ module ibex_core #(
       .pc_mux_i                 ( pc_mux_id              ),
       .exc_pc_mux_i             ( exc_pc_mux_id          ),
       .exc_cause                ( exc_cause              ),
+      .csr_mtvec_init_o         ( csr_mtvec_init         ),
 
       // jump targets
       .jump_target_ex_i         ( jump_target_ex         ),
@@ -561,8 +563,9 @@ module ibex_core #(
       .core_id_i               ( core_id_i              ),
       .cluster_id_i            ( cluster_id_i           ),
 
-      // mtvec reset value
-      .mtvec_resetval_i        ( boot_addr_i            ),
+      // mtvec initialization
+      .csr_mtvec_resetval_i    ( boot_addr_i            ),
+      .csr_mtvec_init_i        ( csr_mtvec_init         ),
 
       // Interface to CSRs (SRAM like)
       .csr_access_i            ( csr_access             ),

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -332,7 +332,7 @@ module ibex_core #(
       // CSRs
       .csr_mepc_i               ( csr_mepc               ), // exception return address
       .csr_depc_i               ( csr_depc               ), // debug return address
-      .csr_mtvec_o              ( csr_mtvec              ), // trap-vector base address
+      .csr_mtvec_i              ( csr_mtvec              ), // trap-vector base address
 
       // pipeline stalls
       .id_in_ready_i            ( id_in_ready            ),
@@ -595,7 +595,7 @@ module ibex_core #(
       .csr_save_id_i           ( csr_save_id            ),
       .csr_restore_mret_i      ( csr_restore_mret_id    ),
       .csr_save_cause_i        ( csr_save_cause         ),
-      .csr_mtvec_i             ( csr_mtvec              ),
+      .csr_mtvec_o             ( csr_mtvec              ),
       .csr_mcause_i            ( exc_cause              ),
       .csr_mtval_i             ( csr_mtval              ),
       .illegal_csr_insn_o      ( illegal_csr_insn_id    ),

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -561,6 +561,9 @@ module ibex_core #(
       .core_id_i               ( core_id_i              ),
       .cluster_id_i            ( cluster_id_i           ),
 
+      // mtvec reset value
+      .mtvec_resetval_i        ( boot_addr_i            ),
+
       // Interface to CSRs (SRAM like)
       .csr_access_i            ( csr_access             ),
       .csr_addr_i              ( csr_addr               ),

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -564,7 +564,7 @@ module ibex_core #(
       .cluster_id_i            ( cluster_id_i           ),
 
       // mtvec initialization
-      .csr_mtvec_resetval_i    ( boot_addr_i            ),
+      .boot_addr_i             ( boot_addr_i            ),
       .csr_mtvec_init_i        ( csr_mtvec_init         ),
 
       // Interface to CSRs (SRAM like)

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -369,7 +369,9 @@ module ibex_cs_registers #(
       CSR_MTVAL: if (csr_we_int) mtval_d = csr_wdata_int;
 
       // mtvec
-      CSR_MTVEC: if (csr_we_int) mtvec_d = csr_wdata_int;
+      // the 2 LSBs of mtvec should always be 01 since we use only vectored mode
+      // we also want mtvec to be 256-byte aligned, so we discard the bottom 8 bits of the input
+      CSR_MTVEC: if (csr_we_int) mtvec_d = {csr_wdata_int[31:8], 6'b0, 2'b01};
 
       CSR_DCSR: begin
         if (csr_we_int) begin

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -39,6 +39,9 @@ module ibex_cs_registers #(
     input  logic  [3:0]          core_id_i,
     input  logic  [5:0]          cluster_id_i,
 
+    // mtvec reset value
+    input  logic [31:0]          mtvec_resetval_i,
+
     // Interface to registers (SRAM like)
     input  logic                 csr_access_i,
     input  ibex_pkg::csr_num_e   csr_addr_i,
@@ -554,8 +557,7 @@ module ibex_cs_registers #(
       mepc_q         <= '0;
       mcause_q       <= '0;
       mtval_q        <= '0;
-      // set mtvec to 1 to signify vectored mode
-      mtvec_q        <= '1;
+      mtvec_q        <= {mtvec_resetval_i[31:8], 6'b0, 2'b01};
       dcsr_q         <= '{
           xdebugver: XDEBUGVER_NO,   // 4'h0
           cause:     DBG_CAUSE_NONE, // 3'h0

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -40,7 +40,7 @@ module ibex_cs_registers #(
     input  logic  [5:0]          cluster_id_i,
 
     // mtvec initialization
-    input  logic [31:0]          csr_mtvec_resetval_i,
+    input  logic [31:0]          boot_addr_i,
     input  logic                 csr_mtvec_init_i,
 
     // Interface to registers (SRAM like)
@@ -322,7 +322,7 @@ module ibex_cs_registers #(
     mepc_d       = mepc_q;
     mcause_d     = mcause_q;
     mtval_d      = mtval_q;
-    mtvec_d      = csr_mtvec_init_i ? csr_mtvec_resetval_i : mtvec_q;
+    mtvec_d      = csr_mtvec_init_i ? boot_addr_i : mtvec_q;
     dcsr_d       = dcsr_q;
     depc_d       = depc_q;
     dscratch0_d  = dscratch0_q;

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -64,6 +64,7 @@ module ibex_if_stage #(
                                                             // the interrupt/exception
     input  logic [31:0]           csr_depc_i,               // PC to restore after handling
                                                             // the debug request
+    output logic [31:0]           csr_mtvec_i,              // base PC to jump to on exception
     input  ibex_pkg::pc_sel_e     pc_mux_i,                 // selector for PC multiplexer
     input  ibex_pkg::exc_pc_sel_e exc_pc_mux_i,             // selects ISR address
     input  ibex_pkg::exc_cause_e  exc_cause,                // selects ISR address for
@@ -71,9 +72,6 @@ module ibex_if_stage #(
 
     // jump and branch target and decision
     input  logic [31:0]           jump_target_ex_i,         // jump target address
-
-    // CSRs
-    output logic [31:0]           csr_mtvec_o,
 
     // pipeline stall
     input  logic                  id_in_ready_i,            // ID stage is ready for new instr
@@ -113,14 +111,13 @@ module ibex_if_stage #(
   assign irq_id         = {exc_cause};
   assign unused_irq_bit = irq_id[5];   // MSB distinguishes interrupts from exceptions
 
-  // trap-vector base address, mtvec.MODE set to vectored
-  assign csr_mtvec_o = {boot_addr_i[31:8], 6'b0, 2'b01};
-
   // exception PC selection mux
   always_comb begin : exc_pc_mux
     unique case (exc_pc_mux_i)
-      EXC_PC_EXC:     exc_pc = { boot_addr_i[31:8], 8'h00                    };
-      EXC_PC_IRQ:     exc_pc = { boot_addr_i[31:8], 1'b0, irq_id[4:0], 2'b00 };
+      EXC_PC_EXC:     exc_pc = {csr_mtvec_i, 2'b0};
+      EXC_PC_IRQ: begin
+        exc_pc = {csr_mtvec_i[31:2], 2'b0} + (csr_mtvec_i[1:0] == '1 ? {irq_id[4:0], 2'b00 } : '0);
+      end
       EXC_PC_DBD:     exc_pc = DmHaltAddr;
       EXC_PC_DBG_EXC: exc_pc = DmExceptionAddr;
       default:        exc_pc = 'X;
@@ -130,7 +127,7 @@ module ibex_if_stage #(
   // fetch address selection mux
   always_comb begin : fetch_addr_mux
     unique case (pc_mux_i)
-      PC_BOOT: fetch_addr_n = { boot_addr_i[31:8], 8'h80 };
+      PC_BOOT: fetch_addr_n = boot_addr_i;
       PC_JUMP: fetch_addr_n = jump_target_ex_i;
       PC_EXC:  fetch_addr_n = exc_pc;                       // set PC to exception handler
       PC_ERET: fetch_addr_n = csr_mepc_i;                   // restore PC when returning from EXC
@@ -262,11 +259,6 @@ module ibex_if_stage #(
   // Assertions //
   ////////////////
 `ifndef VERILATOR
-  // the boot address needs to be aligned to 256 bytes
-  assert property (
-    @(posedge clk_i) (boot_addr_i[7:0] == 8'h00) ) else
-      $error("The provided boot address is not aligned to 256 bytes");
-
   // there should never be a grant when there is no request
   assert property (
     @(posedge clk_i) (instr_gnt_i) |-> (instr_req_o) ) else

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -114,7 +114,7 @@ module ibex_if_stage #(
   // exception PC selection mux
   always_comb begin : exc_pc_mux
     unique case (exc_pc_mux_i)
-      EXC_PC_EXC:     exc_pc = {csr_mtvec_i, 2'b0};
+      EXC_PC_EXC:     exc_pc = {csr_mtvec_i[31:2], 2'b0};
       EXC_PC_IRQ: begin
         exc_pc = {csr_mtvec_i[31:2], 2'b0} + (csr_mtvec_i[1:0] == '1 ? {irq_id[4:0], 2'b00 } : '0);
       end

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -114,7 +114,7 @@ module ibex_if_stage #(
   assign unused_irq_bit = irq_id[5];   // MSB distinguishes interrupts from exceptions
 
   // tell CS register file to initialize mtvec on boot
-  assign csr_mtvec_init_o = (pc_mux_i == PC_BOOT);
+  assign csr_mtvec_init_o = (pc_mux_i == PC_BOOT) && pc_set_i;
 
   // exception PC selection mux
   always_comb begin : exc_pc_mux


### PR DESCRIPTION
This PR aims to change the implementation of the mtvec CSR in order to allow it to be written to and read from by software.
This also allows for the boot address to be set to the input boot address instead of adding an offset to it, and it no longer needs to be 256-byte aligned