### PR TITLE
Correct cause number for illegal instruction exception

### DIFF
--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -190,7 +190,7 @@ typedef enum logic [5:0] {
   // EXC_CAUSE_IRQ_FAST_14     = {1'b1, 5'd30},
   EXC_CAUSE_IRQ_NM             = {1'b1, 5'd31}, // == EXC_CAUSE_IRQ_FAST_15
   EXC_CAUSE_INSN_ADDR_MISA     = {1'b0, 5'd00},
-  EXC_CAUSE_ILLEGAL_INSN       = {1'b0, 5'd01},
+  EXC_CAUSE_ILLEGAL_INSN       = {1'b0, 5'd02},
   EXC_CAUSE_BREAKPOINT         = {1'b0, 5'd03},
   EXC_CAUSE_LOAD_ACCESS_FAULT  = {1'b0, 5'd05},
   EXC_CAUSE_STORE_ACCESS_FAULT = {1'b0, 5'd07},


### PR DESCRIPTION
This bug has beed reported by @taoliug. This resolves #195.