### PR TITLE
Update ibex testbench

### DIFF
--- a/dv/uvm/Makefile
+++ b/dv/uvm/Makefile
@@ -34,6 +34,12 @@ LSF_CMD    		:=
 
 # Privileged CSR YAML description file
 CSR_FILE			:= ${DV_DIR}/riscv_dv_extension/csr_description.yaml
+# Address that privileged CSR test will write to to indicate end of test
+END_SIGNATURE_ADDR	:= 0x8ffffffc
+# Value written to END_SIGNATURE_ADDR that indicates test success
+PASS_VAL  := 0x1
+# Value written to END_SIGNATURE_ADDR that indicates test failure
+FAIL_VAL  := 0x0
 
 SHELL=/bin/bash
 
@@ -50,12 +56,13 @@ clean:
 COMMON_OPTS=--seed=${SEED} \
             --test=${TEST} \
             --testlist=${DV_DIR}/riscv_dv_extension/testlist.yaml \
-            --iterations=${ITERATIONS} \
-            --verbose=${VERBOSE}
+            --iterations=${ITERATIONS}
+            #--verbose=${VERBOSE}
 
 # Options used for privileged CSR test generation
 CSR_OPTS=--csr_yaml=${CSR_FILE} \
-         --isa=${ISA}
+         --isa=${ISA} \
+         --end_signature_addr=${END_SIGNATURE_ADDR}
 
 # Generate random instructions
 .SILENT gen:
@@ -113,6 +120,7 @@ rtl_sim:
      --simulator=${SIMULATOR} \
      --en_cov=${COV} \
      --en_wave=${WAVES} \
+     --sim_opts="+end_signature_addr=${END_SIGNATURE_ADDR} +pass_val=${PASS_VAL} +fail_val=${FAIL_VAL}" \
      ${SIM_OPTS}
 
 # Compare the regression result between ISS and RTL sim

--- a/dv/uvm/common/irq_agent/irq_master_driver.sv
+++ b/dv/uvm/common/irq_agent/irq_master_driver.sv
@@ -52,7 +52,10 @@ class irq_master_driver extends uvm_driver #(irq_seq_item);
     vif.irq_external <= trans.irq_external;
     vif.irq_fast     <= trans.irq_fast;
     vif.irq_nm       <= trans.irq_nm;
-    @(posedge vif.clock);
+    // We hold the interrupt high for two cycles as Ibex is level sensitive,
+    // so this guarantees that Ibex will respond appropriately to the
+    // interrupt
+    repeat (2) @(posedge vif.clock);
     drive_reset_value();
   endtask : drive_seq_item
 

--- a/dv/uvm/env/core_ibex_env_cfg.sv
+++ b/dv/uvm/env/core_ibex_env_cfg.sv
@@ -4,18 +4,26 @@
 
 class core_ibex_env_cfg extends uvm_object;
 
-  bit enable_irq_seq;
-  bit enable_debug_seq;
+  bit       enable_irq_seq;
+  bit       enable_debug_seq;
+  bit[31:0] pass_val, fail_val;
+  bit[31:0] end_signature_addr;
 
   `uvm_object_utils_begin(core_ibex_env_cfg)
     `uvm_field_int(enable_irq_seq,   UVM_DEFAULT)
     `uvm_field_int(enable_debug_seq, UVM_DEFAULT)
+    `uvm_field_int(pass_val, UVM_DEFAULT)
+    `uvm_field_int(fail_val, UVM_DEFAULT)
+    `uvm_field_int(end_signature_addr, UVM_DEFAULT)
   `uvm_object_utils_end
 
   function new(string name = "");
     super.new(name);
     void'($value$plusargs("enable_irq_seq=%0d", enable_irq_seq));
     void'($value$plusargs("enable_debug_seq=%0d", enable_debug_seq));
+    void'($value$plusargs("pass_val=%0h", pass_val));
+    void'($value$plusargs("fail_val=%0h", fail_val));
+    void'($value$plusargs("end_signature_addr=%0h", end_signature_addr));
   endfunction
 
 endclass

--- a/dv/uvm/riscv_dv_extension/csr_description.yaml
+++ b/dv/uvm/riscv_dv_extension/csr_description.yaml
@@ -61,27 +61,28 @@
       msb: 25
       lsb: 0
 
+# TODO(udij) - clarify expected write behavior
 # MHARTID
-- csr: mhartid
-  description: >
-    Contains integer ID of hardware thread running code
-  address: 0xF14
-  privilege_mode: M
-  rv32:
-    - field_name: cluster_id
-      description: >
-        ID of the cluster
-      type: R
-      reset_val: 0
-      msb: 10
-      lsb: 5
-    - field_name: core_id
-      description: >
-        ID of the core within cluster
-      type: R
-      reset_val: 0
-      msb: 3
-      lsb: 0
+#- csr: mhartid
+#  description: >
+#    Contains integer ID of hardware thread running code
+#  address: 0xF14
+#  privilege_mode: M
+#  rv32:
+#    - field_name: cluster_id
+#      description: >
+#        ID of the cluster
+#      type: R
+#      reset_val: 0
+#      msb: 10
+#      lsb: 5
+#    - field_name: core_id
+#      description: >
+#        ID of the core within cluster
+#      type: R
+#      reset_val: 0
+#      msb: 3
+#      lsb: 0
 
 # MSTATUS
 - csr: mstatus

--- a/dv/uvm/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/tb/core_ibex_tb_top.sv
@@ -19,8 +19,7 @@ module core_ibex_tb_top;
 
   // TODO(taliu) Resolve the tied-off ports
   ibex_core_tracing #(.DmHaltAddr(`BOOT_ADDR + 'h50),
-                      .DmExceptionAddr(`BOOT_ADDR + 'h54)
-  ) dut (
+                      .DmExceptionAddr(`BOOT_ADDR + 'h54)) dut (
     .clk_i(clk),
     .rst_ni(rst_n),
     .test_en_i(1'b1),

--- a/dv/uvm/tests/core_ibex_base_test.sv
+++ b/dv/uvm/tests/core_ibex_base_test.sv
@@ -8,6 +8,7 @@ class core_ibex_base_test extends uvm_test;
   core_ibex_env_cfg               cfg;
   virtual clk_if                  clk_vif;
   virtual core_ibex_dut_probe_if  dut_vif;
+  virtual ibex_mem_intf           dmem_vif;
   mem_model_pkg::mem_model        mem;
   core_ibex_vseq                  vseq;
   bit                             enable_irq_seq;
@@ -18,7 +19,10 @@ class core_ibex_base_test extends uvm_test;
   `uvm_component_utils(core_ibex_base_test)
 
   function new(string name="", uvm_component parent=null);
+    core_ibex_report_server ibex_report_server;
     super.new(name, parent);
+    ibex_report_server = new();
+    uvm_report_server::set_server(ibex_report_server);
   endfunction
 
   virtual function void build_phase(uvm_phase phase);
@@ -29,6 +33,9 @@ class core_ibex_base_test extends uvm_test;
     end
     if (!uvm_config_db#(virtual core_ibex_dut_probe_if)::get(null, "", "dut_if", dut_vif)) begin
       `uvm_fatal(get_full_name(), "Cannot get dut_if")
+    end
+    if (!uvm_config_db#(virtual ibex_mem_intf)::get(null, "*data_if_slave*", "vif", dmem_vif)) begin
+      `uvm_fatal(get_full_name(), "Cannot get dmem_vif")
     end
     env = core_ibex_env::type_id::create("env", this);
     cfg = core_ibex_env_cfg::type_id::create("cfg", this);
@@ -51,6 +58,10 @@ class core_ibex_base_test extends uvm_test;
     vseq.stop();
     phase.drop_objection(this);
   endtask
+
+  virtual function void report_phase(uvm_phase phase);
+    super.report_phase(phase);
+  endfunction
 
   function void load_binary_to_mem();
     string      bin;

--- a/dv/uvm/tests/core_ibex_csr_test.sv
+++ b/dv/uvm/tests/core_ibex_csr_test.sv
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class core_ibex_csr_test extends core_ibex_base_test;
+
+  `uvm_component_utils(core_ibex_csr_test)
+
+  function new(string name="", uvm_component parent=null);
+    super.new(name, parent);
+  endfunction
+
+  virtual task wait_for_test_done();
+    fork
+    begin
+      wait(dmem_vif.request && dmem_vif.we && dmem_vif.grant &&
+           dmem_vif.addr == cfg.end_signature_addr);
+      if (dmem_vif.wdata == cfg.pass_val) begin
+        `uvm_info(`gfn, "CSR test completed successfully!", UVM_LOW)
+      end else if (dmem_vif.wdata == cfg.fail_val) begin
+        `uvm_error(`gfn, "CSR TEST_FAILED!")
+      end else begin
+        `uvm_fatal(`gfn, "CSR test values are not configured properly")
+      end
+    end
+    begin
+      clk_vif.wait_clks(timeout_in_cycles);
+      `uvm_fatal(`gfn, "TEST TIMEOUT!!")
+    end
+    join_any
+  endtask
+
+endclass

--- a/dv/uvm/tests/core_ibex_report_server.sv
+++ b/dv/uvm/tests/core_ibex_report_server.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class core_ibex_report_server extends uvm_default_report_server;
+
+  function new(string name = "");
+    super.new(name);
+  endfunction
+
+  function void report_summarize(UVM_FILE file = 0);
+    int error_count;
+    error_count = get_severity_count(UVM_WARNING);
+    error_count = get_severity_count(UVM_ERROR) + error_count;
+    error_count = get_severity_count(UVM_FATAL) + error_count;
+
+    if (error_count == 0) begin
+      $display("\n--- RISC-V UVM TEST PASSED ---\n");
+    end else begin
+      $display("\n--- RISC-V UVM TEST FAILED ---\n");
+    end
+    super.report_summarize(file);
+  endfunction
+
+endclass

--- a/dv/uvm/tests/core_ibex_test_pkg.sv
+++ b/dv/uvm/tests/core_ibex_test_pkg.sv
@@ -12,8 +12,10 @@ package core_ibex_test_pkg;
   import ibex_mem_intf_agent_pkg::*;
   import irq_agent_pkg::*;
 
+  `include "core_ibex_report_server.sv"
   `include "core_ibex_seq_lib.sv"
   `include "core_ibex_vseq.sv"
   `include "core_ibex_base_test.sv"
+  `include "core_ibex_csr_test.sv"
 
 endpackage


### PR DESCRIPTION
- Added a new register file interface, to enable monitoring for any register state updates
- Added a new `core_ibex_csr_test`, to be run with the privileged CSR test generation in `riscv-dv`, that uses this regfile interface to monitor for writes to x3 at the end of test to determine success or failure
- Extended the `uvm_default_report_server` to create a custom reporting class that reports whether simulation has passed or failed (will report for all risc-v simulations, and is just a measure of whether the DV UVM simulation has completed without errors/failures, and as such is useful for self-checking tests)
- Modified interrupt driver to now assert interrupts for 2 cycles, which ensures that Ibex will actually respond to all asserted interrupts, as they are treated as level sensitive