### PR TITLE
Update ibex simulation flow

### DIFF
--- a/dv/uvm/Makefile
+++ b/dv/uvm/Makefile
@@ -2,35 +2,38 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-DV_DIR     := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-GEN_DIR    := $(realpath ${DV_DIR}/../../vendor/google_riscv-dv)
-TOOLCHAIN  := ${RISCV_TOOLCHAIN}
-OUT        := "${DV_DIR}/out"
+DV_DIR     		:= $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+GEN_DIR    		:= $(realpath ${DV_DIR}/../../vendor/google_riscv-dv)
+TOOLCHAIN  		:= ${RISCV_TOOLCHAIN}
+OUT        		:= "${DV_DIR}/out"
 # Run time options for the instruction generator
-GEN_OPTS   :=
+GEN_OPTS   		:=
 # Run time options for ibex RTL simulation
-SIM_OPTS   :=
+SIM_OPTS   		:=
 # Enable waveform dumping
-WAVES      := 1
+WAVES      		:= 1
 # Enable coverage dump
-COV        := 0
+COV        		:= 0
 # RTL simulator
-SIMULATOR  := "vcs"
+SIMULATOR  		:= "vcs"
 # ISS (spike, ovpsim)
-ISS        := "spike"
+ISS        		:= "spike"
 # ISA
-ISA        := "rv32imc"
+ISA        		:= "rv32imc"
 # Test name (default: full regression)
-TEST       := "all"
+TEST       		:= "all"
 # Seed for instruction generator and RTL simulation
-SEED       := -1
+SEED       		:= -1
 # Verbose logging
-VERBOSE    := 0
+VERBOSE    		:=
 # Number of iterations for each test, assign a non-zero value to override the
 # iteration count in the test list
-ITERATIONS := 0
+ITERATIONS 		:= 0
 # LSF CMD
-LSF_CMD    :=
+LSF_CMD    		:=
+
+# Privileged CSR YAML description file
+CSR_FILE			:= ${DV_DIR}/riscv_dv_extension/csr_description.yaml
 
 SHELL=/bin/bash
 
@@ -46,9 +49,13 @@ clean:
 # Common options for all targets
 COMMON_OPTS=--seed=${SEED} \
             --test=${TEST} \
-            --verbose=${VERBOSE} \
             --testlist=${DV_DIR}/riscv_dv_extension/testlist.yaml \
-            --iterations=${ITERATIONS}
+            --iterations=${ITERATIONS} \
+            --verbose=${VERBOSE}
+
+# Options used for privileged CSR test generation
+CSR_OPTS=--csr_yaml=${CSR_FILE} \
+         --isa=${ISA}
 
 # Generate random instructions
 .SILENT gen:
@@ -59,6 +66,7 @@ COMMON_OPTS=--seed=${SEED} \
      --steps=gen \
      --lsf_cmd="${LSF_CMD}" \
      ${COMMON_OPTS} \
+     ${CSR_OPTS} \
      --cmp_opts="+define+RISCV_CORE_SETTING=${DV_DIR}/riscv_dv_extension/ibex_core_setting.sv \
        +define+RISCV_DV_EXT_FILE_LIST=${DV_DIR}/riscv_dv_extension/flist \
        +incdir+${DV_DIR}/riscv_dv_extension/ " \

--- a/dv/uvm/riscv_dv_extension/csr_description.yaml
+++ b/dv/uvm/riscv_dv_extension/csr_description.yaml
@@ -1,0 +1,279 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Base CSR template that should be followed when describing all processor supported CSRs to enable correct generation of directed test sequences
+#- csr: CSR_NAME
+#  description: >
+#    BRIEF_DESCRIPTION
+#  address: 0x###
+#  privilege_mode: MODE (D/M/S/H/U)
+#  rv32:
+#    - MSB_FIELD_NAME:
+#      - description: >
+#          BRIEF_DESCRIPTION
+#      - type: TYPE (WPRI/WLRL/WARL)
+#      - reset_val: RESET_VAL
+#      - msb: MSB_POS
+#      - lsb: LSB_POS
+#    - ...
+#    - ...
+#    - LSB_FIELD_NAME:
+#      - description: ...
+#      - type: ...
+#      - ...
+#  rv64:
+#    - MSB_FIELD_NAME:
+#      - description: >
+#          BRIEF_DESCRIPTION
+#      - type: TYPE (WPRI/WLRL/WARL)
+#      - reset_val: RESET_VAL
+#      - msb: MSB_POS
+#      - lsb: LSB_POS
+#    - ...
+#    - ...
+#    - LSB_FIELD_NAME:
+#      - description: ...
+#      - type: ...
+#      - ...
+
+
+# Ibex MISA CSR
+- csr: misa
+  description: >
+    Machine ISA Register
+  address: 0x301
+  privilege_mode: M
+  rv32:
+    - field_name: MXL
+      description: >
+        Encodes native base ISA width
+      type: R
+      reset_val: 1
+      msb: 31
+      lsb: 30
+    - field_name: Extensions
+      description: >
+          Encodes all supported ISA extensions
+      type: R
+      reset_val: 0x1104
+      msb: 25
+      lsb: 0
+
+# MHARTID
+- csr: mhartid
+  description: >
+    Contains integer ID of hardware thread running code
+  address: 0xF14
+  privilege_mode: M
+  rv32:
+    - field_name: cluster_id
+      description: >
+        ID of the cluster
+      type: R
+      reset_val: 0
+      msb: 10
+      lsb: 5
+    - field_name: core_id
+      description: >
+        ID of the core within cluster
+      type: R
+      reset_val: 0
+      msb: 3
+      lsb: 0
+
+# MSTATUS
+- csr: mstatus
+  descriptipn: >
+    Controls hart's current operating state
+  address: 0x300
+  privilege_mode: M
+  rv32:
+    - field_name: mpp
+      description: >
+        Previous privilege mode
+      type: R
+      reset_val: 0x3
+      msb: 12
+      lsb: 11
+    - field_name: mpie
+      description: >
+        Previous value of interrupt-enable bit
+      type: WARL
+      reset_val: 0
+      msb: 7
+      lsb: 7
+    - field_name: mie
+      description: >
+        M-mode interrupt enable
+      type: WARL
+      reset_val: 0
+      msb: 3
+      lsb: 3
+
+# MIP
+- csr: mip
+  description: >
+    Contains pending interrupt information
+  address: 0x344
+  privilege_mode: M
+  rv32:
+    - field_name: fast
+      description: >
+        platform-specific interrupts
+      type: R
+      reset_val: 0
+      msb: 30
+      lsb: 16
+    - field_name: meip
+      description: >
+        M-mode external interrupts
+      type: R
+      reset_val: 0
+      msb: 11
+      lsb: 11
+    - field_name: mtip
+      description: >
+        M-mode timer interrupts
+      type: R
+      reset_val: 0
+      msb: 7
+      lsb: 7
+    - field_name: msip
+      description: >
+        M-mode software interrupts
+      type: R
+      reset_val: 0
+      msb: 3
+      lsb: 3
+
+# MIE
+- csr: mie
+  description: >
+    Contains interrupt information
+  address: 0x304
+  privilege_mode: M
+  rv32:
+    - field_name: fast
+      description: >
+        platform-specific interrupts
+      type: WARL
+      reset_val: 0
+      msb: 30
+      lsb: 16
+    - field_name: meip
+      description: >
+        M-mode external interrupts
+      type: WARL
+      reset_val: 0
+      msb: 11
+      lsb: 11
+    - field_name: mtip
+      description: >
+        M-mode timer interrupts
+      type: WARL
+      reset_val: 0
+      msb: 7
+      lsb: 7
+    - field_name: msip
+      description: >
+        M-mode software interrupts
+      type: WARL
+      reset_val: 0
+      msb: 3
+      lsb: 3
+
+# MSCRATCH
+- csr: mscratch
+  description: >
+    M-mode scratch register
+  address: 0x340
+  privilege_mode: M
+  rv32:
+    - field_name: mscratch
+      description: >
+        scratch register
+      type: WARL
+      reset_val: 0
+      msb: 31
+      lsb: 0
+
+# MEPC
+- csr: mepc
+  description: >
+    Stores the address of the instruction that was interrupted or caused exception
+  address: 0x341
+  privilege_mode: M
+  rv32:
+    - field_name: mepc
+      description: >
+        M-mode exception PC register
+      type: WARL
+      reset_val: 0
+      msb: 31
+      lsb: 1
+
+# MCAUSE
+- csr: mcause
+  description: >
+    Indicates trap cause
+  address: 0x342
+  privilege_mode: M
+  rv32:
+    - field_name: Interrupt
+      description: >
+        Indicates if trap caused by interrupt
+      type: WARL
+      reset_val: 0
+      msb: 31
+      lsb: 31
+    - field_name: Exception Code
+      type: WLRL
+      reset_val: 0
+      msb: 4
+      lsb: 0
+
+# MTVAL
+- csr: mtval
+  description: >
+    Machine Trap Value register
+  address: 0x343
+  privilege_mode: M
+  rv32:
+    - field_name: mtval
+      description: >
+        Address of faulting instruction
+      type: WARL
+      reset_val: 0
+      msb: 31
+      lsb: 0
+
+# MTVEC
+- csr: mtvec
+  description: >
+    Machine trap vector base address
+  address: 0x305
+  privilege_mode: M
+  rv32:
+    - field_name: base
+      description: >
+        trap vector base address (256 byte aligned)
+      type: WARL
+      reset_val: 0x800000
+      msb: 31
+      lsb: 8
+    - field_name: base_zero_end
+      description: >
+        bottom six bits of base always set to zero
+      type: R
+      reset_val: 0
+      msb: 7
+      lsb: 2
+    - field_name: mode
+      description: >
+        trap handling mode
+      type: R
+      reset_val: 0x1
+      msb: 1
+      lsb: 0

--- a/dv/uvm/riscv_dv_extension/ibex_log_to_trace_csv.py
+++ b/dv/uvm/riscv_dv_extension/ibex_log_to_trace_csv.py
@@ -45,6 +45,43 @@ def process_ibex_sim_log(ibex_log, csv):
     print("Processed instruction count : %d" % instr_cnt)
 
 
+def check_ibex_uvm_log(uvm_log, core_name, test_name, report):
+  """Process Ibex UVM simulation log.
+
+  This function will be used when a test disables the normal post_compare step.
+  Process the UVM simulation log produced by the test to check for correctness
+
+  Args:
+    uvm_log: the uvm simulation log
+    core_name: the name of the core
+    test_name: name of the test being checked
+    report: the output report file
+  """
+  if report:
+    fd = open(report, "a+")
+  else:
+    fd = sys.stdout
+
+  fd.write("%s uvm log : %s\n" % (core_name, uvm_log))
+
+  pass_cnt = 0
+  fail_cnt = 0
+  with open(uvm_log, "r") as log:
+    for line in log:
+      if 'RISC-V UVM TEST PASSED' in line:
+        pass_cnt += 1
+        break
+      elif 'RISC-V UVM TEST FAILED' in line:
+        fail_cnt += 1
+        break
+  if pass_cnt == 1:
+    fd.write("%s : PASSED\n" % test_name)
+  elif fail_cnt == 1:
+    fd.write("%s : FAILED\n" % test_name)
+  if report:
+    fd.close()
+
+
 def main():
   instr_trace = []
   # Parse input arguments

--- a/dv/uvm/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/riscv_dv_extension/testlist.yaml
@@ -1,16 +1,6 @@
-# Copyright Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http:#www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
 
 - test: riscv_arithmetic_basic_test
   description: >
@@ -152,3 +142,11 @@
     +enable_irq_seq=1
   compare_opts: >
     +compare_final_value_only=1
+
+- test: riscv_csr_test
+  description: >
+    Test all CSR instructions on all implemented CSR registers
+  iterations: 5
+  no_iss: 1
+  rtl_test: core_ibex_csr_test
+  no_post_compare: 1

--- a/dv/uvm/sim.py
+++ b/dv/uvm/sim.py
@@ -205,19 +205,24 @@ def compare(test_list, iss, output_dir, verbose):
       elf = ("%s/asm_tests/%s.%d.o" % (output_dir, test['test'], i))
       print("Comparing %s/DUT sim result : %s" % (iss, elf))
       run_cmd(("echo 'Test binary: %s' >> %s" % (elf, report)))
+      uvm_log = ("%s/rtl_sim/%s.%d/sim.log" % (output_dir, test['test'], i))
       rtl_log = ("%s/rtl_sim/%s.%d/trace_core_00_0.log" % (output_dir, test['test'], i))
       rtl_csv = ("%s/rtl_sim/%s.%d/trace_core_00_0.csv" % (output_dir, test['test'], i))
-      process_ibex_sim_log(rtl_log, rtl_csv)
-      iss_log = ("%s/instr_gen/%s_sim/%s.%d.log" % (output_dir, iss, test['test'], i))
-      iss_csv = ("%s/instr_gen/%s_sim/%s.%d.csv" % (output_dir, iss, test['test'], i))
-      if iss == "spike":
-        process_spike_sim_log(iss_log, iss_csv)
-      elif iss == "ovpsim":
-        process_ovpsim_sim_log(iss_log, iss_csv)
+      if 'no_post_compare' in test and test['no_post_compare'] == 1:
+        test_name = "%s.%d" % (test['test'], i)
+        check_ibex_uvm_log(uvm_log, "ibex", test_name, report)
       else:
-        print("Unsupported ISS" % iss)
-        sys.exit(1)
-      compare_trace_csv(rtl_csv, iss_csv, "ibex", iss, report)
+        process_ibex_sim_log(rtl_log, rtl_csv)
+        iss_log = ("%s/instr_gen/%s_sim/%s.%d.log" % (output_dir, iss, test['test'], i))
+        iss_csv = ("%s/instr_gen/%s_sim/%s.%d.csv" % (output_dir, iss, test['test'], i))
+        if iss == "spike":
+          process_spike_sim_log(iss_log, iss_csv)
+        elif iss == "ovpsim":
+          process_ovpsim_sim_log(iss_log, iss_csv)
+        else:
+          print("Unsupported ISS" % iss)
+          sys.exit(1)
+        compare_trace_csv(rtl_csv, iss_csv, "ibex", iss, report)
   passed_cnt = run_cmd("grep PASSED %s | wc -l" % report).strip()
   failed_cnt = run_cmd("grep FAILED %s | wc -l" % report).strip()
   summary = ("%s PASSED, %s FAILED" % (passed_cnt, failed_cnt))


### PR DESCRIPTION
Integrated ibex simulation flow with `riscv-dv` privileged CSR test
- Added options for CSR test generation script to `Makefile`
- Added `csr_description.yaml`, containing YAML descriptions of all implemented CSRs, as per `docs/cs_registers.rst` for use in privileged CSR testing
- Modified license of `testlist.yaml` to match standard Ibex licenses
- Modified `sim.py` to deal with the optional `no_post_compare` license
- Updated  `ibex_log_to_trace_csv.py` to add functionality to parse UVM sim logs for the new report messages