### PR TITLE
Update google_riscv-dv to 63fa0ca

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: 07599f689a385794cb73932922008bdbe8131d82
+    rev: 63fa0ca922ecf10f3cd733d15a0a79a7937a591e
   }
 }

--- a/vendor/google_riscv-dv/scripts/gen_csr_test.py
+++ b/vendor/google_riscv-dv/scripts/gen_csr_test.py
@@ -31,7 +31,12 @@ import sys
 import yaml
 import argparse
 import random
-from bitstring import BitArray as bitarray
+
+try:
+  from bitstring import BitArray as bitarray
+except ImportError as e:
+  logging.error("Please install bitstring package: sudo apt-get install python3-bitstring")
+  sys.exit(1)
 
 """
 Defines the test's success/failure values, one of which will be written to

--- a/vendor/google_riscv-dv/src/riscv_instr_sequence.sv
+++ b/vendor/google_riscv-dv/src/riscv_instr_sequence.sv
@@ -91,6 +91,7 @@ class riscv_instr_sequence extends uvm_sequence;
   // pointer(SP) is reduced by the amount the stack space allocated to this program.
   function void gen_stack_enter_instr();
     bit allow_branch = ((illegal_instr_pct > 0) || (hint_instr_pct > 0)) ? 1'b0 : 1'b1;
+    allow_branch &= !cfg.no_branch_jump;
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(program_stack_len,
       program_stack_len inside {[cfg.min_stack_len_per_program : cfg.max_stack_len_per_program]};
       // Keep stack len word aligned to avoid unaligned load/store

--- a/vendor/google_riscv-dv/src/riscv_rand_instr.sv
+++ b/vendor/google_riscv-dv/src/riscv_rand_instr.sv
@@ -110,6 +110,14 @@ class riscv_rand_instr extends riscv_instr_base;
     }
   }
 
+  // No label is needed if there's no branch/jump instruction
+  function void post_randomize();
+    super.post_randomize();
+    if (cfg.no_branch_jump) begin
+      has_label = 1'b0;
+    end
+  endfunction
+
   `uvm_object_new
 
 endclass


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision 63fa0ca922ecf10f3cd733d15a0a79a7937a591e

* Merge pull request #74 from google/dev (taoliug)
* Add gcc compile options, fix unaligned load/store (Tao Liu)
* Merge pull request #72 from google/dev (taoliug)
* Properly disable branch instruction in push/pop stack operations
  (Tao Liu)