### PR TITLE
Add basic debug test and modify sim flow

### DIFF
--- a/dv/uvm/Makefile
+++ b/dv/uvm/Makefile
@@ -2,45 +2,45 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-DV_DIR        := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-GEN_DIR       := $(realpath ${DV_DIR}/../../vendor/google_riscv-dv)
-TOOLCHAIN     := ${RISCV_TOOLCHAIN}
-OUT           := "${DV_DIR}/out"
+DV_DIR        			:= $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+GEN_DIR       			:= $(realpath ${DV_DIR}/../../vendor/google_riscv-dv)
+TOOLCHAIN     			:= ${RISCV_TOOLCHAIN}
+OUT           			:= "${DV_DIR}/out"
 # Run time options for the instruction generator
-GEN_OPTS      :=
+GEN_OPTS      			:=
 # Run time options for ibex RTL simulation
-SIM_OPTS      :=
+SIM_OPTS      			:=
 # Enable waveform dumping
-WAVES         := 1
+WAVES         			:= 1
 # Enable coverage dump
-COV           := 0
+COV           			:= 0
 # RTL simulator
-SIMULATOR     := "vcs"
+SIMULATOR     			:= "vcs"
 # ISS (spike, ovpsim)
-ISS           := "spike"
+ISS           			:= "spike"
 # ISA
-ISA           := "rv32imc"
+ISA           			:= "rv32imc"
 # Test name (default: full regression)
-TEST          := "all"
+TEST          			:= "all"
 # Seed for instruction generator and RTL simulation
-SEED          := -1
+SEED          			:= -1
 # Verbose logging
-VERBOSE       :=
+VERBOSE       			:=
 # Number of iterations for each test, assign a non-zero value to override the
 # iteration count in the test list
-ITERATIONS    := 0
+ITERATIONS    			:= 0
 # LSF CMD
-LSF_CMD       :=
+LSF_CMD       			:=
 # Generator timeout limit in seconds
-TIMEOUT       := 1800
+TIMEOUT       			:= 1800
 # Privileged CSR YAML description file
-CSR_FILE      := ${DV_DIR}/riscv_dv_extension/csr_description.yaml
+CSR_FILE      			:= ${DV_DIR}/riscv_dv_extension/csr_description.yaml
 # Pass/fail signature address at the end of test
 END_SIGNATURE_ADDR  := 8ffffffc
 # Value written to END_SIGNATURE_ADDR that indicates test success
-PASS_VAL      := 0x1
+PASS_VAL      			:= 0x1
 # Value written to END_SIGNATURE_ADDR that indicates test failure
-FAIL_VAL      := 0x0
+FAIL_VAL      			:= 0x0
 
 SHELL=/bin/bash
 

--- a/dv/uvm/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/riscv_dv_extension/testlist.yaml
@@ -102,10 +102,30 @@
     +no_ebreak=0
   rtl_test: core_ibex_base_test
 
-- test: riscv_ebreak_debug_mode_test
+- test: riscv_debug_basic_test
+  description: >
+    Randomly assert debug_req_i, random instruction sequence in debug_rom section
+  iterations: 10
+  gen_test: riscv_instr_base_test
+  gen_opts: >
+    +no_ebreak=1
+    +instr_cnt=6000
+    +no_branch_jump=1
+    +no_csr_instr=1
+    +no_fence=1
+    +num_of_sub_program=0
+  rtl_test: core_ibex_base_test
+  sim_opts: >
+    +enable_debug_seq=1
+  compare_opts:
+    compare_final_value_only: 1
+    verbose: 1
+
+# TODO(udij) - this test is later in testlist - ignore for now
+- test: riscv_debug_ebreak_mode_test
   description: >
     Ebreak instruction test with debug mode enabled.
-  iterations: 10
+  iterations: 0
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000
@@ -113,8 +133,8 @@
   rtl_test: core_ibex_base_test
   sim_opts: >
     +enable_debug_seq=1
-  compare_opts: >
-    +compare_final_value_only=1
+  compare_opts:
+    compare_final_value_only: 1
 
 - test: riscv_fast_interrupt_test
   description: >
@@ -140,8 +160,8 @@
   rtl_test: core_ibex_base_test
   sim_opts: >
     +enable_irq_seq=1
-  compare_opts: >
-    +compare_final_value_only=1
+  compare_opts:
+    compare_final_value_only: 1
 
 - test: riscv_csr_test
   description: >

--- a/dv/uvm/tests/core_ibex_base_test.sv
+++ b/dv/uvm/tests/core_ibex_base_test.sv
@@ -55,7 +55,6 @@ class core_ibex_base_test extends uvm_test;
     dut_vif.fetch_enable = 1'b1;
     vseq.start(env.vseqr);
     wait_for_test_done();
-    vseq.stop();
     phase.drop_objection(this);
   endtask
 
@@ -91,6 +90,7 @@ class core_ibex_base_test extends uvm_test;
     fork
       begin
         wait (dut_vif.ecall === 1'b1);
+        vseq.stop();
         `uvm_info(`gfn, "ECALL instruction is detected, test done", UVM_LOW)
         // De-assert fetch enable to finish the test
         dut_vif.fetch_enable = 1'b0;


### PR DESCRIPTION
- Modified sim.py to correctly process any sim_opts and compare_opts passed specified in the testlist
- Removed shared utility functions from sim.py (duplicates of functions in lib.py)
- Changed location of vseq.stop() call in testbench to prevent debug or interrupt signal assertions after ecall has been detected