### PR TITLE
Rework CSR-related pipeline flushes

### DIFF
--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -82,7 +82,7 @@ module ibex_decoder #(
     // CSRs
     output logic                 csr_access_o,          // access to CSR
     output ibex_pkg::csr_op_e    csr_op_o,              // operation to perform on CSR
-    output logic                 csr_status_o,          // access to xstatus CSR
+    output logic                 csr_pipe_flush_o,      // CSR-related pipeline flush
 
     // LSU
     output logic                 data_req_o,            // start transaction to data memory
@@ -159,6 +159,32 @@ module ibex_decoder #(
     end
   end
 
+  /////////////////////////////////
+  // CSR-related pipline flushes //
+  /////////////////////////////////
+  always_comb begin : csr_pipeline_flushes
+    csr_pipe_flush_o = 1'b0;
+
+    // A pipeline flush is needed to let the controller react after modifying certain CSRs:
+    // - When enabling interrupts, pending IRQs become visible to the controller only during
+    //   the next cycle. If during that cycle the core disables interrupts again, it does not
+    //   see any pending IRQs and consequently does not start to handle interrupts.
+    // - When modifying debug CSRs - TODO: Check if this is really needed
+    if (csr_access_o == 1'b1 && (csr_op_o == CSR_OP_WRITE || csr_op_o == CSR_OP_SET)) begin
+      if (csr_num_e'(instr[31:20]) == CSR_MSTATUS   ||
+          csr_num_e'(instr[31:20]) == CSR_MIE) begin
+        csr_pipe_flush_o = 1'b1;
+      end
+    end else if (csr_access_o == 1'b1 && csr_op_o != CSR_OP_READ) begin
+      if (csr_num_e'(instr[31:20]) == CSR_DCSR      ||
+          csr_num_e'(instr[31:20]) == CSR_DPC       ||
+          csr_num_e'(instr[31:20]) == CSR_DSCRATCH0 ||
+          csr_num_e'(instr[31:20]) == CSR_DSCRATCH1) begin
+        csr_pipe_flush_o = 1'b1;
+      end
+    end
+  end
+
   /////////////
   // Decoder //
   /////////////
@@ -183,7 +209,6 @@ module ibex_decoder #(
     regfile_we                  = 1'b0;
 
     csr_access_o                = 1'b0;
-    csr_status_o                = 1'b0;
     csr_illegal                 = 1'b0;
     csr_op                      = CSR_OP_READ;
 
@@ -554,17 +579,6 @@ module ibex_decoder #(
             2'b11:   csr_op = CSR_OP_CLEAR;
             default: csr_illegal = 1'b1;
           endcase
-
-          if (!csr_illegal) begin
-            // flush pipeline on access to mstatus or debug CSRs
-            if (csr_num_e'(instr[31:20]) == CSR_MSTATUS   ||
-                csr_num_e'(instr[31:20]) == CSR_DCSR      ||
-                csr_num_e'(instr[31:20]) == CSR_DPC       ||
-                csr_num_e'(instr[31:20]) == CSR_DSCRATCH0 ||
-                csr_num_e'(instr[31:20]) == CSR_DSCRATCH1) begin
-              csr_status_o = 1'b1;
-            end
-          end
 
           illegal_insn = csr_illegal;
         end

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -219,7 +219,7 @@ module ibex_id_stage #(
   logic        data_req_id, data_req_dec;
 
   // CSR control
-  logic        csr_status;
+  logic        csr_pipe_flush;
 
   logic [31:0] alu_operand_a;
   logic [31:0] alu_operand_b;
@@ -378,7 +378,7 @@ module ibex_id_stage #(
       // CSRs
       .csr_access_o                    ( csr_access_o         ),
       .csr_op_o                        ( csr_op_o             ),
-      .csr_status_o                    ( csr_status           ),
+      .csr_pipe_flush_o                ( csr_pipe_flush       ),
 
       // LSU
       .data_req_o                      ( data_req_dec         ),
@@ -413,7 +413,7 @@ module ibex_id_stage #(
       .dret_insn_i                    ( dret_insn_dec          ),
       .wfi_insn_i                     ( wfi_insn_dec           ),
       .ebrk_insn_i                    ( ebrk_insn              ),
-      .csr_status_i                   ( csr_status             ),
+      .csr_pipe_flush_i               ( csr_pipe_flush         ),
 
       // from IF-ID pipeline
       .instr_valid_i                  ( instr_valid_i          ),


### PR DESCRIPTION
This commit clarifies why CSR-related pipeline flushes are needed (e.g. when enabling interrupts), only introduces them when doing the critical modifications (write/set bits in `mstatus` and `mie` CSRs
for enabling interrupts, reads and clears are uncritical for these CSRs), and makes sure the controller is actually able to start handling interrupts while doing a CSR-related pipeline flush.

This resolves lowrisc/ibex#6.