### PR TITLE
Remove unused signal data_reg_offset

### DIFF
--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -175,7 +175,6 @@ module ibex_core #(
   logic        data_we_ex;
   logic [1:0]  data_type_ex;
   logic        data_sign_ext_ex;
-  logic [1:0]  data_reg_offset_ex;
   logic        data_req_ex;
   logic [31:0] data_wdata_ex;
   logic [31:0] regfile_wdata_lsu;
@@ -421,7 +420,6 @@ module ibex_core #(
       .data_we_ex_o                 ( data_we_ex             ), // to load store unit
       .data_type_ex_o               ( data_type_ex           ), // to load store unit
       .data_sign_ext_ex_o           ( data_sign_ext_ex       ), // to load store unit
-      .data_reg_offset_ex_o         ( data_reg_offset_ex     ), // to load store unit
       .data_wdata_ex_o              ( data_wdata_ex          ), // to load store unit
 
       .lsu_addr_incr_req_i          ( lsu_addr_incr_req      ),
@@ -525,7 +523,6 @@ module ibex_core #(
       .data_we_ex_i          ( data_we_ex          ),
       .data_type_ex_i        ( data_type_ex        ),
       .data_wdata_ex_i       ( data_wdata_ex       ),
-      .data_reg_offset_ex_i  ( data_reg_offset_ex  ),
       .data_sign_ext_ex_i    ( data_sign_ext_ex    ),
 
       .data_rdata_ex_o       ( regfile_wdata_lsu   ),

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -91,7 +91,6 @@ module ibex_decoder #(
                                                         // word or word
     output logic                 data_sign_extension_o, // sign extension for data read from
                                                         // memory
-    output logic [1:0]           data_reg_offset_o,     // register byte offset for stores
 
     // jump/branches
     output logic                 jump_in_dec_o,         // jump is being calculated in ALU
@@ -215,7 +214,6 @@ module ibex_decoder #(
     data_we_o                   = 1'b0;
     data_type_o                 = 2'b00;
     data_sign_extension_o       = 1'b0;
-    data_reg_offset_o           = 2'b00;
     data_req_o                  = 1'b0;
 
     illegal_insn                = 1'b0;

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -100,7 +100,6 @@ module ibex_id_stage #(
     output logic                  data_we_ex_o,
     output logic [1:0]            data_type_ex_o,
     output logic                  data_sign_ext_ex_o,
-    output logic [1:0]            data_reg_offset_ex_o,
     output logic [31:0]           data_wdata_ex_o,
 
     input  logic                  lsu_addr_incr_req_i,
@@ -215,7 +214,6 @@ module ibex_id_stage #(
   logic        data_we_id;
   logic [1:0]  data_type_id;
   logic        data_sign_ext_id;
-  logic [1:0]  data_reg_offset_id;
   logic        data_req_id, data_req_dec;
 
   // CSR control
@@ -385,7 +383,6 @@ module ibex_id_stage #(
       .data_we_o                       ( data_we_id           ),
       .data_type_o                     ( data_type_id         ),
       .data_sign_extension_o           ( data_sign_ext_id     ),
-      .data_reg_offset_o               ( data_reg_offset_id   ),
 
       // jump/branches
       .jump_in_dec_o                   ( jump_in_dec          ),
@@ -502,7 +499,6 @@ module ibex_id_stage #(
   assign data_type_ex_o              = data_type_id;
   assign data_sign_ext_ex_o          = data_sign_ext_id;
   assign data_wdata_ex_o             = regfile_rdata_b;
-  assign data_reg_offset_ex_o        = data_reg_offset_id;
 
   assign alu_operator_ex_o           = alu_operator;
   assign alu_operand_a_ex_o          = alu_operand_a;

--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -46,7 +46,6 @@ module ibex_load_store_unit (
     input  logic         data_we_ex_i,         // write enable                     -> from ID/EX
     input  logic [1:0]   data_type_ex_i,       // data type: word, half word, byte -> from ID/EX
     input  logic [31:0]  data_wdata_ex_i,      // data to write to memory          -> from ID/EX
-    input  logic [1:0]   data_reg_offset_ex_i, // register byte offset for stores  -> from ID/EX
     input  logic         data_sign_ext_ex_i,   // sign extension                   -> from ID/EX
 
     output logic [31:0]  data_rdata_ex_o,      // requested data                   -> to ID/EX
@@ -161,9 +160,8 @@ module ibex_load_store_unit (
   /////////////////////
 
   // prepare data to be written to the memory
-  // we handle misaligned accesses, half word and byte accesses and
-  // register offsets here
-  assign wdata_offset = data_addr[1:0] - data_reg_offset_ex_i[1:0];
+  // we handle misaligned accesses, half word and byte accesses here
+  assign wdata_offset = data_addr[1:0];
   always_comb begin
     unique case (wdata_offset)
       2'b00:   data_wdata =  data_wdata_ex_i[31:0];


### PR DESCRIPTION
This removes an unused which was hardwired to ```2'b0``` in the decoder and was passed through to the LSU.
This addresses https://github.com/lowRISC/ibex/issues/229