### PR TITLE
`ram_1p.sv`: Fix `rvalid_o` generation

### DIFF
--- a/examples/fpga/artya7-100/rtl/ram_1p.sv
+++ b/examples/fpga/artya7-100/rtl/ram_1p.sv
@@ -42,7 +42,7 @@ module ram_1p #(
     if (!rst_ni) begin
       rvalid_o <= '0;
     end else begin
-      rvalid_o <= req_i && ~write_i;
+      rvalid_o <= req_i;
     end
   end
 


### PR DESCRIPTION
This signal must also be set in case of write transactions as it is a request valid and not a read valid.