### PR TITLE
Update google_riscv-dv to 73274f2

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: 7cce16c0a212c8713a82516fbf8f2570d3dc4505
+    rev: 73274f227000f1316cb201a8503aad437e427948
   }
 }

--- a/vendor/google_riscv-dv/README.md
+++ b/vendor/google_riscv-dv/README.md
@@ -186,24 +186,27 @@ riscv_instr_group_t supported_isa[] = {RV32I, RV32M, RV64I, RV64M};
 
 ### Runtime options of the generator
 
-| Option                      | Description                                     | Default |
-|:---------------------------:|:-----------------------------------------------:|:-------:|
-| num_of_tests                | Number of assembly tests to be generated        | 1       |
-| num_of_sub_program          | Number of sub-program in one test               | 5       |
-| instr_cnt                   | Instruction count per test                      | 200     |
-| enable_page_table_exception | Enable page table exception                     | 0       |
-| no_ebreak                   | Disable ebreak instruction                      | 1       |
-| no_wfi                      | Disable WFI instruction                         | 1       |
-| no_branch_jump              | Disable branch/jump instruction                 | 0       |
-| no_load_store               | Disable load/store instruction                  | 0       |
-| no_csr_instr                | Disable CSR instruction                         | 0       |
-| no_fence                    | Disable fence instruction                       | 0       |
-| enable_illegal_instruction  | Enable illegal instructions                     | 0       |
-| enable_hint_instruction     | Enable HINT instruction                         | 0       |
-| boot_mode                   | m:Machine mode, s:Supervisor mode, u:User mode  | m       |
-| no_directed_instr           | Disable directed instruction stream             | 0       |
-| enable_interrupt            | Enable MStatus.MIE, used in interrupt test      | 0       |
-| empty_debug_section         | Disables randomized debug_rom section           | 0       |
+| Option                      | Description                                       | Default |
+|:---------------------------:|:-------------------------------------------------:|:-------:|
+| num_of_tests                | Number of assembly tests to be generated          | 1       |
+| num_of_sub_program          | Number of sub-program in one test                 | 5       |
+| instr_cnt                   | Instruction count per test                        | 200     |
+| enable_page_table_exception | Enable page table exception                       | 0       |
+| no_ebreak                   | Disable ebreak instruction                        | 1       |
+| no_wfi                      | Disable WFI instruction                           | 1       |
+| no_branch_jump              | Disable branch/jump instruction                   | 0       |
+| no_load_store               | Disable load/store instruction                    | 0       |
+| no_csr_instr                | Disable CSR instruction                           | 0       |
+| no_fence                    | Disable fence instruction                         | 0       |
+| enable_illegal_instruction  | Enable illegal instructions                       | 0       |
+| enable_hint_instruction     | Enable HINT instruction                           | 0       |
+| boot_mode                   | m:Machine mode, s:Supervisor mode, u:User mode    | m       |
+| no_directed_instr           | Disable directed instruction stream               | 0       |
+| require_signature_addr      | Set to 1 if test needs to talk to testbench       | 0       |
+| signature_addr              | Write to this addr to send data to testbench      | 0       |
+| enable_interrupt            | Enable MStatus.MIE, used in interrupt test        | 0       |
+| gen_debug_section           | Disables randomized debug_rom section             | 0       |
+| num_debug_sub_program       | Number of debug sub-programs in test              | 0       |
 
 
 ### Setup Privileged CSR description

--- a/vendor/google_riscv-dv/scripts/spike_log_to_trace_csv.py
+++ b/vendor/google_riscv-dv/scripts/spike_log_to_trace_csv.py
@@ -65,6 +65,9 @@ def process_spike_sim_log(spike_log, csv):
         rv_instr_trace.instr_str = spike_instr
         rv_instr_trace.addr = m.group("addr")
         rv_instr_trace.binary = m.group("bin")
+        if spike_instr == "wfi":
+          trace_csv.write_trace_entry(rv_instr_trace)
+          continue
         nextline = f.readline()
         if nextline != "":
           m = RD_RE.search(nextline)

--- a/vendor/google_riscv-dv/setting/riscv_core_setting.sv
+++ b/vendor/google_riscv-dv/setting/riscv_core_setting.sv
@@ -32,6 +32,9 @@ riscv_instr_name_t unsupported_instr[];
 // ISA supported by the processor
 riscv_instr_group_t supported_isa[$] = {RV32I, RV32M, RV64I, RV64M, RV32C, RV64C};
 
+// Interrupt mode support
+mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/vendor/google_riscv-dv/src/riscv_instr_pkg.sv
+++ b/vendor/google_riscv-dv/src/riscv_instr_pkg.sv
@@ -24,6 +24,8 @@ package riscv_instr_pkg;
 
   `define include_file(f) `include `"f`"
 
+  parameter CORE_INITIALIZATION_DONE = 2;
+
   typedef enum bit [3:0] {
     BARE = 4'b0000,
     SV32 = 4'b0001,
@@ -32,6 +34,11 @@ package riscv_instr_pkg;
     SV57 = 4'b1010,
     SV64 = 4'b1011
   } satp_mode_t;
+
+  typedef enum bit [1:0] {
+    DIRECT   = 2'b00,
+    VECTORED = 2'b01
+  } mtvec_mode_t;
 
   typedef enum bit [2:0] {
     IMM,    // Signed immediate
@@ -729,7 +736,7 @@ package riscv_instr_pkg;
     // need to use the virtual address to access the kernel stack.
     if((status == MSTATUS) && (SATP_MODE != BARE)) begin
       // We temporarily use tp to check mstatus to avoid changing other GPR. The value of sp has
-      // been saved to xStatus and can be restored later.
+      // been saved to xScratch and can be restored later.
       if(mprv) begin
         instr.push_back($sformatf("csrr tp, 0x%0x // MSTATUS", status));
         instr.push_back("srli tp, tp, 11");  // Move MPP to bit 0

--- a/vendor/google_riscv-dv/yaml/csr_template.yaml
+++ b/vendor/google_riscv-dv/yaml/csr_template.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http:#www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/vendor/google_riscv-dv/yaml/iss.yaml
+++ b/vendor/google_riscv-dv/yaml/iss.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http:#www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/vendor/google_riscv-dv/yaml/simulator.yaml
+++ b/vendor/google_riscv-dv/yaml/simulator.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http:#www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/vendor/google_riscv-dv/yaml/testlist.yaml
+++ b/vendor/google_riscv-dv/yaml/testlist.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http:#www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -185,10 +185,12 @@
   iterations: 2
   gen_test: riscv_rand_instr_test
   gen_opts: >
+    +require_signature_addr=1
     +instr_cnt=6000
     +no_ebreak=0
   rtl_test: core_base_test
   sim_opts: >
+    +require_signature_addr=1
     +enable_debug_seq=1
   compare_opts: >
     +compare_final_value_only=1
@@ -203,10 +205,12 @@
   iterations: 2
   gen_test: riscv_rand_instr_test
   gen_opts: >
+    +require_signature_addr=1
     +skip_trap_handling=1
     +no_wfi=0
   rtl_test: core_base_test
   sim_opts: >
+    +require_signature_addr=1
     +enable_irq_seq=1
 
 - test: riscv_full_interrupt_test
@@ -214,8 +218,11 @@
     Random instruction test with complete interrupt handling
   iterations: 2
   gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +require_signature_addr=1
   rtl_test: core_base_test
   sim_opts: >
+    +require_signature_addr=1
     +enable_irq_seq=1
   compare_opts: >
     +compare_final_value_only=1


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision 73274f227000f1316cb201a8503aad437e427948

* Merge pull request #88 from google/dev (taoliug)
* Fix spike log processing issue (Tao Liu)
* Merge pull request #87 from google/dev (udinator)
* Add vectored interrupt support (Tao Liu)
* Merge pull request #85 from udinator/debug (udinator)
* Add debug sub-programs, and extra options to generator (Udi)
* Merge pull request #84 from imphil/fix-apache-urls (taoliug)
* Fix license URLs in comments (Philipp Wagner)