### PR TITLE
Update google_riscv-dv to e81acc9

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: 73274f227000f1316cb201a8503aad437e427948
+    rev: e81acc9ab4f692ff205a207c2dc3d9f2b0284d39
   }
 }

--- a/vendor/google_riscv-dv/src/riscv_asm_program_gen.sv
+++ b/vendor/google_riscv-dv/src/riscv_asm_program_gen.sv
@@ -645,9 +645,6 @@ class riscv_asm_program_gen extends uvm_object;
     bit is_interrupt = 'b1;
     string tvec_name;
     string instr[$];
-    // The trap handler will occupy one 4KB page, it will be allocated one entry in the page table
-    // with a specific privileged mode.
-    instr_stream.push_back(".align 12");
     if (cfg.mtvec_mode == VECTORED) begin
       gen_interrupt_vector_table(mode, status, cause, scratch, instr);
     end else begin
@@ -667,6 +664,9 @@ class riscv_asm_program_gen extends uvm_object;
                $sformatf("srli a1, a1, %0d", XLEN-1),
                $sformatf("bne a1, x0, %0smode_intr_handler", mode)};
     end
+    // The trap handler will occupy one 4KB page, it will be allocated one entry in the page table
+    // with a specific privileged mode.
+    instr_stream.push_back(".align 12");
     tvec_name = tvec.name();
     gen_section($sformatf("%0s_handler", tvec_name.tolower()), instr);
     // Exception handler


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision e81acc9ab4f692ff205a207c2dc3d9f2b0284d39

* Merge pull request #89 from google/dev (taoliug)
* Fix mtvec alignement (Tao Liu)