### PR TITLE
Lint: Update Verilator waiver file

### DIFF
--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -24,34 +24,34 @@ lint_off -msg UNUSED -file "*/rtl/ibex_if_stage.sv" -lines 40
 
 // Bits of signal are not used: fetch_addr_n[0]
 // cleaner to write all bits even if not all are used
-lint_off -msg UNUSED -file "*/rtl/ibex_if_stage.sv" -lines 96
+lint_off -msg UNUSED -file "*/rtl/ibex_if_stage.sv" -lines 79
 
 // Bits of signal are not used: shift_right_result_ext[32]
 // cleaner to write all bits even if not all are used
-lint_off -msg UNUSED -file "*/rtl/ibex_alu.sv" -lines 122
+lint_off -msg UNUSED -file "*/rtl/ibex_alu.sv" -lines 107
 
 // Bits of signal are not used: alu_adder_ext_i[0]
 // Bottom bit is round, not needed
-lint_off -msg UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -lines 35
+lint_off -msg UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -lines 23
 
 // Bits of signal are not used: mac_res_ext[34]
 // cleaner to write all bits even if not all are used
-lint_off -msg UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -lines 60
+lint_off -msg UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -lines 48
 
 // Bits of signal are not used: res_adder_h[32]
 // cleaner to write all bits even if not all are used
-lint_off -msg UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -lines 80
+lint_off -msg UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -lines 68
 
 // Signal is not used: test_en_i
 // testability signal
-lint_off -msg UNUSED -file "*/rtl/ibex_register_file_ff.sv" -lines 38
+lint_off -msg UNUSED -file "*/rtl/ibex_register_file_ff.sv" -lines 21
 
 // Signal unoptimizable: Feedback to clock or circular logic:
 // ibex_core.id_stage_i.controller_i.ctrl_fsm_cs
 // Issue lowrisc/ibex#211
-lint_off -msg UNOPTFLAT -file "*/rtl/ibex_controller.sv" -lines 114
+lint_off -msg UNOPTFLAT -file "*/rtl/ibex_controller.sv" -lines 97
 
 // Signal unoptimizable: Feedback to clock or circular logic:
 // ibex_core.cs_registers_i.mie_q
 // Issue lowrisc/ibex#212
-lint_off -msg UNOPTFLAT -file "*/rtl/ibex_cs_registers.sv" -lines 157
+lint_off -msg UNOPTFLAT -file "*/rtl/ibex_cs_registers.sv" -lines 141


### PR DESCRIPTION
PR #236 broke the Verilator lint since lines changed. Fix that.