### PR TITLE
CSR: Access checks on Debug CSRs

### DIFF
--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -69,9 +69,9 @@ lint_off -msg UNUSED -file "*/rtl/ibex_core.sv" -lines 201
 // Signal unoptimizable: Feedback to clock or circular logic:
 // ibex_core.id_stage_i.controller_i.ctrl_fsm_cs
 // Issue lowrisc/ibex#211
-lint_off -msg UNOPTFLAT -file "*/rtl/ibex_controller.sv" -lines 97
+lint_off -msg UNOPTFLAT -file "*/rtl/ibex_controller.sv" -lines 98
 
 // Signal unoptimizable: Feedback to clock or circular logic:
 // ibex_core.cs_registers_i.mie_q
 // Issue lowrisc/ibex#212
-lint_off -msg UNOPTFLAT -file "*/rtl/ibex_cs_registers.sv" -lines 149
+lint_off -msg UNOPTFLAT -file "*/rtl/ibex_cs_registers.sv" -lines 150

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -65,6 +65,7 @@ module ibex_controller (
     input  logic                  debug_req_i,
     output ibex_pkg::dbg_cause_e  debug_cause_o,
     output logic                  debug_csr_save_o,
+    output logic                  debug_mode_o,
     input  logic                  debug_single_step_i,
     input  logic                  debug_ebreakm_i,
 
@@ -536,6 +537,9 @@ module ibex_controller (
       end
     endcase
   end
+
+  // signal to CSR when in debug mode
+  assign debug_mode_o = debug_mode_q;
 
   ///////////////////
   // Stall control //

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -201,6 +201,7 @@ module ibex_core #(
   priv_lvl_e   priv_mode;
 
   // debug mode and dcsr configuration
+  logic        debug_mode;
   dbg_cause_e  debug_cause;
   logic        debug_csr_save;
   logic        debug_single_step;
@@ -436,6 +437,7 @@ module ibex_core #(
       .irq_nm_i                     ( irq_nm_i               ),
 
       // Debug Signal
+      .debug_mode_o                 ( debug_mode             ),
       .debug_cause_o                ( debug_cause            ),
       .debug_csr_save_o             ( debug_csr_save         ),
       .debug_req_i                  ( debug_req_i            ),
@@ -600,6 +602,7 @@ module ibex_core #(
 
       // debug
       .csr_depc_o              ( csr_depc               ),
+      .debug_mode_i            ( debug_mode             ),
       .debug_cause_i           ( debug_cause            ),
       .debug_csr_save_i        ( debug_csr_save         ),
       .debug_single_step_o     ( debug_single_step      ),

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -57,6 +57,7 @@ module ibex_cs_registers #(
     output logic [33:0]          csr_pmp_addr_o [PMPNumRegions],
 
     // debug
+    input  logic                 debug_mode_i,
     input  ibex_pkg::dbg_cause_e debug_cause_i,
     input  logic                 debug_csr_save_i,
     output logic [31:0]          csr_depc_o,
@@ -292,10 +293,22 @@ module ibex_cs_registers #(
       CSR_PMPADDR14: csr_rdata_int = pmp_addr_rdata[14];
       CSR_PMPADDR15: csr_rdata_int = pmp_addr_rdata[15];
 
-      CSR_DCSR:      csr_rdata_int = dcsr_q;
-      CSR_DPC:       csr_rdata_int = depc_q;
-      CSR_DSCRATCH0: csr_rdata_int = dscratch0_q;
-      CSR_DSCRATCH1: csr_rdata_int = dscratch1_q;
+      CSR_DCSR: begin
+        csr_rdata_int = dcsr_q;
+        illegal_csr = ~debug_mode_i;
+      end
+      CSR_DPC: begin
+        csr_rdata_int = depc_q;
+        illegal_csr = ~debug_mode_i;
+      end
+      CSR_DSCRATCH0: begin
+        csr_rdata_int = dscratch0_q;
+        illegal_csr = ~debug_mode_i;
+      end
+      CSR_DSCRATCH1: begin
+        csr_rdata_int = dscratch1_q;
+        illegal_csr = ~debug_mode_i;
+      end
 
       // machine counter/timers
       CSR_MCOUNTINHIBIT: csr_rdata_int = mcountinhibit;

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -100,6 +100,7 @@ module ibex_id_stage #(
     input  logic                  lsu_store_err_i,
 
     // Debug Signal
+    output logic                  debug_mode_o,
     output ibex_pkg::dbg_cause_e  debug_cause_o,
     output logic                  debug_csr_save_o,
     input  logic                  debug_req_i,
@@ -439,6 +440,7 @@ module ibex_id_stage #(
       .csr_mtval_o                    ( csr_mtval_o            ),
 
       // Debug Signal
+      .debug_mode_o                   ( debug_mode_o           ),
       .debug_cause_o                  ( debug_cause_o          ),
       .debug_csr_save_o               ( debug_csr_save_o       ),
       .debug_req_i                    ( debug_req_i            ),


### PR DESCRIPTION
  - The RISC-V Debug Spec v.0.13.2 (p.41) mandates that the core
    debug CSRs dcsr, dpc, dscratch0 and dscratch1 must not be
    accessible if not in debug mode. Fixes #275