### PR TITLE
Replace cluster_id/core_id with hart_id (Fixes #29)

### DIFF
--- a/doc/integration.rst
+++ b/doc/integration.rst
@@ -28,8 +28,7 @@ Instantiation Template
       .test_en_i      (),
 
       // Configuration
-      .core_id_i      (),
-      .cluster_id_i   (),
+      .hart_id_i      (),
       .boot_addr_i    (),
 
       // Instruction memory interface
@@ -90,7 +89,6 @@ Parameters
 | ``DmExceptionAddr``   | int         | 0x1A110808 | Address to jump to when an exception occurs while in debug mode |
 +-----------------------+-------------+------------+-----------------------------------------------------------------+
 
-
 Interfaces
 ----------
 
@@ -103,10 +101,8 @@ Interfaces
 +-------------------------+-------------------------+-----+----------------------------------------+
 | ``test_en_i``           | 1                       | in  | Test input, enables clock              |
 +-------------------------+-------------------------+-----+----------------------------------------+
-| ``core_id_i``           | 4                       | in  | Core ID, usually static, can be read   |
+| ``hart_id_i``           | 32                      | in  | Hart ID, usually static, can be read   |
 |                         |                         |     | from :ref:`csr-mhartid` CSR            |
-+-------------------------+-------------------------+-----+                                        +
-| ``cluster_id_i``        | 6                       | in  |                                        |
 +-------------------------+-------------------------+-----+----------------------------------------+
 | ``boot_addr_i``         | 32                      | in  | First program counter after reset      |
 |                         |                         |     | = ``boot_addr_i`` + 0x80,              |

--- a/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
+++ b/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
@@ -110,8 +110,7 @@ module ibex_riscv_compliance (
 
       .test_en_i             ('b0),
 
-      .core_id_i             (4'b0),
-      .cluster_id_i          (6'b0),
+      .hart_id_i             (32'b0),
       // First instruction executed is at 0x0 + 0x80
       .boot_addr_i           (32'h00000000),
 

--- a/dv/uvm/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/tb/core_ibex_tb_top.sv
@@ -23,8 +23,7 @@ module core_ibex_tb_top;
     .clk_i(clk),
     .rst_ni(rst_n),
     .test_en_i(1'b1),
-    .core_id_i('0),
-    .cluster_id_i('0),
+    .hart_id_i(32'b0),
     .boot_addr_i(`BOOT_ADDR), // align with spike boot address
     .debug_req_i(debug_req),
     .irq_software_i(irq_if.irq_software),

--- a/examples/fpga/artya7-100/rtl/top_artya7_100.sv
+++ b/examples/fpga/artya7-100/rtl/top_artya7_100.sv
@@ -48,8 +48,7 @@ module top_artya7_100 (
 
      .test_en_i             ('b0),
 
-     .core_id_i             (4'b0),
-     .cluster_id_i          (6'b0),
+     .hart_id_i             (32'b0),
      // First instruction executed is at 0x0 + 0x80
      .boot_addr_i           (32'h00000000),
 

--- a/examples/sim/tb/ibex_tracing_tb.sv
+++ b/examples/sim/tb/ibex_tracing_tb.sv
@@ -77,8 +77,7 @@ module ibex_tracing_tb;
     .test_en_i              (1'b0),
 
     // Core ID, Cluster ID and boot address are considered more or less static
-    .core_id_i              (4'b0),
-    .cluster_id_i           (6'b0),
+    .hart_id_i              (32'b0),
     .boot_addr_i            (32'b0),
 
     // Instruction memory interface

--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -56,15 +56,15 @@ lint_off -msg UNUSED -file "*/rtl/ibex_pmp.sv" -lines 16
 
 // Signal is not used: csr_pmp_addr
 // Signal not connected when PMP is not configured
-lint_off -msg UNUSED -file "*/rtl/ibex_core.sv" -lines 188
+lint_off -msg UNUSED -file "*/rtl/ibex_core.sv" -lines 186
 
 // Signal is not used: csr_pmp_cfg
 // Signal not connected when PMP is not configured
-lint_off -msg UNUSED -file "*/rtl/ibex_core.sv" -lines 189
+lint_off -msg UNUSED -file "*/rtl/ibex_core.sv" -lines 187
 
 // Signal is not used: priv_mode
 // Signal not connected when PMP is not configured
-lint_off -msg UNUSED -file "*/rtl/ibex_core.sv" -lines 201
+lint_off -msg UNUSED -file "*/rtl/ibex_core.sv" -lines 199
 
 // Signal unoptimizable: Feedback to clock or circular logic:
 // ibex_core.id_stage_i.controller_i.ctrl_fsm_cs
@@ -74,4 +74,4 @@ lint_off -msg UNOPTFLAT -file "*/rtl/ibex_controller.sv" -lines 98
 // Signal unoptimizable: Feedback to clock or circular logic:
 // ibex_core.cs_registers_i.mie_q
 // Issue lowrisc/ibex#212
-lint_off -msg UNOPTFLAT -file "*/rtl/ibex_cs_registers.sv" -lines 150
+lint_off -msg UNOPTFLAT -file "*/rtl/ibex_cs_registers.sv" -lines 149

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -123,7 +123,7 @@ module ibex_controller (
   always_ff @(negedge clk_i) begin
     // print warning in case of decoding errors
     if ((ctrl_fsm_cs == DECODE) && instr_valid_i && illegal_insn) begin
-      $display("%t: Illegal instruction (core %0d) at PC 0x%h: 0x%h", $time, ibex_core.core_id_i,
+      $display("%t: Illegal instruction (hart %0x) at PC 0x%h: 0x%h", $time, ibex_core.hart_id_i,
                ibex_id_stage.pc_id_i, ibex_id_stage.instr_rdata_i);
     end
   end

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -27,9 +27,7 @@ module ibex_core #(
 
     input  logic        test_en_i,     // enable all clock gates for testing
 
-    // Core ID, Cluster ID and boot address are considered more or less static
-    input  logic [ 3:0] core_id_i,
-    input  logic [ 5:0] cluster_id_i,
+    input  logic [31:0] hart_id_i,
     input  logic [31:0] boot_addr_i,
 
     // Instruction memory interface
@@ -566,9 +564,8 @@ module ibex_core #(
       .clk_i                   ( clk                    ),
       .rst_ni                  ( rst_ni                 ),
 
-      // Core and Cluster ID from outside
-      .core_id_i               ( core_id_i              ),
-      .cluster_id_i            ( cluster_id_i           ),
+      // Hart ID from outside
+      .hart_id_i               ( hart_id_i              ),
       .priv_mode_o             ( priv_mode              ),
 
       // mtvec

--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -20,9 +20,7 @@ module ibex_core_tracing #(
 
     input  logic        test_en_i,     // enable all clock gates for testing
 
-    // Core ID, Cluster ID and boot address are considered more or less static
-    input  logic [ 3:0] core_id_i,
-    input  logic [ 5:0] cluster_id_i,
+    input  logic [31:0] hart_id_i,
     input  logic [31:0] boot_addr_i,
 
     // Instruction memory interface
@@ -101,8 +99,7 @@ module ibex_core_tracing #(
 
     .test_en_i,
 
-    .core_id_i,
-    .cluster_id_i,
+    .hart_id_i,
     .boot_addr_i,
 
     .instr_req_o,
@@ -162,8 +159,7 @@ module ibex_core_tracing #(
       .rst_ni           ( rst_ni                 ),
 
       .fetch_enable_i   ( fetch_enable_i         ),
-      .core_id_i        ( core_id_i              ),
-      .cluster_id_i     ( cluster_id_i           ),
+      .hart_id_i        ( hart_id_i              ),
 
       .valid_i          ( rvfi_valid             ),
       .pc_i             ( rvfi_pc_rdata          ),

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -22,9 +22,8 @@ module ibex_cs_registers #(
     input  logic                 clk_i,
     input  logic                 rst_ni,
 
-    // Core and Cluster ID
-    input  logic  [3:0]          core_id_i,
-    input  logic  [5:0]          cluster_id_i,
+    // Hart ID
+    input  logic [31:0]          hart_id_i,
     output ibex_pkg::priv_lvl_e  priv_mode_o,
 
     // mtvec
@@ -222,7 +221,7 @@ module ibex_cs_registers #(
 
     unique case (csr_addr_i)
       // mhartid: unique hardware thread id
-      CSR_MHARTID: csr_rdata_int = {21'b0, cluster_id_i[5:0], 1'b0, core_id_i[3:0]};
+      CSR_MHARTID: csr_rdata_int = hart_id_i;
 
       // mstatus: always M-mode, contains IE bit
       CSR_MSTATUS: begin

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -23,8 +23,7 @@ module ibex_tracer #(
     input  logic                      rst_ni,
 
     input  logic                      fetch_enable_i,
-    input  logic [3:0]                core_id_i,
-    input  logic [5:0]                cluster_id_i,
+    input  logic [31:0]               hart_id_i,
 
     input  logic                      valid_i,
     input  logic [31:0]               pc_i,
@@ -290,7 +289,7 @@ module ibex_tracer #(
   initial begin
     wait(rst_ni == 1'b1);
     wait(fetch_enable_i == 1'b1);
-    $sformat(fn, "trace_core_%h_%h.log", cluster_id_i, core_id_i);
+    $sformat(fn, "trace_core_%h.log", hart_id_i);
     $display("[TRACER] Output filename is: %s", fn);
     f = $fopen(fn, "w");
     $fwrite(f, "                Time          Cycles PC       Instr    Mnemonic\n");


### PR DESCRIPTION
Uncertain if we actually want a HartIDWidth parameter or just hard-code it to 32 bit.