### PR TITLE
Add verilator support to Ibex tracer

### DIFF
--- a/doc/tracer.rst
+++ b/doc/tracer.rst
@@ -5,7 +5,3 @@ Tracer
 
 The module ``ibex_tracer`` can be used to create a log of the executed instructions.
 It is used by ``ibex_core_tracing`` which forwards the signals added by :ref:`rvfi` as an input for the tracer.
-
-.. note::
-
-   ``ibex_tracer`` is not compatible with Verilator.

--- a/examples/sim/tb/ibex_tracing_tb.cpp
+++ b/examples/sim/tb/ibex_tracing_tb.cpp
@@ -1,0 +1,115 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdlib.h>
+#include <iostream>
+#include <utility>
+#include <string>
+#include "Vibex_tracing_tb.h"
+#include "verilated_vcd_c.h"
+
+vluint64_t sim_time = 0;
+
+// This function is needed to ensure verilator
+// knows the current simulation time
+double sc_time_stamp () {
+  return sim_time;
+}
+
+int main(int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Verilated::traceEverOn(true);
+
+  Vibex_tracing_tb *top = new Vibex_tracing_tb;
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+
+  top->trace (tfp, 99);
+  tfp->open ("ibex_trace.vcd");
+
+  top->clk   = 0;
+  top->rst_n = 0;
+
+  while (!Verilated::gotFinish()) {
+    if (sim_time == 160) {
+      top->rst_n = 1;
+    } else if (sim_time == 200) {
+      top->instr_rdata  = 0x81868106;
+      top->instr_rvalid = 0;
+      top->instr_gnt    = 1;
+    } else if (sim_time == 210) {
+      top->instr_rvalid = 1;
+      top->instr_gnt    = 0;
+    } else if (sim_time == 220) {
+      top->instr_rvalid = 0;
+    } else if (sim_time == 250) {
+      top->instr_rdata  = 0x00400113;
+      top->instr_rvalid = 0;
+      top->instr_gnt    = 1;
+    } else if (sim_time == 260) {
+      top->instr_rvalid = 1;
+      top->instr_gnt    = 0;
+    } else if (sim_time == 270) {
+      top->instr_rvalid = 0;
+      top->instr_rdata  = 0xff810113;
+      top->instr_gnt    = 1;
+    } else if (sim_time == 280) {
+      top->instr_rvalid = 1;
+      top->instr_gnt    = 0;
+    } else if (sim_time == 290) {
+      top->instr_rvalid = 0;
+      top->instr_rdata  = 0x4000006f;
+      top->instr_gnt    = 1;
+    } else if (sim_time == 300) {
+      top->instr_rvalid = 1;
+      top->instr_gnt    = 0;
+    } else if (sim_time == 310) {
+      top->instr_rvalid = 0;
+    } else if (sim_time == 320) {
+      top->instr_rdata  = 0x039597b3;
+      top->instr_gnt    = 1;
+    } else if (sim_time == 330) {
+      top->instr_rvalid = 1;
+      top->instr_gnt    = 1;
+    } else if (sim_time == 340) {
+      top->instr_rdata  = 0x13410d13;
+    } else if (sim_time == 350) {
+      top->instr_rdata  = 0xe1070713;
+    } else if (sim_time == 360) {
+      top->instr_rdata  = 0xfff7c793;
+    } else if (sim_time == 370) {
+      top->instr_rdata  = 0x00000013;
+    } else if (sim_time == 380) {
+      top->instr_rdata  = 0x002d2c23;
+    } else if (sim_time == 390) {
+      top->instr_rdata  = 0x00000013;
+    } else if (sim_time == 400) {
+      top->instr_rdata  = 0x000d2083;
+      top->data_rdata   = 0x12345678;
+    } else if (sim_time == 410) {
+      top->instr_rdata  = 0x60008113;
+    } else if (sim_time == 420) {
+      top->instr_rdata  = 0x00000013;
+    } else if (sim_time == 430) {
+      top->instr_rdata  = 0x002d2023;
+    } else if (sim_time == 450) {
+      top->instr_rdata  = 0x0000000f;
+    } else if (sim_time == 460) {
+      top->instr_rdata  = 0x00000113;
+    } else if (sim_time == 490) {
+      top->instr_rdata  = 0x00000013;
+    } else if (sim_time == 500) {
+      top->instr_rdata  = 0x0000000f;
+    }
+    if (sim_time == 560) {
+      top->sim_done = 1;
+    }
+    top->clk = !top->clk;
+    top->eval();
+    tfp->dump (sim_time);
+    sim_time += 5;
+  }
+  tfp->close();
+  delete top;
+  exit(0);
+}

--- a/examples/sim/tb/ibex_tracing_tb.sv
+++ b/examples/sim/tb/ibex_tracing_tb.sv
@@ -5,6 +5,7 @@
 // Sample testbench for Ibex with tracing enabled
 // The `nop` instruction is the only input
 
+`ifndef VERILATOR
 module ibex_tracing_tb;
   logic         clk          = 1'b0;
   logic         rst_n        = 1'b0;
@@ -12,7 +13,20 @@ module ibex_tracing_tb;
   logic [31:0]  data_rdata   = 32'h00000000;
   logic         instr_gnt    = 1'b0;
   logic         instr_rvalid = 1'b0;
+  logic         sim_done     = 1'b0;
+`else
+module ibex_tracing_tb (
+  input logic         clk,
+  input logic         rst_n,
+  input logic [31:0]  instr_rdata,
+  input logic [31:0]  data_rdata,
+  input logic         instr_gnt,
+  input logic         instr_rvalid,
+  input logic         sim_done
+);
+`endif
 
+`ifndef VERILATOR
   initial begin: clock_gen
     forever begin
       #5ns clk = 1'b0;
@@ -69,6 +83,13 @@ module ibex_tracing_tb;
     #30ns  instr_rdata  = 32'h00000013;
     #10ns  instr_rdata  = 32'h0000000f;
   end
+`else
+  always @(posedge clk) begin
+    if (sim_done) begin
+      $finish;
+    end
+  end
+`endif
 
   ibex_core_tracing ibex_i (
     .clk_i                  (clk),

--- a/examples/sim/top_tracing_sim.core
+++ b/examples/sim/top_tracing_sim.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:ibex:top_tracing_sim:0.1"
-description: "Ibex with tracing enabled (ModelSim only right now)"
+description: "Ibex with tracing enabled"
 filesets:
   files_tb:
     depend:
@@ -13,13 +13,27 @@ filesets:
       - tb/ibex_tracing_tb.sv
     file_type: systemVerilogSource
 
+  files_verilator_tb:
+    files:
+      - tb/ibex_tracing_tb.cpp
+    file_type: cSource
+
 targets:
   sim:
     default_tool: modelsim
     filesets:
       - files_tb
+      - tool_verilator ? (files_verilator_tb)
     toplevel:
       - ibex_tracing_tb
     tools:
       modelsim:
         vlog_options: [-timescale 1ns/1ns]
+      verilator:
+        mode: cc
+        verilator_options:
+          - "--exe"
+          - "--trace"
+          - "-Wno-UNOPTFLAT"
+          - "-Wno-WIDTH"
+          - "-Wno-CASEX"

--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -65,6 +65,8 @@ module ibex_core_tracing #(
     Fatal error: RVFI needs to be defined globally.
   `endif
 
+  parameter int unsigned RegAddrWidth = RV32E ? 4 : 5;
+
   logic        rvfi_valid;
   logic [63:0] rvfi_order;
   logic [31:0] rvfi_insn;
@@ -152,9 +154,9 @@ module ibex_core_tracing #(
     .core_sleep_o
   );
 
-
-`ifndef VERILATOR
-  ibex_tracer u_ibex_tracer (
+  ibex_tracer #(
+    .RegAddrWidth(RegAddrWidth)
+  ) u_ibex_tracer (
       .clk_i            ( clk_i                  ),
       .rst_ni           ( rst_ni                 ),
 
@@ -172,8 +174,5 @@ module ibex_core_tracing #(
       .ex_data_wdata_i  ( rvfi_mem_wdata         ),
       .ex_data_rdata_i  ( rvfi_mem_rdata         )
   );
-`else
-    // ibex_tracer uses language constructs which Verilator doesn't understand.
-`endif
 
 endmodule

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -3,17 +3,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Source/Destination register instruction index
-`define REG_S1 19:15
-`define REG_S2 24:20
-`define REG_S3 29:25
-`define REG_D  11:07
-
 /**
  * Traces the executed instructions
- *
- * Note: Verilator does not support the language constructs used in this
- * module!
  */
 module ibex_tracer #(
     parameter int unsigned RegAddrWidth = 5
@@ -40,17 +31,18 @@ module ibex_tracer #(
   import ibex_pkg::*;
   import ibex_tracer_pkg::*;
 
-  integer      f;
-  string       fn;
-  integer      cycles;
+  int          file_handle;
+  string       file_name;
+
   logic [ 4:0] rd, rs1, rs2, rs3;
 
-  typedef struct {
+  typedef struct packed {
     logic [(RegAddrWidth-1):0] addr;
     logic [31:0] value;
   } reg_t;
 
-  typedef struct {
+  typedef struct packed {
+    logic        valid;
     logic [31:0] addr;
     logic        we;
     logic [ 3:0] be;
@@ -58,389 +50,392 @@ module ibex_tracer #(
     logic [31:0] rdata;
   } mem_acc_t;
 
-  class instr_trace_t;
-    time         simtime;
-    integer      cycles;
-    logic [31:0] pc;
-    logic [31:0] instr;
-    string       str;
-    reg_t        regs_read[$];
-    reg_t        regs_write[$];
-    mem_acc_t    mem_access[$];
+  integer      cycles;
+  logic [31:0] pc;
+  logic [31:0] instr;
+  string       str;
+  reg_t        regs_read[3];
+  reg_t        regs_write[3];
+  mem_acc_t    mem_access[3];
 
-    function new ();
-      str        = "";
-      regs_read  = {};
-      regs_write = {};
-      mem_access = {};
-    endfunction
+  function void init();
+    str        = "";
+    for (int i = 0; i < 3; i++) begin
+      regs_read[i].addr   = {{RegAddrWidth{1'b0}}};
+      regs_read[i].value  = 32'h0;
+      regs_write[i].addr  = {{RegAddrWidth{1'b0}}};
+      regs_write[i].value = 32'h0;
+      mem_access[i].valid = 1'b0;
+      mem_access[i].addr  = 32'h0;
+      mem_access[i].we    = 1'b0;
+      mem_access[i].be    = 4'h0;
+      mem_access[i].wdata = 32'h0;
+      mem_access[i].rdata = 32'h0;
+    end
+    rd  = instr_i[11:7];
+    rs1 = instr_i[19:15];
+    rs2 = instr_i[24:20];
+    rs3 = instr_i[29:25];
+  endfunction
 
-    function string regAddrToStr(input logic [(RegAddrWidth-1):0] addr);
-      begin
-        if (addr < 10) begin
-          return $sformatf(" x%0d", addr);
-        end else begin
-          return $sformatf("x%0d", addr);
+  function string reg_addr_to_str(input logic [(RegAddrWidth-1):0] addr);
+    begin
+      if (addr < 10) begin
+        return $sformatf(" x%0d", addr);
+      end else begin
+        return $sformatf("x%0d", addr);
+      end
+    end
+  endfunction
+
+  function void dump_printbuffer_to_file();
+    begin
+      if (file_handle == 32'h0) begin
+        $sformat(file_name, "trace_core_%h.log", hart_id_i);
+        $display("[TRACER] Output filename is: %s", file_name);
+        file_handle = $fopen(file_name, "w");
+        $fwrite(file_handle, "                Time          Cycles PC       Instr    Mnemonic\n");
+      end
+
+      $fwrite(file_handle, "%t %15d %h %h %s", $time,
+                                        cycles,
+                                        pc_i,
+                                        instr_i,
+                                        str);
+
+      foreach (regs_write[i]) begin
+        if (regs_write[i].addr != 0) begin
+          $fwrite(file_handle, " %s=0x%08x",
+                                 reg_addr_to_str(regs_write[i].addr), regs_write[i].value);
         end
       end
-    endfunction
 
-    function void printInstrTrace();
-      mem_acc_t mem_acc;
-      begin
-        $fwrite(f, "%t %15d %h %h %-36s", simtime,
-                                          cycles,
-                                          pc_i,
-                                          instr_i,
-                                          str);
-
-        foreach(regs_write[i]) begin
-          if (regs_write[i].addr != 0) begin
-            $fwrite(f, " %s=0x%08x", regAddrToStr(regs_write[i].addr), regs_write[i].value);
-          end
+      foreach (regs_read[i]) begin
+        if (regs_read[i].addr != 0) begin
+          $fwrite(file_handle, " %s:0x%08x",
+                                 reg_addr_to_str(regs_read[i].addr), regs_read[i].value);
         end
+      end
 
-        foreach(regs_read[i]) begin
-          if (regs_read[i].addr != 0) begin
-            $fwrite(f, " %s:0x%08x", regAddrToStr(regs_read[i].addr), regs_read[i].value);
-          end
-        end
+      foreach (mem_access[i]) begin
+        if (mem_access[i].valid) begin
+          $fwrite(file_handle, " PA:0x%08x", mem_access[i].addr);
 
-        if (mem_access.size() > 0) begin
-          mem_acc = mem_access.pop_front();
-
-          $fwrite(f, " PA:0x%08x", mem_acc.addr);
-
-          if (mem_acc.we == 1'b1) begin
-            $fwrite(f, " store:0x%08x", mem_acc.wdata);
+          if (mem_access[i].we == 1'b1) begin
+            $fwrite(file_handle, " store:0x%08x", mem_access[i].wdata);
           end else begin
-            $fwrite(f, "  load:0x%08x", mem_acc.rdata);
+            $fwrite(file_handle, "  load:0x%08x", mem_access[i].rdata);
           end
         end
-
-        $fwrite(f, "\n");
       end
-    endfunction
 
-    function void printMnemonic(input string mnemonic);
-      begin
-        str = mnemonic;
+      $fwrite(file_handle, "\n");
+    end
+  endfunction
+
+  function void regs_read_push_back(input logic [1:0] idx, input logic [(RegAddrWidth-1):0] addr,
+                                    input logic [31:0] value);
+    begin
+      regs_read[idx].addr  = addr;
+      regs_read[idx].value = value;
+    end
+  endfunction
+
+  function void regs_write_push_back(input logic [1:0] idx, input logic [(RegAddrWidth-1):0] addr,
+                                     input logic [31:0] value);
+    begin
+      regs_write[idx].addr  = addr;
+      regs_write[idx].value = value;
+    end
+  endfunction
+
+  function void mem_access_push_back(input logic [1:0] idx, input logic [31:0] addr,
+                                     input logic we = 1'b0, input logic [3:0] be = 4'h0,
+                                     input logic [31:0] wdata = 'x, input logic [31:0] rdata = 'x);
+    begin
+      mem_access[idx].valid = 1'b1;
+      mem_access[idx].addr  = addr;
+      mem_access[idx].we    = we;
+      mem_access[idx].be    = be;
+      mem_access[idx].wdata = wdata;
+      mem_access[idx].rdata = rdata;
+    end
+  endfunction
+
+  function void print_mnemonic(input string mnemonic);
+    begin
+      str = mnemonic;
+    end
+  endfunction
+
+  function void print_r_instr(input string mnemonic);
+    begin
+      regs_read_push_back(2'b00, rs1, rs1_value_i);
+      regs_read_push_back(2'b01, rs2, rs2_value_i);
+      regs_write_push_back(2'b00, rd, 'x);
+      str = $sformatf("%s x%0d, x%0d, x%0d", mnemonic, rd, rs1, rs2);
+    end
+  endfunction
+
+  function void print_i_instr(input string mnemonic);
+    begin
+      regs_read_push_back(2'b00, rs1, rs1_value_i);
+      regs_write_push_back(2'b00, rd, 'x);
+      str = $sformatf("%s x%0d, x%0d, %0d", mnemonic, rd, rs1,
+                       $signed({{20 {instr[31]}}, instr[31:20]}));
+    end
+  endfunction
+
+  function void print_u_instr(input string mnemonic);
+    begin
+      regs_write_push_back(2'b00, rd, 'x);
+      str = $sformatf("%s x%0d, 0x%0h", mnemonic, rd, {instr[31:12], 12'h000});
+    end
+  endfunction
+
+  function void print_j_instr(input string mnemonic);
+    begin
+      regs_write_push_back(2'b00, rd, 'x);
+      str =  $sformatf("%s x%0d, %0d", mnemonic, rd,
+                        $signed({ {12 {instr[31]}}, instr[19:12], instr[20], instr[30:21], 1'b0 }));
+    end
+  endfunction
+
+  function void print_b_instr(input string mnemonic);
+    begin
+      regs_read_push_back(2'b00, rs1, rs1_value_i);
+      regs_read_push_back(2'b01, rs2, rs2_value_i);
+      str =  $sformatf("%s x%0d, x%0d, %0d", mnemonic, rs1, rs2,
+                        $signed({ {19 {instr[31]}}, instr[31], instr[7], instr[30:25],
+                                  instr[11:8], 1'b0 }));
+    end
+  endfunction
+
+  function void print_csr_instr(input string mnemonic);
+    logic [11:0] csr;
+    begin
+      csr = instr_i[31:20];
+
+      regs_write_push_back(2'b00, rd, 'x);
+
+      if (!instr_i[14]) begin
+        regs_read_push_back(2'b00, rs1, rs1_value_i);
+        str = $sformatf("%s x%0d, x%0d, 0x%h", mnemonic, rd, rs1, csr);
+      end else begin
+        str = $sformatf("%s x%0d, 0x%h, 0x%h", mnemonic, rd, { 27'b0, instr[19:15] }, csr);
       end
-    endfunction // printMnemonic
+    end
+  endfunction
 
-    function void printRInstr(input string mnemonic);
-      begin
-        regs_read.push_back('{rs1, rs1_value_i});
-        regs_read.push_back('{rs2, rs2_value_i});
-        regs_write.push_back('{rd, 'x});
-        str = $sformatf("%-16s x%0d, x%0d, x%0d", mnemonic, rd, rs1, rs2);
+  function void print_cr_instr(input string mnemonic);
+    begin
+      rs1 = instr_i[11:7];
+      rs2 = instr_i[6:2];
+
+      if (rs2 == 5'b0) begin
+        regs_read_push_back(2'b00, rs1, rs1_value_i);
+        str = $sformatf("%s x%0d", mnemonic, rs1);
+      end else begin
+        regs_write_push_back(2'b00, rs1, 'x);
+        regs_read_push_back(2'b00, rs2, rs2_value_i);
+        str = $sformatf("%s x%0d, x%0d", mnemonic, rs1, rs2);
       end
-    endfunction // printRInstr
+    end
+  endfunction
 
-    function void printIInstr(input string mnemonic);
-      begin
-        regs_read.push_back('{rs1, rs1_value_i});
-        regs_write.push_back('{rd, 'x});
-        str = $sformatf("%-16s x%0d, x%0d, %0d", mnemonic, rd, rs1, $signed({{20 {instr[31]}}, instr[31:20]}));
+  function void print_ci_instr(input string mnemonic);
+    begin
+      regs_write_push_back(2'b00, rd, 'x);
+      str = $sformatf("%s x%0d, 0x%h", mnemonic, rd, {instr_i[12], instr_i[4:0]});
+    end
+  endfunction
+
+  function void print_ciw_instr(input string mnemonic);
+    begin
+      rd = {2'b01, instr_i[4:2]};
+      regs_write_push_back(2'b00, rd, 'x);
+      str = $sformatf("%s x%0d, 0x%h", mnemonic, rd,
+                      {instr_i[10:7], instr_i[12:11], instr_i[5], instr_i[6]});
+    end
+  endfunction
+
+  function void print_cb_instr(input string mnemonic);
+    logic [8:1] imm;
+    begin
+      rs1 = {2'b01, instr_i[9:7]};
+      if ((instr_i[15:13] == 3'b110) || (instr_i[15:13] == 3'b111)) begin
+        imm = {instr_i[12], instr_i[6:5], instr_i[2], instr_i[11:10], instr_i[4:3]};
+        regs_read_push_back(2'b00, rs1, rs1_value_i);
+      end else begin
+        imm = {instr_i[12], instr_i[6:2], 2'b00};
+        regs_write_push_back(2'b00, rs1, 'x);
       end
-    endfunction // printIInstr
+      str = $sformatf("%s x%0d, 0x%h", mnemonic, rs1, imm);
+    end
+  endfunction
 
-    function void printIuInstr(input string mnemonic);
-      begin
-        regs_read.push_back('{rs1, rs1_value_i});
-        regs_write.push_back('{rd, 'x});
-        str = $sformatf("%-16s x%0d, x%0d, 0x%0x", mnemonic, rd, rs1, {{20 {instr[31]}}, instr[31:20]});
-      end
-    endfunction // printIuInstr
+  function void print_cs_instr(input string mnemonic);
+    begin
+      rd  = {2'b01, instr_i[9:7]};
+      rs2 = {2'b01, instr_i[4:2]};
 
-    function void printUInstr(input string mnemonic);
-      begin
-        regs_write.push_back('{rd, 'x});
-        str = $sformatf("%-16s x%0d, 0x%0h", mnemonic, rd, {instr[31:12], 12'h000});
-      end
-    endfunction // printUInstr
+      regs_write_push_back(2'b00, rd, 'x);
+      regs_read_push_back(2'b00, rs2, rs2_value_i);
+      str = $sformatf("%s x%0d, x%0d", mnemonic, rd, rs2);
+    end
+  endfunction
 
-    function void printUJInstr(input string mnemonic);
-      begin
-        regs_write.push_back('{rd, 'x});
-        str =  $sformatf("%-16s x%0d, %0d", mnemonic, rd, $signed({ {12 {instr[31]}}, instr[19:12], instr[20], instr[30:21], 1'b0 }));
-      end
-    endfunction // printUJInstr
+  function void print_cj_instr(input string mnemonic);
+    logic [11:1] imm;
+    imm = {instr_i[12], instr_i[8], instr_i[10:9], instr_i[6],
+           instr_i[7], instr[2], instr[11], instr_i[5:3]};
+    begin
+      str = $sformatf("%s 0x%h", mnemonic, imm);
+    end
+  endfunction
 
-    function void printSBInstr(input string mnemonic);
-      begin
-        regs_read.push_back('{rs1, rs1_value_i});
-        regs_read.push_back('{rs2, rs2_value_i});
-        str =  $sformatf("%-16s x%0d, x%0d, %0d", mnemonic, rs1, rs2, $signed({ {19 {instr[31]}}, instr[31], instr[7], instr[30:25], instr[11:8], 1'b0 }));
-      end
-    endfunction // printSBInstr
-
-    function void printCSRInstr(input string mnemonic);
-      logic [11:0] csr;
-      begin
-        csr = instr_i[31:20];
-
-        regs_write.push_back('{rd, 'x});
-
-        if (!instr_i[14]) begin
-          regs_read.push_back('{rs1, rs1_value_i});
-          str = $sformatf("%-16s x%0d, x%0d, 0x%h", mnemonic, rd, rs1, csr);
-        end else begin
-          str = $sformatf("%-16s x%0d, 0x%h, 0x%h", mnemonic, rd, { 27'b0, instr[`REG_S1] }, csr);
-        end
-      end
-    endfunction // printCSRInstr
-
-    function void printCRInstr(input string mnemonic);
-      logic [4:0] rs1;
-      logic [4:0] rs2;
-      begin
-        rs1 = instr_i[11:7];
-        rs2 = instr_i[6:2];
-
-        if (rs2 == 5'b0) begin
-          regs_read.push_back('{rs1, rs1_value_i});
-          str = $sformatf("%-16s x%0d", mnemonic, rs1);
-        end else begin
-          regs_write.push_back('{rs1, 'x});
-          regs_read.push_back('{rs2, rs2_value_i});
-          str = $sformatf("%-16s x%0d, x%0d", mnemonic, rs1, rs2);
-        end
-      end
-    endfunction // printCRInstr
-
-    function void printCIInstr(input string mnemonic);
-      begin
-        regs_write.push_back('{rd, 'x});
-        str = $sformatf("%-16s x%0d, 0x%h", mnemonic, rd, {instr_i[12], instr_i[4:0]});
-      end
-    endfunction // printCIInstr
-
-    function void printCIWInstr(input string mnemonic);
-      logic [4:0] rd;
-      begin
+  function void print_compressed_load_instr(input string mnemonic);
+    logic [7:0] imm;
+    begin
+      // Detect C.LW intruction
+      if (instr_i[1:0] == OPCODE_C0) begin
         rd = {2'b01, instr_i[4:2]};
-        regs_write.push_back('{rd, 'x});
-        str = $sformatf("%-16s x%0d, 0x%h", mnemonic, rd, {instr_i[10:7], instr_i[12:11], instr_i[5], instr_i[6]});
-      end
-    endfunction // printCIWInstr
-
-    function void printCBInstr(input string mnemonic);
-      logic [4:0] rs1;
-      logic [8:1] imm;
-      begin
         rs1 = {2'b01, instr_i[9:7]};
-        if ((instr_i[15:13] == 3'b110) || (instr_i[15:13] == 3'b111)) begin
-          imm = {instr_i[12], instr_i[6:5], instr_i[2], instr_i[11:10], instr_i[4:3]};
-          regs_read.push_back('{rs1, rs1_value_i});
-        end else begin
-          imm = {instr_i[12], instr_i[6:2], 2'b00};
-          regs_write.push_back('{rs1, 'x});
-        end
-        str = $sformatf("%-16s x%0d, 0x%h", mnemonic, rs1, imm);
+        imm = {1'b0, instr[5], instr[12:10], instr[6], 2'b00};
+      end else begin
+        // LWSP instruction
+        rd = instr_i[11:7];
+        rs1 = 5'h2;
+        imm = {instr[3:2], instr[12], instr[6:4], 2'b00};
       end
-    endfunction // printCBInstr
+      regs_write_push_back(2'b00, rd, 'x);
+      regs_read_push_back(2'b00, rs1, rs1_value_i);
+      str = $sformatf("%s x%0d, %0d(x%0d)", mnemonic, rd, rs1, imm);
+      mem_access_push_back(2'b00, .addr(ex_data_addr_i), .rdata(ex_data_rdata_i));
+    end
+  endfunction
 
-    function void printCSInstr(input string mnemonic);
-      logic [4:0] rd;
-      logic [4:0] rs2;
-      begin
-        rd  = {2'b01, instr_i[9:7]};
+  function void print_compressed_store_instr(input string mnemonic);
+    logic [7:0] imm;
+    begin
+      // Detect C.SW instruction
+      if (instr_i[1:0] == OPCODE_C0) begin
+        rs1 = {2'b01, instr_i[9:7]};
         rs2 = {2'b01, instr_i[4:2]};
-
-        regs_write.push_back('{rd, 'x});
-        regs_read.push_back('{rs2, rs2_value_i});
-        str = $sformatf("%-16s x%0d, x%0d", mnemonic, rd, rs2);
+        imm = {1'b0, instr[5], instr[12:10], instr[6], 2'b00};
+      end else begin
+        // SWSP instruction
+        rs1 = 5'h2;
+        rs2 = instr_i[11:7];
+        imm = {instr[8:7], instr[12:9], 2'b00};
       end
-    endfunction // printCSInstr
+      str = $sformatf("%s x%0d, %0d(x%0d)", mnemonic, rs2, rs1, imm);
+      regs_read_push_back(2'b00, rs1, rs1_value_i);
+      regs_read_push_back(2'b01, rs2, rs2_value_i);
+      mem_access_push_back(2'b00, .addr(ex_data_addr_i), .we(1'b1), .wdata(ex_data_wdata_i));
+    end
+  endfunction
 
-    function void printCJInstr(input string mnemonic);
-      logic [11:1] imm;
-      imm = {instr_i[12], instr_i[8], instr_i[10:9], instr_i[6],
-             instr_i[7], instr[2], instr[11], instr_i[5:3]};
-      begin
-        str = $sformatf("%-16s 0x%h", mnemonic, imm);
+  function void print_load_instr();
+    string      mnemonic;
+    logic [2:0] size;
+    begin
+      // detect reg-reg load and find size
+      size = instr_i[14:12];
+      if (instr_i[14:12] == 3'b111) begin
+        size = instr_i[30:28];
       end
-    endfunction // printCJInstr
 
-    function void printCompressedLoadInstr(input string mnemonic);
-      logic [4:0] rd;
-      logic [4:0] rs1;
-      logic [7:0] imm;
-      mem_acc_t   mem_acc;
-      begin
-        // Detect C.LW intruction
-        if (instr_i[1:0] == OPCODE_C0) begin
-          rd = {2'b01, instr_i[4:2]};
-          rs1 = {2'b01, instr_i[9:7]};
-          imm = {1'b0, instr[5], instr[12:10], instr[6], 2'b00};
-        end else begin
-          // LWSP instruction
-          rd = instr_i[11:7];
-          rs1 = 5'h2;
-          imm = {instr[3:2], instr[12], instr[6:4], 2'b00};
+      unique case (size)
+        3'b000: mnemonic = "lb";
+        3'b001: mnemonic = "lh";
+        3'b010: mnemonic = "lw";
+        3'b100: mnemonic = "lbu";
+        3'b101: mnemonic = "lhu";
+        3'b110: mnemonic = "p.elw";
+        3'b011,
+        3'b111: begin
+          print_mnemonic("INVALID");
+          return;
         end
-        regs_write.push_back('{rd, 'x});
-        regs_read.push_back('{rs1, rs1_value_i});
-        str = $sformatf("%-16s x%0d, %0d(x%0d)", mnemonic, rd, rs1, imm);
-        mem_acc.addr  = ex_data_addr_i;
-        mem_acc.rdata = ex_data_rdata_i;
-        mem_access.push_back(mem_acc);
-      end
-    endfunction // printCompressedLoadInstr()
-
-    function void printCompressedStoreInstr(input string mnemonic);
-      logic [4:0] rs1;
-      logic [4:0] rs2;
-      logic [7:0] imm;
-      mem_acc_t   mem_acc;
-      begin
-        // Detect C.SW instruction
-        if (instr_i[1:0] == OPCODE_C0) begin
-          rs1 = {2'b01, instr_i[9:7]};
-          rs2 = {2'b01, instr_i[4:2]};
-          imm = {1'b0, instr[5], instr[12:10], instr[6], 2'b0};
-        end else begin
-          // SWSP instruction
-          rs1 = 5'h2;
-          rs2 = instr_i[11:7];
-          imm = {instr[8:7], instr[12:9], 2'b00};
+        default: begin
+          print_mnemonic("INVALID");
+          return;
         end
-        str = $sformatf("%-16s x%0d, %0d(x%0d)", mnemonic, rs2, rs1, imm);
-        regs_read.push_back('{rs1, rs1_value_i});
-        regs_read.push_back('{rs2, rs2_value_i});
-        mem_acc.addr  = ex_data_addr_i;
-        mem_acc.we    = 1'b1;
-        mem_acc.wdata = ex_data_wdata_i;
-        mem_access.push_back(mem_acc);
+      endcase
+
+      regs_write_push_back(2'b00, rd, 'x);
+
+      if (instr_i[14:12] != 3'b111) begin
+        // regular load
+        regs_read_push_back(2'b00, rs1, rs1_value_i);
+        str = $sformatf("%s x%0d, %0d(x%0d)", mnemonic, rd,
+                         $signed({{20 {instr[31]}}, instr[31:20]}), rs1);
+      end else begin
+        print_mnemonic("INVALID");
       end
-    endfunction // printCompressedStoreInstr
 
-    function void printLoadInstr();
-      string      mnemonic;
-      logic [2:0] size;
-      mem_acc_t   mem_acc;
-      begin
-        // detect reg-reg load and find size
-        size = instr_i[14:12];
-        if (instr_i[14:12] == 3'b111) begin
-          size = instr_i[30:28];
+      mem_access_push_back(2'b00, .addr(ex_data_addr_i), .rdata(ex_data_rdata_i));
+    end
+  endfunction
+
+  function void print_store_instr();
+    string    mnemonic;
+    begin
+
+      unique case (instr_i[13:12])
+        2'b00:  mnemonic = "sb";
+        2'b01:  mnemonic = "sh";
+        2'b10:  mnemonic = "sw";
+        2'b11: begin
+          print_mnemonic("INVALID");
+          return;
         end
-
-        unique case (size)
-          3'b000: mnemonic = "lb";
-          3'b001: mnemonic = "lh";
-          3'b010: mnemonic = "lw";
-          3'b100: mnemonic = "lbu";
-          3'b101: mnemonic = "lhu";
-          3'b110: mnemonic = "p.elw";
-          3'b011,
-          3'b111: begin
-            printMnemonic("INVALID");
-            return;
-          end
-          default: begin
-            printMnemonic("INVALID");
-            return;
-          end
-        endcase
-
-        regs_write.push_back('{rd, 'x});
-
-        if (instr_i[14:12] != 3'b111) begin
-          // regular load
-          regs_read.push_back('{rs1, rs1_value_i});
-          str = $sformatf("%-16s x%0d, %0d(x%0d)", mnemonic, rd, $signed({{20 {instr[31]}}, instr[31:20]}), rs1);
-        end else begin
-          printMnemonic("INVALID");
+        default: begin
+          print_mnemonic("INVALID");
+          return;
         end
+      endcase
 
-        mem_acc.addr  = ex_data_addr_i;
-        mem_acc.rdata = ex_data_rdata_i;
-        mem_access.push_back(mem_acc);
+      if (!instr_i[14]) begin
+        // regular store
+        regs_read_push_back(2'b00, rs1, rs1_value_i);
+        regs_read_push_back(2'b01, rs2, rs2_value_i);
+        str = $sformatf("%s x%0d, %0d(x%0d)", mnemonic, rs2,
+                          $signed({ {20 {instr[31]}}, instr[31:25], instr[11:7] }), rs1);
+      end else begin
+        print_mnemonic("INVALID");
       end
-    endfunction
 
-    function void printStoreInstr();
-      string    mnemonic;
-      mem_acc_t mem_acc;
-      begin
-
-        unique case (instr_i[13:12])
-          2'b00:  mnemonic = "sb";
-          2'b01:  mnemonic = "sh";
-          2'b10:  mnemonic = "sw";
-          2'b11: begin
-            printMnemonic("INVALID");
-            return;
-          end
-          default: begin
-            printMnemonic("INVALID");
-            return;
-          end
-        endcase
-
-        if (!instr_i[14]) begin
-          // regular store
-          regs_read.push_back('{rs2, rs2_value_i});
-          regs_read.push_back('{rs1, rs1_value_i});
-          str = $sformatf("%-16s x%0d, %0d(x%0d)", mnemonic, rs2, $signed({ {20 {instr[31]}}, instr[31:25], instr[11:7] }), rs1);
-        end else begin
-          printMnemonic("INVALID");
-        end
-
-        mem_acc.addr  = ex_data_addr_i;
-        mem_acc.we    = 1'b1;
-        mem_acc.wdata = ex_data_wdata_i;
-        mem_access.push_back(mem_acc);
-      end
-    endfunction // printSInstr
-
-  endclass
-
-  mailbox #(instr_trace_t) instr_ex = new ();
-  mailbox #(instr_trace_t) instr_wb = new ();
+      mem_access_push_back(2'b00, .addr(ex_data_addr_i), .we(1'b1), .wdata(ex_data_wdata_i));
+    end
+  endfunction
 
   // cycle counter
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      cycles = 0;
+      cycles <= 0;
     end else begin
-      cycles = cycles + 1;
+      cycles <= cycles + 1;
     end
   end
 
-  // open/close output file for writing
-  initial begin
-    wait(rst_ni == 1'b1);
-    wait(fetch_enable_i == 1'b1);
-    $sformat(fn, "trace_core_%h.log", hart_id_i);
-    $display("[TRACER] Output filename is: %s", fn);
-    f = $fopen(fn, "w");
-    $fwrite(f, "                Time          Cycles PC       Instr    Mnemonic\n");
-  end
-
+  // close output file for writing
   final begin
-    $fclose(f);
+    if (file_handle != 32'h0) begin
+      $fclose(file_handle);
+    end
   end
-
-  assign rd  = instr_i[`REG_D];
-  assign rs1 = instr_i[`REG_S1];
-  assign rs2 = instr_i[`REG_S2];
-  assign rs3 = instr_i[`REG_S3];
 
   // log execution
-  always @(posedge clk_i) begin
-    instr_trace_t trace;
-    mem_acc_t     mem_acc;
+  always_ff @(posedge clk_i) begin
     // special case for WFI because we don't wait for unstalling there
     if (valid_i) begin
-      trace = new ();
 
-      trace.simtime    = $time;
-      trace.cycles     = cycles;
-      trace.pc         = pc_i;
-      trace.instr      = instr_i;
+      init();
+      cycles     = cycles;
+      pc         = pc_i;
+      instr      = instr_i;
 
       // Check for compressed instructions
       if (instr_i[1:0] != 2'b11) begin
@@ -448,132 +443,127 @@ module ibex_tracer #(
         if ((instr_i[15:13] == 3'b100) && (instr_i[1:0] == 2'b10)) begin
           if (instr_i[12]) begin
             if (instr_i[11:2] == 10'h0) begin
-              trace.printMnemonic("c.ebreak");
+              print_mnemonic("c.ebreak");
             end else if (instr_i[6:2] == 5'b0) begin
-              trace.printCRInstr("c.jalr");
+              print_cr_instr("c.jalr");
             end else begin
-              trace.printCRInstr("c.add");
+              print_cr_instr("c.add");
             end
           end else begin
             if (instr_i[6:2] == 5'h0) begin
-              trace.printCRInstr("c.jr");
+              print_cr_instr("c.jr");
             end else begin
-              trace.printCRInstr("c.mv");
+              print_cr_instr("c.mv");
             end
           end
         end else begin
           // use casex instead of case inside due to ModelSim bug
-          unique casex (instr_i)
+          unique casex (instr_i[15:0])
             // C0 Opcodes
-            INSTR_CADDI4SPN:  trace.printCIWInstr("c.addi4spn");
-            INSTR_CLW:        trace.printCompressedLoadInstr("c.lw");
-            INSTR_CSW:        trace.printCompressedStoreInstr("c.sw");
+            INSTR_CADDI4SPN:  print_ciw_instr("c.addi4spn");
+            INSTR_CLW:        print_compressed_load_instr("c.lw");
+            INSTR_CSW:        print_compressed_store_instr("c.sw");
             // C1 Opcodes
-            INSTR_CADDI:      trace.printCIInstr("c.addi");
-            INSTR_CJAL:       trace.printCJInstr("c.jal");
-            INSTR_CJ:         trace.printCJInstr("c.j");
-            INSTR_CLI:        trace.printCIInstr("c.li");
-            INSTR_CLUI:       trace.printCIInstr("c.lui");
-            INSTR_CSRLI:      trace.printCBInstr("c.srli");
-            INSTR_CSRAI:      trace.printCBInstr("c.srai");
-            INSTR_CANDI:      trace.printCBInstr("c.andi");
-            INSTR_CSUB:       trace.printCSInstr("c.sub");
-            INSTR_CXOR:       trace.printCSInstr("c.xor");
-            INSTR_COR:        trace.printCSInstr("c.or");
-            INSTR_CAND:       trace.printCSInstr("c.and");
-            INSTR_CBEQZ:      trace.printCBInstr("c.beqz");
-            INSTR_CBNEZ:      trace.printCBInstr("c.bnez");
+            INSTR_CADDI:      print_ci_instr("c.addi");
+            INSTR_CJAL:       print_cj_instr("c.jal");
+            INSTR_CJ:         print_cj_instr("c.j");
+            INSTR_CLI:        print_ci_instr("c.li");
+            INSTR_CLUI:       print_ci_instr("c.lui");
+            INSTR_CSRLI:      print_cb_instr("c.srli");
+            INSTR_CSRAI:      print_cb_instr("c.srai");
+            INSTR_CANDI:      print_cb_instr("c.andi");
+            INSTR_CSUB:       print_cs_instr("c.sub");
+            INSTR_CXOR:       print_cs_instr("c.xor");
+            INSTR_COR:        print_cs_instr("c.or");
+            INSTR_CAND:       print_cs_instr("c.and");
+            INSTR_CBEQZ:      print_cb_instr("c.beqz");
+            INSTR_CBNEZ:      print_cb_instr("c.bnez");
             // C2 Opcodes
-            INSTR_CSLLI:      trace.printCIInstr("c.slli");
-            INSTR_CLWSP:      trace.printCompressedLoadInstr("c.lwsp");
-            INSTR_SWSP:       trace.printCompressedStoreInstr("c.swsp");
-            default:          trace.printMnemonic("INVALID");
+            INSTR_CSLLI:      print_ci_instr("c.slli");
+            INSTR_CLWSP:      print_compressed_load_instr("c.lwsp");
+            INSTR_SWSP:       print_compressed_store_instr("c.swsp");
+            default:          print_mnemonic("INVALID");
           endcase // unique casex (instr_i)
         end
       end else if (instr_i == 32'h00_00_00_13) begin
         // separate case for 'nop' instruction to avoid overlapping with 'addi'
-        trace.printMnemonic("nop");
+        print_mnemonic("nop");
       end else begin
         // use casex instead of case inside due to ModelSim bug
         unique casex (instr_i)
           // Regular opcodes
-          INSTR_LUI:        trace.printUInstr("lui");
-          INSTR_AUIPC:      trace.printUInstr("auipc");
-          INSTR_JAL:        trace.printUJInstr("jal");
-          INSTR_JALR:       trace.printIInstr("jalr");
+          INSTR_LUI:        print_u_instr("lui");
+          INSTR_AUIPC:      print_u_instr("auipc");
+          INSTR_JAL:        print_j_instr("jal");
+          INSTR_JALR:       print_i_instr("jalr");
           // BRANCH
-          INSTR_BEQ:        trace.printSBInstr("beq");
-          INSTR_BNE:        trace.printSBInstr("bne");
-          INSTR_BLT:        trace.printSBInstr("blt");
-          INSTR_BGE:        trace.printSBInstr("bge");
-          INSTR_BLTU:       trace.printSBInstr("bltu");
-          INSTR_BGEU:       trace.printSBInstr("bgeu");
+          INSTR_BEQ:        print_b_instr("beq");
+          INSTR_BNE:        print_b_instr("bne");
+          INSTR_BLT:        print_b_instr("blt");
+          INSTR_BGE:        print_b_instr("bge");
+          INSTR_BLTU:       print_b_instr("bltu");
+          INSTR_BGEU:       print_b_instr("bgeu");
           // OPIMM
-          INSTR_ADDI:       trace.printIInstr("addi");
-          INSTR_SLTI:       trace.printIInstr("slti");
-          INSTR_SLTIU:      trace.printIInstr("sltiu");
-          INSTR_XORI:       trace.printIInstr("xori");
-          INSTR_ORI:        trace.printIInstr("ori");
-          INSTR_ANDI:       trace.printIInstr("andi");
-          INSTR_SLLI:       trace.printIuInstr("slli");
-          INSTR_SRLI:       trace.printIuInstr("srli");
-          INSTR_SRAI:       trace.printIuInstr("srai");
+          INSTR_ADDI:       print_i_instr("addi");
+          INSTR_SLTI:       print_i_instr("slti");
+          INSTR_SLTIU:      print_i_instr("sltiu");
+          INSTR_XORI:       print_i_instr("xori");
+          INSTR_ORI:        print_i_instr("ori");
+          INSTR_ANDI:       print_i_instr("andi");
+          INSTR_SLLI:       print_i_instr("slli");
+          INSTR_SRLI:       print_i_instr("srli");
+          INSTR_SRAI:       print_i_instr("srai");
           // OP
-          INSTR_ADD:        trace.printRInstr("add");
-          INSTR_SUB:        trace.printRInstr("sub");
-          INSTR_SLL:        trace.printRInstr("sll");
-          INSTR_SLT:        trace.printRInstr("slt");
-          INSTR_SLTU:       trace.printRInstr("sltu");
-          INSTR_XOR:        trace.printRInstr("xor");
-          INSTR_SRL:        trace.printRInstr("srl");
-          INSTR_SRA:        trace.printRInstr("sra");
-          INSTR_OR:         trace.printRInstr("or");
-          INSTR_AND:        trace.printRInstr("and");
+          INSTR_ADD:        print_r_instr("add");
+          INSTR_SUB:        print_r_instr("sub");
+          INSTR_SLL:        print_r_instr("sll");
+          INSTR_SLT:        print_r_instr("slt");
+          INSTR_SLTU:       print_r_instr("sltu");
+          INSTR_XOR:        print_r_instr("xor");
+          INSTR_SRL:        print_r_instr("srl");
+          INSTR_SRA:        print_r_instr("sra");
+          INSTR_OR:         print_r_instr("or");
+          INSTR_AND:        print_r_instr("and");
           // SYSTEM (CSR manipulation)
-          INSTR_CSRRW:      trace.printCSRInstr("csrrw");
-          INSTR_CSRRS:      trace.printCSRInstr("csrrs");
-          INSTR_CSRRC:      trace.printCSRInstr("csrrc");
-          INSTR_CSRRWI:     trace.printCSRInstr("csrrwi");
-          INSTR_CSRRSI:     trace.printCSRInstr("csrrsi");
-          INSTR_CSRRCI:     trace.printCSRInstr("csrrci");
+          INSTR_CSRRW:      print_csr_instr("csrrw");
+          INSTR_CSRRS:      print_csr_instr("csrrs");
+          INSTR_CSRRC:      print_csr_instr("csrrc");
+          INSTR_CSRRWI:     print_csr_instr("csrrwi");
+          INSTR_CSRRSI:     print_csr_instr("csrrsi");
+          INSTR_CSRRCI:     print_csr_instr("csrrci");
           // SYSTEM (others)
-          INSTR_ECALL:      trace.printMnemonic("ecall");
-          INSTR_EBREAK:     trace.printMnemonic("ebreak");
-          INSTR_MRET:       trace.printMnemonic("mret");
-          INSTR_DRET:       trace.printMnemonic("dret");
-          INSTR_WFI:        trace.printMnemonic("wfi");
+          INSTR_ECALL:      print_mnemonic("ecall");
+          INSTR_EBREAK:     print_mnemonic("ebreak");
+          INSTR_MRET:       print_mnemonic("mret");
+          INSTR_DRET:       print_mnemonic("dret");
+          INSTR_WFI:        print_mnemonic("wfi");
           // RV32M
-          INSTR_PMUL:       trace.printRInstr("mul");
-          INSTR_PMUH:       trace.printRInstr("mulh");
-          INSTR_PMULHSU:    trace.printRInstr("mulhsu");
-          INSTR_PMULHU:     trace.printRInstr("mulhu");
-          INSTR_DIV:        trace.printRInstr("div");
-          INSTR_DIVU:       trace.printRInstr("divu");
-          INSTR_REM:        trace.printRInstr("rem");
-          INSTR_REMU:       trace.printRInstr("remu");
+          INSTR_PMUL:       print_r_instr("mul");
+          INSTR_PMUH:       print_r_instr("mulh");
+          INSTR_PMULHSU:    print_r_instr("mulhsu");
+          INSTR_PMULHU:     print_r_instr("mulhu");
+          INSTR_DIV:        print_r_instr("div");
+          INSTR_DIVU:       print_r_instr("divu");
+          INSTR_REM:        print_r_instr("rem");
+          INSTR_REMU:       print_r_instr("remu");
           // LOAD & STORE
-          INSTR_LOAD:       trace.printLoadInstr();
-          INSTR_STORE:      trace.printStoreInstr();
+          INSTR_LOAD:       print_load_instr();
+          INSTR_STORE:      print_store_instr();
           // MISC-MEM
-          INSTR_FENCE:      trace.printMnemonic("fence");
-          default:          trace.printMnemonic("INVALID");
+          INSTR_FENCE:      print_mnemonic("fence");
+          default:          print_mnemonic("INVALID");
         endcase // unique case (instr_i)
       end
 
       // replace register written back
-      foreach(trace.regs_write[i]) begin
-        if ((trace.regs_write[i].addr == ex_reg_addr_i)) begin
-          trace.regs_write[i].value = ex_reg_wdata_i;
+      foreach (regs_write[i]) begin
+        if (regs_write[i].addr == ex_reg_addr_i) begin
+          regs_write[i].value = ex_reg_wdata_i;
         end
       end
 
-      trace.printInstrTrace();
+      dump_printbuffer_to_file();
     end
-  end // always @ (posedge clk_i)
+  end // always_ff @(posedge clk_i)
 
 endmodule
-
-`undef REG_S1
-`undef REG_S2
-`undef REG_S3
-`undef REG_D


### PR DESCRIPTION
- Removed the tracer class in the ibex_tracer file and implemented class methods and properties as functions and global variables
- Updated the class new method with init function which implements the same functionality
- Updated usage of queues to systemverilog arrays of structs
- Updated $fwrite function to use verilator friendly string formatting
- Added verilator top-tb which performs the same sequence of instructions as the system-verilog top tracing TB
- Updated top_tracing_sim.core file to support verilator as well