### PR TITLE
[RTL] Fix I-side timing loop

### DIFF
--- a/rtl/ibex_fetch_fifo.sv
+++ b/rtl/ibex_fetch_fifo.sv
@@ -6,64 +6,90 @@
 /**
  * Fetch Fifo for 32 bit memory interface
  *
- * input port: send address one cycle before the data
- * clear_i clears the FIFO for the following cycle. in_addr_i can be sent in
- * this cycle already.
+ * input port: send address and data to the FIFO
+ * clear_i clears the FIFO for the following cycle, including any new request
  */
 module ibex_fetch_fifo (
     input  logic        clk_i,
     input  logic        rst_ni,
 
     // control signals
-    input  logic        clear_i,          // clears the contents of the fifo
+    input  logic        clear_i,          // clears the contents of the FIFO
 
     // input port
+    input  logic        in_valid_i,
+    output logic        in_ready_o,
     input  logic [31:0] in_addr_i,
     input  logic [31:0] in_rdata_i,
     input  logic        in_err_i,
-    input  logic        in_valid_i,
-    output logic        in_ready_o,
-
 
     // output port
     output logic        out_valid_o,
     input  logic        out_ready_i,
-    output logic [31:0] out_rdata_o,
     output logic [31:0] out_addr_o,
-    output logic        out_err_o,
-
-    output logic        out_valid_stored_o // same as out_valid_o, except that if something is
-                                           // incoming now it is not included. This signal is
-                                           // available immediately as it comes directly out of FFs
+    output logic [31:0] out_rdata_o,
+    output logic        out_err_o
 );
 
   localparam int unsigned DEPTH = 3; // must be 3 or greater
 
   // index 0 is used for output
-  logic [DEPTH-1:0] [31:0]  addr_n,    addr_int,    addr_q;
-  logic [DEPTH-1:0] [31:0]  rdata_n,   rdata_int,   rdata_q;
-  logic [DEPTH-1:0]         err_n,     err_int,     err_q;
-  logic [DEPTH-1:0]         valid_n,   valid_int,   valid_q;
+  logic [DEPTH-1:0] [31:2]  addr_d,    addr_q;
+  logic [DEPTH-1:0] [31:0]  rdata_d,   rdata_q;
+  logic [DEPTH-1:0]         err_d,     err_q;
+  logic [DEPTH-1:0]         valid_d,   valid_q;
+  logic [DEPTH-1:0]         lowest_free_entry;
+  logic [DEPTH-1:0]         valid_pushed, valid_popped;
+  logic [DEPTH-1:0]         entry_en;
 
-  logic             [31:2]  addr_next;
+  logic                     pop_fifo;
   logic             [31:0]  rdata, rdata_unaligned;
   logic                     err,   err_unaligned;
   logic                     valid, valid_unaligned;
 
+  logic                     entry0_unaligned_d, entry0_unaligned_q;
   logic                     aligned_is_compressed, unaligned_is_compressed;
-  logic                     unaligned_is_compressed_st;
+  
+  logic                     unused_addr_in;
 
   /////////////////
   // Output port //
   /////////////////
 
-
   assign rdata = valid_q[0] ? rdata_q[0] : in_rdata_i;
   assign err   = valid_q[0] ? err_q[0]   : in_err_i;
   assign valid = valid_q[0] | in_valid_i;
 
+  // The FIFO contains word aligned memory fetches, but the instructions contained in each entry
+  // might be half-word aligned (due to compressed instructions)
+  // e.g.
+  //              | 31               16 | 15               0 |
+  // FIFO entry 0 | Instr 1 [15:0]      | Instr 0 [15:0]     |
+  // FIFO entry 1 | Instr 2 [15:0]      | Instr 1 [31:16]    |
+  //
+  // The FIFO also has a direct bypass path, so a complete instruction might be made up of data
+  // from the FIFO and new incoming data.
+  //
+  // Additionally, branches can cause a fetch from an unaligned address. The full data word will be
+  // fetched, but the FIFO must output the unaligned instruction as the first valid data.
+
+  // Alignment is tracked with a flag, this records whether entry[0] of the FIFO has become unaligned.
+  // The flag is set once any compressed instruction enters the FIFO and is only cleared once a
+  // a compressed instruction realigns the FIFO, or the FIFO is cleared.
+  
+                              // New incoming unaligned request (must be a branch) or already unaligned
+  assign entry0_unaligned_d = ((((in_valid_i & in_addr_i[1]) | entry0_unaligned_q) &
+                                // cleared by a compressed unaligned instruction
+                                ~(out_ready_i & unaligned_is_compressed)) |
+                               // Also set when a new aligned compressed instruction is driven
+                               (valid & out_ready_i & ~out_addr_o[1] & aligned_is_compressed)) &
+                              // reset by a FIFO clear
+                              ~clear_i;
+
+  // Construct the output data for an unaligned instruction
   assign rdata_unaligned = valid_q[1] ? {rdata_q[1][15:0], rdata[31:16]} :
                                         {in_rdata_i[15:0], rdata[31:16]};
+
   // If entry[1] is valid, an error can come from entry[0] or entry[1], unless the
   // instruction in entry[0] is compressed (entry[1] is a new instruction)
   // If entry[1] is not valid, and entry[0] is, an error can come from entry[0] or the incoming
@@ -72,22 +98,19 @@ module ibex_fetch_fifo (
   assign err_unaligned   = valid_q[1] ? ((err_q[1] & ~unaligned_is_compressed) | err_q[0]) :
                                         ((valid_q[0] & err_q[0]) |
                                          (in_err_i & (~valid_q[0] | ~unaligned_is_compressed)));
+
   // An uncompressed unaligned instruction is only valid if both parts are available
   assign valid_unaligned = valid_q[1] ? 1'b1 :
                                         (valid_q[0] & in_valid_i);
 
   assign unaligned_is_compressed    = rdata[17:16] != 2'b11;
   assign aligned_is_compressed      = rdata[ 1: 0] != 2'b11;
-  assign unaligned_is_compressed_st = rdata_q[0][17:16] != 2'b11;
 
   ////////////////////////////////////////
   // Instruction aligner (if unaligned) //
   ////////////////////////////////////////
 
   always_comb begin
-    // serve the aligned case even though the output address is unaligned when
-    // the next instruction will be from a hardware loop target
-    // in this case the current instruction is already prealigned in element 0
     if (out_addr_o[1]) begin
       // unaligned case
       out_rdata_o = rdata_unaligned;
@@ -106,29 +129,18 @@ module ibex_fetch_fifo (
     end
   end
 
-  assign out_addr_o = valid_q[0] ? addr_q[0] : in_addr_i;
+  assign out_addr_o[31:2] = valid_q[0] ? addr_q[0]          : in_addr_i[31:2];
+  assign out_addr_o[1]    = valid_q[0] ? entry0_unaligned_q : in_addr_i[1];
+  assign out_addr_o[0]    = 1'b0;
 
-  // this valid signal must not depend on signals from outside!
-  always_comb begin
-    out_valid_stored_o = 1'b1;
-
-    if (out_addr_o[1]) begin
-      if (unaligned_is_compressed_st) begin
-        out_valid_stored_o = 1'b1;
-      end else begin
-        out_valid_stored_o = valid_q[1];
-      end
-    end else begin
-      out_valid_stored_o = valid_q[0];
-    end
-  end
-
+  // The LSB of the address is unused, since all addresses are halfword aligned
+  assign unused_addr_in = in_addr_i[0];
 
   ////////////////
   // input port //
   ////////////////
 
-  // we accept data as long as our fifo is not full
+  // we accept data as long as our FIFO is not full
   // we don't care about clear here as the data will be received one cycle
   // later anyway
   assign in_ready_o = ~valid_q[DEPTH-2];
@@ -137,78 +149,65 @@ module ibex_fetch_fifo (
   // FIFO management //
   /////////////////////
 
-  always_comb begin
-    addr_int    = addr_q;
-    rdata_int   = rdata_q;
-    err_int     = err_q;
-    valid_int   = valid_q;
-    if (in_valid_i) begin
-      for (int j = 0; j < DEPTH; j++) begin
-        if (!valid_q[j]) begin
-          addr_int[j]  = in_addr_i;
-          rdata_int[j] = in_rdata_i;
-          err_int[j]   = in_err_i;
-          valid_int[j] = 1'b1;
-          break;
-        end
-      end
+  // Since an entry can contain unaligned instructions, popping an entry can leave the entry valid
+  assign pop_fifo = out_ready_i & out_valid_o & (~aligned_is_compressed | out_addr_o[1]);
+
+  for (genvar i = 0; i < (DEPTH - 1); i++) begin : g_fifo_next
+    // Calculate lowest free entry (write pointer)
+    if (i == 0) begin : g_ent0
+      assign lowest_free_entry[i] = ~valid_q[i];
+    end else begin : g_ent_others
+      assign lowest_free_entry[i] = ~valid_q[i] & (&valid_q[i-1:0]);
     end
+
+    // An entry is set when an incoming request chooses the lowest available entry
+    assign valid_pushed[i] = (in_valid_i & lowest_free_entry[i]) |
+                             valid_q[i];
+    // Popping the FIFO shifts all entries down
+    assign valid_popped[i] = pop_fifo ? valid_pushed[i+1] : valid_pushed[i];
+    // All entries are wiped out on a clear
+    assign valid_d[i] = valid_popped[i] & ~clear_i;
+
+    // data flops are enabled if there is new data to shift into it, or
+    assign entry_en[i] = (valid_pushed[i+1] & pop_fifo) |
+                         // a new request is incoming and this is the lowest free entry
+                         (in_valid_i & lowest_free_entry[i] & ~pop_fifo);
+
+    // take the next entry or the incoming data
+    assign addr_d [i]  = valid_q[i+1] ? addr_q [i+1] : in_addr_i[31:2];
+    assign rdata_d[i]  = valid_q[i+1] ? rdata_q[i+1] : in_rdata_i;
+    assign err_d  [i]  = valid_q[i+1] ? err_q  [i+1] : in_err_i;
   end
+  // The top entry is similar but with simpler muxing
+  assign lowest_free_entry[DEPTH-1] = ~valid_q[DEPTH-1] & (&valid_q[DEPTH-2:0]);
+  assign valid_pushed     [DEPTH-1] = valid_q[DEPTH-1] | (in_valid_i & lowest_free_entry[DEPTH-1]);
+  assign valid_popped     [DEPTH-1] = pop_fifo ? 1'b0 : valid_pushed[DEPTH-1];
+  assign valid_d [DEPTH-1]          = valid_popped[DEPTH-1] & ~clear_i;
+  assign entry_en[DEPTH-1]          = in_valid_i & lowest_free_entry[DEPTH-1];
+  assign addr_d  [DEPTH-1]          = in_addr_i[31:2];
+  assign rdata_d [DEPTH-1]          = in_rdata_i;
+  assign err_d   [DEPTH-1]          = in_err_i;
 
-  assign addr_next[31:2] = addr_int[0][31:2] + 30'h1;
-
-  // move everything by one step
-  always_comb begin
-    addr_n     = addr_int;
-    rdata_n    = rdata_int;
-    err_n      = err_int;
-    valid_n    = valid_int;
-
-    if (out_ready_i && out_valid_o) begin
-      if (addr_int[0][1]) begin
-        // unaligned case
-        if (unaligned_is_compressed) begin
-          addr_n[0] = {addr_next[31:2], 2'b00};
-        end else begin
-          addr_n[0] = {addr_next[31:2], 2'b10};
-        end
-
-        rdata_n  = {32'b0, rdata_int[DEPTH-1:1]};
-        err_n    = {1'b0,  err_int[DEPTH-1:1]};
-        valid_n  = {1'b0,  valid_int[DEPTH-1:1]};
-      end else if (aligned_is_compressed) begin
-        // just increase address, do not move to next entry in FIFO
-        addr_n[0] = {addr_int[0][31:2], 2'b10};
-      end else begin
-        // move to next entry in FIFO
-        addr_n[0] = {addr_next[31:2], 2'b00};
-        rdata_n   = {32'b0, rdata_int[DEPTH-1:1]};
-        err_n     = {1'b0,  err_int[DEPTH-1:1]};
-        valid_n   = {1'b0,  valid_int[DEPTH-1:1]};
-      end
-    end
-  end
-
-  ///////////////
-  // registers //
-  ///////////////
+  ////////////////////
+  // FIFO registers //
+  ////////////////////
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      addr_q    <= '{default: '0};
-      rdata_q   <= '{default: '0};
-      err_q     <= '0;
-      valid_q   <= '0;
+      valid_q            <= '0;
+      entry0_unaligned_q <= '0;
     end else begin
-      // on a clear signal from outside we invalidate the content of the FIFO
-      // completely and start from an empty state
-      if (clear_i) begin
-        valid_q   <= '0;
-      end else begin
-        addr_q    <= addr_n;
-        rdata_q   <= rdata_n;
-        err_q     <= err_n;
-        valid_q   <= valid_n;
+      valid_q            <= valid_d;
+      entry0_unaligned_q <= entry0_unaligned_d;
+    end
+  end
+
+  for (genvar i = 0; i < DEPTH; i++) begin : g_fifo_regs
+    always_ff @(posedge clk_i) begin
+      if (entry_en[i]) begin
+        addr_q[i]    <= addr_d[i];
+        rdata_q[i]   <= rdata_d[i];
+        err_q[i]     <= err_d[i];
       end
     end
   end
@@ -217,7 +216,13 @@ module ibex_fetch_fifo (
   // Assertions //
   ////////////////
 `ifndef VERILATOR
+  // Code changes required to support > 2 outstanding requests
   assert property (
-    @(posedge clk_i) (in_valid_i) |-> ((valid_q[DEPTH-1] == 1'b0) || (clear_i == 1'b1)) );
+    @(posedge clk_i) disable iff (!rst_ni)
+    (NUM_REQS <= 2) );
+
+  assert property (
+    @(posedge clk_i) disable iff (!rst_ni)
+    (in_valid_i) |-> ((valid_q[DEPTH-1] == 1'b0) || (clear_i == 1'b1)) );
 `endif
 endmodule

--- a/rtl/ibex_prefetch_buffer.sv
+++ b/rtl/ibex_prefetch_buffer.sv
@@ -39,27 +39,30 @@ module ibex_prefetch_buffer (
     output logic        busy_o
 );
 
-  typedef enum logic [1:0] {
-    IDLE, WAIT_GNT, WAIT_RVALID, WAIT_ABORTED
-  } pf_fsm_e;
+  // Changes to the address flops would be required for > 2 outstanding requests
+  localparam int unsigned NUM_REQS = 2;
 
-  pf_fsm_e pf_fsm_cs, pf_fsm_ns;
+  logic                valid_req;
+  logic                valid_req_d, valid_req_q;
+  logic                gnt_or_pmp_err, rvalid_or_pmp_err;
+  logic [NUM_REQS-1:0] rdata_outstanding_n, rdata_outstanding_s, rdata_outstanding_q;
+  logic [NUM_REQS-1:0] branch_abort_n, branch_abort_s, branch_abort_q;
 
-  logic [31:0] instr_addr_q, fetch_addr;
-  logic [31:0] instr_addr, instr_addr_w_aligned;
-  logic        addr_valid;
-  logic        pmp_err_q;
-  logic        instr_or_pmp_err;
+  logic [31:0]         instr_addr_q, fetch_addr;
+  logic [31:0]         instr_addr, instr_addr_w_aligned;
+  logic                addr_valid;
+  logic                pmp_err_q;
+  logic                instr_or_pmp_err;
 
-  logic        fifo_valid;
-  logic        fifo_ready;
-  logic        fifo_clear;
+  logic                fifo_valid;
+  logic                fifo_ready;
+  logic                fifo_clear;
 
   ////////////////////////////
   // Prefetch buffer status //
   ////////////////////////////
 
-  assign busy_o = (pf_fsm_cs != IDLE) | instr_req_o;
+  assign busy_o = (|rdata_outstanding_q) | instr_req_o;
 
   //////////////////////////////////////////////
   // Fetch fifo - consumes addresses and data //
@@ -69,16 +72,19 @@ module ibex_prefetch_buffer (
   // PMP errors are generated in the address phase, and registered into a fake data phase
   assign instr_or_pmp_err = instr_err_i | pmp_err_q;
 
+  // A branch will invalidate any previously fetched instructions
+  assign fifo_clear = branch_i;
+
   ibex_fetch_fifo fifo_i (
       .clk_i                 ( clk_i             ),
       .rst_ni                ( rst_ni            ),
 
       .clear_i               ( fifo_clear        ),
 
+      .in_valid_i            ( fifo_valid        ),
       .in_addr_i             ( instr_addr_q      ),
       .in_rdata_i            ( instr_rdata_i     ),
       .in_err_i              ( instr_or_pmp_err  ),
-      .in_valid_i            ( fifo_valid        ),
       .in_ready_o            ( fifo_ready        ),
 
 
@@ -86,130 +92,95 @@ module ibex_prefetch_buffer (
       .out_ready_i           ( ready_i           ),
       .out_rdata_o           ( rdata_o           ),
       .out_addr_o            ( addr_o            ),
-      .out_err_o             ( err_o             ),
-
-      .out_valid_stored_o    (                   )
+      .out_err_o             ( err_o             )
   );
 
+  //////////////
+  // Requests //
+  //////////////
+
+  // Make a new request any time there is space in the FIFO, and space in the request queue
+  assign valid_req = req_i & (fifo_ready | branch_i) &
+                     ~&rdata_outstanding_q;
+
+  // If a request address triggers a PMP error, the external bus request is suppressed. We might
+  // therefore never receive a grant for such a request. The grant is faked in this case to make
+  // sure the request proceeds and the error is pushed to the FIFO.
+  // We always use the registered version of the signal since it will be held stable throughout
+  // the request, and the penalty of waiting for an extra cycle to consume the error is irrelevant.
+  // A branch could update the address (and therefore data_pmp_err_i) on the cycle a request is
+  // issued, in which case we must ignore the registered version.
+  assign gnt_or_pmp_err = instr_gnt_i | (pmp_err_q & ~branch_i);
+
+  // As with the grant, the rvalid must be faked for a PMP error, since the request was suppressed.
+  // Since the pmp_err_q flop is only updated when the address updates, it will always point to the
+  // PMP error status of the oldest outstanding request
+  assign rvalid_or_pmp_err = instr_rvalid_i | pmp_err_q;
+
+  // Hold the address stable for requests that couldn't be issued, or didn't get granted
+  assign valid_req_d = (branch_i | valid_req_q) & ~(valid_req & instr_gnt_i);
 
   ////////////////
   // Fetch addr //
   ////////////////
 
+  // The address flop is used to hold the address steady for ungranted requests and also to 
+  // push the address to the FIFO for completed requests. For this reason, the address is only
+  // updated once a request is the oldest outstanding to ensure that newer requests do not
+  // overwrite the addresses of older ones. Branches are an exception to this, since all older
+  // addresses will be discarded due to the branch.
+
+  // Update the addr_q flop on any branch, or
+  assign addr_valid = branch_i |
+                      // A new request which will be the oldest, or
+                      (req_i & fifo_ready & ~rdata_outstanding_q[0]) |
+                      // each time a valid request becomes the oldest
+                      (rvalid_or_pmp_err & ~branch_abort_q[0] &
+                       ((valid_req & instr_gnt_i) | rdata_outstanding_q[1]));
+
+  // Fetch the next word-aligned instruction address
   assign fetch_addr = {instr_addr_q[31:2], 2'b00} + 32'd4;
-  assign fifo_clear = branch_i;
 
-  //////////////////////////////////////////////////////////////////////////////
-  // Instruction fetch FSM -deals with instruction memory / instruction cache //
-  //////////////////////////////////////////////////////////////////////////////
+  // Address mux
+  assign instr_addr = branch_i    ? addr_i :
+                      valid_req_q ? instr_addr_q :
+                                    fetch_addr;
 
-  always_comb begin
-    instr_req_o = 1'b0;
-    instr_addr  = fetch_addr;
-    fifo_valid  = 1'b0;
-    addr_valid  = 1'b0;
-    pf_fsm_ns   = pf_fsm_cs;
+  assign instr_addr_w_aligned = {instr_addr[31:2], 2'b00};
 
-    unique case(pf_fsm_cs)
-      // default state, not waiting for requested data
-      IDLE: begin
-        instr_addr  = fetch_addr;
-        instr_req_o = 1'b0;
+  ///////////////////////////////
+  // Request outstanding queue //
+  ///////////////////////////////
 
-        if (branch_i) begin
-          instr_addr = addr_i;
-        end
+  for (genvar i = 0; i < NUM_REQS; i++) begin : g_outstanding_reqs
+    // Request 0 (always the oldest outstanding request)
+    if (i == 0) begin : g_req0
+      // A request becomes outstanding once granted, and is cleared once the rvalid is received.
+      // Outstanding requests shift down the queue towards entry 0. Entry 0 considers the PMP
+      // error cases while newer entries do not (pmp_err_q is only valid for entry 0)
+      assign rdata_outstanding_n[i] = (valid_req & gnt_or_pmp_err) |
+                                      rdata_outstanding_q[i];
+      // If a branch is received at any point while a request is outstanding, it must be tracked
+      // to ensure we discard the data once received
+      assign branch_abort_n[i]      = (branch_i & rdata_outstanding_q[i]) | branch_abort_q[i];
 
-        if (req_i && (fifo_ready || branch_i )) begin
-          instr_req_o = 1'b1;
-          addr_valid  = 1'b1;
+    end else begin : g_reqtop
 
-
-          //~> granted request or not
-          pf_fsm_ns = instr_gnt_i ? WAIT_RVALID : WAIT_GNT;
-        end
-      end // case: IDLE
-
-      // we sent a request but did not yet get a grant
-      WAIT_GNT: begin
-        instr_addr  = instr_addr_q;
-        instr_req_o = 1'b1;
-
-        if (branch_i) begin
-          instr_addr = addr_i;
-          addr_valid = 1'b1;
-        end
-
-        //~> granted request or not
-        // If the instruction generated a PMP error, we may or may not
-        // get granted (the external valid is suppressed by the error)
-        // but we proceed to WAIT_RVALID to push the error to the fifo
-        pf_fsm_ns = (instr_gnt_i || pmp_err_q) ? WAIT_RVALID : WAIT_GNT;
-      end // case: WAIT_GNT
-
-      // we wait for rvalid, after that we are ready to serve a new request
-      WAIT_RVALID: begin
-        instr_addr = fetch_addr;
-
-        if (branch_i) begin
-          instr_addr = addr_i;
-        end
-
-        if (req_i && (fifo_ready || branch_i)) begin
-          // prepare for next request
-
-          // Fake the rvalid for PMP errors to push the error to the fifo
-          if (instr_rvalid_i || pmp_err_q) begin
-            instr_req_o = 1'b1;
-            fifo_valid  = 1'b1;
-            addr_valid  = 1'b1;
-
-            //~> granted request or not
-            pf_fsm_ns = instr_gnt_i ? WAIT_RVALID : WAIT_GNT;
-          end else begin
-            // we are requested to abort our current request
-            // we didn't get an rvalid yet, so wait for it
-            if (branch_i) begin
-              addr_valid = 1'b1;
-              pf_fsm_ns  = WAIT_ABORTED;
-            end
-          end
-        end else begin
-          // just wait for rvalid and go back to IDLE, no new request
-
-          // Fake the rvalid for PMP errors to push the error to the fifo
-          if (instr_rvalid_i || pmp_err_q) begin
-            fifo_valid = 1'b1;
-            pf_fsm_ns  = IDLE;
-          end
-        end
-      end // case: WAIT_RVALID
-
-      // our last request was aborted, but we didn't yet get a rvalid and
-      // there was no new request sent yet
-      // we assume that req_i is set to high
-      WAIT_ABORTED: begin
-        instr_addr = instr_addr_q;
-
-        if (branch_i) begin
-          instr_addr = addr_i;
-          addr_valid = 1'b1;
-        end
-
-        if (instr_rvalid_i) begin
-          instr_req_o = 1'b1;
-          // no need to send address, already done in WAIT_RVALID
-
-          //~> granted request or not
-          pf_fsm_ns = instr_gnt_i ? WAIT_RVALID : WAIT_GNT;
-        end
-      end
-
-      default: begin
-        pf_fsm_ns = pf_fsm_e'(1'bX);
-      end
-    endcase
+      assign rdata_outstanding_n[i] = (valid_req & instr_gnt_i &
+                                       (&rdata_outstanding_q[i-1:0])) |
+                                      rdata_outstanding_q[i];
+      assign branch_abort_n[i]      = (branch_i & rdata_outstanding_q[i]) | branch_abort_q[i];
+    end
   end
+
+  // Shift the entries down on each instr_rvalid_i
+  assign rdata_outstanding_s = rvalid_or_pmp_err ? {1'b0,rdata_outstanding_n[NUM_REQS-1:1]} :
+                                                   rdata_outstanding_n;
+  assign branch_abort_s      = rvalid_or_pmp_err ? {1'b0,branch_abort_n[NUM_REQS-1:1]} :
+                                                   branch_abort_n;
+
+  // Push a new entry to the FIFO once complete (and not aborted by a branch)
+  assign fifo_valid = rdata_outstanding_q[0] & ~branch_abort_q[0] & rvalid_or_pmp_err;
 
   ///////////////
   // Registers //
@@ -217,23 +188,29 @@ module ibex_prefetch_buffer (
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      pf_fsm_cs      <= IDLE;
-      instr_addr_q   <= '0;
-      pmp_err_q      <= '0;
+      valid_req_q          <= 1'b0;
+      rdata_outstanding_q  <= 'b0;
+      branch_abort_q       <= 'b0;
     end else begin
-      pf_fsm_cs      <= pf_fsm_ns;
-
-      if (addr_valid) begin
-        instr_addr_q <= instr_addr;
-        pmp_err_q    <= instr_pmp_err_i;
-      end
+      valid_req_q          <= valid_req_d;
+      rdata_outstanding_q  <= rdata_outstanding_s;
+      branch_abort_q       <= branch_abort_s;
     end
   end
 
-  /////////////////
-  // Output Addr //
-  /////////////////
-  assign instr_addr_w_aligned = {instr_addr[31:2], 2'b00};
+  // CPU resets with a branch, so no need to reset these
+  always_ff @(posedge clk_i) begin
+    if (addr_valid) begin
+      instr_addr_q <= instr_addr;
+      pmp_err_q    <= instr_pmp_err_i;
+    end
+  end
+
+  /////////////
+  // Outputs //
+  /////////////
+
+  assign instr_req_o          = valid_req;
   assign instr_addr_o         =  instr_addr_w_aligned;
 
 endmodule


### PR DESCRIPTION
- See issue #265 (partially fixes)
- Remove path from instr_rvalid_i to instr_req_o
- Prefetch buffer unit can now issue up to two outstanding requests
- Structure moved from state machine to request queue
- Change fetch fifo to use an unaligned flag rather than updating
  the address each time