### PR TITLE
Add core_sleep_o to ibex interface (fixes #258)

### DIFF
--- a/doc/integration.rst
+++ b/doc/integration.rst
@@ -60,8 +60,9 @@ Instantiation Template
       // Debug interface
       .debug_req_i    (),
 
-      // Special control signal
-      .fetch_enable_i ()
+      // Special control signals
+      .fetch_enable_i (),
+      .core_sleep_o   ()
   );
 
 Parameters
@@ -117,4 +118,9 @@ Interfaces
 | ``debug_*``             | Debug interface, see :ref:`debug-support`                              |
 +-------------------------+-------------------------+-----+----------------------------------------+
 | ``fetch_enable_i``      | 1                       | in  | Enable the core, won't fetch when 0    |
++-------------------------+-------------------------+-----+----------------------------------------+
+| ``core_sleep_o``        | 1                       | out | Core in WFI with no outstanding data   |
+|                         |                         |     | or instruction accesses.  Deasserts    |
+|                         |                         |     | if an external event (interrupt or     |
+|                         |                         |     | debug req) wakes the core up           |
 +-------------------------+-------------------------+-----+----------------------------------------+

--- a/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
+++ b/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
@@ -139,7 +139,8 @@ module ibex_riscv_compliance (
 
       .debug_req_i           ('b0),
 
-      .fetch_enable_i        ('b1)
+      .fetch_enable_i        ('b1),
+      .core_sleep_o          ()
     );
 
   // SRAM block for instruction and data storage

--- a/examples/fpga/artya7-100/rtl/top_artya7_100.sv
+++ b/examples/fpga/artya7-100/rtl/top_artya7_100.sv
@@ -78,7 +78,8 @@ module top_artya7_100 (
 
      .debug_req_i           ('b0),
 
-     .fetch_enable_i        ('b1)
+     .fetch_enable_i        ('b1),
+     .core_sleep_o          ()
   );
 
   // Connect Ibex to SRAM

--- a/examples/sim/tb/ibex_tracing_tb.sv
+++ b/examples/sim/tb/ibex_tracing_tb.sv
@@ -110,7 +110,8 @@ module ibex_tracing_tb;
     .debug_req_i            (1'b0),
 
     // CPU Control Signals
-    .fetch_enable_i         (1'b1)
+    .fetch_enable_i         (1'b1),
+    .core_sleep_o           ()
   );
 
 endmodule

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -87,8 +87,8 @@ module ibex_core #(
 `endif
 
     // CPU Control Signals
-    input  logic        fetch_enable_i
-
+    input  logic        fetch_enable_i,
+    output logic        core_sleep_o
 );
 
   import ibex_pkg::*;
@@ -271,6 +271,8 @@ module ibex_core #(
   end
 
   assign core_busy   = core_ctrl_firstfetch ? 1'b1 : core_busy_q;
+
+  assign core_sleep_o = ~clock_en;
 
   assign clock_en    = core_busy | debug_req_i | irq_pending | irq_nm_i;
 

--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -53,7 +53,8 @@ module ibex_core_tracing #(
     input  logic        debug_req_i,
 
     // CPU Control Signals
-    input  logic        fetch_enable_i
+    input  logic        fetch_enable_i,
+    output logic        core_sleep_o
 
 );
 
@@ -150,6 +151,7 @@ module ibex_core_tracing #(
     .rvfi_mem_wdata,
 
     .fetch_enable_i
+    .core_sleep_o
   );
 
 


### PR DESCRIPTION
Signals the core is totally idle (WFI with no outstanding memory
transactions).