### PR TITLE
Controller: fix `nmi_mode` default assignment

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -215,7 +215,7 @@ module ibex_controller (
     debug_csr_save_o      = 1'b0;
     debug_cause_o         = DBG_CAUSE_EBREAK;
     debug_mode_d          = debug_mode_q;
-    nmi_mode_d            = 1'b0;
+    nmi_mode_d            = nmi_mode_q;
 
     perf_tbranch_o        = 1'b0;
     perf_jump_o           = 1'b0;


### PR DESCRIPTION
Without this commit, the `nmi_mode` register is continuously cleared and set again, and the core can never handle the NMI.

This resolves lowRISC/ibex#300 reported by @udinator.