### PR TITLE
Add clang-format configuration for C/C++ files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: Google
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+DerivePointerAlignment: false
+PointerAlignment: Right

--- a/dv/riscv_compliance/ibex_riscv_compliance.cc
+++ b/dv/riscv_compliance/ibex_riscv_compliance.cc
@@ -12,8 +12,8 @@
 
 VERILATED_TOPLEVEL(ibex_riscv_compliance)
 
-ibex_riscv_compliance* top;
-VerilatorSimCtrl* simctrl;
+ibex_riscv_compliance *top;
+VerilatorSimCtrl *simctrl;
 
 static void SignalHandler(int sig) {
   if (!simctrl) {
@@ -52,7 +52,7 @@ static void SetupSignalHandler() {
  */
 double sc_time_stamp() { return simctrl->GetTime(); }
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   int retcode;
   top = new ibex_riscv_compliance;
   simctrl = new VerilatorSimCtrl(top, top->IO_CLK, top->IO_RST_N,

--- a/dv/verilator/simutil_verilator/cpp/verilated_toplevel.h
+++ b/dv/verilator/simutil_verilator/cpp/verilated_toplevel.h
@@ -31,35 +31,25 @@
  */
 class VerilatedTracer {
  public:
-  VerilatedTracer() : impl_(nullptr) {
-    impl_ = new VM_TRACE_CLASS_NAME();
-  };
+  VerilatedTracer() : impl_(nullptr) { impl_ = new VM_TRACE_CLASS_NAME(); };
 
-  ~VerilatedTracer() {
-    delete impl_;
+  ~VerilatedTracer() { delete impl_; }
+
+  bool isOpen() const { return impl_->isOpen(); };
+
+  void open(const char *filename) { impl_->open(filename); };
+
+  void close() { impl_->close(); };
+
+  void dump(vluint64_t timeui) { impl_->dump(timeui); }
+
+  operator VM_TRACE_CLASS_NAME *() const {
+    assert(impl_);
+    return impl_;
   }
-
-
-  bool isOpen() const {
-    return impl_->isOpen();
-  };
-
-  void open(const char* filename) {
-    impl_->open(filename);
-  };
-
-  void close() {
-    impl_->close();
-  };
-
-  void dump(vluint64_t timeui) {
-    impl_->dump(timeui);
-  }
-
-  operator VM_TRACE_CLASS_NAME*() const { assert(impl_); return impl_; }
 
  private:
-  VM_TRACE_CLASS_NAME* impl_;
+  VM_TRACE_CLASS_NAME *impl_;
 };
 #else
 /**
@@ -67,14 +57,14 @@ class VerilatedTracer {
  */
 class VerilatedTracer {
  public:
-  VerilatedTracer() {};
+  VerilatedTracer(){};
   ~VerilatedTracer() {}
   bool isOpen() const { return false; };
-  void open(const char* filename) {};
-  void close() {};
+  void open(const char *filename){};
+  void close(){};
   void dump(vluint64_t timeui) {}
 };
-#endif // VM_TRACE == 1
+#endif  // VM_TRACE == 1
 
 /**
  * Pure abstract class (interface) for verilated toplevel modules
@@ -97,37 +87,37 @@ class VerilatedTracer {
  * of the tracer-specific class.
  */
 class VerilatedToplevel {
-public:
-  VerilatedToplevel() {};
-  virtual ~VerilatedToplevel() {};
+ public:
+  VerilatedToplevel(){};
+  virtual ~VerilatedToplevel(){};
 
   virtual void eval() = 0;
   virtual void final() = 0;
-  virtual const char* name() const = 0;
-  virtual void trace(VerilatedTracer& tfp, int levels, int options) = 0;
+  virtual const char *name() const = 0;
+  virtual void trace(VerilatedTracer &tfp, int levels, int options) = 0;
 };
 
 #define STR(s) #s
 
 #if VM_TRACE == 1
-#define VERILATED_TOPLEVEL_TRACE_CALL(topname) \
-  V##topname::trace(static_cast<VM_TRACE_CLASS_NAME*>(tfp), levels, options);
+#  define VERILATED_TOPLEVEL_TRACE_CALL(topname) \
+    V##topname::trace(static_cast<VM_TRACE_CLASS_NAME *>(tfp), levels, options);
 #else
-#define VERILATED_TOPLEVEL_TRACE_CALL(topname) \
-  assert(0 && "Tracing not enabled.");
+#  define VERILATED_TOPLEVEL_TRACE_CALL(topname) \
+    assert(0 && "Tracing not enabled.");
 #endif
 
-
-#define VERILATED_TOPLEVEL(topname)                                            \
-  class topname : public V##topname, public VerilatedToplevel {                \
-   public:                                                                     \
-    topname(const char* name="TOP") : V##topname(name), VerilatedToplevel() {} \
-    const char* name() const { return STR(topname); }                          \
-    void eval() { V##topname::eval(); }                                        \
-    void final() { V##topname::final(); }                                      \
-    void trace(VerilatedTracer& tfp, int levels, int options=0) {              \
-      VERILATED_TOPLEVEL_TRACE_CALL(topname)                                   \
-    }                                                                          \
+#define VERILATED_TOPLEVEL(topname)                                 \
+  class topname : public V##topname, public VerilatedToplevel {     \
+   public:                                                          \
+    topname(const char *name = "TOP")                               \
+        : V##topname(name), VerilatedToplevel() {}                  \
+    const char *name() const { return STR(topname); }               \
+    void eval() { V##topname::eval(); }                             \
+    void final() { V##topname::final(); }                           \
+    void trace(VerilatedTracer &tfp, int levels, int options = 0) { \
+      VERILATED_TOPLEVEL_TRACE_CALL(topname)                        \
+    }                                                               \
   };
 
-#endif // VERILATED_TOPLEVEL_H_
+#endif  // VERILATED_TOPLEVEL_H_

--- a/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -18,11 +18,11 @@
 
 // DPI Exports
 extern "C" {
-extern void simutil_verilator_memload(const char* file);
+extern void simutil_verilator_memload(const char *file);
 }
 
-VerilatorSimCtrl::VerilatorSimCtrl(VerilatedToplevel* top, CData& sig_clk,
-                                   CData& sig_rst, VerilatorSimCtrlFlags flags)
+VerilatorSimCtrl::VerilatorSimCtrl(VerilatedToplevel *top, CData &sig_clk,
+                                   CData &sig_rst, VerilatorSimCtrlFlags flags)
     : top_(top),
       sig_clk_(sig_clk),
       sig_rst_(sig_rst),
@@ -143,15 +143,15 @@ void VerilatorSimCtrl::InitFlash(std::string flash) {
             << std::endl;
 }
 
-bool VerilatorSimCtrl::ParseCommandArgs(int argc, char** argv, int& retcode) {
+bool VerilatorSimCtrl::ParseCommandArgs(int argc, char **argv, int &retcode) {
   const struct option long_options[] = {
-      {"rominit",   required_argument, nullptr, 'r'},
-      {"raminit",   required_argument, nullptr, 'm'},
+      {"rominit", required_argument, nullptr, 'r'},
+      {"raminit", required_argument, nullptr, 'm'},
       {"flashinit", required_argument, nullptr, 'f'},
       {"term-after-cycles", required_argument, nullptr, 'c'},
-      {"trace",     no_argument,       nullptr, 't'},
-      {"help",      no_argument,       nullptr, 'h'},
-      {nullptr,     no_argument,       nullptr, 0}};
+      {"trace", no_argument, nullptr, 't'},
+      {"help", no_argument, nullptr, 'h'},
+      {nullptr, no_argument, nullptr, 0}};
 
   while (1) {
     int c = getopt_long(argc, argv, ":r:m:f:th", long_options, nullptr);
@@ -250,7 +250,7 @@ void VerilatorSimCtrl::Trace() {
   tracer_.dump(GetTime());
 }
 
-const char* VerilatorSimCtrl::GetSimulationFileName() const {
+const char *VerilatorSimCtrl::GetSimulationFileName() const {
 #ifdef VM_TRACE_FMT_FST
   return "sim.fst";
 #else
@@ -301,8 +301,7 @@ void VerilatorSimCtrl::Run() {
     }
     if (term_after_cycles_ && time_ > term_after_cycles_) {
       std::cout << "Simulation timeout of " << term_after_cycles_
-                << " cycles reached, shutting down simulation."
-                << std::endl;
+                << " cycles reached, shutting down simulation." << std::endl;
       break;
     }
   }
@@ -344,7 +343,7 @@ bool VerilatorSimCtrl::IsFileReadable(std::string filepath) {
   return stat(filepath.data(), &statbuf) == 0;
 }
 
-bool VerilatorSimCtrl::FileSize(std::string filepath, int& size_byte) {
+bool VerilatorSimCtrl::FileSize(std::string filepath, int &size_byte) {
   struct stat statbuf;
   if (stat(filepath.data(), &statbuf) != 0) {
     size_byte = 0;

--- a/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h
+++ b/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h
@@ -19,7 +19,7 @@ enum VerilatorSimCtrlFlags {
 
 class VerilatorSimCtrl {
  public:
-  VerilatorSimCtrl(VerilatedToplevel* top, CData& clk, CData& rst_n,
+  VerilatorSimCtrl(VerilatedToplevel *top, CData &clk, CData &rst_n,
                    VerilatorSimCtrlFlags flags = Defaults);
 
   /**
@@ -36,7 +36,7 @@ class VerilatorSimCtrl {
    * retcode: if this method returns true, do *not* exit; if it returns *false*,
    * do exit.
    */
-  bool ParseCommandArgs(int argc, char** argv, int& retcode);
+  bool ParseCommandArgs(int argc, char **argv, int &retcode);
 
   /**
    * Run the main loop of the simulation
@@ -120,12 +120,12 @@ class VerilatorSimCtrl {
    */
   void PrintStatistics();
 
-  const char* GetSimulationFileName() const;
+  const char *GetSimulationFileName() const;
 
  private:
-  VerilatedToplevel* top_;
-  CData& sig_clk_;
-  CData& sig_rst_;
+  VerilatedToplevel *top_;
+  CData &sig_clk_;
+  CData &sig_rst_;
   VerilatorSimCtrlFlags flags_;
   unsigned long time_;
   bool init_rom_;
@@ -150,7 +150,7 @@ class VerilatorSimCtrl {
   void SetReset();
   void UnsetReset();
   bool IsFileReadable(std::string filepath);
-  bool FileSize(std::string filepath, int& size_byte);
+  bool FileSize(std::string filepath, int &size_byte);
   void Trace();
 };
 


### PR DESCRIPTION
We have more and more C/C++ code in this repository. Add a clang-format configuration following the standard lowRISC coding style to help developers format their code consistently.