### PR TITLE
Verilator simulation utility: Make it easier to use generated toplevel class

### DIFF
--- a/dv/riscv_compliance/ibex_riscv_compliance.cc
+++ b/dv/riscv_compliance/ibex_riscv_compliance.cc
@@ -6,11 +6,8 @@
 
 #include <iostream>
 
-#include "Vibex_riscv_compliance.h"
 #include "verilated_toplevel.h"
 #include "verilator_sim_ctrl.h"
-
-VERILATED_TOPLEVEL(ibex_riscv_compliance)
 
 ibex_riscv_compliance *top;
 VerilatorSimCtrl *simctrl;

--- a/dv/riscv_compliance/ibex_riscv_compliance.core
+++ b/dv/riscv_compliance/ibex_riscv_compliance.core
@@ -56,7 +56,7 @@ targets:
 # -O
 #   Optimization levels have a large impact on the runtime performance of the
 #   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -g -O0"'
+          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_riscv_compliance -g -O0"'
           - '-LDFLAGS "-pthread -lutil"'
           - "-Wall"
           - "-Wno-PINCONNECTEMPTY"

--- a/dv/verilator/simutil_verilator/cpp/verilated_toplevel.cc
+++ b/dv/verilator/simutil_verilator/cpp/verilated_toplevel.cc
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "verilated_toplevel.h"
+
+TOPLEVEL_NAME &VerilatedToplevel::dut() {
+  // The static_cast below is generally unsafe, but we know the types involved.
+  // It's safe for these.
+  TOPLEVEL_NAME &dut = static_cast<TOPLEVEL_NAME&>(*this);
+  return dut;
+}

--- a/dv/verilator/simutil_verilator/simutil_verilator.core
+++ b/dv/verilator/simutil_verilator/simutil_verilator.core
@@ -9,6 +9,7 @@ filesets:
   files_cpp:
     files:
       - cpp/verilator_sim_ctrl.cc
+      - cpp/verilated_toplevel.cc
       - cpp/verilator_sim_ctrl.h: { is_include_file: true }
       - cpp/verilated_toplevel.h: { is_include_file: true }
     file_type: cppSource


### PR DESCRIPTION
Currently, we generate a toplevel class (I'll call it topname here), inheriting from the Verilator-generated toplevel class (V*), and from the VerilatedToplevel abstract class. This allows us to pass around pointers to VerilatedToplevel whenever we need any toplevel, e.g. to call `eval()` on.

```
                      topname
                   /          \
         VerilatedTopevel      Vtopname
           public eval()   public: clk_i, rst_ni, etc.
                           public eval(), etc.
```
We now want to access the members of Vtopname from a pointer to VerilatedToplevel. That's achievable by casting VerilatedToplevel* to topname*, and then simply accessing the inherited members:


```cpp
void dosomething(VerilatedToplevel* top) {
  dynamic_cast<topname*>(top)->clk_i = 1;

  // (or, using a convenience method in this PR)
  top->dut()->clk_i = 1;
}
```
(Edited for new version to not require cast any more here.)

Doing this cast requires type information for topname to be available, i.e. it requires including the corresponding header file in the compilation unit.

Previously, including `verilated_toplevel.h` wasn't sufficient: the `class topname` was only available when the `VERILATED_TOPLEVEL()` macro was called. 

With this PR, `#include verilated_toplevel.h` and adding `-DTOPLEVEL_NAME=topname` is all that is needed.

Thanks @lenary for help trying out various options to achieve this, and thanks to the C preprocessor for its unlimited supply of magic.


Side notes:
- ~`VM_TRACE` is always defined as 1 or 0 by Verilator, so we can use it directly in the `assert`.~ (That's true, but doesn't help, because `VERILATED_TOPLEVEL_NAME::trace()` doesn't exist without VM_TRACE.)
- The alternative approach we tried out earlier is available at https://github.com/imphil/ibex/commit/51e59dfe0ef1752b0bc56eecf7b5617264e3f2d6. It essentially does the same thing, but additionally changes the class hierarchy to have VerilatedToplevel at the top. I didn't follow through with that once since it's more intrusive, and I don't like the idea of a class of a given name (VerilatedToplevel) having different members available depending on how it's compiled.