### PR TITLE
Compliance test suite: Prefer D over I accesses

### DIFF
--- a/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
+++ b/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
@@ -23,10 +23,11 @@ module ibex_riscv_compliance (
   assign clk_sys = IO_CLK;
   assign rst_sys_n = IO_RST_N;
 
+  // Bus hosts, ordered in decreasing priority
   typedef enum {
     TestUtilHost,
-    CoreI,
-    CoreD
+    CoreD,
+    CoreI
   } bus_host_e;
 
   typedef enum {


### PR DESCRIPTION
Give higher priority to data accesses from the CPU to improve
performance. This is the recommended setup for Ibex.