### PR TITLE
Ignore common editor files in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
-*.swp
-include/riscv_config.sv.bak
+# Build output
 build
+
+# Common editor/IDE config and temporary files
+.project
+.vscode/
+.sw[a-p]


### PR DESCRIPTION
Also removes the include/riscv_config.sv.bak line, which was added
in 346d14c5. We have no code that generates this file any more.