### PR TITLE
[RTL] Quartus compatibility

### DIFF
--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -284,10 +284,9 @@ parameter logic [11:0] CSR_OFF_PMP_CFG  = 12'h3A0; // pmp_cfg  @ 12'h3a0 - 12'h3
 parameter logic [11:0] CSR_OFF_PMP_ADDR = 12'h3B0; // pmp_addr @ 12'h3b0 - 12'h3bf
 
 // CSR mhpmcounter-related offsets and mask
-parameter logic [11:0] CSR_OFF_MCOUNTER_SETUP = 12'h320; // mcounter_setup @ 12'h323 - 12'h33F
-parameter logic [11:0] CSR_OFF_MCOUNTER       = 12'hB00; // mcounter       @ 12'hB03 - 12'hB1F
-parameter logic [11:0] CSR_OFF_MCOUNTERH      = 12'hB80; // mcounterh      @ 12'hB83 - 12'hB9F
-parameter logic [11:0] CSR_MASK_MCOUNTER      = 12'hFE0;
+parameter logic [11:0] CSR_Z_MCOUNTER_SETUP = 12'b0011001?????; // mcounter_setup @ 12'h323 - 12'h33F
+parameter logic [11:0] CSR_Z_MCOUNTER       = 12'b1011000?????; // mcounter       @ 12'hB03 - 12'hB1F
+parameter logic [11:0] CSR_Z_MCOUNTERH      = 12'b1011100?????; // mcounterh      @ 12'hB83 - 12'hB9F
 
 // CSR status bits
 parameter int unsigned CSR_MSTATUS_MIE_BIT      = 3;


### PR DESCRIPTION
I am working on porting PULPissimo project to support Altera/Intel Quartus and thus Intel FPGAs. Besides issues stated in #117 I had some weird problems with core not willing to enter debug mode. As it turns out Quartus isn't interpreting SystemVerilog in the same way as Vivado does (I'm currently documenting all the stuff I've stumbled upon [here](https://github.com/MarekPikula/quartus-sv-gotchas)) and makes some assumptions regarding `case` statement, which are not necessarily true.

In this commit I propose some changes, which result in correct RTL for Quartus (didn't test it in Vivado yet, but I guess it should work just fine) and IMHO make the code more readable in some places.

It's definitely not to be merged since I'd need to make some correct indentation and some cosmetic changes for a final version. I just wanted to make changes only in the places, which have indeed been changed, so that the diff is more readable. Purpose of this PR is to open discussion on some specific places in code, which don't synthesize correctly with Quartus.

Here's the list of changes with explanations:

## ibex_cs_registers.sv

Here is the place where Quartus just cut entire `default` section (line 319 in upstream), leaving `illegal_csr` high for some reason. I presume that it's caused by some partial cases being handled before (like `CSR_MCOUNTINHIBIT`, `CSR_MCYCLE`, …).

### CSR read logic 
Since we don't use `unique case inside` as pointed out in [style guides](https://github.com/lowRISC/style-guides) (this construct isn't supported in Quartus either way) I propose to use `casez` with wildcarded `CSR_OFF_MCOUNTER_SETUP`, `CSR_OFF_MCOUNTER` and `CSR_OFF_MCOUNTERH` with internal `unique case` for distinguishing between subaddresses in the same address range. This results in less code and IMHO more readable code, as a reader now clearly sees that these subaddresses are indded in this address range and that not all subaddresses are illegal as code suggests.

### CSR write logic

Similar thing is done for write section and I'd have suggestion to change assignment for `illegal_csr_write` from global assign without much meaning to an assignment inside this case statement for particular cases and some additional ones, which are not handled by global assign.

Another thing, which reduces clutter is making `if (csr_we_int == 1'b1)` condition outside case statement. That's a minor change not particularly connected with topic of this PR, but I'd say it makes the code more readable.

### Use of constant expression in case statement

As stated [here](https://github.com/MarekPikula/quartus-sv-gotchas/blob/master/Intel%20Quartus%20SystemVerilog%20gotchas.md#1252-constant-expression-in-case-statement) it simply doesn't synthesize correctly. For example for the code starting at line 499 in upstream the synthesizer basically replaced this case statement with `exception_pc = pc_if_i;` totally ignoring the second case. Correct me if I'm wrong, but I think that syntax in my patch is equivalent to constant expression case.

## ibex_id_stage.sv and ibex_multdiv_fast.sv 

The only problem was constant expression case.