### PR TITLE
Tracing: Wrap fatal error message with `$fatal()`

### DIFF
--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -62,7 +62,7 @@ module ibex_core_tracing #(
 
   // ibex_tracer relies on the signals from the RISC-V Formal Interface
   `ifndef RVFI
-    Fatal error: RVFI needs to be defined globally.
+    $fatal("Fatal error: RVFI needs to be defined globally.");
   `endif
 
   logic        rvfi_valid;


### PR DESCRIPTION
The syntax of this statement is not correct without the `$fatal()` SV construct. This causes errors in some tools even if the error condition is not met.