### PR TITLE
[syn] Add initial Yosys synthesis script with example lib

### DIFF
--- a/syn/cmos_cells.lib
+++ b/syn/cmos_cells.lib
@@ -1,0 +1,73 @@
+// yosys -- Yosys Open SYnthesis Suite
+// 
+// Copyright (C) 2012 - 2019  Clifford Wolf <clifford@clifford.at>
+// 
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// This file is copied from here:
+// https://github.com/YosysHQ/yosys/blob/master/examples/cmos/cmos_cells.lib
+
+/* test comment */
+library(demo) {
+  cell(BUF) {
+    area: 6;
+    pin(A) { direction: input; }
+    pin(Y) { direction: output;
+              function: "A"; }
+  }
+  cell(NOT) {
+    area: 3;
+    pin(A) { direction: input; }
+    pin(Y) { direction: output;
+              function: "A'"; }
+  }
+  cell(NAND) {
+    area: 4;
+    pin(A) { direction: input; }
+    pin(B) { direction: input; }
+    pin(Y) { direction: output;
+             function: "(A*B)'"; }
+  }
+  cell(NOR) {
+    area: 4;
+    pin(A) { direction: input; }
+    pin(B) { direction: input; }
+    pin(Y) { direction: output;
+             function: "(A+B)'"; }
+  }
+  cell(DFF) {
+    area: 18;
+    ff(IQ, IQN) { clocked_on: C;
+                  next_state: D; }
+    pin(C) { direction: input;
+                 clock: true; }
+    pin(D) { direction: input; }
+    pin(Q) { direction: output;
+              function: "IQ"; }
+  }
+  cell(DFFSR) {
+    area: 18;
+    ff("IQ", "IQN") { clocked_on: C;
+                  next_state: D;
+                      preset: S;
+                       clear: R; }
+    pin(C) { direction: input;
+                 clock: true; }
+    pin(D) { direction: input; }
+    pin(Q) { direction: output;
+              function: "IQ"; }
+    pin(S) { direction: input; }
+    pin(R) { direction: input; }
+    ; // empty statement
+  }
+}

--- a/syn/prim_clock_gating.v
+++ b/syn/prim_clock_gating.v
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Dummy clock gating module without the clock gate for yosys synthesis
+
+module prim_clock_gating (
+  input  clk_i,
+  input  en_i,
+  input  test_en_i,
+  output clk_o
+);
+
+  assign clk_o = clk_i;
+
+endmodule

--- a/syn/syn.ys
+++ b/syn/syn.ys
@@ -1,0 +1,18 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# yosys synthesis script
+
+read -sv prim_clock_gating.v syn_out/*.v
+synth -top ibex_core
+write_verilog ibex_core_premap.v
+
+# mapping to cmos_cells.lib
+dfflibmap -liberty cmos_cells.lib
+abc -liberty cmos_cells.lib
+write_verilog ibex_core_netlist.v
+
+# reports
+check
+stat

--- a/syn/syn_yosys.sh
+++ b/syn/syn_yosys.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script converts all SystemVerilog RTL files to Verilog and then
+# runs Yosys for ibex_core
+#
+# The following tools are required:
+#  - sv2v: SystemVerilog-to-Verilog converter from github.com/zachjs/sv2v
+#  - yosys: synthesis tool from github.com/YosysHQ/yosys
+#
+# Usage:
+#   syn_yosys.sh 2>&1 | tee syn.std
+#
+# Above command generates two files:
+#   ibex_core_premap.v  : premap netlist (before mapping it onto std. cells)
+#   ibex_core_netlist.v : final netlist
+
+# TODO: below should be replaced by elegant fusesoc commands
+
+#-------------------------------------------------------------------------
+# use sv2v to convert all SystemVerilog files to Verilog
+#-------------------------------------------------------------------------
+rm -Rf syn_out
+mkdir syn_out
+
+for file in ../rtl/*.sv; do
+  module=`basename -s .sv $file`
+  sv2v \
+    --define=SYNTHESIS \
+    ../rtl/*_pkg.sv \
+    $file \
+    > syn_out/${module}.v
+
+  # TODO: eventually remove below hack. It removes "unsigned" from params
+  # because Yosys doesn't support unsigned parameters
+  sed -i 's/parameter unsigned/parameter/g'   syn_out/${module}.v
+  sed -i 's/localparam unsigned/localparam/g' syn_out/${module}.v
+done
+
+# remove generated *pkg.v files (they are empty files and not needed)
+rm -f syn_out/*_pkg.v
+
+# remove the latch-based register file (because we will use the
+# flop-based one instead)
+rm -f syn_out/ibex_register_file_latch.v
+
+#-------------------------------------------------------------------------
+# run yosys
+#-------------------------------------------------------------------------
+yosys syn.ys -l syn.log


### PR DESCRIPTION
This PR includes the following:
- add script syn_yosys.sh, which runs sv2v and yosys for ibex_core
- add example std. cell lib cmos_cells.lib (copied from yosys repo)
- add dummy prim_clock_gating.v module
- add initial yosys synthesis script syn.ys