### PR TITLE
[rtl/ibex_core] Added missing parameter assignment

### DIFF
--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -557,6 +557,7 @@ module ibex_core #(
   ibex_cs_registers #(
       .MHPMCounterNum   ( MHPMCounterNum   ),
       .MHPMCounterWidth ( MHPMCounterWidth ),
+      .PMPEnable        ( PMPEnable        ),
       .PMPGranularity   ( PMPGranularity   ),
       .PMPNumRegions    ( PMPNumRegions    ),
       .RV32E            ( RV32E            ),


### PR DESCRIPTION
Added missing parameter assignment for PMPEnable of ibex_cs_registers.