### PR TITLE
Tracer: Update copyright notice to match other files

### DIFF
--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -1,5 +1,5 @@
 // Copyright lowRISC contributors.
-// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright 2018 ETH Zurich and University of Bologna, see also CREDITS.md.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
In this file I missed updating the ETH/UniBo copyright notice to include
a reference to the CREDITS.md. Fixing that for consistency.