### PR TITLE
Tracer: Fix default file name

### DIFF
--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -92,7 +92,7 @@ module ibex_tracer (
     string rvfi_insn_str;
 
     if (file_handle == 32'h0) begin
-      string file_name_base = "trace_core_";
+      string file_name_base = "trace_core";
       $value$plusargs("ibex_tracer_file_base=%s", file_name_base);
       $sformat(file_name, "%s_%h.log", file_name_base, hart_id_i);
 


### PR DESCRIPTION
We document the default file name to be trace_core_00000000.log, but
actually used trace_core__00000000.log. Fix that.