### PR TITLE
RISC-V Compliance test: Enable tracing

### DIFF
--- a/dv/riscv_compliance/ibex_riscv_compliance.core
+++ b/dv/riscv_compliance/ibex_riscv_compliance.core
@@ -8,7 +8,7 @@ filesets:
   files_sim_verilator:
     depend:
       - lowrisc:dv_verilator:simutil_verilator
-      - lowrisc:ibex:ibex_core
+      - lowrisc:ibex:ibex_core_tracing
 
     files:
       - rtl/ibex_riscv_compliance.sv

--- a/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
+++ b/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
@@ -100,7 +100,7 @@ module ibex_riscv_compliance (
     .cfg_device_addr_mask
   );
 
-  ibex_core #(
+  ibex_core_tracing #(
       .DmHaltAddr(32'h00000000),
       .DmExceptionAddr(32'h00000000),
       .RV32E(RV32E),


### PR DESCRIPTION
Use the tracing-enabled core wrapper when executing the RISC-V
compliance test suite to help with debugging it.