### PR TITLE
[DV] Top level toggle coverage

### DIFF
--- a/dv/uvm/cover.cfg
+++ b/dv/uvm/cover.cfg
@@ -1,1 +1,4 @@
 +tree core_ibex_tb_top.dut
+begin tgl
+  -tree core_ibex_tb_top.dut.*
+end

--- a/dv/uvm/riscv_dv_extension/ibex_log_to_trace_csv.py
+++ b/dv/uvm/riscv_dv_extension/ibex_log_to_trace_csv.py
@@ -33,7 +33,7 @@ def process_ibex_sim_log(ibex_log, csv):
             # Extract instruction information
             m = re.search(r"^\s*(?P<time>\d+)\s+(?P<cycle>\d+)\s+" \
                           "(?P<pc>[0-9a-f]+)\s+(?P<bin>[0-9a-f]+)\s+(?P<instr>.*)" \
-                          ".*x(?P<rd>\d+)=0x(?P<val>[0-9a-f]+)", line)
+                          ".*x(?P<rd>[1-9]\d*)=0x(?P<val>[0-9a-f]+)", line)
             if m:
                 # Write the extracted instruction to a csvcol buffer file
                 rv_instr_trace = RiscvInstructiontTraceEntry()


### PR DESCRIPTION
1) Enable toggle coverage of only top level I/O pins
2) Tighten ibex log regex to exclude writes to `x0`