### PR TITLE
Remove reference to simulation

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -5,11 +5,6 @@ Examples
 
 To make use of Ibex it has to be integrated as described in :ref:`core-integration`.
 
-Tracer Simulation
------------------
-
-How to run a simple testbench to test the tracer is described in ``examples/sim/README.md``.
-
 FPGA
 ----
 


### PR DESCRIPTION
The testbench does not exist anymore. Was removed with #360 