### PR TITLE
Allow setting RF implementation with FuseSoC use flag

### DIFF
--- a/ibex_core.core
+++ b/ibex_core.core
@@ -22,10 +22,8 @@ filesets:
       - rtl/ibex_multdiv_slow.sv
       - rtl/ibex_prefetch_buffer.sv
       - rtl/ibex_pmp.sv
-      # XXX: Figure out the best way to switch these two implementations
-      # dynamically on the target.
-#      - rtl/ibex_register_file_latch.sv # ASIC
-      - rtl/ibex_register_file_ff.sv # FPGA
+      - " ibex_rf_latch? (rtl/ibex_register_file_latch.sv)" # ASIC
+      - "!ibex_rf_latch? (rtl/ibex_register_file_ff.sv)" # FPGA
       - rtl/ibex_core.sv
     file_type: systemVerilogSource
 


### PR DESCRIPTION
**NOTE** This requires https://github.com/olofk/fusesoc/commit/0351dd09dfdd6a6a5e404d1375bf1fafd8b9652c which is not yet in a released FuseSoC version at this point

FuseSoC has gained support for use flags. This patch adds support
for setting the Ibex RF implementation with the ibex_rf_latch use
flag. Default is the FF implementation.

Example: Run the verilator linter with the latch-based RF
fusesoc run --target=lint --flag=ibex_rf_latch lowrisc:ibex:ibex_core