### PR TITLE
[RTL] Enable reading mstatus.tw

### DIFF
--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -244,6 +244,7 @@ module ibex_cs_registers #(
         csr_rdata_int[CSR_MSTATUS_MPIE_BIT]                             = mstatus_q.mpie;
         csr_rdata_int[CSR_MSTATUS_MPP_BIT_HIGH:CSR_MSTATUS_MPP_BIT_LOW] = mstatus_q.mpp;
         csr_rdata_int[CSR_MSTATUS_MPRV_BIT]                             = mstatus_q.mprv;
+        csr_rdata_int[CSR_MSTATUS_TW_BIT]                               = mstatus_q.tw;
       end
 
       // misa


### PR DESCRIPTION
Current documentation lists `mstatus.tw` as a `RW` field, but this readability is not reflected in RTL, this PR allows `mstatus.tw` to be read.