### PR TITLE
[DV] Add reset test

### DIFF
--- a/dv/uvm/common/ibex_mem_intf_agent/ibex_mem_intf_slave_agent.sv
+++ b/dv/uvm/common/ibex_mem_intf_agent/ibex_mem_intf_slave_agent.sv
@@ -32,4 +32,8 @@ class ibex_mem_intf_slave_agent extends uvm_agent;
     end
   endfunction : connect_phase
 
+  function void reset();
+    sequencer.reset();
+  endfunction
+
 endclass : ibex_mem_intf_slave_agent

--- a/dv/uvm/common/ibex_mem_intf_agent/ibex_mem_intf_slave_sequencer.sv
+++ b/dv/uvm/common/ibex_mem_intf_agent/ibex_mem_intf_slave_sequencer.sv
@@ -18,4 +18,9 @@ class ibex_mem_intf_slave_sequencer extends uvm_sequencer #(ibex_mem_intf_seq_it
     addr_ph_port = new("addr_ph_port_sequencer", this);
   endfunction : new
 
+  // On reset, empty the tlm fifo
+  function void reset();
+    addr_ph_port.flush();
+  endfunction
+
 endclass : ibex_mem_intf_slave_sequencer

--- a/dv/uvm/common/irq_agent/irq_monitor.sv
+++ b/dv/uvm/common/irq_agent/irq_monitor.sv
@@ -22,7 +22,15 @@ class irq_monitor extends uvm_monitor;
   endfunction: build_phase
 
   virtual task run_phase(uvm_phase phase);
-    collect_irq();
+    forever begin
+      wait(vif.reset === 1'b0);
+      fork : monitor_irq
+        collect_irq();
+        wait(vif.reset === 1'b1);
+      join_any
+      // Will only reach here on mid-test reset
+      disable monitor_irq;
+    end
   endtask : run_phase
 
   // We know that for Ibex, any given interrupt stimulus will be asserted until the core signals the

--- a/dv/uvm/common/utils/clk_if.sv
+++ b/dv/uvm/common/utils/clk_if.sv
@@ -8,7 +8,11 @@
 //
 //------------------------------------------------------------------------------
 
-interface clk_if(input logic clk);
+interface clk_if(inout clk,
+                 inout rst_n);
+
+  logic clk_o;
+  logic rst_no;
 
   clocking cb @(posedge clk);
   endclocking
@@ -25,5 +29,29 @@ interface clk_if(input logic clk);
   task wait_n_clks(int num_clks);
     repeat (num_clks) @cbn;
   endtask
+
+  // generate mid-test reset
+  task reset();
+    rst_no = 1'b0;
+    wait_clks(100);
+    rst_no = 1'b1;
+  endtask
+
+  // generate clock
+  initial begin
+    clk_o = 1'b0;
+    forever begin
+      #10 clk_o = ~clk_o;
+    end
+  end
+
+  // generate initial reset
+  initial begin
+    reset();
+  end
+
+  // Interface assignments
+  assign clk = clk_o;
+  assign rst_n = rst_no;
 
 endinterface

--- a/dv/uvm/env/core_ibex_dut_probe_if.sv
+++ b/dv/uvm/env/core_ibex_dut_probe_if.sv
@@ -4,6 +4,7 @@
 
 // Interface to probe DUT internal signal
 interface core_ibex_dut_probe_if(input logic clk);
+  logic reset;
   logic illegal_instr;
   logic ecall;
   logic wfi;
@@ -13,4 +14,9 @@ interface core_ibex_dut_probe_if(input logic clk);
   logic fetch_enable;
   logic core_sleep;
   logic debug_req;
+
+  initial begin
+    debug_req = 1'b0;
+  end
+
 endinterface

--- a/dv/uvm/env/core_ibex_env.sv
+++ b/dv/uvm/env/core_ibex_env.sv
@@ -37,4 +37,9 @@ class core_ibex_env extends uvm_env;
     vseqr.irq_seqr = irq_agent.sequencer;
   endfunction : connect_phase
 
+  function void reset();
+    data_if_slave_agent.reset();
+    instr_if_slave_agent.reset();
+  endfunction
+
 endclass

--- a/dv/uvm/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/riscv_dv_extension/testlist.yaml
@@ -340,3 +340,16 @@
   compare_opts:
     compare_final_value_only: 1
     verbose: 1
+
+- test: riscv_reset_test
+  description: >
+    Randomly reset the core once in the middle of program execution
+  iterations: 10
+  gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +instr_cnt=10000
+    +num_of_sub_program=5
+  rtl_test: core_ibex_reset_test
+  compare_opts:
+    compare_final_value_only: 1
+    verbose: 1

--- a/dv/uvm/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/tb/core_ibex_tb_top.sv
@@ -7,11 +7,11 @@ module core_ibex_tb_top;
   import uvm_pkg::*;
   import core_ibex_test_pkg::*;
 
-  logic clk;
-  logic rst_n;
+  wire clk;
+  wire rst_n;
   logic fetch_enable;
 
-  clk_if         ibex_clk_if(.clk(clk));
+  clk_if         ibex_clk_if(.clk(clk), .rst_n(rst_n));
   irq_if         irq_vif();
   ibex_mem_intf  data_mem_vif();
   ibex_mem_intf  instr_mem_vif();
@@ -94,6 +94,7 @@ module core_ibex_tb_top;
   assign dut_if.dret            = dut.u_ibex_core.id_stage_i.dret_insn_dec;
   assign dut_if.mret            = dut.u_ibex_core.id_stage_i.mret_insn_dec;
   assign dut_if.core_sleep      = dut.u_ibex_core.core_sleep_o;
+  assign dut_if.reset           = ~rst_n;
 
 
   initial begin
@@ -104,22 +105,6 @@ module core_ibex_tb_top;
     uvm_config_db#(virtual ibex_mem_intf)::set(null, "*instr_if_slave*", "vif", instr_mem_vif);
     uvm_config_db#(virtual irq_if)::set(null, "*", "vif", irq_vif);
     run_test();
-  end
-
-  // Generate clk
-  initial begin
-    clk = 1'b0;
-    forever begin
-      #10 clk = ~clk;
-    end
-  end
-
-  // Generate reset
-  initial begin
-    rst_n = 1'b0;
-    repeat(100) @(posedge clk);
-    rst_n = 1'b1;
-    dut_if.debug_req = 1'b0;
   end
 
 endmodule

--- a/dv/uvm/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/tests/core_ibex_test_lib.sv
@@ -31,6 +31,37 @@ class core_ibex_csr_test extends core_ibex_base_test;
 
 endclass
 
+// Reset test
+class core_ibex_reset_test extends core_ibex_base_test;
+
+  `uvm_component_utils(core_ibex_reset_test)
+  `uvm_component_new
+
+  virtual task send_stimulus();
+    vseq.start(env.vseqr);
+    // Mid-test reset is possible in a wide range of times
+    clk_vif.wait_clks($urandom_range(20000, 200000));
+    fork
+      begin
+        dut_vif.fetch_enable = 1'b0;
+        clk_vif.reset();
+      end
+      begin
+        clk_vif.wait_clks(1);
+        // Flush FIFOs
+        item_collected_port.flush();
+        irq_collected_port.flush();
+        // Reset testbench state
+        env.reset();
+        load_binary_to_mem();
+      end
+    join
+    // Assert fetch_enable to have the core start executing from boot address
+    dut_vif.fetch_enable = 1'b1;
+  endtask
+
+endclass
+
 // Performance counter test class
 class core_ibex_perf_test extends core_ibex_base_test;
 


### PR DESCRIPTION
- Major changes to driver/monitor components throughout the testbench to allow for mid-test reset stimulus to be driven
- Modifications to tb_top to move all clock and initial reset stimulus to `initial begin...end` blocks in the `clk_if`.