### PR TITLE
[RTL] Prevent CSR write on any illegal CSR reason

### DIFF
--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -552,7 +552,7 @@ module ibex_cs_registers #(
   end
 
   // only write CSRs during one clock cycle
-  assign csr_we_int  = csr_wreq & ~illegal_csr_priv & instr_new_id_i;
+  assign csr_we_int  = csr_wreq & ~illegal_csr_insn_o & instr_new_id_i;
 
   assign csr_rdata_o = csr_rdata_int;
 


### PR DESCRIPTION
Debug register access sets illegal_csr if not in debug mode but CSR
write still went ahead. This modifies the CSR write to ensure that
anything that results in an illegal CSR instruction being signalled will
prevent a CSR write.