### PR TITLE
[RTL] Fix single stepping on exceptions

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -566,10 +566,13 @@ module ibex_controller (
           end
         end // exc_req_q
 
-        // single stepping
-        // set exception registers, but do not jump into handler [Debug Spec v0.13.2, p.44]
+        // Entering debug mode due to either single step or debug_req. Ensure
+        // registers are set for exception but then enter debug handler rather
+        // than exception handler [Debug Spec v0.13.2, p.44]
+        // Leave all other signals as is to ensure CSRs and PC get set as if
+        // core was entering exception handler, entry to debug mode will then
+        // see the appropriate state and setup dpc correctly.
         if (enter_debug_mode) begin
-          pc_set_o    = 1'b0;
           ctrl_fsm_ns = DBG_TAKEN_IF;
         end
       end // FLUSH


### PR DESCRIPTION
When we single step over an instruction that causes an exception DPC
should be set to point to the exception handler (where we would have
gone were we not single stepping).

As discussed on Zulip this looks to be the correct behaviour, see response to issue on riscv-debug-spec here https://github.com/riscv/riscv-debug-spec/issues/497