### PR TITLE
Docs: Make licensing docs more user-friendly

### DIFF
--- a/doc/copyright.rst
+++ b/doc/copyright.rst
@@ -1,5 +1,0 @@
-Copyright
-=========
-
-Ibex is released under the Apache license, version 2.0.
-The full license text is available in the ``LICENSE`` file in the source code.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -27,4 +27,4 @@ Ibex User Manual
 .. toctree::
    :hidden:
 
-   copyright
+   licensing

--- a/doc/licensing.rst
+++ b/doc/licensing.rst
@@ -10,3 +10,7 @@ Please see the ``LICENSE`` file in the source code for the full (and legally bin
 
 Even though the license doesn't require it, we appreciate feedback and contributions to make Ibex work better for everyone.
 Please open an `issue <https://github.com/lowRISC/ibex/issues>`_ for bug reports, questions, or suggested improvements, or a `pull request <https://github.com/lowRISC/ibex/pulls>`_ if you'd like to contribute code.
+
+.. note::
+
+  Commercial support for Ibex is available from `lowRISC <https://www.lowrisc.org/>`_.

--- a/doc/licensing.rst
+++ b/doc/licensing.rst
@@ -1,0 +1,12 @@
+Licensing
+=========
+
+Ibex is released under the Apache license, version 2.0.
+
+Ibex can be used, modified, and distributed for any purpose (including commercial) and without any royalties.
+There are some requirements on including copyright notices and the original license.
+
+Please see the ``LICENSE`` file in the source code for the full (and legally binding) license text.
+
+Even though the license doesn't require it, we appreciate feedback and contributions to make Ibex work better for everyone.
+Please open an `issue <https://github.com/lowRISC/ibex/issues>`_ for bug reports, questions, or suggested improvements, or a `pull request <https://github.com/lowRISC/ibex/pulls>`_ if you'd like to contribute code.


### PR DESCRIPTION
Currently we have a section "Copyright" in our docs [1]. This section is badly named, and not overly helpful to people unfamiliar with open source and the Apache license in particular. This PR rewords some of that content to make it more accessible for a broader audience.

A second commit adds information about lowRISC offering commercial support for Ibex, which could be helpful information for some people looking at this page.


[1] https://ibex-core.readthedocs.io/en/latest/copyright.html