### PR TITLE
[Doc] Added extra setup info for Verification

### DIFF
--- a/doc/verification.rst
+++ b/doc/verification.rst
@@ -30,11 +30,13 @@ Please note that this work is still working in progress.
 Getting Started
 ---------------
 
-Prerequisites
-~~~~~~~~~~~~~
+Prerequisites & Environment Setup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  VCS RTL simulator (need to support UVM 1.2)
--  `Setup the RISC-V instruction generator and ISS sim environment <https://github.com/google/riscv-dv#getting-started>`_
+- VCS RTL simulator (needed to support UVM 1.2)
+- RISCV-DV Prerequisites - https://github.com/google/riscv-dv#prerequisites
+- GCC setup - https://github.com/google/riscv-dv#compile-generated-programs-with-gcc
+- ISS setup - https://github.com/google/riscv-dv#run-iss-instruction-set-simulator-simulation - note that commit log must be enabled in spike by passing ``--enable-commitlog`` to the configure script.
 
 End-to-end RTL/ISS co-simulation flow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Having just tried running the DV stuff for the first time thought this tweak to the getting started information would help (the RISC-DV document has lots of irrelevant information so I thought it was better to point to the relevant sections)