### PR TITLE
[rtl/alu] Remove unused comparison operations

### DIFF
--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -28,7 +28,7 @@ lint_off -msg UNUSED -file "*/rtl/ibex_if_stage.sv" -lines 80
 
 // Bits of signal are not used: shift_right_result_ext[32]
 // cleaner to write all bits even if not all are used
-lint_off -msg UNUSED -file "*/rtl/ibex_alu.sv" -lines 107
+lint_off -msg UNUSED -file "*/rtl/ibex_alu.sv" -lines 105
 
 // Bits of signal are not used: alu_adder_ext_i[0]
 // Bottom bit is round, not needed

--- a/rtl/ibex_alu.sv
+++ b/rtl/ibex_alu.sv
@@ -50,10 +50,8 @@ module ibex_alu (
 
       // Comparator OPs
       ALU_EQ,   ALU_NE,
-      ALU_GTU,  ALU_GEU,
-      ALU_LTU,  ALU_LEU,
-      ALU_GT,   ALU_GE,
-      ALU_LT,   ALU_LE,
+      ALU_GE,   ALU_GEU,
+      ALU_LT,   ALU_LTU,
       ALU_SLT,  ALU_SLTU,
       ALU_SLET, ALU_SLETU: adder_op_b_negate = 1'b1;
 
@@ -128,10 +126,8 @@ module ibex_alu (
     cmp_signed = 1'b0;
 
     unique case (operator_i)
-      ALU_GT,
       ALU_GE,
       ALU_LT,
-      ALU_LE,
       ALU_SLT,
       ALU_SLET: begin
         cmp_signed = 1'b1;
@@ -143,7 +139,6 @@ module ibex_alu (
 
   assign is_equal = (adder_result == 32'b0);
   assign is_equal_result_o = is_equal;
-
 
   // Is greater equal
   always_comb begin
@@ -166,8 +161,6 @@ module ibex_alu (
   // (a[31] == 1 && b[31] == 0) => 0
   // (a[31] == 0 && b[31] == 1) => 1
 
-
-
   // generate comparison result
   logic cmp_result;
 
@@ -175,23 +168,18 @@ module ibex_alu (
     cmp_result = is_equal;
 
     unique case (operator_i)
-      ALU_EQ:            cmp_result =  is_equal;
-      ALU_NE:            cmp_result = ~is_equal;
-      ALU_GT,  ALU_GTU:  cmp_result = is_greater_equal & ~is_equal;
-      ALU_GE,  ALU_GEU:  cmp_result = is_greater_equal;
-      ALU_LT,  ALU_SLT,
-      ALU_LTU, ALU_SLTU: cmp_result = ~is_greater_equal;
-      ALU_SLET,
-      ALU_SLETU,
-      ALU_LE,  ALU_LEU:  cmp_result = ~is_greater_equal | is_equal;
+      ALU_EQ:              cmp_result =  is_equal;
+      ALU_NE:              cmp_result = ~is_equal;
+      ALU_GE,  ALU_GEU:    cmp_result = is_greater_equal;
+      ALU_LT,  ALU_LTU,
+      ALU_SLT, ALU_SLTU:   cmp_result = ~is_greater_equal;
+      ALU_SLET, ALU_SLETU: cmp_result = ~is_greater_equal | is_equal;
 
       default:;
     endcase
   end
 
   assign comparison_result_o = cmp_result;
-
-
 
   ////////////////
   // Result mux //
@@ -215,10 +203,8 @@ module ibex_alu (
 
       // Comparison Operations
       ALU_EQ,   ALU_NE,
-      ALU_GTU,  ALU_GEU,
-      ALU_LTU,  ALU_LEU,
-      ALU_GT,   ALU_GE,
-      ALU_LT,   ALU_LE,
+      ALU_GE,   ALU_GEU,
+      ALU_LT,   ALU_LTU,
       ALU_SLT,  ALU_SLTU,
       ALU_SLET, ALU_SLETU: result_o = {31'h0,cmp_result};
 

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -50,10 +50,6 @@ typedef enum logic [4:0] {
   // Comparisons
   ALU_LT,
   ALU_LTU,
-  ALU_LE,
-  ALU_LEU,
-  ALU_GT,
-  ALU_GTU,
   ALU_GE,
   ALU_GEU,
   ALU_EQ,


### PR DESCRIPTION
These operations (ALU_GT, ALU_GTU, ALU_LE, ALU_LEU) are remnants of of the original OpenRISC design. RISC-V does not have these instructions and instead implements the operations by reversing operands for ALU_LT, ALU_LTU, ALU_GE, ALU_GEU.

This resolves lowRISC/ibex#420 reported by @udinator.