### PR TITLE
[DV] Increase number of illegal instructions generated

### DIFF
--- a/dv/uvm/Makefile
+++ b/dv/uvm/Makefile
@@ -17,7 +17,7 @@ COV                 := 0
 # RTL simulator
 SIMULATOR           := "vcs"
 # ISS (spike, ovpsim)
-ISS                 := "spike"
+ISS                 := "ovpsim"
 # ISA
 ISA                 := "rv32imc"
 # Test name (default: full regression)
@@ -101,6 +101,7 @@ iss_sim:
      ${COMMON_OPTS} \
      --iss=${ISS} \
      --isa=${ISA} \
+     --core_setting_dir=${DV_DIR}/riscv_dv_extension \
 
 # Compile ibex core TB
 compile:

--- a/dv/uvm/riscv_dv_extension/riscvOVPsim.ic
+++ b/dv/uvm/riscv_dv_extension/riscvOVPsim.ic
@@ -1,0 +1,21 @@
+# riscOVPsim configuration file converted from YAML
+--variant RV32I
+--override riscvOVPsim/cpu/add_Extensions=MC
+--override riscvOVPsim/cpu/misa_MXL=1
+--override riscvOVPsim/cpu/misa_MXL_mask=0x0 # 0
+--override riscvOVPsim/cpu/misa_Extensions_mask=0x0 # 0
+--override riscvOVPsim/cpu/unaligned=T
+--override riscvOVPsim/cpu/mtvec_mask=0xffffff03
+--override riscvOVPsim/cpu/tvec_align=256
+--override riscvOVPsim/cpu/user_version=2.3
+--override riscvOVPsim/cpu/priv_version=1.11
+--override riscvOVPsim/cpu/mvendorid=0
+--override riscvOVPsim/cpu/marchid=0
+--override riscvOVPsim/cpu/mimpid=0
+--override riscvOVPsim/cpu/mhartid=0
+--override riscvOVPsim/cpu/cycle_undefined=F
+--override riscvOVPsim/cpu/instret_undefined=F
+--override riscvOVPsim/cpu/time_undefined=F
+--override riscvOVPsim/cpu/reset_address=0x80000080
+--override riscvOVPsim/cpu/simulateexceptions=T
+--override riscvOVPsim/cpu/wfi_is_nop=T

--- a/dv/uvm/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/riscv_dv_extension/testlist.yaml
@@ -90,10 +90,10 @@
     instruction and handle corresponding exception properly. An exception
     handling routine is designed to resume execution after illegal
     instruction exception.
-  iterations: 10
+  iterations: 15
   gen_test: riscv_rand_instr_test
   gen_opts: >
-    +illegal_instr_ratio=5
+    +illegal_instr_ratio=25
   rtl_test: core_ibex_base_test
 
 - test: riscv_hint_instr_test


### PR DESCRIPTION
Additionally:
1) Add configuration file for OVPsim, and update Makefile to pass correct config file into iss_sim target
2) Additionally, changed default ISS to OVPsim, it has been fully configured for Ibex, and can handle `mie.mtie` being enabled without any weird side-effects.