### PR TITLE
Reduce mtvec alignment requirement

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,7 +123,7 @@ jobs:
           # There's no easy way to get the test results in machine-readable
           # form to properly exclude known-failing tests. Going with an
           # approximate solution for now.
-          if [ $isa == rv32i ] && grep -q 'FAIL: 5/55' run.log; then
+          if [ $isa == rv32i ] && grep -q 'FAIL: 3/55' run.log; then
             echo -n "##vso[task.logissue type=error]"
             echo "Expected failure for rv32i, see lowrisc/ibex#100 more more information."
           else

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -378,6 +378,7 @@ module ibex_cs_registers #(
     mepc_d       = mepc_q;
     mcause_d     = mcause_q;
     mtval_d      = mtval_q;
+    // TODO Should this assignment use boot_addr_i[31:1]? [7:2] always 6'b0
     mtvec_d      = csr_mtvec_init_i ? {boot_addr_i[31:8], 6'b0, 2'b01} : mtvec_q;
     dcsr_d       = dcsr_q;
     depc_d       = depc_q;
@@ -430,8 +431,8 @@ module ibex_cs_registers #(
 
         // mtvec
         // mtvec.MODE set to vectored
-        // mtvec.BASE must be 256-byte aligned
-        CSR_MTVEC: mtvec_d = {csr_wdata_int[31:8], 6'b0, 2'b01};
+        // mtvec.BASE must be 4-byte aligned
+        CSR_MTVEC: mtvec_d = {csr_wdata_int[31:2], 2'b01};
 
         CSR_DCSR: begin
           dcsr_d = csr_wdata_int;

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -93,10 +93,10 @@ module ibex_if_stage #(
   logic              if_id_pipe_reg_we; // IF-ID pipeline reg write enable
 
   logic        [7:0] unused_boot_addr;
-  logic        [7:0] unused_csr_mtvec;
+  logic        [1:0] unused_csr_mtvec;
 
   assign unused_boot_addr = boot_addr_i[7:0];
-  assign unused_csr_mtvec = csr_mtvec_i[7:0];
+  assign unused_csr_mtvec = csr_mtvec_i[1:0];
 
   // extract interrupt ID from exception cause
   assign irq_id         = {exc_cause};
@@ -105,7 +105,7 @@ module ibex_if_stage #(
   // exception PC selection mux
   always_comb begin : exc_pc_mux
     unique case (exc_pc_mux_i)
-      EXC_PC_EXC:     exc_pc = { csr_mtvec_i[31:8], 8'h00                    };
+      EXC_PC_EXC:     exc_pc = { csr_mtvec_i[31:2], 2'h00                    };
       EXC_PC_IRQ:     exc_pc = { csr_mtvec_i[31:8], 1'b0, irq_id[4:0], 2'b00 };
       EXC_PC_DBD:     exc_pc = DmHaltAddr;
       EXC_PC_DBG_EXC: exc_pc = DmExceptionAddr;


### PR DESCRIPTION
RISC-V Privileged Spec v1.11 allows BASE filed of mtvec to be 4-byte
aligned.

Update the assignment and usage of mtvec to use 4-byte aligned
addresses.

This fixes `I-EBREAK` and `I-ECALL` tests of RISC-V compliance failures
reported in lowrisc/ibex#100.