### PR TITLE
[rtl] Remove unused set-less-or-equal-than ALU ops

### DIFF
--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -28,7 +28,7 @@ lint_off -msg UNUSED -file "*/rtl/ibex_if_stage.sv" -lines 80
 
 // Bits of signal are not used: shift_right_result_ext[32]
 // cleaner to write all bits even if not all are used
-lint_off -msg UNUSED -file "*/rtl/ibex_alu.sv" -lines 105
+lint_off -msg UNUSED -file "*/rtl/ibex_alu.sv" -lines 104
 
 // Bits of signal are not used: alu_adder_ext_i[0]
 // Bottom bit is round, not needed

--- a/rtl/ibex_alu.sv
+++ b/rtl/ibex_alu.sv
@@ -52,8 +52,7 @@ module ibex_alu (
       ALU_EQ,   ALU_NE,
       ALU_GE,   ALU_GEU,
       ALU_LT,   ALU_LTU,
-      ALU_SLT,  ALU_SLTU,
-      ALU_SLET, ALU_SLETU: adder_op_b_negate = 1'b1;
+      ALU_SLT,  ALU_SLTU: adder_op_b_negate = 1'b1;
 
       default:;
     endcase
@@ -128,8 +127,7 @@ module ibex_alu (
     unique case (operator_i)
       ALU_GE,
       ALU_LT,
-      ALU_SLT,
-      ALU_SLET: begin
+      ALU_SLT: begin
         cmp_signed = 1'b1;
       end
 
@@ -168,12 +166,11 @@ module ibex_alu (
     cmp_result = is_equal;
 
     unique case (operator_i)
-      ALU_EQ:              cmp_result =  is_equal;
-      ALU_NE:              cmp_result = ~is_equal;
-      ALU_GE,  ALU_GEU:    cmp_result = is_greater_equal;
+      ALU_EQ:            cmp_result =  is_equal;
+      ALU_NE:            cmp_result = ~is_equal;
+      ALU_GE,  ALU_GEU:  cmp_result = is_greater_equal;
       ALU_LT,  ALU_LTU,
-      ALU_SLT, ALU_SLTU:   cmp_result = ~is_greater_equal;
-      ALU_SLET, ALU_SLETU: cmp_result = ~is_greater_equal | is_equal;
+      ALU_SLT, ALU_SLTU: cmp_result = ~is_greater_equal;
 
       default:;
     endcase
@@ -205,8 +202,7 @@ module ibex_alu (
       ALU_EQ,   ALU_NE,
       ALU_GE,   ALU_GEU,
       ALU_LT,   ALU_LTU,
-      ALU_SLT,  ALU_SLTU,
-      ALU_SLET, ALU_SLETU: result_o = {31'h0,cmp_result};
+      ALU_SLT,  ALU_SLTU: result_o = {31'h0,cmp_result};
 
       default:;
     endcase

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -57,9 +57,7 @@ typedef enum logic [4:0] {
 
   // Set lower than
   ALU_SLT,
-  ALU_SLTU,
-  ALU_SLET,
-  ALU_SLETU
+  ALU_SLTU
 } alu_op_e;
 
 typedef enum logic [1:0] {


### PR DESCRIPTION
These operations (ALU_SLET, ALU_SLETU) are remnants of of the original OpenRISC design. RISC-V just has set-less-than (ALU_SLT, ALU_SLTU).

This resolves lowRISC/ibex#432 reported by @udinator.