### PR TITLE
[verilator] Fix a few verilator DV issues

### DIFF
--- a/dv/cs_registers/tb/tb_cs_registers.sv
+++ b/dv/cs_registers/tb/tb_cs_registers.sv
@@ -62,6 +62,7 @@ module tb_cs_registers #(
   logic [31:0]          csr_depc_o;
   logic                 debug_single_step_o;
   logic                 debug_ebreakm_o;
+  logic                 debug_ebreaku_o;
 
   logic [31:0]          pc_if_i;
   logic [31:0]          pc_id_i;

--- a/dv/cs_registers/tb_cs_registers.core
+++ b/dv/cs_registers/tb_cs_registers.core
@@ -60,24 +60,25 @@ targets:
       verilator:
         mode: cc
         libs:
-          - '${PWD}/build/bin/reg_dpi.so'
+          - '${PWD}/../../../build/bin/reg_dpi.so'
         verilator_options:
-# Disabling tracing reduces compile times by multiple times, but doesn't have a
-# huge influence on runtime performance. (Based on early observations.)
+          # Disabling tracing reduces compile times but doesn't have a
+          # huge influence on runtime performance.
           - '--trace'
           - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
+          # Remove FST options for VCD trace (~100 x faster but larger files)
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-# compiler flags
-#
-# -O
-#   Optimization levels have a large impact on the runtime performance of the
-#   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++14 -Wall -DTOPLEVEL_NAME=tb_cs_registers -DVM_TRACE_FMT_FST -g -O0"'
+          - '-CFLAGS "-std=c++14 -Wall -DTOPLEVEL_NAME=tb_cs_registers -DVM_TRACE_FMT_FST -g"'
           - '-LDFLAGS "-pthread -lutil"'
           - "-Wall"
           - "-Wno-PINCONNECTEMPTY"
           # XXX: Cleanup all warnings and remove this option
           # (or make it more fine-grained at least)
           - "-Wno-fatal"
+        make_options:
+          # Optimization levels have a large impact on the runtime performance
+          # of the simulation model. -O2 and -O3 are pretty similar, -Os is
+          # slower than -O2/-O3
+          - OPT_FAST="-O2"

--- a/dv/riscv_compliance/ibex_riscv_compliance.core
+++ b/dv/riscv_compliance/ibex_riscv_compliance.core
@@ -44,22 +44,23 @@ targets:
       verilator:
         mode: cc
         verilator_options:
-# Disabling tracing reduces compile times by multiple times, but doesn't have a
-# huge influence on runtime performance. (Based on early observations.)
+          # Disabling tracing reduces compile times but doesn't have a
+          # huge influence on runtime performance.
           - '--trace'
           - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
+          # Remove FST options for VCD trace (~100 x faster but larger files)
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-# compiler flags
-#
-# -O
-#   Optimization levels have a large impact on the runtime performance of the
-#   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_riscv_compliance -g -O0"'
+          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_riscv_compliance -g"'
           - '-LDFLAGS "-pthread -lutil"'
           - "-Wall"
           - "-Wno-PINCONNECTEMPTY"
           # XXX: Cleanup all warnings and remove this option
           # (or make it more fine-grained at least)
           - "-Wno-fatal"
+        make_options:
+          # Optimization levels have a large impact on the runtime performance
+          # of the simulation model. -O2 and -O3 are pretty similar, -Os is
+          # slower than -O2/-O3
+          - OPT_FAST="-O2"


### PR DESCRIPTION
- Speed up compile time by only optimizing hot code
- Fix some incorrect references in tb_cs_registers
- Add a comment for FST vs VCD tracing