### PR TITLE
[rtl] Rework `core_busy` signals, remove feedback to clk

### DIFF
--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -55,11 +55,6 @@ lint_off -msg UNUSED -file "*/rtl/ibex_pmp.sv" -lines 15
 lint_off -msg UNUSED -file "*/rtl/ibex_pmp.sv" -lines 16
 
 // Signal unoptimizable: Feedback to clock or circular logic:
-// ibex_core.id_stage_i.controller_i.ctrl_fsm_cs
-// Issue lowrisc/ibex#211
-lint_off -msg UNOPTFLAT -file "*/rtl/ibex_controller.sv" -lines 102
-
-// Signal unoptimizable: Feedback to clock or circular logic:
 // ibex_core.cs_registers_i.mie_q
 // Issue lowrisc/ibex#212
 lint_off -msg UNOPTFLAT -file "*/rtl/ibex_cs_registers.sv" -lines 164

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -24,7 +24,6 @@ module ibex_id_stage #(
 
     input  logic                  fetch_enable_i,
     output logic                  ctrl_busy_o,
-    output logic                  core_ctrl_firstfetch_o,
     output logic                  illegal_insn_o,
 
     // Interface to IF stage
@@ -388,7 +387,6 @@ module ibex_id_stage #(
 
       .fetch_enable_i                 ( fetch_enable_i         ),
       .ctrl_busy_o                    ( ctrl_busy_o            ),
-      .first_fetch_o                  ( core_ctrl_firstfetch_o ),
 
       // decoder related signals
       .illegal_insn_i                 ( illegal_insn_o         ),


### PR DESCRIPTION
This commit reworks the generation of the `core_busy` signal used to control the main clock gate of the core. Without this commit, the controller generates a separate `first_fetch` signal only asserted in the FIRST_FETCH state that directly controls `core_busy` and thus the main clock gate. This is problematic as it introduces a feedback to from the controller state into the clock.

This commit removes the problematic signal and changes the generation of `ctrl_busy` in the FIRST_FETCH state of the controller. This signal is now used to control the main clock gate in all states (previously all except FIRST_FETCH) but it gets registered, thus it does not introduce the feedback into the clock.

This resolves lowRISC/ibex#211.