### PR TITLE
[funct_cov] Update Ibex log parsing

### DIFF
--- a/dv/uvm/Makefile
+++ b/dv/uvm/Makefile
@@ -142,8 +142,11 @@ post_compare:
 
 # Generate functional coverage
 fcov:
-	cd ${GEN_DIR}; \
-	python3 ./cov.py --dir ${OUT}/instr_gen/spike_sim -o ${OUT}/fcov
+	python3 ${GEN_DIR}/cov.py \
+          --core ibex \
+          --dir ${OUT}/rtl_sim \
+          -o ${OUT}/fcov \
+          ${RISCV_DV_OPTS} \
 
 # Load verdi to review coverage
 cov:

--- a/dv/uvm/riscv_dv_extension/ibex_log_to_trace_csv.py
+++ b/dv/uvm/riscv_dv_extension/ibex_log_to_trace_csv.py
@@ -13,8 +13,12 @@ sys.path.insert(0, "../../vendor/google_riscv-dv/scripts")
 from riscv_trace_csv import *
 from lib import *
 
+REGS = ["zero","ra","sp","gp","tp","t0","t1","t2","s0","s1",
+        "a0","a1","a2","a3","a4","a5","a6","a7",
+        "s2","s3","s4","s5","s6","s7","s8","s9","s10","s11",
+        "t3","t4","t5","t6"]
 
-def process_ibex_sim_log(ibex_log, csv):
+def process_ibex_sim_log(ibex_log, csv, full_trace = 1):
     """Process ibex simulation log.
 
     Extract instruction and affected register information from ibex simulation
@@ -24,6 +28,10 @@ def process_ibex_sim_log(ibex_log, csv):
     instr_cnt = 0
     ibex_instr = ""
 
+    gpr = {}
+    for g in REGS:
+      gpr[g] = 0
+
     with open(ibex_log, "r") as f, open(csv, "w") as csv_fd:
         trace_csv = RiscvInstructionTraceCsv(csv_fd)
         trace_csv.start_new_trace()
@@ -31,19 +39,55 @@ def process_ibex_sim_log(ibex_log, csv):
             if re.search("ecall", line):
               break
             # Extract instruction information
-            m = re.search(r"^\s*(?P<time>\d+)\s+(?P<cycle>\d+)\s+" \
-                          "(?P<pc>[0-9a-f]+)\s+(?P<bin>[0-9a-f]+)\s+(?P<instr>.*)" \
-                          ".*x(?P<rd>[1-9]\d*)=0x(?P<val>[0-9a-f]+)", line)
+            m = re.search(r"^\s*(?P<time>\d+)\s+" \
+                          "(?P<cycle>\d+)\s+" \
+                          "(?P<pc>[0-9a-f]+)\s+" \
+                          "(?P<bin>[0-9a-f]+)\s+" \
+                          "(?P<instr>\S+\s+\S+)\s*" \
+                          "(x(?P<rs1>\d+):0x(?P<rs1_val>[0-9a-f]+))?\s*" \
+                          "(x(?P<rs2>\d+):0x(?P<rs2_val>[0-9a-f]+))?\s*" \
+                          "(x(?P<rd>[1-9]\d*)=0x(?P<rd_val>[0-9a-f]+))", line)
             if m:
+                instr_cnt += 1
                 # Write the extracted instruction to a csvcol buffer file
                 rv_instr_trace = RiscvInstructionTraceEntry()
                 rv_instr_trace.rd = gpr_to_abi("x%0s" % m.group("rd"))
-                rv_instr_trace.rd_val = m.group("val")
+                rv_instr_trace.rd_val = m.group("rd_val")
+                rv_instr_trace.rs1 = gpr_to_abi("x%0s" % m.group("rs1"))
+                rv_instr_trace.rs1_val = m.group("rs1_val")
+                rv_instr_trace.rs2 = gpr_to_abi("x%0s" % m.group("rs2"))
+                rv_instr_trace.rs2_val = m.group("rs2_val")
                 rv_instr_trace.addr = m.group("pc")
                 rv_instr_trace.binary = m.group("bin")
                 rv_instr_trace.instr_str = m.group("instr")
+                rv_instr_trace.instr = rv_instr_trace.instr_str.split()[0]
+
+                # Extract all missing operand values
+                if full_trace:
+                  logging.info("full trace enabled")
+                  o = re.search(r"(?P<instr_name>[a-z.]*)\s+(?P<operands>.*)", rv_instr_trace.instr_str)
+                  if o:
+                    operands = o.group("operands").split(",")
+                    # Convert to ABI representation
+                    for i in range(len(operands)):
+                      abi = re.search(r"(^|\()(?P<gpr>x\d+)", operands[i])
+                      if abi:
+                        reg = abi.group("gpr")
+                        operands[i] = operands[i].replace(reg, gpr_to_abi(reg))
+                    if rv_instr_trace.instr in ['jalr']:
+                      # Ibex displays two operands for jalr
+                      rv_instr_trace.rd = operands[0]
+                      rv_instr_trace.rd_val = gpr[rv_instr_trace.rd]
+                      n = ADDR_RE.search(operands[1])
+                      if n:
+                        rv_instr_trace.rs1 = n.group("rs1")
+                        rv_instr_trace.rs1_val = gpr[rv_instr_trace.rs1]
+                        rv_instr_trace.imm = get_imm_hex_val(n.group("imm"))
+                    else:
+                      assign_operand(rv_instr_trace, operands, gpr)
+
+                gpr[rv_instr_trace.rd] = rv_instr_trace.rd_val
                 trace_csv.write_trace_entry(rv_instr_trace)
-                instr_cnt += 1
 
     logging.info("Processed instruction count : %d" % instr_cnt)
 
@@ -97,9 +141,11 @@ def main():
   parser = argparse.ArgumentParser()
   parser.add_argument("--log", type=str, help="Input ibex simulation log")
   parser.add_argument("--csv", type=str, help="Output trace csv_buf file")
+  parser.add_argument("--full_trace", type=int, default=1,
+                      help="Enable full log trace")
   args = parser.parse_args()
   # Process ibex log
-  process_ibex_sim_log(args.log, args.csv)
+  process_ibex_sim_log(args.log, args.csv, args.full_trace)
 
 
 if __name__ == "__main__":

--- a/dv/uvm/sim.py
+++ b/dv/uvm/sim.py
@@ -181,10 +181,10 @@ def compare(test_list, iss, output_dir, verbose):
       rtl_log = ("%s/rtl_sim/%s.%d/trace_core_00000000.log" % (output_dir, test['test'], i))
       rtl_csv = ("%s/rtl_sim/%s.%d/trace_core_00000000.csv" % (output_dir, test['test'], i))
       test_name = "%s.%d" % (test['test'], i)
+      process_ibex_sim_log(rtl_log, rtl_csv, 1)
       if 'no_post_compare' in test and test['no_post_compare'] == 1:
         check_ibex_uvm_log(uvm_log, "ibex", test_name, report)
       else:
-        process_ibex_sim_log(rtl_log, rtl_csv)
         iss_log = ("%s/instr_gen/%s_sim/%s.%d.log" % (output_dir, iss, test['test'], i))
         iss_csv = ("%s/instr_gen/%s_sim/%s.%d.csv" % (output_dir, iss, test['test'], i))
         if iss == "spike":


### PR DESCRIPTION
- Update parsing of ibex tracer log to extract all register information (rs1/rs2/rd) if available
- enable riscv_csr_test trace logs to get converted to CSV format for functional coverage

Note: depends on https://github.com/google/riscv-dv/pull/291