### PR TITLE
Update expected failure for riscv-compliance

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,7 +114,7 @@ jobs:
       export RISCV_TARGET=ibex
       export RISCV_DEVICE=rv32imc
       fail=0
-      for isa in rv32i rv32im rv32imc; do
+      for isa in rv32i rv32im rv32imc rv32Zicsr; do
         make -C build/riscv-compliance RISCV_ISA=$isa 2>&1 | tee run.log
         if [ ${PIPESTATUS[0]} != 0 ]; then
           echo -n "##vso[task.logissue type=error]"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,7 +123,7 @@ jobs:
           # There's no easy way to get the test results in machine-readable
           # form to properly exclude known-failing tests. Going with an
           # approximate solution for now.
-          if [ $isa == rv32i ] && grep -q 'FAIL: 5/55' run.log; then
+          if [ $isa == rv32i ] && grep -q 'FAIL: 4/48' run.log; then
             echo -n "##vso[task.logissue type=error]"
             echo "Expected failure for rv32i, see lowrisc/ibex#100 more more information."
           else


### PR DESCRIPTION
[riscv-compliance] changes the tests for rv32i.
Update the expected output.

[riscv-compliance]: https://github.com/riscv/riscv-compliance/commit/df18fa8d95e78f2c54d7a5d59a8b94b3f19967ef