### PR TITLE
Fix behavior of exceptions in debug mode, document debug CSRs

### DIFF
--- a/doc/cs_registers.rst
+++ b/doc/cs_registers.rst
@@ -371,12 +371,5 @@ Hardware Thread ID (mhartid)
 
 CSR Address: ``0xF14``
 
-Reset Value: Defined
-
-+-------+-----+------------------------------------------------------------------+
-| Bit#  | R/W | Description                                                      |
-+-------+-----+------------------------------------------------------------------+
-| 10:5  | R   | **Cluster ID:** ID of the cluster                                |
-+-------+-----+------------------------------------------------------------------+
-| 3:0   | R   | **Core ID:** ID of the core within the cluster                   |
-+-------+-----+------------------------------------------------------------------+
+Reads directly return the value of the ``hart_id_i`` input signal.
+See also :ref:`core-integration`.

--- a/doc/cs_registers.rst
+++ b/doc/cs_registers.rst
@@ -46,7 +46,7 @@ Ibex implements all the Control and Status Registers (CSRs) listed in the follow
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x3BF  | ``pmpaddr15``      | WARL   | PMP Address Register                          |
 +---------+--------------------+--------+-----------------------------------------------+
-|  0x7B0  | ``dcsr``           | RW     | Debug Control and Status Register             |
+|  0x7B0  | ``dcsr``           | WARL   | Debug Control and Status Register             |
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x7B1  | ``dpc``            | RW     | Debug PC                                      |
 +---------+--------------------+--------+-----------------------------------------------+
@@ -281,6 +281,79 @@ Reset Value: ``0x0000_0000``
 +----------------+
 | address[33:2]  |
 +----------------+
+
+.. _csr-dcsr:
+
+Debug Control and Status Register (dcsr)
+----------------------------------------
+
+CSR Address: ``0x7B0``
+
+Reset Value: ``0x4000_0003``
+
+Accessible in Debug Mode only.
+Ibex implements the following bit fields.
+Other bit fields read as zero.
+
++-------+------+------------------------------------------------------------------+
+| Bit#  | R/W  | Description                                                      |
++-------+------+------------------------------------------------------------------+
+| 31:28 | R    | **xdebugver:** 4 = External spec-compliant debug support exists. |
++-------+------+------------------------------------------------------------------+
+| 15    | RW   | **ebreakm:** EBREAK in M-Mode behaves as described in Privileged |
+|       |      | Spec (0), or enters Debug Mode (1).                              |
++-------+------+------------------------------------------------------------------+
+| 12    | WARL | **ebreaku:** EBREAK in U-Mode behaves as described in Privileged |
+|       |      | Spec (0), or enters Debug Mode (1).                              |
++-------+------+------------------------------------------------------------------+
+| 8:6   | R    | **cause:** 1 = EBREAK, 3 = halt request, 4 = step                |
++-------+------+------------------------------------------------------------------+
+| 2     | RW   | **step:** When set and not in Debug Mode, execute a single       |
+|       |      | instruction and enter Debug Mode.                                |
++-------+------+------------------------------------------------------------------+
+| 1:0   | WARL | **prv:** Privilege level the core was operating in when Debug    |
+|       |      | Mode was entered. May be modified by debugger to change          |
+|       |      | privilege level. Ibex allows transitions to all supported modes. |
+|       |      | (M- and U-Mode).                                                 |
++-------+------+------------------------------------------------------------------+
+
+Details of these configuration bits can be found in the RISC-V Debug Specification, version 0.13.2 (see Core Debug Registers, Section 4.8).
+Note that **ebreaku** and **prv** are accidentally specified as RW in version 0.13.2 of the RISC-V Debug Specification.
+More recent versions of the specification define these fields correctly as WARL.
+
+.. _csr-dpc:
+
+Debug PC Register (dpc)
+-----------------------
+
+CSR Address: ``0x7B1``
+
+Reset Value: ``0x0000_0000``
+
+When entering Debug Mode, ``dpc`` is updated with the address of the next instruction that would be executed (if Debug Mode would not have been entered).
+When resuming, the PC is set to the address stored in ``dpc``.
+The debug module may modify ``dpc``.
+Accessible in Debug Mode only.
+
+Debug Scratch Register 0 (dscratch0)
+------------------------------------
+
+CSR Address: ``0x7B2``
+
+Reset Value: ``0x0000_0000``
+
+Scratch register to be used by the debug module.
+Accessible in Debug Mode only.
+
+Debug Scratch Register 1 (dscratch1)
+------------------------------------
+
+CSR Address: ``0x7B3``
+
+Reset Value: ``0x0000_0000``
+
+Scratch register to be used by the debug module.
+Accessible in Debug Mode only.
 
 Time Registers (time(h))
 ------------------------

--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -11,10 +11,10 @@ Interface
 +-----------------+-----------+-----------------------------+
 | Signal          | Direction | Description                 |
 +=================+===========+=============================+
-| ``debug_req_i`` | input     | Request to enter debug mode |
+| ``debug_req_i`` | input     | Request to enter Debug Mode |
 +-----------------+-----------+-----------------------------+
 
-``debug_req_i`` is the "debug interrupt", issued by the debug module when the core should enter debug mode.
+``debug_req_i`` is the "debug interrupt", issued by the debug module when the core should enter Debug Mode.
 
 Parameters
 ----------
@@ -22,7 +22,14 @@ Parameters
 +---------------------+-----------------------------------------------------------------+
 | Parameter           | Description                                                     |
 +=====================+=================================================================+
-| ``DmHaltAddr``      | Address to jump to when entering debug mode                     |
+| ``DmHaltAddr``      | Address to jump to when entering Debug Mode                     |
 +---------------------+-----------------------------------------------------------------+
-| ``DmExceptionAddr`` | Address to jump to when an exception occurs while in debug mode |
+| ``DmExceptionAddr`` | Address to jump to when an exception occurs while in Debug Mode |
 +---------------------+-----------------------------------------------------------------+
+
+Core Debug Registers
+--------------------
+
+Ibex implements four core debug registers, namely :ref:`csr-dcsr`, :ref:`csr-dpc`, and two debug scratch registers.
+All those registers are accessible from Debug Mode only.
+If software tries to access them without the core being in Debug Mode, an illegal instruction exception is triggered.

--- a/doc/exception_interrupts.rst
+++ b/doc/exception_interrupts.rst
@@ -55,7 +55,7 @@ It has interrupt ID 31, i.e., it has the highest priority of all interrupts and 
 All interrupt lines are level-sensitive.
 It is assumed that the interrupt handler signals completion of the handling routine to the interrupt source, e.g., through a memory-mapped register, which then deasserts the corresponding interrupt line.
 
-In debug mode, all interrupts including the NMI are ignored independent of ``mstatus``.MIE and the content of the ``mie`` CSR.
+In Debug Mode, all interrupts including the NMI are ignored independent of ``mstatus``.MIE and the content of the ``mie`` CSR.
 
 
 Recoverable Non-Maskable Interrupt

--- a/doc/integration.rst
+++ b/doc/integration.rst
@@ -88,9 +88,9 @@ Parameters
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
 | ``MultiplierImplementation`` | string      | "fast"     | Multiplicator type, "slow", or "fast"                           |
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
-| ``DmHaltAddr``               | int         | 0x1A110800 | Address to jump to when entering debug mode                     |
+| ``DmHaltAddr``               | int         | 0x1A110800 | Address to jump to when entering Debug Mode                     |
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
-| ``DmExceptionAddr``          | int         | 0x1A110808 | Address to jump to when an exception occurs while in debug mode |
+| ``DmExceptionAddr``          | int         | 0x1A110808 | Address to jump to when an exception occurs while in Debug Mode |
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
 
 Interfaces

--- a/doc/verification.rst
+++ b/doc/verification.rst
@@ -68,7 +68,7 @@ Testplan
 
 The goal of this bench is to fully verify the Ibex core with 100%
 coverage. This includes testing all RV32IMC instructions, privileged
-spec compliance, exception and interrupt testing, debug mode operation etc.
+spec compliance, exception and interrupt testing, Debug Mode operation etc.
 The complete test list can be found in the file `dv/uvm/riscv_dv_extension/testlist.yaml
 <https://github.com/lowRISC/ibex/blob/master/dv/uvm/riscv_dv_extension/testlist.yaml>`_.
 
@@ -103,7 +103,7 @@ However, this checking model quickly falls apart once situations involving exter
 as interrupts and debug requests) start being tested, as while ISS models can simulate traps due to
 exceptions, they cannot model traps due to external stimulus.
 In order to provide support for these sorts of scenarios to verify if the core has entered the
-proper interrupt handler, entered debug mode properly, updated any CSRs correctly, and so on, the
+proper interrupt handler, entered Debug Mode properly, updated any CSRs correctly, and so on, the
 handshaking mechanism provided by the RISCV-DV instruction generator is heavily used, which
 effectively allows the core to send status information to the testbench during program execution for
 any analysis that is required to increase verification effectiveness.

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -522,7 +522,9 @@ module ibex_cs_registers #(
           dcsr_d.prv   = priv_lvl_q;
           dcsr_d.cause = debug_cause_i;
           depc_d       = exception_pc;
-        end else begin
+        end else if (!debug_mode_i) begin
+          // In debug mode, "exceptions do not update any registers. That
+          // includes cause, epc, tval, dpc and mstatus." [Debug Spec v0.13.2, p.39]
           mtval_d        = csr_mtval_i;
           mstatus_d.mie  = 1'b0; // disable interrupts
           // save current status


### PR DESCRIPTION
This PR consists of three small commits which implement the following changes:
- Exceptions in debug mode shall not modify any CSRs. This resolves #168 and is related to #365.
- Document debug CSRs. This resolves #307.
- Update documentation of `mhartid` CSR. Previously, the doc was still describing the cluster and core ID bit fields. 