### PR TITLE
Proposal: Add Makefile for common tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+all: help
+
+.PHONY: help
+help:
+	@echo "This is a short hand for running popular tasks."
+	@echo "Please check the documentation on how to get started"
+	@echo "or how to set-up the different environments."
+
+# Use a parallel run (make -j N) for a faster build
+build-all: build-riscv-compliance build-simple-system build-arty
+
+
+# RISC-V compliance
+.PHONY: build-riscv-compliance
+build-riscv-compliance:
+	fusesoc --cores-root=. run --target=sim --setup --build \
+		lowrisc:ibex:ibex_riscv_compliance
+
+
+# Simple system
+# Use the following targets:
+# - "build-simple-system"
+# - "run-simple-system"
+.PHONY: build-simple-system
+build-simple-system:
+	fusesoc --cores-root=. run --target=sim --setup --build \
+		lowrisc:ibex:ibex_simple_system
+
+simple-system-program = examples/sw/simple_system/hello_test/hello_test.vmem
+sw-simple-hello: $(simple-system-program)
+
+.PHONY: $(simple-system-program)
+$(simple-system-program):
+	make -C examples/sw/simple_system/hello_test
+
+Vibex_simple_system = \
+      build/lowrisc_ibex_ibex_simple_system_0/sim-verilator/Vibex_simple_system
+$(Vibex_simple_system):
+	@echo "$@ not found"
+	@echo "Run \"make build-simple-system\" to created the dependency"
+	@false
+
+run-simple-system: sw-simple-hello | $(Vibex_simple_system)
+	build/lowrisc_ibex_ibex_simple_system_0/sim-verilator/Vibex_simple_system \
+		--raminit=$(simple-system-program)
+
+
+# Arty A7 100T
+# Use the following targets:
+# - "build-arty"
+# - "program-arty"
+arty-sw-program = examples/sw/led/led.vmem
+sw-led: $(arty-sw-program)
+
+.PHONY: $(arty-sw-program)
+$(arty-sw-program):
+	make -C examples/sw/led
+
+build-arty: sw-led
+	fusesoc --cores-root=. run --target=synth --setup --build \
+		lowrisc:ibex:top_artya7_100
+
+.PHONY: program-arty
+program-arty:
+	fusesoc --cores-root=. pgm lowrisc:ibex:top_artya7_100
+
+
+# Lint check
+.PHONY: lint-core-tracing
+lint-core-tracing:
+	fusesoc --cores-root . run --target=lint lowrisc:ibex:ibex_core_tracing


### PR DESCRIPTION
This PR is optional. Using the Makefile was helpful for me lately and maybe it could be useful for others, so please give feedback.
One reason to not add this: It might confuse people not familiar with the project structure. Instead of following the documentation, using a target of the Makfile without a set-up will fail.
But the intention of this file is not to create an automatic build flow, just a way to run some tasks for the experienced user.

Instead of copying the commands from the documentation or using the
shell history to find the commands use a Makefile as a convenience to
run some common tasks.
A shell's completion system can make use of the targets and provide tab
completion.