### PR TITLE
[DV] umode_tw test

### DIFF
--- a/dv/uvm/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/riscv_dv_extension/testlist.yaml
@@ -450,3 +450,27 @@
     +num_of_sub_program=5
     +boot_mode=u
   rtl_test: core_ibex_base_test
+
+- test: riscv_umode_tw_test
+  desc: >
+    Set mstatus.tw and enable generation of WFI instructions.
+    Boot into U-mode, upon encountering WFI instruction, core should trap to M-mode
+    due to illegal instruction exception.
+  iterations: 10
+  gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +require_signature_addr=1
+    +gen_debug_section=1
+    +no_ebreak=1
+    +instr_cnt=6000
+    +no_csr_instr=1
+    +no_fence=1
+    +no_wfi=0
+    +set_mstatus_tw=1
+    +randomize_csr=1
+    +num_of_sub_program=0
+    +boot_mode=u
+  rtl_test: core_ibex_umode_tw_test
+  compare_opts:
+    compare_final_value_only: 1
+    verbose: 1


### PR DESCRIPTION
- Add mstatus.tw test for U-mode - core jumps into illegal instruction handler correctly after seeing `wfi`
- refactored mcause checking in several places in the test class hierarchy

Signed-off-by: Udi <udij@google.com>