### PR TITLE
Reverse return code of simutil_verilator_set_mem()

### DIFF
--- a/dv/cs_registers/tb/tb_cs_registers.cc
+++ b/dv/cs_registers/tb/tb_cs_registers.cc
@@ -9,7 +9,7 @@
 // TODO : remove this - see Ibex #317
 extern "C" {
 void simutil_verilator_memload(const char *file) {}
-int simutil_verilator_set_mem(int index, const svLogicVecVal *val) { return 1; }
+int simutil_verilator_set_mem(int index, const svLogicVecVal *val) { return 0; }
 }
 
 int main(int argc, char **argv) {

--- a/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -64,7 +64,19 @@ double sc_time_stamp() {
 
 // DPI Exports
 extern "C" {
+
+/**
+ * Write |file| to a memory
+ *
+ * @param file path to a SystemVerilog $readmemh()-compatible file (VMEM file)
+ */
 extern void simutil_verilator_memload(const char *file);
+
+/**
+ * Write a 32 bit word |val| to memory at index |index|
+ *
+ * @return 1 if successful, 0 otherwise
+ */
 extern int simutil_verilator_set_mem(int index, const svLogicVecVal *val);
 }
 
@@ -360,7 +372,7 @@ bool VerilatorSimCtrl::WriteElfToMem(const svScope &scope,
     goto ret;
   }
   for (int i = 0; i < len_bytes / 4; ++i) {
-    if (simutil_verilator_set_mem(i, (svLogicVecVal *)&buf[4 * i])) {
+    if (!simutil_verilator_set_mem(i, (svLogicVecVal *)&buf[4 * i])) {
       std::cerr << "ERROR: Could not set memory byte: " << i * 4 << "/"
                 << len_bytes << "" << std::endl;
 

--- a/shared/rtl/ram_1p.sv
+++ b/shared/rtl/ram_1p.sv
@@ -51,26 +51,26 @@ module ram_1p #(
   end
 
   `ifdef VERILATOR
-    // Task for loading 'mem' with SystemVerilog system task readmemh
+    // Task for loading 'mem' with SystemVerilog system task $readmemh()
     export "DPI-C" task simutil_verilator_memload;
-    // Function for setting a specific 32 bit element in 'mem'
-    // Returns 0 for success, 1 for error
+    // Function for setting a specific 32 bit element in |mem|
+    // Returns 1 (true) for success, 0 (false) for errors.
     export "DPI-C" function simutil_verilator_set_mem;
 
     task simutil_verilator_memload;
-    input string file;
-    $readmemh(file, mem);
+      input string file;
+      $readmemh(file, mem);
     endtask
 
     // TODO: Allow 'val' to have other widths than 32 bit
     function int simutil_verilator_set_mem(input int index,
-      input logic[31:0] val);
-      if (index < Depth) begin
-        mem[index] = val;
+                                           input logic[31:0] val);
+      if (index >= Depth) begin
         return 0;
-      end else begin
-        return 1;
       end
+
+      mem[index] = val;
+      return 1;
     endfunction
   `endif
 
@@ -82,4 +82,3 @@ module ram_1p #(
     end
   `endif
 endmodule
-


### PR DESCRIPTION
All functions in simutil_verilator return booleans to indicate
success/failure, where 1 == true, and 0 == false.
simutil_verilator_set_mem() returns an int due to DPI interface
restrictions. Before, 0 meant success, and 1 meant error.

To keep things nice and consistent, turn things around and align with
the bool meaning.