### PR TITLE
[examples] Add fstream header

### DIFF
--- a/examples/simple_system/ibex_simple_system.cc
+++ b/examples/simple_system/ibex_simple_system.cc
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fstream>
 #include <iostream>
 
 #include "ibex_pcounts.h"


### PR DESCRIPTION
The fstream header is needed for `ofstream()` in ibex_simple_system.