### PR TITLE
[verilator] Clarify ELF BSS handling

### DIFF
--- a/dv/verilator/simutil_verilator/README.md
+++ b/dv/verilator/simutil_verilator/README.md
@@ -1,0 +1,13 @@
+# Verilator simulator support
+
+## ELF support
+
+### BSS sections
+
+When loading ELF files into the memory, only the data stored in the file is loaded into the memory.
+Data specified by the memory size is not set.
+This is the case for BSS sections for which only the size information is stored in the ELF file.
+The zero-ing of this sections is the responsibility of the executed code.
+This is typically achieved by setting symbols for the start and end of the BSS section in the linker script and zero-ing the intermediate addresses by the startup routine.
+
+**Requirement: BSS zero-ing must be implemented by the executed software.**

--- a/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -737,8 +737,6 @@ bool VerilatorSimCtrl::ElfFileToBinary(const std::string &filepath,
     buffers.push_back(buf_data);
   }
 
-  // TODO: Check for the case that phdr.p_memsz > phdr.p_filesz
-
   // Put the collected data into a continuous buffer
   // Memory is freed by the caller
   *data = (uint8_t *)malloc(len_bytes);


### PR DESCRIPTION
Add a requirement for the software loaded by the simulator for zero-ing
the BSS section.

Fixes lowRISC/ibex#496