### PR TITLE
[rtl] Replace X assignments

### DIFF
--- a/dv/uvm/ibex_dv.f
+++ b/dv/uvm/ibex_dv.f
@@ -10,6 +10,7 @@ ${PRJ_DIR}/ibex/shared/rtl/prim_clock_gating.sv
 
 // ibex CORE RTL files
 +incdir+${PRJ_DIR}/ibex/rtl
+${PRJ_DIR}/ibex/shared/rtl/prim_assert.sv
 ${PRJ_DIR}/ibex/rtl/ibex_pkg.sv
 ${PRJ_DIR}/ibex/rtl/ibex_tracer_pkg.sv
 ${PRJ_DIR}/ibex/rtl/ibex_tracer.sv

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -6,6 +6,8 @@ name: "lowrisc:ibex:ibex_core:0.1"
 description: "CPU core with 2 stage pipeline implementing the RV32IMC_Zicsr ISA"
 filesets:
   files_rtl:
+    depend:
+      - lowrisc:prim:assert
     files:
       - rtl/ibex_pkg.sv
       - rtl/ibex_alu.sv

--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -49,10 +49,14 @@ lint_off -msg UNUSED -file "*/rtl/ibex_register_file_ff.sv" -lines 21
 // Signal is not used: clk_i
 // leaving clk and reset connected in-case we want to add assertions
 lint_off -msg UNUSED -file "*/rtl/ibex_pmp.sv" -lines 15
+lint_off -msg UNUSED -file "*/rtl/ibex_compressed_decoder.sv" -lines 14
+lint_off -msg UNUSED -file "*/rtl/ibex_decoder.sv" -lines 21
 
 // Signal is not used: rst_ni
 // leaving clk and reset connected in-case we want to add assertions
 lint_off -msg UNUSED -file "*/rtl/ibex_pmp.sv" -lines 16
+lint_off -msg UNUSED -file "*/rtl/ibex_compressed_decoder.sv" -lines 15
+lint_off -msg UNUSED -file "*/rtl/ibex_decoder.sv" -lines 22
 
 // Signal unoptimizable: Feedback to clock or circular logic:
 // ibex_core.cs_registers_i.mie_q

--- a/rtl/ibex_compressed_decoder.sv
+++ b/rtl/ibex_compressed_decoder.sv
@@ -25,10 +25,11 @@ module ibex_compressed_decoder (
   ////////////////////////
 
   always_comb begin
+    // By default, forward incoming instruction, mark it as legal.
+    instr_o         = instr_i;
     illegal_instr_o = 1'b0;
-    // Default instruction is NOP (ADDI x0, x0, 0)
-    instr_o         = {12'd0, 5'd0, 3'd0, 5'd0, OPCODE_OP_IMM};
 
+    // Check if incoming instruction is compressed.
     unique case (instr_i[1:0])
       // C0
       2'b00: begin
@@ -51,6 +52,14 @@ module ibex_compressed_decoder (
             instr_o = {5'b0, instr_i[5], instr_i[12], 2'b01, instr_i[4:2],
                        2'b01, instr_i[9:7], 3'b010, instr_i[11:10], instr_i[6],
                        2'b00, {OPCODE_STORE}};
+          end
+
+          3'b001,
+          3'b011,
+          3'b100,
+          3'b101,
+          3'b111: begin
+            illegal_instr_o = 1'b1;
           end
 
           default: begin
@@ -249,9 +258,11 @@ module ibex_compressed_decoder (
         endcase
       end
 
+      // Incoming instruction is not compressed.
+      2'b11:;
+
       default: begin
-        // 32 bit (or more) instruction
-        instr_o = instr_i;
+        illegal_instr_o = 1'b1;
       end
     endcase
   end
@@ -263,6 +274,8 @@ module ibex_compressed_decoder (
   ////////////////
 
   // Selectors must be known/valid.
+  `ASSERT_KNOWN(IbexInstrLSBsKnown, instr_i[1:0], clk_i, !rst_ni)
+  `ASSERT(IbexC0Known1, (instr_i[1:0] == 2'b00) |-> !$isunknown(instr_i[15:13]), clk_i, !rst_ni)
   `ASSERT(IbexC1Known1, (instr_i[1:0] == 2'b01) |-> !$isunknown(instr_i[15:13]), clk_i, !rst_ni)
   `ASSERT(IbexC1Known2,
       ((instr_i[1:0] == 2'b01) && (instr_i[15:13] == 3'b100)) |->

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -585,7 +585,7 @@ module ibex_controller (
 
       default: begin
         instr_req_o = 1'b0;
-        ctrl_fsm_ns = ctrl_fsm_e'(1'bX);
+        ctrl_fsm_ns = RESET;
       end
     endcase
   end
@@ -635,5 +635,15 @@ module ibex_controller (
       illegal_insn_q <= illegal_insn_d;
     end
   end
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  // Selectors must be known/valid.
+  `ASSERT(IbexCtrlStateValid, ctrl_fsm_cs inside {
+      RESET, BOOT_SET, WAIT_SLEEP, SLEEP, FIRST_FETCH, DECODE, FLUSH,
+      IRQ_TAKEN, DBG_TAKEN_IF, DBG_TAKEN_ID
+      }, clk_i, !rst_ni)
 
 endmodule

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -613,8 +613,8 @@ module ibex_cs_registers #(
         csr_wreq      = 1'b0;
       end
       default: begin
-        csr_wdata_int = 'X;
-        csr_wreq      = 1'bX;
+        csr_wdata_int = csr_wdata_i;
+        csr_wreq      = 1'b0;
       end
     endcase
   end
@@ -777,7 +777,7 @@ module ibex_cs_registers #(
           2'b10   : pmp_cfg_wdata[i].mode = (PMPGranularity == 0) ? PMP_MODE_NA4:
                                                                     PMP_MODE_OFF;
           2'b11   : pmp_cfg_wdata[i].mode = PMP_MODE_NAPOT;
-          default : pmp_cfg_wdata[i].mode = pmp_cfg_mode_e'('X);
+          default : pmp_cfg_wdata[i].mode = PMP_MODE_OFF;
         endcase
       end
       assign pmp_cfg_wdata[i].exec  = csr_wdata_int[(i%4)*PMP_CFG_W+2];
@@ -1012,5 +1012,18 @@ module ibex_cs_registers #(
     assign tmatch_value_rdata   = 'b0;
     assign trigger_match_o      = 'b0;
   end
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  // Selectors must be known/valid.
+  `ASSERT(IbexCsrOpValid, csr_op_i inside {
+      CSR_OP_READ,
+      CSR_OP_WRITE,
+      CSR_OP_SET,
+      CSR_OP_CLEAR
+      }, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IbexCsrWdataIntKnown, csr_wdata_int, clk_i, !rst_ni)
 
 endmodule

--- a/rtl/ibex_fetch_fifo.sv
+++ b/rtl/ibex_fetch_fifo.sv
@@ -219,15 +219,13 @@ module ibex_fetch_fifo #(
   ////////////////
   // Assertions //
   ////////////////
-`ifndef VERILATOR
-  // must not push and pop simultaneously when FIFO full
-  assert property (@(posedge clk_i) disable iff (!rst_ni)
-      (in_valid_i && pop_fifo) |-> (!valid_q[DEPTH-1] || clear_i)) else
-    $display("Simultaneous pushing and popping not supported when FIFO full");
 
-  // must not push to FIFO when full
-  assert property (@(posedge clk_i) disable iff (!rst_ni)
-      (in_valid_i) |-> (!valid_q[DEPTH-1] || clear_i)) else
-    $display("Must not push when FIFO full");
-`endif
+  // Must not push and pop simultaneously when FIFO full.
+  `ASSERT(IbexFetchFifoPushPopFull,
+      (in_valid_i && pop_fifo) |-> (!valid_q[DEPTH-1] || clear_i), clk_i, !rst_ni)
+
+  // Must not push to FIFO when full.
+  `ASSERT(IbexFetchFifoPushFull,
+      (in_valid_i) |-> (!valid_q[DEPTH-1] || clear_i), clk_i, !rst_ni)
+
 endmodule

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -268,26 +268,16 @@ module ibex_if_stage #(
       PC_DRET
       }, clk_i, !rst_ni)
 
-`ifndef VERILATOR
-  // boot address must be aligned to 256 bytes
-  assert property (@(posedge clk_i) disable iff (!rst_ni)
-      (boot_addr_i[7:0] == 8'h00)) else
-    $error("Provided boot address not aligned to 256 bytes");
+  // Boot address must be aligned to 256 bytes.
+  `ASSERT(IbexBootAddrUnaligned, boot_addr_i[7:0] == 8'h00, clk_i, !rst_ni)
 
-  // errors must only be sent together with rvalid
-  assert property (@(posedge clk_i) disable iff (!rst_ni)
-      (instr_err_i) |-> (instr_rvalid_i)) else
-    $display("Instruction error not sent with rvalid");
+  // Errors must only be sent together with rvalid.
+  `ASSERT(IbexInstrErrWithoutRvalid, instr_err_i |-> instr_rvalid_i, clk_i, !rst_ni)
 
-  // address must not contain X when request is sent
-  assert property (@(posedge clk_i) disable iff (!rst_ni)
-      (instr_req_o) |-> (!$isunknown(instr_addr_o))) else
-    $display("Instruction address not valid");
+  // Address must not contain X when request is sent.
+  `ASSERT(IbexInstrAddrUnknown, instr_req_o |-> !$isunknown(instr_addr_o), clk_i, !rst_ni)
 
-  // address must be word aligned when request is sent
-  assert property (@(posedge clk_i) disable iff (!rst_ni)
-      (instr_req_o) |-> (instr_addr_o[1:0] == 2'b00)) else
-    $display("Instruction address not word aligned");
-`endif
+  // Address must be word aligned when request is sent.
+  `ASSERT(IbexInstrAddrUnaligned, instr_req_o |-> (instr_addr_o[1:0] == 2'b00), clk_i, !rst_ni)
 
 endmodule

--- a/rtl/ibex_multdiv_fast.sv
+++ b/rtl/ibex_multdiv_fast.sv
@@ -238,7 +238,7 @@ module ibex_multdiv_fast (
       end
 
       default: begin
-        md_state_n = md_fsm_e'(1'bX);
+        md_state_n = MD_IDLE;
       end
     endcase // md_state_q
   end
@@ -318,9 +318,15 @@ module ibex_multdiv_fast (
         mult_valid   = 1'b1;
       end
       default: begin
-        mult_state_n = mult_fsm_e'(1'bX);
+        mult_state_n = ALBL;
       end
     endcase // mult_state_q
   end
+
+  // States must be knwon/valid.
+  `ASSERT(IbexMultDivStateValid, md_state_q inside {
+      MD_IDLE, MD_ABS_A, MD_ABS_B, MD_COMP, MD_LAST, MD_CHANGE_SIGN, MD_FINISH
+      }, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IbexMultStateKnown, mult_state_q, clk_i, !rst_ni)
 
 endmodule // ibex_mult

--- a/rtl/ibex_multdiv_slow.sv
+++ b/rtl/ibex_multdiv_slow.sv
@@ -272,7 +272,7 @@ module ibex_multdiv_slow (
         end
 
         default: begin
-          md_state_d = md_fsm_e'(1'bX);
+          md_state_d = MD_IDLE;
         end
         endcase // md_state_q
       end
@@ -282,5 +282,10 @@ module ibex_multdiv_slow (
                    (md_state_q == MD_LAST &
                    (operator_i == MD_OP_MULL |
                     operator_i == MD_OP_MULH));
+
+  // State must be valid.
+  `ASSERT(IbexMultDivStateValid, md_state_q inside {
+      MD_IDLE, MD_ABS_A, MD_ABS_B, MD_COMP, MD_LAST, MD_CHANGE_SIGN, MD_FINISH
+      }, clk_i, !rst_ni)
 
 endmodule // ibex_mult

--- a/shared/prim_assert.core
+++ b/shared/prim_assert.core
@@ -2,15 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:ibex:ibex_tracer:0.1"
-description: "Tracer for use with Ibex using the RVFI interface"
+
+name: "lowrisc:prim:assert:0.1"
+description: "Assertion primitives"
 filesets:
   files_rtl:
-    depend:
-      - lowrisc:prim:assert
     files:
-      - rtl/ibex_tracer_pkg.sv
-      - rtl/ibex_tracer.sv
+      - rtl/prim_assert.sv
     file_type: systemVerilogSource
 
 targets:

--- a/shared/rtl/prim_assert.sv
+++ b/shared/rtl/prim_assert.sv
@@ -1,0 +1,197 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Macros and helper code for using assertions.
+//  - Provides default clk and rst options to simplify code
+//  - Provides boiler plate template for common assertions
+
+// TODO:
+//  - check if ASSERT_FINAL needs an `ifndef SYNTHESIS
+//  - should we add ASSERT_INIT_DISABLE?
+//  - can we remove pragma translate_off and ifndef VERILATOR?
+//  - should we add "pragma coverage off" and "VCS coverage off"?
+
+`ifdef UVM_PKG_SV
+  // report assertion error with UVM if compiled
+  package assert_rpt_pkg;
+    import uvm_pkg::*;
+    `include "uvm_macros.svh"
+    function void assert_rpt(string msg);
+      `uvm_error("ASSERT FAILED", msg)
+    endfunction
+  endpackage
+`endif
+
+
+///////////////////
+// Helper macros //
+///////////////////
+
+
+// Converts an arbitrary block of code into a Verilog string
+`define PRIM_STRINGIFY(__x) `"__x`"
+
+  // ASSERT_RPT is available to change the reporting mechanism when an assert fails
+`define ASSERT_RPT(__name, __msg)                                         \
+`ifdef UVM_PKG_SV                                                         \
+  assert_rpt_pkg::assert_rpt($sformatf("[%m] %s: %s (%s:%0d)",            \
+                             __name, __msg, `__FILE__, `__LINE__));       \
+`else                                                                     \
+  $error("[ASSERT FAILED] [%m] %s: %s", __name, __msg);                   \
+`endif
+
+///////////////////////////////////////
+// Simple assertion and cover macros //
+///////////////////////////////////////
+
+// Immediate assertion
+// Note that immediate assertions are sensitive to simulation glitches.
+`define ASSERT_I(__name, __prop)                                       \
+`ifndef VERILATOR                                                      \
+  //pragma translate_off                                               \
+  __name: assert (__prop)                                              \
+    else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop)) \
+  //pragma translate_on                                                \
+`endif
+
+// Assertion in initial block. Can be used for things like parameter checking.
+`define ASSERT_INIT(__name, __prop)                                      \
+`ifndef VERILATOR                                                        \
+  //pragma translate_off                                                 \
+  initial                                                                \
+    __name: assert (__prop)                                              \
+      else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop)) \
+  //pragma translate_on                                                  \
+`endif
+
+// Assertion in final block. Can be used for things like queues being empty
+// at end of sim, all credits returned at end of sim, state machines in idle
+// at end of sim.
+`define ASSERT_FINAL(__name, __prop)                                         \
+`ifndef VERILATOR                                                            \
+  //pragma translate_off                                                     \
+  final                                                                      \
+    __name: assert (__prop || $test$plusargs("disable_assert_final_checks")) \
+      else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop))     \
+  //pragma translate_on                                                      \
+`endif
+
+// Assert a concurrent property directly.
+// It can be called as a module (or interface) body item.
+`define ASSERT(__name, __prop, __clk, __rst)                                     \
+`ifndef VERILATOR                                                                \
+  //pragma translate_off                                                         \
+  __name: assert property (@(posedge __clk) disable iff (__rst !== '0) (__prop)) \
+    else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop))           \
+  //pragma translate_on                                                          \
+`endif
+// Note: Above we use (__rst !== '0) in the disable iff statements instead of
+// (__rst == '1).  This properly disables the assertion in cases when reset is X at
+// the beginning of a simulation. For that case, (reset == '1) does not disable the
+// assertion.
+
+// Assert a concurrent property NEVER happens
+`define ASSERT_NEVER(__name, __prop, __clk, __rst)                                   \
+`ifndef VERILATOR                                                                    \
+  //pragma translate_off                                                             \
+  __name: assert property (@(posedge __clk) disable iff (__rst !== '0) not (__prop)) \
+    else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop))               \
+  //pragma translate_on                                                              \
+`endif
+
+// Assert that signal has a known value (each bit is either '0' or '1') after reset.
+// It can be called as a module (or interface) body item.
+`define ASSERT_KNOWN(__name, __sig, __clk, __rst)   \
+`ifndef VERILATOR                                   \
+  //pragma translate_off                            \
+  `ASSERT(__name, !$isunknown(__sig), __clk, __rst) \
+  //pragma translate_on                             \
+`endif
+
+//  Cover a concurrent property
+`define COVER(__name, __prop, __clk, __rst)                                      \
+`ifndef VERILATOR                                                                \
+  //pragma translate_off                                                         \
+  __name: cover property (@(posedge __clk) disable iff (__rst !== '0) (__prop)); \
+  //pragma translate_on                                                          \
+`endif
+
+//////////////////////////////
+// Complex assertion macros //
+//////////////////////////////
+
+// Assert that signal is an active-high pulse with pulse length of 1 clock cycle
+`define ASSERT_PULSE(__name, __sig, __clk, __rst)          \
+`ifndef VERILATOR                                          \
+  //pragma translate_off                                   \
+  `ASSERT(__name, $rose(__sig) |=> !(__sig), __clk, __rst) \
+  //pragma translate_on                                    \
+`endif
+
+// Assert that valid is known after reset and data is known when valid == 1
+`define ASSERT_VALID_DATA(__name, __valid, __dat, __clk, __rst)                  \
+`ifndef VERILATOR                                                                \
+  //pragma translate_off                                                         \
+  `ASSERT_KNOWN(__name``KnownValid, __valid, __clk, __rst)                       \
+  `ASSERT_NEVER(__name``KnownData, (__valid) && $isunknown(__dat), __clk, __rst) \
+  //pragma translate_on                                                          \
+`endif
+
+// Same as ASSERT_VALID_DATA, but also assert that ready is known after reset
+`define ASSERT_VALID_READY_DATA(__name, __valid, __ready, __dat, __clk, __rst)   \
+`ifndef VERILATOR                                                                \
+  //pragma translate_off                                                         \
+  `ASSERT_KNOWN(__name``KnownValid, __valid, __clk, __rst)                       \
+  `ASSERT_KNOWN(__name``KnownReady, __ready, __clk, __rst)                       \
+  `ASSERT_NEVER(__name``KnownData, (__valid) && $isunknown(__dat), __clk, __rst) \
+  //pragma translate_on                                                          \
+`endif
+
+///////////////////////
+// Assumption macros //
+///////////////////////
+
+// Assume a concurrent property
+`define ASSUME(__name, __prop, __clk, __rst)                                      \
+`ifndef VERILATOR                                                                 \
+  __name: assume property (@(posedge __clk) disable iff (__rst !== '0) (__prop))  \
+     else begin `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop)) end \
+`endif
+
+// Assume an immediate property
+`define ASSUME_I(__name, __prop)                                       \
+`ifndef VERILATOR                                                      \
+  //pragma translate_off                                               \
+  __name: assume (__prop)                                              \
+    else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop)) \
+  //pragma translate_on                                                \
+`endif
+
+//////////////////////////////////
+// For formal verification only //
+//////////////////////////////////
+
+// Note that the existing set of ASSERT macros specified above shall be used for FPV,
+// thereby ensuring that the assertions are evaluated during DV simulations as well.
+
+// ASSUME_FPV
+// Assume a concurrent property during formal verification only.
+`define ASSUME_FPV(__name, __prop, __clk, __rst) \
+`ifdef FPV_ON                                    \
+   `ASSUME(__name, __prop, __clk, __rst)         \
+`endif
+
+// ASSUME_I_FPV
+// Assume a concurrent property during formal verification only.
+`define ASSUME_I_FPV(__name, __prop)             \
+`ifdef FPV_ON                                    \
+   `ASSUME_I(__name, __prop)                     \
+`endif
+
+// COVER_FPV
+// Cover a concurrent property during formal verification
+`define COVER_FPV(__name, __prop, __clk, __rst)  \
+`ifdef FPV_ON                                    \
+   `COVER(__name, __prop, __clk, __rst)          \
+`endif


### PR DESCRIPTION
This PR:
- Replaces all X assignments in the RTL with defined values. 
- Imports a new file from OpenTitan containing macros for SystemVerilog assertions (SVAs).
- Rewrites existing SVAs using these macros.
- Adds SVAs to catch invalid signal values in simulation.