### PR TITLE
Update google_riscv-dv to google/riscv-dv@74b8cb6

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: 5b1dd4e2eb11d49d3275da80953efc0c50f90447
+    rev: 74b8cb65838f575d6e59e1c80a145d305fbca381
   }
 }

--- a/vendor/google_riscv-dv/src/riscv_instr_gen_config.sv
+++ b/vendor/google_riscv-dv/src/riscv_instr_gen_config.sv
@@ -149,6 +149,7 @@ class riscv_instr_gen_config extends uvm_object;
   string                 asm_test_suffix;
   // Enable interrupt bit in MSTATUS (MIE, SIE, UIE)
   bit                    enable_interrupt;
+  bit                    enable_nested_interrupt;
   // We need a separate control knob for enabling timer interrupts, as Spike
   // throws an exception if xIE.xTIE is enabled
   bit                    enable_timer_irq;
@@ -440,6 +441,7 @@ class riscv_instr_gen_config extends uvm_object;
     get_int_arg_value("+num_of_tests=", num_of_tests);
     get_int_arg_value("+enable_page_table_exception=", enable_page_table_exception);
     get_bool_arg_value("+enable_interrupt=", enable_interrupt);
+    get_bool_arg_value("+enable_nested_interrupt=", enable_nested_interrupt);
     get_bool_arg_value("+enable_timer_irq=", enable_timer_irq);
     get_int_arg_value("+num_of_sub_program=", num_of_sub_program);
     get_int_arg_value("+instr_cnt=", instr_cnt);

--- a/vendor/google_riscv-dv/src/riscv_instr_stream.sv
+++ b/vendor/google_riscv-dv/src/riscv_instr_stream.sv
@@ -221,6 +221,9 @@ class riscv_rand_instr_stream extends riscv_instr_stream;
         ((avail_regs.size() > 0) && !(SP inside {avail_regs}))) begin
       exclude_instr = {C_ADDI4SPN, C_ADDI16SP, C_LWSP, C_LDSP};
     end
+    if (is_in_debug && !cfg.enable_ebreak_in_debug_rom) begin
+      exclude_instr = {exclude_instr, EBREAK, C_EBREAK};
+    end
     instr = riscv_instr::get_rand_instr(.include_instr(allowed_instr),
                                         .exclude_instr(exclude_instr));
     randomize_gpr(instr);


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision 74b8cb65838f575d6e59e1c80a145d305fbca381

* fix ebreak generation in debug ROM (Udi Jonnalagadda)
* enable nested traps (Udi Jonnalagadda)

Signed-off-by: Udi <udij@google.com>