### PR TITLE
[DV] Fix TB read responses

### DIFF
--- a/dv/uvm/tests/core_ibex_vseq.sv
+++ b/dv/uvm/tests/core_ibex_vseq.sv
@@ -26,6 +26,7 @@ class core_ibex_vseq extends uvm_sequence;
   virtual task body();
     instr_intf_seq = ibex_mem_intf_slave_seq::type_id::create("instr_intf_seq");
     data_intf_seq  = ibex_mem_intf_slave_seq::type_id::create("data_intf_seq");
+    data_intf_seq.is_dmem_seq = 1'b1;
     if (cfg.enable_irq_single_seq) begin
       irq_raise_single_seq_h = irq_raise_single_seq::type_id::create("irq_single_seq_h");
       irq_raise_single_seq_h.num_of_iterations = 1;


### PR DESCRIPTION
Currently, when the testbench returns a read response to the core, for either a load instruction or instruction fetch response, the testbench will perform a whole word read of the requested address, after word-alignment.
However, for byte or halfword loads, this is not ideal, since it is possible that the extraneous bytes read by the testbench outside of the requested byte/halfword are not initialized in the testbench system memory.
This PR fixes this issue by having the dmem_intf_sequence only read bytes from the system memory that correspond to high bits in the `byte_enable` signal that the core outputs on LSU transactions to ensure that only valid byte addresses are accessed.

Signed-off-by: Udi <udij@google.com>