### PR TITLE
SimCtrlExtension: Add a default destructor

### DIFF
--- a/dv/verilator/simutil_verilator/cpp/sim_ctrl_extension.h
+++ b/dv/verilator/simutil_verilator/cpp/sim_ctrl_extension.h
@@ -7,6 +7,8 @@
 
 class SimCtrlExtension {
  public:
+  virtual ~SimCtrlExtension() = default;
+
   /**
    * Parse command line arguments
    *


### PR DESCRIPTION
This base class needs a default destructor for potential future extensions.