### PR TITLE
[DV] Continue argument parsing

### DIFF
--- a/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -175,7 +175,7 @@ bool VerilatorSimCtrl::ParseCommandArgs(int argc, char **argv, bool &exit_app) {
       case 'h':
         PrintHelp();
         exit_app = true;
-        return true;
+        break;
       case ':':  // missing argument
         std::cerr << "ERROR: Missing argument." << std::endl << std::endl;
         return false;
@@ -213,8 +213,8 @@ void VerilatorSimCtrl::PrintHelp() const {
                "  Terminate simulation after N cycles\n\n"
                "-h|--help\n"
                "  Show help\n\n"
-               "All further arguments are passed to the design and can be used "
-               "in the design, e.g. by DPI modules.\n";
+               "All arguments are passed to the design and can be used "
+               "in the design, e.g. by DPI modules.\n\n";
 }
 
 bool VerilatorSimCtrl::TraceOn() {


### PR DESCRIPTION
In case one of the arguments is '-h' the parsing of the arguments is
aborted and only `PrintHelp()` of *verilator_sim_ctrl.cc* is executed.
Do not abort at this point in order to forward the arguments to the
registered extensions. This allows to execute the respective
`PrintHelp()` function and print the help message. For example
`VerilatorMemUtil` needs to parse the arguments in order to print the
help message.
The execution of the simulation is still terminated as `exit_app` is set
and then evaluated after parsing of the registered extensions.