### PR TITLE
[rtl] Don't elaborate unused mhpmcounter flops

### DIFF
--- a/doc/performance_counters.rst
+++ b/doc/performance_counters.rst
@@ -9,7 +9,6 @@ The performance counters are placed inside the Control and Status Registers (CSR
 Ibex implements the clock cycle counter ``mcycle(h)``, the retired instruction counter ``minstret(h)``, as well as the 29 event counters ``mhpmcounter3(h)`` - ``mhpmcounter31(h)`` and the corresponding event selector CSRs ``mhpmevent3`` - ``mhpmevent31``, and the ``mcountinhibit`` CSR to individually enable/disable the counters.
 ``mcycle(h)`` and ``minstret(h)`` are always available and 64 bit wide.
 The ``mhpmcounter`` performance counters are optional (unavailable by default) and parametrizable in width.
-To ensure that the ``mhpmcounter`` registers are optimized away when not required, some synthesis tools might need extra settings (e.g. increasing the "effort" to high).
 
 Event Selector
 --------------

--- a/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/examples/simple_system/rtl/ibex_simple_system.sv
@@ -198,7 +198,7 @@ module ibex_simple_system (
   logic [63:0] mhpmcounter_vals [32] /*verilator public_flat*/;
 
   for(genvar i = 0;i < 32; i = i + 1) begin
-      assign mhpmcounter_vals[i] = u_core.u_ibex_core.cs_registers_i.mhpmcounter_q[i];
+      assign mhpmcounter_vals[i] = u_core.u_ibex_core.cs_registers_i.mhpmcounter[i];
   end
 endmodule
 


### PR DESCRIPTION
Refactors performance counters so only flops that are required from the
given parameters are explicitly elaborated without relying on
optimization to remove unused flops.

Fixes #473

The previous RTL produced a circuit where the value of all mhpmcounter flops would be maintained, unused bits would be reset to 0 and written 0 but before reset they could be some other value. Whilst it was possible for synthesis tools to decide this meant they could be ignored and seen as constant 0 values it requires setting optimization to 'high' or similar in some tools (see discussion on #473). My yosys flow couldn't perform the necessary optimization at all so synthesized many unused flops. This alters things so it's explicit what gets elaborated and doesn't rather than relying on apparently complex optimizations to remove them.

I still need to try this on an OpenTitan FPGA build and make sure everything is fine but testing with simple system looks good. 