### PR TITLE
[syn] Feed ABC faster clock for better results

### DIFF
--- a/syn/ibex_core_lr_synth_conf.tcl
+++ b/syn/ibex_core_lr_synth_conf.tcl
@@ -51,6 +51,12 @@ set lr_synth_clk_input clk_i
 set lr_synth_rst_input rst_ni
 
 # clock period in ps, this gives a 250 MHz clock.  using the nangate45 library
-# Ibex can meet this on reg2reg paths but sees some failures on the IO paths
+# Ibex can happily meet this on all paths with the lr_synth_abc_clk_uprate
+# setting below. With a lower uprate timing may not be met.
 set lr_synth_clk_period 4000.0
 
+# Amount to subtract from clk period to give the clock period passed to ABC in
+# the synth flow. ABC maps the design to the standard cell library and
+# optimises paths for timing, better results are obtained by giving it a faster
+# clock period so it optimises more.
+set lr_synth_abc_clk_uprate 2000.0

--- a/syn/tcl/lr_synth_flow_var_setup.tcl
+++ b/syn/tcl/lr_synth_flow_var_setup.tcl
@@ -43,6 +43,11 @@ if { $lr_synth_timing_run } {
   set_flow_var sta_paths_per_group 100 "STA paths reported per group"
   set_flow_var sta_overall_paths 1000 "STA paths reported in overall report"
   puts "clock period: $lr_synth_clk_period ps"
+
+  if { $lr_synth_abc_clk_uprate > $lr_synth_clk_period } {
+    puts "WARNING: abc_clk_uprate must be less than clk_period otherwise ABC will be given a negative clk period"
+  }
+
 }
 
 puts "================================================="

--- a/syn/tcl/yosys_run_synth.tcl
+++ b/syn/tcl/yosys_run_synth.tcl
@@ -23,8 +23,10 @@ yosys "write_verilog $lr_synth_pre_map_out"
 yosys "dfflibmap -liberty $lr_synth_cell_library_path"
 yosys "opt"
 
+set yosys_abc_clk_period [expr $lr_synth_clk_period - $lr_synth_abc_clk_uprate]
+
 if { $lr_synth_timing_run } {
-  yosys "abc -liberty $lr_synth_cell_library_path -constr $lr_synth_sdc_file_out -D $lr_synth_clk_period"
+  yosys "abc -liberty $lr_synth_cell_library_path -constr $lr_synth_sdc_file_out -D $yosys_abc_clk_period"
 } else {
   yosys "abc -liberty $lr_synth_cell_library_path"
 }


### PR DESCRIPTION
Adds an 'uprate' clock period which is subtracted off the desired period
and given to ABC as the target clock period. This gives better overal
timing results with minimal area impact.