### PR TITLE
[DV] Test nested interrupts

### DIFF
--- a/dv/uvm/env/core_ibex_env_cfg.sv
+++ b/dv/uvm/env/core_ibex_env_cfg.sv
@@ -6,6 +6,7 @@ class core_ibex_env_cfg extends uvm_object;
 
   bit       enable_irq_single_seq;
   bit       enable_irq_multiple_seq;
+  bit       enable_nested_irq;
   bit       enable_debug_seq;
   bit[31:0] max_interval;
   bit       require_signature_addr;
@@ -15,6 +16,7 @@ class core_ibex_env_cfg extends uvm_object;
   `uvm_object_utils_begin(core_ibex_env_cfg)
     `uvm_field_int(enable_irq_single_seq,   UVM_DEFAULT)
     `uvm_field_int(enable_irq_multiple_seq,   UVM_DEFAULT)
+    `uvm_field_int(enable_nested_irq, UVM_DEFAULT)
     `uvm_field_int(enable_debug_seq, UVM_DEFAULT)
     `uvm_field_int(max_interval, UVM_DEFAULT)
     `uvm_field_int(require_signature_addr, UVM_DEFAULT)
@@ -25,6 +27,7 @@ class core_ibex_env_cfg extends uvm_object;
     super.new(name);
     void'($value$plusargs("enable_irq_single_seq=%0d", enable_irq_single_seq));
     void'($value$plusargs("enable_irq_multiple_seq=%0d", enable_irq_multiple_seq));
+    void'($value$plusargs("enable_nested_irq=%0d", enable_nested_irq));
     void'($value$plusargs("enable_debug_seq=%0d", enable_debug_seq));
     void'($value$plusargs("max_interval=%0d", max_interval));
     void'($value$plusargs("require_signature_addr=%0d", require_signature_addr));

--- a/dv/uvm/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/riscv_dv_extension/testlist.yaml
@@ -343,6 +343,26 @@
   compare_opts:
     compare_final_value_only: 1
 
+- test: riscv_nested_interrupt_test
+  description: >
+    Assert interrupt, and then assert another interrupt during the first irq_handler routine
+  iterations: 10
+  gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +instr_cnt=10000
+    +require_signature_addr=1
+    +enable_interrupt=1
+    +enable_nested_interrupt=1
+    +randomize_csr=1
+    +no_csr_instr=1
+  rtl_test: core_ibex_nested_irq_test
+  sim_opts: >
+    +require_signature_addr=1
+    +enable_irq_multiple_seq=1
+    +enable_nested_irq=1
+  compare_opts:
+    compare_final_value_only: 1
+
 - test: riscv_interrupt_wfi_test
   description: >
     Inject interrupts after a encountering wfi instructions.

--- a/dv/uvm/tests/core_ibex_seq_lib.sv
+++ b/dv/uvm/tests/core_ibex_seq_lib.sv
@@ -70,12 +70,13 @@ class irq_raise_seq extends core_base_seq#(irq_seq_item);
 
   `uvm_object_utils(irq_raise_seq)
   `uvm_object_new
+  bit no_nmi;
 
   virtual task send_req();
     irq_seq_item irq;
     irq = irq_seq_item::type_id::create($sformatf("irq_raise_single[%0d]", iteration_cnt));
     start_item(irq);
-    `DV_CHECK_RANDOMIZE_WITH_FATAL(irq, num_of_interrupt > 1;)
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(irq, num_of_interrupt > 1; irq_nm == ~no_nmi;)
     finish_item(irq);
     get_response(irq);
   endtask
@@ -86,12 +87,13 @@ class irq_raise_single_seq extends core_base_seq#(irq_seq_item);
 
   `uvm_object_utils(irq_raise_single_seq)
   `uvm_object_new
+  bit no_nmi;
 
   virtual task send_req();
     irq_seq_item irq;
     irq = irq_seq_item::type_id::create($sformatf("irq_raise_single[%0d]", iteration_cnt));
     start_item(irq);
-    `DV_CHECK_RANDOMIZE_WITH_FATAL(irq, num_of_interrupt == 1;)
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(irq, num_of_interrupt == 1; irq_nm == ~no_nmi;)
     finish_item(irq);
     get_response(irq);
   endtask

--- a/dv/uvm/tests/core_ibex_vseq.sv
+++ b/dv/uvm/tests/core_ibex_vseq.sv
@@ -45,7 +45,7 @@ class core_ibex_vseq extends uvm_sequence;
       irq_drop_seq_h = irq_drop_seq::type_id::create("irq_drop_seq_h");
       irq_drop_seq_h.num_of_iterations = 1;
       irq_drop_seq_h.max_interval = 1;
-      irq_drop_seq_h.max_delay = 1;
+      irq_drop_seq_h.max_delay = 0;
       irq_drop_seq_h.interval = 0;
     end
     if (cfg.enable_debug_seq) begin
@@ -93,11 +93,13 @@ class core_ibex_vseq extends uvm_sequence;
     debug_seq_single_h.start(null);
   endtask
 
-  virtual task start_irq_raise_single_seq();
+  virtual task start_irq_raise_single_seq(bit no_nmi = 1'b0);
+    irq_raise_single_seq_h.no_nmi = no_nmi;
     irq_raise_single_seq_h.start(p_sequencer.irq_seqr);
   endtask
 
-  virtual task start_irq_raise_seq();
+  virtual task start_irq_raise_seq(bit no_nmi = 1'b0);
+    irq_raise_seq_h.no_nmi = no_nmi;
     irq_raise_seq_h.start(p_sequencer.irq_seqr);
   endtask
 


### PR DESCRIPTION
Tests scenarios where Ibex is executing an interrupt handler and receives a second set of interrupts in the middle of the first handler.
As per the discussion in #557, I have eliminated nested NMI interrupt test scenarios from this testcase.
This PR relies on https://github.com/google/riscv-dv/pull/444 to be functionally correct, so will only merge this PR after vendoring the latest riscv-dv copy.

Signed-off-by: Udi <udij@google.com>