### PR TITLE
Support for Riviera 2019 10

### DIFF
--- a/dv/uvm/riscv_dv_extension/riscv_core_setting.sv
+++ b/dv/uvm/riscv_dv_extension/riscv_core_setting.sv
@@ -80,7 +80,7 @@ int kernel_program_instr_cnt = 400;
 // ----------------------------------------------------------------------------
 
 // Implemented previlieged CSR list
-parameter privileged_reg_t implemented_csr[] = {
+const privileged_reg_t implemented_csr[] = {
     // Machine mode mode CSR
     MVENDORID,        // Vendor ID
     MARCHID,          // Architecture ID
@@ -151,14 +151,12 @@ parameter privileged_reg_t implemented_csr[] = {
 // --------------------------------------------------------------------------
 // Supported interrupt/exception setting, used for functional coverage
 // --------------------------------------------------------------------------
-
-parameter interrupt_cause_t implemented_interrupt[] = {
+const interrupt_cause_t implemented_interrupt[] = {
   M_SOFTWARE_INTR,
   M_TIMER_INTR,
   M_EXTERNAL_INTR
 };
-
-parameter exception_cause_t implemented_exception[] = {
+const exception_cause_t implemented_exception[] = {
   INSTRUCTION_ACCESS_FAULT,
   ILLEGAL_INSTRUCTION,
   BREAKPOINT,

--- a/dv/uvm/tests/core_ibex_seq_lib.sv
+++ b/dv/uvm/tests/core_ibex_seq_lib.sv
@@ -121,8 +121,7 @@ endclass
 
 // Simple debug sequence
 // debug_req is just a single bit sideband signal, use the interface to drive it directly
-class debug_seq extends core_base_seq;
-
+class debug_seq extends core_base_seq#(irq_seq_item);
   virtual core_ibex_dut_probe_if dut_vif;
 
   `uvm_object_utils(debug_seq)

--- a/dv/uvm/yaml/rtl_simulation.yaml
+++ b/dv/uvm/yaml/rtl_simulation.yaml
@@ -88,3 +88,19 @@
       -covbaserun test
     wave_opts: >
       -input <cwd>/ius.tcl
+
+- tool: riviera
+  env_var: ALDEC_PATH
+  compile:
+    cmd:
+      - "vlib <out>/work"
+      - "vlog -work <out>/work
+        +incdir+<ALDEC_PATH>/vlib/uvm-1.2/src
+        -l uvm_1_2
+        -f ibex_dv.f"
+
+  sim:
+    cmd: >
+      vsim -c <sim_opts> <cov_opts> -lib <out>/work +access +r+w -l <out>/logfile.log -do "run -all; endsim; quit -force" +ibex_tracer_file_base="trace_core"
+    cov_opts: >
+      -acdb_file <out>/cov.acdb


### PR DESCRIPTION
Initial support for Riviera 2019.10 and some issue fixed in ibex it self.
There is also riscv-dv changed to work with Riviera added. 