### PR TITLE
RTL fixes discovered by running Riviera

### DIFF
--- a/dv/uvm/ibex_dv.f
+++ b/dv/uvm/ibex_dv.f
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-+define+BOOT_ADDR=32'h8000_0000
+// Boot address specified in decimal to avoid single quote in number, which
+// causes parsing errors of this file in Riviera.
++define+BOOT_ADDR=2147483648 // 32'h8000_0000
 +define+TRACE_EXECUTION
 +define+RVFI
 

--- a/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/examples/simple_system/rtl/ibex_simple_system.sv
@@ -78,7 +78,6 @@ module ibex_simple_system (
   `else
     initial begin
       rst_sys_n = 1'b0;
-      device_err = '{default:1'b0};
       #8
       rst_sys_n = 1'b1;
     end
@@ -87,6 +86,10 @@ module ibex_simple_system (
       #1 clk_sys = 1'b1;
     end
   `endif
+
+  // Tie-off unused error signals
+  assign device_err[Ram] = 1'b0;
+  assign device_err[SimCtrl] = 1'b0;
 
   bus #(
     .NrDevices   (NrDevices),

--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -25,7 +25,7 @@ lint_off -msg UNUSED -file "*/rtl/ibex_if_stage.sv" -lines 40
 
 // Bits of signal are not used: fetch_addr_n[0]
 // cleaner to write all bits even if not all are used
-lint_off -msg UNUSED -file "*/rtl/ibex_if_stage.sv" -lines 80
+lint_off -msg UNUSED -file "*/rtl/ibex_if_stage.sv" -lines 83
 
 // Bits of signal are not used: shift_right_result_ext[32]
 // cleaner to write all bits even if not all are used
@@ -33,15 +33,15 @@ lint_off -msg UNUSED -file "*/rtl/ibex_alu.sv" -lines 104
 
 // Bits of signal are not used: alu_adder_ext_i[0]
 // Bottom bit is round, not needed
-lint_off -msg UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -lines 23
+lint_off -msg UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -lines 26
 
 // Bits of signal are not used: mac_res_ext[34]
 // cleaner to write all bits even if not all are used
-lint_off -msg UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -lines 48
+lint_off -msg UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -lines 51
 
 // Bits of signal are not used: res_adder_h[32]
 // cleaner to write all bits even if not all are used
-lint_off -msg UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -lines 68
+lint_off -msg UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -lines 71
 
 // Signal is not used: test_en_i
 // testability signal
@@ -51,17 +51,17 @@ lint_off -msg UNUSED -file "*/rtl/ibex_register_file_fpga.sv" -lines 22
 // Signal is not used: clk_i
 // leaving clk and reset connected in-case we want to add assertions
 lint_off -msg UNUSED -file "*/rtl/ibex_pmp.sv" -lines 15
-lint_off -msg UNUSED -file "*/rtl/ibex_compressed_decoder.sv" -lines 14
-lint_off -msg UNUSED -file "*/rtl/ibex_decoder.sv" -lines 21
+lint_off -msg UNUSED -file "*/rtl/ibex_compressed_decoder.sv" -lines 17
+lint_off -msg UNUSED -file "*/rtl/ibex_decoder.sv" -lines 24
 
 // Signal is not used: rst_ni
 // leaving clk and reset connected in-case we want to add assertions
-lint_off -msg UNUSED -file "*/rtl/ibex_pmp.sv" -lines 16
-lint_off -msg UNUSED -file "*/rtl/ibex_compressed_decoder.sv" -lines 15
-lint_off -msg UNUSED -file "*/rtl/ibex_decoder.sv" -lines 22
+lint_off -msg UNUSED -file "*/rtl/ibex_pmp.sv" -lines 19
+lint_off -msg UNUSED -file "*/rtl/ibex_compressed_decoder.sv" -lines 18
+lint_off -msg UNUSED -file "*/rtl/ibex_decoder.sv" -lines 25
 lint_off -msg UNUSED -file "*/rtl/ibex_register_file_fpga.sv" -lines 20
 
 // Signal unoptimizable: Feedback to clock or circular logic:
 // ibex_core.cs_registers_i.mie_q
 // Issue lowrisc/ibex#212
-lint_off -msg UNOPTFLAT -file "*/rtl/ibex_cs_registers.sv" -lines 167
+lint_off -msg UNOPTFLAT -file "*/rtl/ibex_cs_registers.sv" -lines 170

--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -19,10 +19,6 @@ lint_off -msg DECLFILENAME -file "*/rtl/ibex_register_file_ff.sv"
 lint_off -msg DECLFILENAME -file "*/rtl/ibex_register_file_latch.sv"
 lint_off -msg DECLFILENAME -file "*/rtl/ibex_register_file_fpga.sv"
 
-// Bits of signal are not used: boot_addr_i[7:0]
-// Boot address is 256B aligned, cleaner to pass all bits in
-lint_off -msg UNUSED -file "*/rtl/ibex_if_stage.sv" -lines 40
-
 // Bits of signal are not used: fetch_addr_n[0]
 // cleaner to write all bits even if not all are used
 lint_off -msg UNUSED -file "*/rtl/ibex_if_stage.sv" -lines 83
@@ -50,13 +46,11 @@ lint_off -msg UNUSED -file "*/rtl/ibex_register_file_fpga.sv" -lines 22
 
 // Signal is not used: clk_i
 // leaving clk and reset connected in-case we want to add assertions
-lint_off -msg UNUSED -file "*/rtl/ibex_pmp.sv" -lines 15
 lint_off -msg UNUSED -file "*/rtl/ibex_compressed_decoder.sv" -lines 17
 lint_off -msg UNUSED -file "*/rtl/ibex_decoder.sv" -lines 24
 
 // Signal is not used: rst_ni
 // leaving clk and reset connected in-case we want to add assertions
-lint_off -msg UNUSED -file "*/rtl/ibex_pmp.sv" -lines 19
 lint_off -msg UNUSED -file "*/rtl/ibex_compressed_decoder.sv" -lines 18
 lint_off -msg UNUSED -file "*/rtl/ibex_decoder.sv" -lines 25
 lint_off -msg UNUSED -file "*/rtl/ibex_register_file_fpga.sv" -lines 20

--- a/rtl/ibex_compressed_decoder.sv
+++ b/rtl/ibex_compressed_decoder.sv
@@ -10,6 +10,9 @@
  * This module is fully combinatorial, clock and reset are used for
  * assertions only.
  */
+
+`include "prim_assert.sv"
+
 module ibex_compressed_decoder (
     input  logic        clk_i,
     input  logic        rst_ni,

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -6,6 +6,9 @@
 /**
  * Main controller of the processor
  */
+
+`include "prim_assert.sv"
+
 module ibex_controller (
     input  logic                  clk_i,
     input  logic                  rst_ni,

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -9,6 +9,9 @@
  * Control and Status Registers (CSRs) following the RISC-V Privileged
  * Specification, draft version 1.11
  */
+
+`include "prim_assert.sv"
+
 module ibex_cs_registers #(
     parameter bit          DbgTriggerEn     = 0,
     parameter int unsigned MHPMCounterNum   = 8,

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -14,6 +14,9 @@
  * This module is fully combinatorial, clock and reset are used for
  * assertions only.
  */
+
+`include "prim_assert.sv"
+
 module ibex_decoder #(
     parameter bit RV32E = 0,
     parameter bit RV32M = 1

--- a/rtl/ibex_fetch_fifo.sv
+++ b/rtl/ibex_fetch_fifo.sv
@@ -9,6 +9,9 @@
  * input port: send address and data to the FIFO
  * clear_i clears the FIFO for the following cycle, including any new request
  */
+
+`include "prim_assert.sv"
+
 module ibex_fetch_fifo #(
   parameter int unsigned NUM_REQS = 2
 ) (

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -13,6 +13,9 @@
  * Decode stage of the core. It decodes the instructions and hosts the register
  * file.
  */
+
+`include "prim_assert.sv"
+
 module ibex_id_stage #(
     parameter bit RV32E = 0,
     parameter bit RV32M = 1

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -9,6 +9,9 @@
  * Instruction fetch unit: Selection of the next PC, and buffering (sampling) of
  * the read instruction.
  */
+
+`include "prim_assert.sv"
+
 module ibex_if_stage #(
     parameter int unsigned DmHaltAddr      = 32'h1A110800,
     parameter int unsigned DmExceptionAddr = 32'h1A110808

--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -9,6 +9,9 @@
  * Load Store Unit, used to eliminate multiple access during processor stalls,
  * and to align bytes and halfwords.
  */
+
+`include "prim_assert.sv"
+
 module ibex_load_store_unit (
     input  logic         clk_i,
     input  logic         rst_ni,

--- a/rtl/ibex_multdiv_fast.sv
+++ b/rtl/ibex_multdiv_fast.sv
@@ -11,6 +11,9 @@
  *
  * 16x16 kernel multiplier and Long Division
  */
+
+`include "prim_assert.sv"
+
 module ibex_multdiv_fast (
     input  logic             clk_i,
     input  logic             rst_ni,

--- a/rtl/ibex_multdiv_slow.sv
+++ b/rtl/ibex_multdiv_slow.sv
@@ -8,6 +8,9 @@
  *
  * Baugh-Wooley multiplier and Long Division
  */
+
+`include "prim_assert.sv"
+
 module ibex_multdiv_slow (
     input  logic             clk_i,
     input  logic             rst_ni,

--- a/shared/prim_assert.core
+++ b/shared/prim_assert.core
@@ -8,7 +8,7 @@ description: "Assertion primitives"
 filesets:
   files_rtl:
     files:
-      - rtl/prim_assert.sv
+      - rtl/prim_assert.sv : {is_include_file : true}
     file_type: systemVerilogSource
 
 targets:

--- a/shared/rtl/prim_assert.sv
+++ b/shared/rtl/prim_assert.sv
@@ -6,6 +6,9 @@
 //  - Provides default clk and rst options to simplify code
 //  - Provides boiler plate template for common assertions
 
+`ifndef PRIM_ASSERT_SV
+`define PRIM_ASSERT_SV
+
 `ifdef UVM
   // report assertion error with UVM if compiled
   package assert_rpt_pkg;
@@ -172,3 +175,5 @@
 `ifdef FPV_ON                                    \
    `COVER(__name, __prop, __clk, __rst)          \
 `endif
+
+`endif // PRIM_ASSERT_SV

--- a/shared/rtl/timer.sv
+++ b/shared/rtl/timer.sv
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Example memory mapped timer
+
+`include "prim_assert.sv"
+
 module timer #(
   // Bus data width (must be 32)
   parameter int unsigned DataWidth    = 32,


### PR DESCRIPTION
This is a spin-off from https://github.com/lowRISC/ibex/pull/566 with only the fixes that affect RTL. All issues were caught when running Riviera 2019.10 on our code base.
The fixes are generally and not related to Riviera per se, keeping them in this PR to reduce the dependency chain. Support for Riviera running DV will come in a follow-up.