### PR TITLE
Fix FPGA part number for Arty A7-100T

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build-arty-35: sw-led
 .PHONY: build-arty-100
 build-arty-100: sw-led
 	fusesoc --cores-root=. run --target=synth --setup --build \
-		lowrisc:ibex:top_artya7 --part xc7a100ticsg324-1
+		lowrisc:ibex:top_artya7 --part xc7a100tcsg324-1
 
 .PHONY: program-arty
 program-arty:


### PR DESCRIPTION
For some reason the part number between the Arty A7-35T and the Arty
A7-100T differs by 1 letter (TICSG vs TCSG). This patch fixes the part
number for the Arty A7-100T to remove the "i".

Signed-off-by: Stephano Cetola <scetola@linuxfoundation.org>