### PR TITLE
[verilator] Fix ELF loading

### DIFF
--- a/dv/verilator/memutil/cpp/verilator_memutil.cc
+++ b/dv/verilator/memutil/cpp/verilator_memutil.cc
@@ -422,7 +422,7 @@ bool VerilatorMemUtil::WriteElfToMem(const svScope &scope,
     retcode = false;
     goto ret;
   }
-  for (int i = 0; i < len_bytes / 4; ++i) {
+  for (int i = 0; i < (len_bytes + 3) / 4; ++i) {
     if (!simutil_verilator_set_mem(i, (svLogicVecVal *)&buf[4 * i])) {
       std::cerr << "ERROR: Could not set memory byte: " << i * 4 << "/"
                 << len_bytes << "" << std::endl;


### PR DESCRIPTION
In `VerilatorMemUtil::WriteElfToMem`, the verilator memory is written
with the ELF segment data, 4 bytes at a time . If the segment size isn't
a multiple of 4 (e.g. when using the RISC-V C extension) the last word
wouldn't be written. This patch rounds the size up to a multiple of 4,
solving that issue.