### PR TITLE
Fix incdirs of src_files.yml

### DIFF
--- a/src_files.yml
+++ b/src_files.yml
@@ -1,6 +1,7 @@
 ibex:
   incdirs: [
     rtl,
+    shared/rtl,
   ]
   files: [
     rtl/ibex_pkg.sv,


### PR DESCRIPTION
This PR fixes `incdirs` of `src_files.yml`.
#570 added `` `include "prim_assert.sv"``, but no incdir added.