### PR TITLE
[dv] enable PMP

### DIFF
--- a/dv/uvm/ibex_dv.f
+++ b/dv/uvm/ibex_dv.f
@@ -31,6 +31,7 @@ ${PRJ_DIR}/ibex/rtl/ibex_multdiv_fast.sv
 ${PRJ_DIR}/ibex/rtl/ibex_prefetch_buffer.sv
 ${PRJ_DIR}/ibex/rtl/ibex_fetch_fifo.sv
 ${PRJ_DIR}/ibex/rtl/ibex_register_file_ff.sv
+${PRJ_DIR}/ibex/rtl/ibex_pmp.sv
 ${PRJ_DIR}/ibex/rtl/ibex_core.sv
 ${PRJ_DIR}/ibex/rtl/ibex_core_tracing.sv
 

--- a/dv/uvm/riscv_dv_extension/riscv_core_setting.sv
+++ b/dv/uvm/riscv_dv_extension/riscv_core_setting.sv
@@ -50,6 +50,9 @@ mtvec_mode_t supported_interrupt_mode[$] = {VECTORED};
 // supported
 int max_interrupt_vector_num = 32;
 
+// Physical memory protection support
+bit support_pmp = 1;
+
 // Debug mode support
 bit support_debug_mode = 1;
 

--- a/dv/uvm/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/riscv_dv_extension/testlist.yaml
@@ -574,3 +574,13 @@
   rtl_test: core_ibex_invalid_csr_test
   sim_opts: >
     +require_signature_addr=1
+
+- test: riscv_pmp_test
+  desc: >
+    Random PMP settings
+  iterations: 1
+  gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +instr_cnt=6000
+    +num_of_sub_program=2
+  rtl_test: core_ibex_base_test

--- a/dv/uvm/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/tb/core_ibex_tb_top.sv
@@ -27,7 +27,10 @@ module core_ibex_tb_top;
   core_ibex_csr_if csr_if(.clk(clk));
 
   ibex_core_tracing #(.DmHaltAddr(`BOOT_ADDR + 'h0),
-                      .DmExceptionAddr(`BOOT_ADDR + 'h4)) dut (
+                      .DmExceptionAddr(`BOOT_ADDR + 'h4),
+                      .PMPEnable(1'b1),
+                      .PMPGranularity(0),
+                      .PMPNumRegions(16)) dut (
     .clk_i(clk),
     .rst_ni(rst_n),
     .test_en_i(1'b1),


### PR DESCRIPTION
-enable the ibex PMP module to be included in simulations
-add basic PMP test
-set some initial default value to the rtl PMP configuration parameters
-simulations with this setup pass successfully with cosimulating with OVPsim

Signed-off-by: Udi <udij@google.com>