### PR TITLE
Update google_riscv-dv to google/riscv-dv@6e2bc2e

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: e63c5427b0bf543aebb9c62bba8217065b029a76
+    rev: 6e2bc2e01fb20799c9eff29a26852eb1917b977a
   }
 }

--- a/vendor/google_riscv-dv/src/riscv_pmp_cfg.sv
+++ b/vendor/google_riscv-dv/src/riscv_pmp_cfg.sv
@@ -114,14 +114,14 @@ class riscv_pmp_cfg extends uvm_object;
       if (i == pmp_cfg.size() - 1) begin
         instr.push_back($sformatf("li x%0d, 0x%0x", scratch_reg, pmp_word));
         instr.push_back($sformatf("csrw 0x%0x, x%0d",
-                                  base_pmpcfg_addr + pmp_id),
+                                  base_pmpcfg_addr + pmp_id,
                                   scratch_reg));
         return;
       end else if ((i + 1) % cfg_per_csr == 0) begin
         // if we've filled up pmp_word, write to the corresponding CSR
         instr.push_back($sformatf("li x%0d, 0x%0x", scratch_reg, pmp_word));
         instr.push_back($sformatf("csrw 0x%0x, x%0d",
-                                  base_pmpcfg_addr + pmp_id),
+                                  base_pmpcfg_addr + pmp_id,
                                   scratch_reg));
         pmp_word = 0;
       end


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision 6e2bc2e01fb20799c9eff29a26852eb1917b977a

* fix a missed syntax error in pmp_cfg (Udi Jonnalagadda)

Signed-off-by: Udi <udij@google.com>