### PR TITLE
:zap: Reduce latency of slow multiplier

### DIFF
--- a/doc/instruction_decode_execute.rst
+++ b/doc/instruction_decode_execute.rst
@@ -82,7 +82,7 @@ Fast Multiplier
   - In some cases it may be desirable to replace this with a specific implementation (such as a hard macro in an FPGA or an explicit gate level implementation).
 
 Slow Multiplier
-  - Completes multiply in 33 cycles using a Baugh-Wooley multiplier (for both MUL and MULH).
+  - Completes multiply in clog2(``op_b``) + 1 cycles (for MUL) or 33 cycles (for MULH) using a Baugh-Wooley multiplier.
   - The ALU block is used to compute additions.
 
 Divider

--- a/doc/pipeline_details.rst
+++ b/doc/pipeline_details.rst
@@ -30,57 +30,57 @@ In the table below when an instruction stalls for X cycles X + 1 cycles pass bef
 Some instructions stall for a variable time, this is indicated as a range e.g. 1 - N means the instruction stalls a minimum of 1 cycle with an indeterminate maximum cycles.
 Read the description for more information.
 
-+-----------------------+-----------------------+-------------------------------------------------------------+
-| Instruction Type      | Stall Cycles          | Description                                                 |
-+=======================+=======================+=============================================================+
-| Integer Computational | 0                     | Integer Computational Instructions are defined in the       |
-|                       |                       | RISCV-V RV32I Base Integer Instruction Set.                 |
-+-----------------------+-----------------------+-------------------------------------------------------------+
-| CSR Access            | 0                     | CSR Access Instruction are defined in 'Zicsr' of the        |
-|                       |                       | RISC-V specification.                                       |
-+-----------------------+-----------------------+-------------------------------------------------------------+
-| Load/Store            | 1 - N                 | Both loads and stores stall for at least one cycle to await |
-|                       |                       | a response.  For loads this response is the load data       |
-|                       |                       | (which is written directly to the register file the same    |
-|                       |                       | cycle it is received).  For stores this is whether an error |
-|                       |                       | was seen or not.  The longer the data side memory interface |
-|                       |                       | takes to receive a response the longer loads and stores     |
-|                       |                       | will stall.                                                 |
-+-----------------------+-----------------------+-------------------------------------------------------------+
-| Multiplication        | 2/3 (Fast Multiplier) | 2 for MUL, 3 for MULH.                                      |
-|                       |                       | See details in :ref:`mult-div`                              |
-|                       | 32 (Slow Multiplier)  |                                                             |
-+-----------------------+-----------------------+-------------------------------------------------------------+
-| Division              | 1 or 37               | 1 stall cycle if divide by 0, otherwise full long division. |
-|                       |                       | See details in :ref:`mult-div`                              |
-| Remainder             |                       |                                                             |
-+-----------------------+-----------------------+-------------------------------------------------------------+
-| Jump                  | 1 - N                 | Minimum one cycle stall to flush the prefetch counter and   |
-|                       |                       | begin fetching from the new Program Counter (PC).  The new  |
-|                       |                       | PC request will appear on the instruction-side memory       |
-|                       |                       | interface the same cycle the jump instruction enters ID/EX. |
-|                       |                       | The longer the instruction-side memory interface takes to   |
-|                       |                       | receive data the longer the jump will stall.                |
-+-----------------------+-----------------------+-------------------------------------------------------------+
-| Branch (Not-Taken)    | 0                     | Any branch where the condition is not met will              |
-|                       |                       | not stall.                                                  |
-+-----------------------+-----------------------+-------------------------------------------------------------+
-| Branch (Taken)        | 2 - N                 | Any branch where the condition is met will stall for 2      |
-|                       |                       | cycles as in the first cycle the branch is in ID/EX the ALU |
-|                       | 1 - N (Branch Target  | is used to calculate the branch condition.  The following   |
-|                       | ALU enabled)          | cycle the ALU is used again to calculate the branch target  |
-|                       |                       | where it proceeds as Jump does above (Flush IF stage and    |
-|                       |                       | prefetch buffer, new PC on instruction-side memory          |
-|                       |                       | interface the same cycle it is calculated).  The longer the |
-|                       |                       | instruction-side memory interface takes to receive data the |
-|                       |                       | longer the branch will stall. With the parameter            |
-|                       |                       | ``BranchTargetALU`` set to ``1`` a seperate ALU calculates  |
-|                       |                       | the branch target simultaneously to calculating the branch  |
-|                       |                       | condition with the main ALU so 1 less stall cycle is        |
-|                       |                       | required.                                                   |
-+-----------------------+-----------------------+-------------------------------------------------------------+
-| Instruction Fence     | 1 - N                 | The FENCE.I instruction as defined in 'Zifencei' of the     |
-|                       |                       | RISC-V specification. Internally it is implemented as a     |
-|                       |                       | jump (which does the required flushing) so it has the same  |
-|                       |                       | stall characteristics (see above).                          |
-+-----------------------+-----------------------+-------------------------------------------------------------+
++-----------------------+--------------------------------------+-------------------------------------------------------------+
+|   Instruction Type    |             Stall Cycles             |                         Description                         |
++=======================+======================================+=============================================================+
+| Integer Computational | 0                                    | Integer Computational Instructions are defined in the       |
+|                       |                                      | RISCV-V RV32I Base Integer Instruction Set.                 |
++-----------------------+--------------------------------------+-------------------------------------------------------------+
+| CSR Access            | 0                                    | CSR Access Instruction are defined in 'Zicsr' of the        |
+|                       |                                      | RISC-V specification.                                       |
++-----------------------+--------------------------------------+-------------------------------------------------------------+
+| Load/Store            | 1 - N                                | Both loads and stores stall for at least one cycle to await |
+|                       |                                      | a response.  For loads this response is the load data       |
+|                       |                                      | (which is written directly to the register file the same    |
+|                       |                                      | cycle it is received).  For stores this is whether an error |
+|                       |                                      | was seen or not.  The longer the data side memory interface |
+|                       |                                      | takes to receive a response the longer loads and stores     |
+|                       |                                      | will stall.                                                 |
++-----------------------+--------------------------------------+-------------------------------------------------------------+
+| Multiplication        | 2/3 (Fast Multiplier)                | Fast: 2 for MUL, 3 for MULH.                                |
+|                       |                                      | Slow: clog2(``op_b``) for MUL, 32 for MULH.                 |
+|                       | clog2(``op_b``)/32 (Slow Multiplier) | See details in :ref:`mult-div`                              |
++-----------------------+--------------------------------------+-------------------------------------------------------------+
+| Division              | 1 or 37                              | 1 stall cycle if divide by 0, otherwise full long division. |
+|                       |                                      | See details in :ref:`mult-div`                              |
+| Remainder             |                                      |                                                             |
++-----------------------+--------------------------------------+-------------------------------------------------------------+
+| Jump                  | 1 - N                                | Minimum one cycle stall to flush the prefetch counter and   |
+|                       |                                      | begin fetching from the new Program Counter (PC).  The new  |
+|                       |                                      | PC request will appear on the instruction-side memory       |
+|                       |                                      | interface the same cycle the jump instruction enters ID/EX. |
+|                       |                                      | The longer the instruction-side memory interface takes to   |
+|                       |                                      | receive data the longer the jump will stall.                |
++-----------------------+--------------------------------------+-------------------------------------------------------------+
+| Branch (Not-Taken)    | 0                                    | Any branch where the condition is not met will              |
+|                       |                                      | not stall.                                                  |
++-----------------------+--------------------------------------+-------------------------------------------------------------+
+| Branch (Taken)        | 2 - N                                | Any branch where the condition is met will stall for 2      |
+|                       |                                      | cycles as in the first cycle the branch is in ID/EX the ALU |
+|                       | 1 - N (Branch Target                 | is used to calculate the branch condition.  The following   |
+|                       | ALU enabled)                         | cycle the ALU is used again to calculate the branch target  |
+|                       |                                      | where it proceeds as Jump does above (Flush IF stage and    |
+|                       |                                      | prefetch buffer, new PC on instruction-side memory          |
+|                       |                                      | interface the same cycle it is calculated).  The longer the |
+|                       |                                      | instruction-side memory interface takes to receive data the |
+|                       |                                      | longer the branch will stall. With the parameter            |
+|                       |                                      | ``BranchTargetALU`` set to ``1`` a seperate ALU calculates  |
+|                       |                                      | the branch target simultaneously to calculating the branch  |
+|                       |                                      | condition with the main ALU so 1 less stall cycle is        |
+|                       |                                      | required.                                                   |
++-----------------------+--------------------------------------+-------------------------------------------------------------+
+| Instruction Fence     | 1 - N                                | The FENCE.I instruction as defined in 'Zifencei' of the     |
+|                       |                                      | RISC-V specification. Internally it is implemented as a     |
+|                       |                                      | jump (which does the required flushing) so it has the same  |
+|                       |                                      | stall characteristics (see above).                          |
++-----------------------+--------------------------------------+-------------------------------------------------------------+

--- a/rtl/ibex_multdiv_slow.sv
+++ b/rtl/ibex_multdiv_slow.sv
@@ -173,7 +173,7 @@ module ibex_multdiv_slow (
               accum_window_d = {       ~(op_a_ext[32]   &     op_b_i[0]),
                                          op_a_ext[31:0] & {32{op_b_i[0]}}  };
               op_b_shift_d   = op_b_ext >> 1;
-              md_state_d     = MD_COMP;
+              md_state_d     = !(op_b_ext >> 1) ? MD_LAST : MD_COMP;
             end
             MD_OP_MULH: begin
               op_a_shift_d   = op_a_ext;
@@ -221,19 +221,20 @@ module ibex_multdiv_slow (
               accum_window_d = res_adder_l;
               op_a_shift_d   = op_a_shift_q << 1;
               op_b_shift_d   = op_b_shift_q >> 1;
+              md_state_d     = !(op_b_shift_q >> 1) ? MD_LAST : MD_COMP;
             end
             MD_OP_MULH: begin
               accum_window_d = res_adder_h;
               op_a_shift_d   = op_a_shift_q;
               op_b_shift_d   = op_b_shift_q >> 1;
+              md_state_d     = (multdiv_state_q == 5'd1) ? MD_LAST : MD_COMP;
             end
             default: begin
               accum_window_d = {next_reminder[31:0], op_numerator_q[multdiv_state_m1]};
               op_a_shift_d   = next_quotient;
+              md_state_d     = (multdiv_state_q == 5'd1) ? MD_LAST : MD_COMP;
             end
           endcase
-
-          md_state_d = (multdiv_state_q == 5'd1) ? MD_LAST : MD_COMP;
         end
 
         MD_LAST: begin


### PR DESCRIPTION
- The slow multiplier is modified to terminate iterations early instead
  of always going the full 32 iterations.
- Multiplications now terminate early after clog2(`op_b`) iterations.
- The slow multiplier can be further optimized by swapping the smaller
  operand into `op_b` when in the `MD_IDLE` state.