### PR TITLE
[rtl] Change misa for RV32E

### DIFF
--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -105,18 +105,18 @@ module ibex_cs_registers #(
   // misa
   localparam logic [1:0] MXL = 2'd1; // M-XLEN: XLEN in M-Mode for RV32
   localparam logic [31:0] MISA_VALUE =
-      (0          <<  0)  // A - Atomic Instructions extension
-    | (1          <<  2)  // C - Compressed extension
-    | (0          <<  3)  // D - Double precision floating-point extension
-    | (32'(RV32E) <<  4)  // E - RV32E base ISA
-    | (0          <<  5)  // F - Single precision floating-point extension
-    | (1          <<  8)  // I - RV32I/64I/128I base ISA
-    | (32'(RV32M) << 12)  // M - Integer Multiply/Divide extension
-    | (0          << 13)  // N - User level interrupts supported
-    | (0          << 18)  // S - Supervisor mode implemented
-    | (1          << 20)  // U - User mode implemented
-    | (0          << 23)  // X - Non-standard extensions present
-    | (32'(MXL)   << 30); // M-XLEN
+      (0           <<  0)  // A - Atomic Instructions extension
+    | (1           <<  2)  // C - Compressed extension
+    | (0           <<  3)  // D - Double precision floating-point extension
+    | (32'(RV32E)  <<  4)  // E - RV32E base ISA
+    | (0           <<  5)  // F - Single precision floating-point extension
+    | (32'(!RV32E) <<  8)  // I - RV32I/64I/128I base ISA
+    | (32'(RV32M)  << 12)  // M - Integer Multiply/Divide extension
+    | (0           << 13)  // N - User level interrupts supported
+    | (0           << 18)  // S - Supervisor mode implemented
+    | (1           << 20)  // U - User mode implemented
+    | (0           << 23)  // X - Non-standard extensions present
+    | (32'(MXL)    << 30); // M-XLEN
 
   typedef struct packed {
     logic      mie;


### PR DESCRIPTION
Following RISC-V privileged architecture version 1.11,
the "E" bit of misa should return the complement of the "I" bit.

Set the "I" bit only if RV32E is not used.

Closes lowRISC/ibex#612.