### PR TITLE
Update google_riscv-dv to google/riscv-dv@6bd3233

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: 6e2bc2e01fb20799c9eff29a26852eb1917b977a
+    rev: 6bd323385d454858ea5e50dedd42a563b37931fe
   }
 }

--- a/vendor/google_riscv-dv/README.md
+++ b/vendor/google_riscv-dv/README.md
@@ -62,6 +62,17 @@ run --help
 cov --help
 ```
 
+Use below command to install Verible, which is the tool to check Verilog style
+```bash
+verilog_style/build-verible.sh
+```
+
+This is the command to run Verilog style check. It's recommended to run and clean up
+all the style violations before submit a PR
+```bash
+verilog_style/run.sh
+```
+
 ## Document
 
 To understand how to setup and customize the generator, please check the full

--- a/vendor/google_riscv-dv/run.py
+++ b/vendor/google_riscv-dv/run.py
@@ -534,8 +534,8 @@ def run_c_from_dir(c_test_dir, iss_yaml, isa, mabi, gcc_opts, iss,
     logging.error("No c test(*.c) found under %s" % c_test_dir)
 
 
-def iss_sim(test_list, output_dir, iss_list, iss_yaml, isa,
-            setting_dir, timeout_s, debug_cmd):
+def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
+            isa, setting_dir, timeout_s, debug_cmd):
   """Run ISS simulation with the generated test program
 
   Args:
@@ -543,6 +543,7 @@ def iss_sim(test_list, output_dir, iss_list, iss_yaml, isa,
     output_dir  : Output directory of the ELF files
     iss_list    : List of instruction set simulators
     iss_yaml    : ISS configuration file in YAML format
+    iss_opts    : ISS command line options
     isa         : ISA variant passed to the ISS
     setting_dir : Generator setting directory
     timeout_s   : Timeout limit in seconds
@@ -562,6 +563,9 @@ def iss_sim(test_list, output_dir, iss_list, iss_yaml, isa,
           elf = prefix + ".o"
           log = ("%s/%s.%d.log" % (log_dir, test['test'], i))
           cmd = get_iss_cmd(base_cmd, elf, log)
+          if 'iss_opts' in test:
+            cmd += ' '
+            cmd += test['iss_opts']
           logging.info("Running %s sim: %s" % (iss, elf))
           if iss == "ovpsim":
             run_cmd(cmd, timeout_s, check_return_code=False, debug_cmd = debug_cmd)
@@ -687,6 +691,8 @@ def setup_parser():
                       help="Generator timeout limit in seconds")
   parser.add_argument("--end_signature_addr", type=str, default="0",
                       help="Address that privileged CSR test writes to at EOT")
+  parser.add_argument("--iss_opts", type=str, default="",
+                      help="Any ISS command line arguments")
   parser.add_argument("--iss_timeout", type=int, default=10,
                       help="ISS sim timeout limit in seconds")
   parser.add_argument("--iss_yaml", type=str, default="",
@@ -924,7 +930,7 @@ def main():
 
       # Run ISS simulation
       if args.steps == "all" or re.match(".*iss_sim.*", args.steps):
-        iss_sim(matched_list, output_dir, args.iss, args.iss_yaml,
+        iss_sim(matched_list, output_dir, args.iss, args.iss_yaml, args.iss_opts,
                 args.isa, args.core_setting_dir, args.iss_timeout, args.debug)
 
       # Compare ISS simulation result

--- a/vendor/google_riscv-dv/src/isa/riscv_compressed_instr.sv
+++ b/vendor/google_riscv-dv/src/isa/riscv_compressed_instr.sv
@@ -261,7 +261,7 @@ class riscv_compressed_instr extends riscv_instr;
         binary = $sformatf("%4h", {get_func3(), imm[11], imm[4], imm[9:8],
                                    imm[10], imm[6], imm[7], imm[3:1], imm[5], get_c_opcode()});
       C_ADDI16SP:
-        binary = $sformatf("%4h", {get_func3(), imm[9], 5'b10,
+        binary = $sformatf("%4h", {get_func3(), imm[9], 5'b00010,
                                    imm[4], imm[6], imm[8:7], imm[5], get_c_opcode()});
       C_LUI:
         binary = $sformatf("%4h", {get_func3(), imm[5], rd, imm[4:0], get_c_opcode()});

--- a/vendor/google_riscv-dv/src/isa/riscv_instr.sv
+++ b/vendor/google_riscv-dv/src/isa/riscv_instr.sv
@@ -554,13 +554,13 @@ class riscv_instr extends uvm_object;
         else if(instr_name == ECALL)
           binary = $sformatf("%8h", {get_func7(), 18'b0, get_opcode()});
         else if(instr_name inside {URET, SRET, MRET})
-          binary = $sformatf("%8h", {get_func7(), 5'b10, 13'b0, get_opcode()});
+          binary = $sformatf("%8h", {get_func7(), 5'b00010, 13'b0, get_opcode()});
         else if(instr_name inside {DRET})
           binary = $sformatf("%8h", {get_func7(), 5'b10010, 13'b0, get_opcode()});
         else if(instr_name == EBREAK)
-          binary = $sformatf("%8h", {get_func7(), 5'b01, 13'b0, get_opcode()});
+          binary = $sformatf("%8h", {get_func7(), 5'd1, 13'b0, get_opcode()});
         else if(instr_name == WFI)
-          binary = $sformatf("%8h", {get_func7(), 5'b101, 13'b0, get_opcode()});
+          binary = $sformatf("%8h", {get_func7(), 5'b00101, 13'b0, get_opcode()});
         else
           binary = $sformatf("%8h", {imm[11:0], rs1, get_func3(), rd, get_opcode()});
       end

--- a/vendor/google_riscv-dv/src/riscv_asm_program_gen.sv
+++ b/vendor/google_riscv-dv/src/riscv_asm_program_gen.sv
@@ -555,11 +555,14 @@ class riscv_asm_program_gen extends uvm_object;
         // is complete, for any initial state analysis
         case(riscv_instr_pkg::supported_privileged_mode[i])
           SUPERVISOR_MODE: begin
-            gen_signature_handshake(.instr(csr_handshake), .signature_type(WRITE_CSR), .csr(SSTATUS));
-            gen_signature_handshake(.instr(csr_handshake), .signature_type(WRITE_CSR), .csr(SIE));
+            gen_signature_handshake(.instr(csr_handshake), .signature_type(WRITE_CSR),
+                                    .csr(SSTATUS));
+            gen_signature_handshake(.instr(csr_handshake), .signature_type(WRITE_CSR),
+                                    .csr(SIE));
           end
           USER_MODE: begin
-            gen_signature_handshake(.instr(csr_handshake), .signature_type(WRITE_CSR), .csr(USTATUS));
+            gen_signature_handshake(.instr(csr_handshake), .signature_type(WRITE_CSR),
+                                    .csr(USTATUS));
             gen_signature_handshake(.instr(csr_handshake), .signature_type(WRITE_CSR), .csr(UIE));
           end
         endcase
@@ -744,15 +747,15 @@ class riscv_asm_program_gen extends uvm_object;
       // Push user mode GPR to kernel stack before executing exception handling, this is to avoid
       // exception handling routine modify user program state unexpectedly
       push_gpr_to_kernel_stack(status, scratch, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr);
-      // Checking xStatus can be optional if ISS (like spike) has different implementation of certain
-      // fields compared with the RTL processor.
+      // Checking xStatus can be optional if ISS (like spike) has different implementation of
+      // certain fields compared with the RTL processor.
       if (cfg.check_xstatus) begin
         instr = {instr, $sformatf("csrr x%0d, 0x%0x # %0s", cfg.gpr[0], status, status.name())};
       end
       instr = {instr,
                // Use scratch CSR to save a GPR value
-               // Check if the exception is caused by an interrupt, if yes, jump to interrupt handler
-               // Interrupt is indicated by xCause[XLEN-1]
+               // Check if the exception is caused by an interrupt, if yes, jump to interrupt
+               // handler Interrupt is indicated by xCause[XLEN-1]
                $sformatf("csrr x%0d, 0x%0x # %0s", cfg.gpr[0], cause, cause.name()),
                $sformatf("srli x%0d, x%0d, %0d", cfg.gpr[0], cfg.gpr[0], XLEN-1),
                $sformatf("bne x%0d, x0, %0smode_intr_handler", cfg.gpr[0], mode)};
@@ -833,7 +836,8 @@ class riscv_asm_program_gen extends uvm_object;
     for (int i = 1; i < max_interrupt_vector_num; i++) begin
       string intr_handler[$];
       push_gpr_to_kernel_stack(status, scratch, cfg.mstatus_mprv, cfg.sp, cfg.tp, intr_handler);
-      gen_signature_handshake(.instr(intr_handler), .signature_type(CORE_STATUS), .core_status(HANDLING_IRQ));
+      gen_signature_handshake(.instr(intr_handler), .signature_type(CORE_STATUS),
+                              .core_status(HANDLING_IRQ));
       intr_handler = {intr_handler,
                       $sformatf("csrr x%0d, 0x%0x # %0s", cfg.gpr[0], cause, cause.name()),
                       // Terminate the test if xCause[31] != 0 (indicating exception)
@@ -1193,7 +1197,8 @@ class riscv_asm_program_gen extends uvm_object;
 
   virtual function void add_directed_instr_stream(string name, int unsigned ratio);
     directed_instr_stream_ratio[name] = ratio;
-    `uvm_info(`gfn, $sformatf("Adding directed instruction stream:%0s ratio:%0d/1000", name, ratio), UVM_LOW)
+    `uvm_info(`gfn, $sformatf("Adding directed instruction stream:%0s ratio:%0d/1000", name, ratio),
+              UVM_LOW)
   endfunction
 
   virtual function void get_directed_instr_stream();

--- a/vendor/google_riscv-dv/src/riscv_debug_rom_gen.sv
+++ b/vendor/google_riscv-dv/src/riscv_debug_rom_gen.sv
@@ -82,7 +82,7 @@ class riscv_debug_rom_gen extends riscv_asm_program_gen;
       format_section(debug_main);
       gen_sub_program(sub_program, sub_program_name,
                       cfg.num_debug_sub_program, 1'b1, "debug_sub");
-      main_program = riscv_instr_sequence::type_id::create("debug_program");
+      main_program = riscv_instr_sequence::type_id::create("main_program");
       main_program.instr_cnt = cfg.debug_program_instr_cnt;
       main_program.is_debug_program = 1;
       main_program.cfg = cfg;

--- a/vendor/google_riscv-dv/src/riscv_illegal_instr.sv
+++ b/vendor/google_riscv-dv/src/riscv_illegal_instr.sv
@@ -320,12 +320,12 @@ class riscv_illegal_instr extends uvm_object;
   constraint illegal_func7_c {
     if (!compressed) {
       if (exception == kIllegalFunc7) {
-        !(func7 inside {7'b0, 7'b0100000, 7'b1});
-        if (opcode == 7'b001001) { // SLLI, SRLI, SRAI
-          !(func7[6:1] inside {6'b0, 6'b010000});
+        !(func7 inside {7'd0, 7'b0100000, 7'd1});
+        if (opcode == 7'b0001001) { // SLLI, SRLI, SRAI
+          !(func7[6:1] inside {6'd0, 6'b010000});
         }
       } else {
-        func7 inside {7'b0, 7'b0100000, 7'b1};
+        func7 inside {7'd0, 7'b0100000, 7'd1};
       }
     }
   }

--- a/vendor/google_riscv-dv/src/riscv_instr_cov_item.sv
+++ b/vendor/google_riscv-dv/src/riscv_instr_cov_item.sv
@@ -73,7 +73,8 @@ class riscv_instr_cov_item extends riscv_instr;
       mem_addr = rs1_value + imm;
       unaligned_mem_access = is_unaligned_mem_access();
       if (unaligned_mem_access) begin
-        `uvm_info(`gfn, $sformatf("Unaligned: %0s, mem_addr:%0x", instr_name.name(), mem_addr), UVM_HIGH)
+        `uvm_info(`gfn, $sformatf("Unaligned: %0s, mem_addr:%0x", instr_name.name(), mem_addr),
+                  UVM_HIGH)
       end
     end
     if (category == LOGICAL) begin

--- a/vendor/google_riscv-dv/src/riscv_instr_gen_config.sv
+++ b/vendor/google_riscv-dv/src/riscv_instr_gen_config.sv
@@ -245,8 +245,8 @@ class riscv_instr_gen_config extends uvm_object;
       enable_sfence == 1'b1;
       (init_privileged_mode != SUPERVISOR_MODE) || (mstatus_tvm == 1'b1);
     } else {
-      (init_privileged_mode != SUPERVISOR_MODE || !riscv_instr_pkg::support_sfence || mstatus_tvm || no_fence)
-                                                     -> (enable_sfence == 1'b0);
+      (init_privileged_mode != SUPERVISOR_MODE || !riscv_instr_pkg::support_sfence || mstatus_tvm
+          || no_fence) -> (enable_sfence == 1'b0);
     }
   }
 
@@ -640,7 +640,8 @@ class riscv_instr_gen_config extends uvm_object;
     end
   endfunction
 
-  // Populate invalid_priv_mode_csrs with the main implemented CSRs for each supported privilege mode
+  // Populate invalid_priv_mode_csrs with the main implemented CSRs for each supported privilege
+  // mode
   // TODO(udi) - include performance/pmp/trigger CSRs?
   virtual function void get_invalid_priv_lvl_csr();
     string invalid_lvl[$];

--- a/vendor/google_riscv-dv/src/riscv_page_table_entry.sv
+++ b/vendor/google_riscv-dv/src/riscv_page_table_entry.sv
@@ -23,16 +23,16 @@
 class riscv_page_table_entry#(satp_mode_t MODE = SV39) extends uvm_object;
 
   // Note that only SV32, SV39, SV48 are supported
-  parameter PPN0_WIDTH  = (MODE == SV32) ? 10 : 9;
-  parameter PPN1_WIDTH  = (MODE == SV32) ? 12 : 9;
-  parameter PPN2_WIDTH  = (MODE == SV39) ? 26 : ((MODE == SV48) ? 9 : 1);
-  parameter PPN3_WIDTH  = (MODE == SV48) ? 9  : 1;
-  parameter RSVD_WIDTH  = (MODE == SV32) ? 1  : 10;
-  parameter VPN_WIDTH   = (MODE == SV32) ? 10 : 9;
+  parameter int PPN0_WIDTH  = (MODE == SV32) ? 10 : 9;
+  parameter int PPN1_WIDTH  = (MODE == SV32) ? 12 : 9;
+  parameter int PPN2_WIDTH  = (MODE == SV39) ? 26 : ((MODE == SV48) ? 9 : 1);
+  parameter int PPN3_WIDTH  = (MODE == SV48) ? 9  : 1;
+  parameter int RSVD_WIDTH  = (MODE == SV32) ? 1  : 10;
+  parameter int VPN_WIDTH   = (MODE == SV32) ? 10 : 9;
   // Spare bits in virtual address = XLEN - used virtual address bits
-  parameter VADDR_SPARE = (MODE == SV32) ? 0  : (MODE == SV39) ? 25 : 16;
+  parameter int VADDR_SPARE = (MODE == SV32) ? 0  : (MODE == SV39) ? 25 : 16;
   // Virtual address bit width
-  parameter VADDR_WIDTH = (MODE == SV32) ? 31 : (MODE == SV39) ? 38 : 48;
+  parameter int VADDR_WIDTH = (MODE == SV32) ? 31 : (MODE == SV39) ? 38 : 48;
 
   rand bit                    v;     // PTE is valid
   rand pte_permission_t       xwr;   // PTE execute-write-read permission

--- a/vendor/google_riscv-dv/src/riscv_page_table_list.sv
+++ b/vendor/google_riscv-dv/src/riscv_page_table_list.sv
@@ -27,11 +27,11 @@
 
 class riscv_page_table_list#(satp_mode_t MODE = SV39) extends uvm_object;
 
-  localparam PTE_SIZE   = XLEN / 8;
-  localparam PTE_CNT    = 4096 / PTE_SIZE;
-  localparam PAGE_LEVEL = (MODE == SV32) ? 2 : ((MODE == SV39) ? 3 : 4);
-  localparam LINK_PTE_PER_TABLE = 2;
-  localparam SUPER_LEAF_PTE_PER_TABLE = 2;
+  localparam int PteSize   = XLEN / 8;
+  localparam int PteCnt    = 4096 / PteSize;
+  localparam int PageLevel = (MODE == SV32) ? 2 : ((MODE == SV39) ? 3 : 4);
+  localparam int LinkPtePerTable = 2;
+  localparam int SuperLeafPtePerTable = 2;
 
   satp_mode_t mode = MODE;
 
@@ -92,7 +92,7 @@ class riscv_page_table_list#(satp_mode_t MODE = SV39) extends uvm_object;
     exception_cfg = riscv_page_table_exception_cfg::type_id::create("exception_cfg");
     valid_leaf_pte = riscv_page_table_entry#(MODE)::type_id::create("valid_leaf_pte");
     valid_link_pte = riscv_page_table_entry#(MODE)::type_id::create("valid_link_pte");
-    valid_data_leaf_pte = riscv_page_table_entry#(MODE)::type_id::create("valid_link_pte");
+    valid_data_leaf_pte = riscv_page_table_entry#(MODE)::type_id::create("valid_data_leaf_pte");
     illegal_pte = riscv_page_table_entry#(MODE)::type_id::create("illegal_pte");
   endfunction
 
@@ -101,8 +101,8 @@ class riscv_page_table_list#(satp_mode_t MODE = SV39) extends uvm_object;
   // higher level page table, only PTE[0] and PTE[1] is non-leaf PTE, all other PTEs are leaf
   // PTE. All leaf PTE should have PPN map to the real physical address of the instruction
   // or data. For non-leaf PTE, the PPN should map to the physical address of the next PTE.
-  // Take SV39 for example: (PTE_SIZE = 8B)
-  // Table size is 4KB, PTE_SIZE=8B, entry count = 4K/8 = 512
+  // Take SV39 for example: (PteSize = 8B)
+  // Table size is 4KB, PteSize=8B, entry count = 4K/8 = 512
   // Level 2: Root table, 2 entries, PTE[0] and PTE[1] is non-leaf PTE, PTE[2] is leaf PTE, all
   //          other PTEs are invalid, totalling 1 page table with 3 PTEs at this level.
   // Level 1: Two page tables, map to PTE[0] and PTE[1] of the root table.
@@ -130,10 +130,10 @@ class riscv_page_table_list#(satp_mode_t MODE = SV39) extends uvm_object;
       foreach(page_table[i].pte[j]) begin
         if(page_table[i].level > 0) begin
           // Superpage
-          if (j < LINK_PTE_PER_TABLE) begin
+          if (j < LinkPtePerTable) begin
             // First few super pages are link PTE to the next level
             $cast(page_table[i].pte[j], valid_link_pte.clone());
-          end else if (j < SUPER_LEAF_PTE_PER_TABLE + LINK_PTE_PER_TABLE) begin
+          end else if (j < SuperLeafPtePerTable + LinkPtePerTable) begin
             // Non-link superpage table entry
             $cast(page_table[i].pte[j], valid_leaf_pte.clone());
           end else begin
@@ -405,9 +405,9 @@ class riscv_page_table_list#(satp_mode_t MODE = SV39) extends uvm_object;
   endfunction
 
   virtual function void default_page_table_setting();
-    num_of_page_table = new[PAGE_LEVEL];
+    num_of_page_table = new[PageLevel];
     foreach(num_of_page_table[i]) begin
-      num_of_page_table[i] = LINK_PTE_PER_TABLE ** (PAGE_LEVEL - i - 1);
+      num_of_page_table[i] = LinkPtePerTable ** (PageLevel - i - 1);
     end
   endfunction
 
@@ -415,7 +415,7 @@ class riscv_page_table_list#(satp_mode_t MODE = SV39) extends uvm_object;
     page_table = new[num_of_page_table.sum()];
     foreach(page_table[i]) begin
       page_table[i] = riscv_page_table#(MODE)::type_id::create($sformatf("page_table_%0d",i));
-      page_table[i].init_page_table(PTE_CNT);
+      page_table[i].init_page_table(PteCnt);
       page_table[i].table_id = i;
       page_table[i].level = get_level(i);
     end
@@ -441,8 +441,8 @@ class riscv_page_table_list#(satp_mode_t MODE = SV39) extends uvm_object;
       instr = {instr, $sformatf("la x%0d, page_table_%0d+2048 # Process PT_%0d",
                                 cfg.gpr[1], i, i)};
       foreach(page_table[i].pte[j]) begin
-        if(j >= SUPER_LEAF_PTE_PER_TABLE) continue;
-        pte_addr_offset = (j * PTE_SIZE) - 2048;
+        if(j >= SuperLeafPtePerTable) continue;
+        pte_addr_offset = (j * PteSize) - 2048;
         `uvm_info(`gfn, $sformatf("Processing PT_%0d_PTE_%0d, v = %0d, level = %0d",
                         i, j, page_table[i].pte[j].v, page_table[i].level), UVM_LOW)
         if(page_table[i].pte[j].xwr == NEXT_LEVEL_PAGE) begin
@@ -531,14 +531,14 @@ class riscv_page_table_list#(satp_mode_t MODE = SV39) extends uvm_object;
   // If you want to create custom page table topology, override the below tasks to specify the
   // level and parent of each table.
   virtual function int get_level(int table_id);
-    for(int level = PAGE_LEVEL - 1; level >= 0; level--) begin
+    for(int level = PageLevel - 1; level >= 0; level--) begin
       if(table_id < num_of_page_table[level]) return level;
       table_id -= num_of_page_table[level];
     end
   endfunction
 
   virtual function int get_child_table_id(int table_id, int pte_id);
-    return table_id * LINK_PTE_PER_TABLE + pte_id + 1;
+    return table_id * LinkPtePerTable + pte_id + 1;
   endfunction
 
 endclass

--- a/vendor/google_riscv-dv/target/ml/riscvOVPsim.ic
+++ b/vendor/google_riscv-dv/target/ml/riscvOVPsim.ic
@@ -1,5 +1,5 @@
 # riscOVPsim configuration file converted from YAML
---variant RV64I
+--variant RVB64I
 --override riscvOVPsim/cpu/add_Extensions=MC
 --override riscvOVPsim/cpu/misa_MXL=2
 --override riscvOVPsim/cpu/misa_MXL_mask=0x0 # 0
@@ -17,3 +17,6 @@
 --override riscvOVPsim/cpu/time_undefined=T
 --override riscvOVPsim/cpu/reset_address=0x80000000
 --override riscvOVPsim/cpu/simulateexceptions=T
+--override riscvOVPsim/cpu/defaultsemihost=F
+--override riscvOVPsim/cpu/wfi_is_nop=T
+--exitonsymbol _exit

--- a/vendor/google_riscv-dv/target/rv32i/riscvOVPsim.ic
+++ b/vendor/google_riscv-dv/target/rv32i/riscvOVPsim.ic
@@ -1,5 +1,5 @@
 # riscOVPsim configuration file converted from YAML
---variant RV32I
+--variant RVB32I
 --override riscvOVPsim/cpu/misa_MXL=1
 --override riscvOVPsim/cpu/misa_MXL_mask=0x0 # 0
 --override riscvOVPsim/cpu/misa_Extensions_mask=0x0 # 0
@@ -16,3 +16,6 @@
 --override riscvOVPsim/cpu/time_undefined=T
 --override riscvOVPsim/cpu/reset_address=0x80000000
 --override riscvOVPsim/cpu/simulateexceptions=T
+--override riscvOVPsim/cpu/defaultsemihost=F
+--override riscvOVPsim/cpu/wfi_is_nop=T
+--exitonsymbol _exit

--- a/vendor/google_riscv-dv/target/rv32imc/riscvOVPsim.ic
+++ b/vendor/google_riscv-dv/target/rv32imc/riscvOVPsim.ic
@@ -1,5 +1,5 @@
 # riscOVPsim configuration file converted from YAML
---variant RV32I
+--variant RVB32I
 --override riscvOVPsim/cpu/add_Extensions=MC
 --override riscvOVPsim/cpu/misa_MXL=1
 --override riscvOVPsim/cpu/misa_MXL_mask=0x0 # 0
@@ -17,3 +17,6 @@
 --override riscvOVPsim/cpu/time_undefined=T
 --override riscvOVPsim/cpu/reset_address=0x80000000
 --override riscvOVPsim/cpu/simulateexceptions=T
+--override riscvOVPsim/cpu/defaultsemihost=F
+--override riscvOVPsim/cpu/wfi_is_nop=T
+--exitonsymbol _exit

--- a/vendor/google_riscv-dv/target/rv32imc/testlist.yaml
+++ b/vendor/google_riscv-dv/target/rv32imc/testlist.yaml
@@ -53,3 +53,14 @@
     +hint_instr_ratio=5
   rtl_test: core_base_test
 
+- test: riscv_pmp_test
+  description: >
+    Provide some PMP configuration parameters, and setup PMP CSRs appropriately
+  iterations: 2
+  gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +pmp_randomize=0
+    +pmp_num_regions=1
+    +pmp_granularity=1
+    +pmp_region_0=L:0,A:NAPOT,X=1,W=1,R=1,ADDR=0x090000000
+  rtl_test: core_base_test

--- a/vendor/google_riscv-dv/target/rv64gc/riscvOVPsim.ic
+++ b/vendor/google_riscv-dv/target/rv64gc/riscvOVPsim.ic
@@ -16,3 +16,6 @@
 --override riscvOVPsim/cpu/time_undefined=T
 --override riscvOVPsim/cpu/reset_address=0x80000000
 --override riscvOVPsim/cpu/simulateexceptions=T
+--override riscvOVPsim/cpu/defaultsemihost=F
+--override riscvOVPsim/cpu/wfi_is_nop=T
+--exitonsymbol _exit

--- a/vendor/google_riscv-dv/target/rv64gcv/riscvOVPsim.ic
+++ b/vendor/google_riscv-dv/target/rv64gcv/riscvOVPsim.ic
@@ -17,3 +17,6 @@
 --override riscvOVPsim/cpu/time_undefined=T
 --override riscvOVPsim/cpu/reset_address=0x80000000
 --override riscvOVPsim/cpu/simulateexceptions=T
+--override riscvOVPsim/cpu/defaultsemihost=F
+--override riscvOVPsim/cpu/wfi_is_nop=T
+--exitonsymbol _exit

--- a/vendor/google_riscv-dv/target/rv64imc/riscvOVPsim.ic
+++ b/vendor/google_riscv-dv/target/rv64imc/riscvOVPsim.ic
@@ -1,5 +1,5 @@
 # riscOVPsim configuration file converted from YAML
---variant RV64I
+--variant RVB64I
 --override riscvOVPsim/cpu/add_Extensions=MC
 --override riscvOVPsim/cpu/misa_MXL=2
 --override riscvOVPsim/cpu/misa_MXL_mask=0x0 # 0
@@ -17,3 +17,6 @@
 --override riscvOVPsim/cpu/time_undefined=T
 --override riscvOVPsim/cpu/reset_address=0x80000000
 --override riscvOVPsim/cpu/simulateexceptions=T
+--override riscvOVPsim/cpu/defaultsemihost=F
+--override riscvOVPsim/cpu/wfi_is_nop=T
+--exitonsymbol _exit

--- a/vendor/google_riscv-dv/verilog_style/build-verible.sh
+++ b/vendor/google_riscv-dv/verilog_style/build-verible.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERIBLE_VERSION=03c7102ab8ed63037159f479ce17b3487401f082
+INSTALL_DIR=/tools/verible
+
+# this requires the bazel build system and GCC7
+# see https://docs.bazel.build/versions/master/install-ubuntu.html
+
+echo "checking whether bazel is installed..."
+if which bazel; then
+  echo "OK"
+else
+  echo "bazel is not installed. installing bazel..."
+  sudo apt install curl -y
+  curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+  echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" \
+    | sudo tee /etc/apt/sources.list.d/bazel.list
+  sudo apt update && sudo apt install bazel -y
+fi
+
+# upgrade to GCC7
+# TODO: check whether we need to maintain the default symlinks here
+# for gcc -> GCC-5* such that other tools still work.
+echo "checking whether GCC7 is installed..."
+if which gcc-7; then
+  echo "OK"
+else
+  echo "Error: GCC7 is not installed. Exit and Verible isn't installed"
+  exit 0
+fi
+
+# get verible and install under /tools/verible
+# note: you may add $INSTALL_DIR to the PATH, but it is not
+# required for the run scripts to work.
+echo "Installing Verible ($VERIBLE_VERSION)..."
+
+mkdir -p build && cd build
+git clone https://github.com/google/verible.git
+cd verible
+git pull origin master
+git checkout $VERIBLE_VERSION
+
+bazel build --cxxopt='-std=c++17' //...
+bazel test --cxxopt='-std=c++17' //...
+
+sudo mkdir -p $INSTALL_DIR
+
+sudo install bazel-bin/verilog/tools/syntax/verilog_syntax $INSTALL_DIR
+sudo install bazel-bin/verilog/tools/formatter/verilog_format $INSTALL_DIR
+sudo install bazel-bin/verilog/tools/lint/verilog_lint $INSTALL_DIR
+
+echo "done"
+
+

--- a/vendor/google_riscv-dv/verilog_style/exclude_filelist.f
+++ b/vendor/google_riscv-dv/verilog_style/exclude_filelist.f
@@ -1,0 +1,10 @@
+# Current Verible can not support some syntax used in following files. List them here to exclude
+# from Verilog style check
+# tool does not support macro very well. Issue at github.com/google/verible/issues/102
+riscv_instr_cover_group.sv
+riscv_instr_pkg.sv
+# tool does not support included file very well. Issue at github.com/google/verible/issues/178
+riscv_custom_instr_enum.sv
+# tool bug. Issue at github.com/google/verible/issues/172
+riscv_instr_stream.sv
+riscv_reg.sv

--- a/vendor/google_riscv-dv/verilog_style/run.sh
+++ b/vendor/google_riscv-dv/verilog_style/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+find src/ -type f \( -name "*.sv" -o -name "*.svh" \) \
+  | grep -vFf ./verilog_style/exclude_filelist.f \
+  | xargs /tools/verible/verilog_lint --rules=-macro-name-style

--- a/vendor/google_riscv-dv/yaml/iss.yaml
+++ b/vendor/google_riscv-dv/yaml/iss.yaml
@@ -23,7 +23,6 @@
     <path_var>/riscvOVPsim.exe
     --controlfile <cfg_path>/riscvOVPsim.ic
     --objfilenoentry <elf>
-    --override riscvOVPsim/cpu/PMP_registers=0
     --override riscvOVPsim/cpu/simulateexceptions=T
     --trace --tracechange --traceshowicount --tracemode --traceregs
     --finishafter 1000000

--- a/vendor/google_riscv-dv/yaml/simulator.yaml
+++ b/vendor/google_riscv-dv/yaml/simulator.yaml
@@ -20,6 +20,7 @@
               +incdir+<user_extension>
              -f <cwd>/files.f -full64
              -l <out>/compile.log
+             -LDFLAGS '-Wl,--no-as-needed'
              -Mdir=<out>/vcs_simv.csrc
              -o <out>/vcs_simv <cmp_opts> <cov_opts> "
     cov_opts: >
@@ -42,7 +43,7 @@
               -l <out>/compile.log <cmp_opts>"
   sim:
     cmd: >
-      irun -R <sim_opts> -svseed <seed>
+      irun -R <sim_opts> -svseed <seed> -svrnc rand_struct
 
 - tool: questa
   compile:


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision 6bd323385d454858ea5e50dedd42a563b37931fe

* VCS compile option fix (Udi Jonnalagadda)
* Improve pmp config object - enable cmdline args (Udi Jonnalagadda)
* Fix ovpsim setting (google/riscv-dv#478) (taoliug)
* IUS - enable rand structs in simulation (google/riscv-dv#477)
  (udinator)
* fix macro definition compile issue (Udi Jonnalagadda)
* add ISS command line options (google/riscv-dv#474) (udinator)
* Add style check (Weicai Yang)

Signed-off-by: Udi <udij@google.com>