### PR TITLE
Separate 0x from hex number

### DIFF
--- a/dv/uvm/core_ibex/env/core_ibex_env_cfg.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_env_cfg.sv
@@ -32,7 +32,8 @@ class core_ibex_env_cfg extends uvm_object;
     void'($value$plusargs("max_interval=%0d", max_interval));
     void'($value$plusargs("require_signature_addr=%0d", require_signature_addr));
     void'($value$plusargs("signature_addr=%s", signature_addr_str));
-    if(signature_addr_str.substr(0,1)=="0x") signature_addr_str=signature_addr_str.substr(2,signature_addr_str.len()-1);
+    if(signature_addr_str.substr(0,1) == "0x") 
+      signature_addr_str = signature_addr_str.substr(2,signature_addr_str.len()-1);
     signature_addr = signature_addr_str.atohex();
   endfunction
 

--- a/dv/uvm/core_ibex/env/core_ibex_env_cfg.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_env_cfg.sv
@@ -32,6 +32,7 @@ class core_ibex_env_cfg extends uvm_object;
     void'($value$plusargs("max_interval=%0d", max_interval));
     void'($value$plusargs("require_signature_addr=%0d", require_signature_addr));
     void'($value$plusargs("signature_addr=%s", signature_addr_str));
+    if(signature_addr_str.substr(0,1)=="0x") signature_addr_str=signature_addr_str.substr(2,signature_addr_str.len()-1);
     signature_addr = signature_addr_str.atohex();
   endfunction
 


### PR DESCRIPTION
Hey!
I add `if` statement for separate `0x` from hex number, because when `0x` is argument of `atohex`, this function returns wrong number