### PR TITLE
Riscv-formal Verilog source

### DIFF
--- a/dv/uvm/core_ibex/env/core_ibex_rvfi_if.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_rvfi_if.sv
@@ -11,6 +11,7 @@ interface core_ibex_rvfi_if(input logic clk);
   logic        halt;
   logic        intr;
   logic [1:0]  mode;
+  logic [1:0]  ixl;
   logic [4:0]  rs1_addr;
   logic [4:0]  rs2_addr;
   logic [31:0] rs1_rdata;

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -78,6 +78,7 @@ module core_ibex_tb_top;
   assign rvfi_if.trap           = dut.rvfi_trap;
   assign rvfi_if.intr           = dut.rvfi_intr;
   assign rvfi_if.mode           = dut.rvfi_mode;
+  assign rvfi_if.ixl            = dut.rvfi_ixl;
   assign rvfi_if.rs1_addr       = dut.rvfi_rs1_addr;
   assign rvfi_if.rs2_addr       = dut.rvfi_rs2_addr;
   assign rvfi_if.rs1_rdata      = dut.rvfi_rs1_rdata;

--- a/formal/.gitignore
+++ b/formal/.gitignore
@@ -1,0 +1,2 @@
+build/
+ibex.v

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -1,0 +1,67 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Provide a convenient way to create a Verilog source of Ibex.
+# This is used by riscv-formal. See README.md for more details.
+
+IBEX_ENABLE_WB ?= 0
+
+# Name of the output file
+IBEX_OUT := ibex.v
+# Build folder name
+OUTDIR   := build
+# Source directory relative to this Makefile
+SRC_DIR  := ../rtl
+# Include directory relative to this Makefile
+INC_DIR  := ../shared/rtl
+
+# SystemVerilog sources of Ibex
+SRCS_SV ?= $(SRC_DIR)/ibex_alu.sv 		\
+        $(SRC_DIR)/ibex_compressed_decoder.sv 	\
+        $(SRC_DIR)/ibex_controller.sv 		\
+        $(SRC_DIR)/ibex_counters.sv     	\
+        $(SRC_DIR)/ibex_cs_registers.sv 	\
+        $(SRC_DIR)/ibex_decoder.sv 		\
+        $(SRC_DIR)/ibex_ex_block.sv 		\
+        $(SRC_DIR)/ibex_fetch_fifo.sv 		\
+        $(SRC_DIR)/ibex_id_stage.sv 		\
+        $(SRC_DIR)/ibex_if_stage.sv 		\
+        $(SRC_DIR)/ibex_load_store_unit.sv 	\
+        $(SRC_DIR)/ibex_multdiv_fast.sv 	\
+        $(SRC_DIR)/ibex_multdiv_slow.sv 	\
+        $(SRC_DIR)/ibex_prefetch_buffer.sv 	\
+        $(SRC_DIR)/ibex_pmp.sv 			\
+        $(SRC_DIR)/ibex_register_file_ff.sv 	\
+        $(SRC_DIR)/ibex_wb_stage.sv             \
+        $(SRC_DIR)/ibex_core.sv
+
+PKG ?= $(SRC_DIR)/ibex_pkg.sv
+PRIM ?= ../syn/rtl/prim_clock_gating.v
+
+GEN_V := $(patsubst %.sv,%.v,$(patsubst $(SRC_DIR)%,$(OUTDIR)%,$(SRCS_SV)))
+
+all: $(IBEX_OUT)
+
+verilog: $(GEN_V)
+
+$(OUTDIR):
+	mkdir -p $(OUTDIR)
+
+# Convert each SystemVerilog source into a Verilog file
+$(GEN_V): $(OUTDIR)%.v: $(SRC_DIR)%.sv $(PKG) $(INC_DIR) | $(OUTDIR)
+	sv2v --define=RISCV_FORMAL -I$(INC_DIR) $(PKG) \
+		$< > $@
+
+# Combine multiple Verilog sources into one Ibex Verilog file
+# Disable "M" extension
+$(IBEX_OUT): $(GEN_V) $(PRIM)
+	yosys -p "read_verilog -sv $(PRIM) $(GEN_V)"                          \
+                -p "chparam -set RV32M 0 ibex_core"                           \
+                -p "chparam -set WritebackStage $(IBEX_ENABLE_WB) ibex_core"  \
+                -p "synth -top ibex_core"                                     \
+                -p "write_verilog $(IBEX_OUT)"
+
+.PHONY: clean
+clean:
+	-rm -rf $(IBEX_OUT) $(OUTDIR)

--- a/formal/README.md
+++ b/formal/README.md
@@ -1,0 +1,36 @@
+# Formal
+
+**Unsupported Verilog source creation for RISC-V Formal Verification.**
+
+The Verilog source created here is used by [riscv-formal](https://github.com/SymbioticEDA/riscv-formal).
+
+Riscv-formal uses Yosys, but the SystemVerilog front-end of Yosys does not support all the language features used by Ibex.
+The `Makefile` provided here uses sv2v and Yosys to create a single Verilog source of Ibex.
+
+This flow has some similarities to [syn](../syn/README.md), but uses only a simplified subset.
+
+In order to make it easier to use with riscv-formal, the conversion is done with a simple `Makefile`.
+
+## Prerequisites
+
+Install the following, if not used with the container flow described in riscv-formal.
+
+  - [sv2v](https://github.com/zachjs/sv2v), best option is to use the latest version, but [packed arrays](https://github.com/zachjs/sv2v/commit/aea64e903cd0ff8e8437cae7f989e8bc29ac01a2) is required
+  - [Yosys](https://github.com/YosysHQ/yosys)
+
+## Limitations
+
+The "M" extension is currently disabled.
+
+## Usage
+
+It should not be necessary to create the Verilog source manually as it is used by the riscv-formal Ibex build system.
+
+Run the following command from the top level directory of Ibex to create the Verilog source.
+
+```console
+make -C formal
+```
+
+This will create a directory *formal/build* which contains an equivalent Verilog file for each SystemVerilog source.
+The single output file *formal/ibex.v* contains the complete Ibex source, which can then be imported by riscv-formal.

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -80,6 +80,7 @@ module ibex_core #(
     output logic        rvfi_halt,
     output logic        rvfi_intr,
     output logic [ 1:0] rvfi_mode,
+    output logic [ 1:0] rvfi_ixl,
     output logic [ 4:0] rvfi_rs1_addr,
     output logic [ 4:0] rvfi_rs2_addr,
     output logic [ 4:0] rvfi_rs3_addr,
@@ -959,6 +960,7 @@ module ibex_core #(
   logic        rvfi_stage_halt      [RVFI_STAGES-1:0];
   logic        rvfi_stage_intr      [RVFI_STAGES-1:0];
   logic [ 1:0] rvfi_stage_mode      [RVFI_STAGES-1:0];
+  logic [ 1:0] rvfi_stage_ixl       [RVFI_STAGES-1:0];
   logic [ 4:0] rvfi_stage_rs1_addr  [RVFI_STAGES-1:0];
   logic [ 4:0] rvfi_stage_rs2_addr  [RVFI_STAGES-1:0];
   logic [ 4:0] rvfi_stage_rs3_addr  [RVFI_STAGES-1:0];
@@ -984,6 +986,7 @@ module ibex_core #(
   assign rvfi_halt      = rvfi_stage_halt     [RVFI_STAGES-1];
   assign rvfi_intr      = rvfi_stage_intr     [RVFI_STAGES-1];
   assign rvfi_mode      = rvfi_stage_mode     [RVFI_STAGES-1];
+  assign rvfi_ixl       = rvfi_stage_ixl      [RVFI_STAGES-1];
   assign rvfi_rs1_addr  = rvfi_stage_rs1_addr [RVFI_STAGES-1];
   assign rvfi_rs2_addr  = rvfi_stage_rs2_addr [RVFI_STAGES-1];
   assign rvfi_rs3_addr  = rvfi_stage_rs3_addr [RVFI_STAGES-1];
@@ -1044,6 +1047,7 @@ module ibex_core #(
         rvfi_stage_order[i]     <= '0;
         rvfi_stage_insn[i]      <= '0;
         rvfi_stage_mode[i]      <= {PRIV_LVL_M};
+        rvfi_stage_ixl[i]       <= CSR_MISA_MXL;
         rvfi_stage_rs1_addr[i]  <= '0;
         rvfi_stage_rs2_addr[i]  <= '0;
         rvfi_stage_rs3_addr[i]  <= '0;
@@ -1071,6 +1075,7 @@ module ibex_core #(
             rvfi_stage_order[i]     <= rvfi_order + 64'(rvfi_valid);
             rvfi_stage_insn[i]      <= rvfi_insn_id;
             rvfi_stage_mode[i]      <= {priv_mode_id};
+            rvfi_stage_ixl[i]       <= CSR_MISA_MXL;
             rvfi_stage_rs1_addr[i]  <= rvfi_rs1_addr_d;
             rvfi_stage_rs2_addr[i]  <= rvfi_rs2_addr_d;
             rvfi_stage_rs3_addr[i]  <= rvfi_rs3_addr_d;
@@ -1095,6 +1100,7 @@ module ibex_core #(
             rvfi_stage_order[i]     <= rvfi_stage_order[i-1];
             rvfi_stage_insn[i]      <= rvfi_stage_insn[i-1];
             rvfi_stage_mode[i]      <= rvfi_stage_mode[i-1];
+            rvfi_stage_ixl[i]       <= rvfi_stage_ixl[i-1];
             rvfi_stage_rs1_addr[i]  <= rvfi_stage_rs1_addr[i-1];
             rvfi_stage_rs2_addr[i]  <= rvfi_stage_rs2_addr[i-1];
             rvfi_stage_rs3_addr[i]  <= rvfi_stage_rs3_addr[i-1];

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -1105,7 +1105,6 @@ module ibex_core #(
             rvfi_stage_rs1_rdata[i] <= rvfi_stage_rs1_rdata[i-1];
             rvfi_stage_rs2_rdata[i] <= rvfi_stage_rs2_rdata[i-1];
             rvfi_stage_rs3_rdata[i] <= rvfi_stage_rs3_rdata[i-1];
-            rvfi_stage_rd_addr[i]   <= rvfi_stage_rd_addr[i-1];
             rvfi_stage_mem_wdata[i] <= rvfi_stage_mem_wdata[i-1];
             rvfi_stage_mem_addr[i]  <= rvfi_stage_mem_addr[i-1];
 

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -1066,7 +1066,7 @@ module ibex_core #(
             rvfi_stage_halt[i]      <= '0;
             rvfi_stage_trap[i]      <= illegal_insn_id;
             rvfi_stage_intr[i]      <= rvfi_intr_d;
-            rvfi_stage_order[i]     <= rvfi_order + 64'(rvfi_valid);
+            rvfi_stage_order[i]     <= rvfi_stage_order[i] + 64'(rvfi_stage_valid_d[i]);
             rvfi_stage_insn[i]      <= rvfi_insn_id;
             rvfi_stage_mode[i]      <= {priv_mode_id};
             rvfi_stage_ixl[i]       <= CSR_MISA_MXL;

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -1080,7 +1080,7 @@ module ibex_core #(
             rvfi_stage_rs2_addr[i]  <= rvfi_rs2_addr_d;
             rvfi_stage_rs3_addr[i]  <= rvfi_rs3_addr_d;
             rvfi_stage_pc_rdata[i]  <= pc_id;
-            rvfi_stage_pc_wdata[i]  <= pc_if;
+            rvfi_stage_pc_wdata[i]  <= pc_set ? branch_target_ex : pc_if;
             rvfi_stage_mem_rmask[i] <= rvfi_mem_mask_int;
             rvfi_stage_mem_wmask[i] <= data_we_o ? rvfi_mem_mask_int : 4'b0000;
             rvfi_stage_rs1_rdata[i] <= rvfi_rs1_data_d;

--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -83,6 +83,7 @@ module ibex_core_tracing #(
   logic        rvfi_halt;
   logic        rvfi_intr;
   logic [ 1:0] rvfi_mode;
+  logic [ 1:0] rvfi_ixl;
   logic [ 4:0] rvfi_rs1_addr;
   logic [ 4:0] rvfi_rs2_addr;
   logic [ 4:0] rvfi_rs3_addr;
@@ -158,6 +159,7 @@ module ibex_core_tracing #(
     .rvfi_halt,
     .rvfi_intr,
     .rvfi_mode,
+    .rvfi_ixl,
     .rvfi_rs1_addr,
     .rvfi_rs2_addr,
     .rvfi_rs3_addr,
@@ -192,6 +194,7 @@ module ibex_core_tracing #(
     .rvfi_halt,
     .rvfi_intr,
     .rvfi_mode,
+    .rvfi_ixl,
     .rvfi_rs1_addr,
     .rvfi_rs2_addr,
     .rvfi_rs3_addr,

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -112,20 +112,19 @@ module ibex_cs_registers #(
   import ibex_pkg::*;
 
   // misa
-  localparam logic [1:0] MXL = 2'd1; // M-XLEN: XLEN in M-Mode for RV32
   localparam logic [31:0] MISA_VALUE =
-      (0           <<  0)  // A - Atomic Instructions extension
-    | (1           <<  2)  // C - Compressed extension
-    | (0           <<  3)  // D - Double precision floating-point extension
-    | (32'(RV32E)  <<  4)  // E - RV32E base ISA
-    | (0           <<  5)  // F - Single precision floating-point extension
-    | (32'(!RV32E) <<  8)  // I - RV32I/64I/128I base ISA
-    | (32'(RV32M)  << 12)  // M - Integer Multiply/Divide extension
-    | (0           << 13)  // N - User level interrupts supported
-    | (0           << 18)  // S - Supervisor mode implemented
-    | (1           << 20)  // U - User mode implemented
-    | (0           << 23)  // X - Non-standard extensions present
-    | (32'(MXL)    << 30); // M-XLEN
+      (0                 <<  0)  // A - Atomic Instructions extension
+    | (1                 <<  2)  // C - Compressed extension
+    | (0                 <<  3)  // D - Double precision floating-point extension
+    | (32'(RV32E)        <<  4)  // E - RV32E base ISA
+    | (0                 <<  5)  // F - Single precision floating-point extension
+    | (32'(!RV32E)       <<  8)  // I - RV32I/64I/128I base ISA
+    | (32'(RV32M)        << 12)  // M - Integer Multiply/Divide extension
+    | (0                 << 13)  // N - User level interrupts supported
+    | (0                 << 18)  // S - Supervisor mode implemented
+    | (1                 << 20)  // U - User mode implemented
+    | (0                 << 23)  // X - Non-standard extensions present
+    | (32'(CSR_MISA_MXL) << 30); // M-XLEN
 
   typedef struct packed {
     logic      mie;

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -148,6 +148,10 @@ module ibex_id_stage #(
     input  logic [31:0]               rf_rdata_a_i,
     output logic [4:0]                rf_raddr_b_o,
     input  logic [31:0]               rf_rdata_b_i,
+`ifdef RVFI
+    output logic                      rf_ren_a_o,
+    output logic                      rf_ren_b_o,
+`endif
 
     // Register file write (via writeback)
     output logic [4:0]                rf_waddr_id_o,
@@ -226,6 +230,11 @@ module ibex_id_stage #(
   rf_wd_sel_e  rf_wdata_sel;
   logic        rf_we_dec, rf_we_raw;
   logic        rf_ren_a, rf_ren_b;
+
+`ifdef RVFI
+  assign rf_ren_a_o = rf_ren_a;
+  assign rf_ren_b_o = rf_ren_b;
+`endif
 
   logic [31:0] rf_rdata_a_fwd;
   logic [31:0] rf_rdata_b_fwd;

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -443,6 +443,9 @@ parameter int unsigned CSR_MSTATUS_MPP_BIT_HIGH = 12;
 parameter int unsigned CSR_MSTATUS_MPRV_BIT     = 17;
 parameter int unsigned CSR_MSTATUS_TW_BIT       = 21;
 
+// CSR machine ISA
+parameter logic [1:0] CSR_MISA_MXL = 2'd1; // M-XLEN: XLEN in M-Mode for RV32
+
 // CSR interrupt pending/enable bits
 parameter int unsigned CSR_MSIX_BIT      = 3;
 parameter int unsigned CSR_MTIX_BIT      = 7;

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -46,6 +46,7 @@ module ibex_tracer (
   input logic        rvfi_halt,
   input logic        rvfi_intr,
   input logic [ 1:0] rvfi_mode,
+  input logic [ 1:0] rvfi_ixl,
   input logic [ 4:0] rvfi_rs1_addr,
   input logic [ 4:0] rvfi_rs2_addr,
   input logic [ 4:0] rvfi_rs3_addr,
@@ -72,6 +73,7 @@ module ibex_tracer (
   logic        unused_rvfi_halt = rvfi_halt;
   logic        unused_rvfi_intr = rvfi_intr;
   logic [ 1:0] unused_rvfi_mode = rvfi_mode;
+  logic [ 1:0] unused_rvfi_ixl = rvfi_ixl;
 
   import ibex_tracer_pkg::*;
 


### PR DESCRIPTION
Provide a conversion of SystemVerilog to Verilog for riscv-formal.

Update RVFI to include IXL (following upstream update). For this I made the local parameter MXL a global parameter CSR_MISA_MXL so it can be used in `ibex_core.sv`.

A new top level folder `formal` is used. This reflects the usage of `formal` in OpenTitan `hw`, instead of putting it into `dv/formal`.
The conversion is done with a Makefile and does not use FuseSoC, which is somewhat not good as the list for the source files is replicated, but this makes it easier to be used by riscv-formal.
It also stores output artifacts in `formal/build`. The intention here is to decouple it from the FuseSoC system, but I can see that it can also at some confusion.