### PR TITLE
Tiny docs fix in examples/simple_system

### DIFF
--- a/examples/simple_system/README.md
+++ b/examples/simple_system/README.md
@@ -61,9 +61,10 @@ file built as described above. Use
 `./examples/sw/simple_system/hello_test/hello_test.elf` to run the `hello_test`
 binary.
 
-Pass `-t` to get an FST trace of execution that be viewed with [GTKWave](http://gtkwave.sourceforge.net/)
-If using the `hello_test` binary the simulator will halt itself, outputting some
-simulation statistics:
+Pass `-t` to get an FST trace of execution that can be viewed with
+[GTKWave](http://gtkwave.sourceforge.net/). If using the `hello_test`
+binary the simulator will halt itself, outputting some simulation
+statistics:
 
 ```
 Simulation statistics


### PR DESCRIPTION
Missing "can" (which sounds a bit like a pirate!) and full stop.