### PR TITLE
Set the ELF entry point in simple system linker script

### DIFF
--- a/examples/sw/simple_system/common/link.ld
+++ b/examples/sw/simple_system/common/link.ld
@@ -16,12 +16,17 @@ _min_stack      = 0x2000;   /* 8K - minimum stack space to reserve */
 _stack_len     = LENGTH(stack);
 _stack_start   = ORIGIN(stack) + LENGTH(stack);
 
+_entry_point = _vectors_start + 0x80;
+ENTRY(_entry_point)
+
 SECTIONS
 {
     .vectors :
     {
         . = ALIGN(4);
+		_vectors_start = .;
         KEEP(*(.vectors))
+		_vectors_end = .;
     } > ram
 
     .text : {


### PR DESCRIPTION
This is part of work to run binaries created for the simple system
under Spike. Spike's default behaviour (after a weird 'rom' trampoline
at 0x1000) is to obey the entry point given in the ELF file. So let's
set it correctly.