### PR TITLE
[dv] Increase timeouts to fix failures

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -186,11 +186,11 @@ class core_ibex_debug_intr_basic_test extends core_ibex_base_test;
   endfunction
 
   virtual task wait_for_core_setup();
-    wait_for_csr_write(CSR_MSTATUS, 1000);
+    wait_for_csr_write(CSR_MSTATUS, 10000);
     core_init_mstatus = signature_data;
     // capture the initial privilege mode ibex will boot into
     init_operating_mode = priv_lvl_e'(core_init_mstatus[12:11]);
-    wait_for_csr_write(CSR_MIE, 500);
+    wait_for_csr_write(CSR_MIE, 5000);
     core_init_mie = signature_data;
     check_next_core_status(INITIALIZED, "Core initialization handshake failure", 500);
   endtask


### PR DESCRIPTION
I was seeing various failures due to these timeouts. Upon looking at the waves seems things were working fine it just needed more time to get to the store instructions that output the CSR info wait_for_csr_write is waiting for. So I added a large timeout increase here (it'll still die pretty quickly if we actually need the timeout).

Surprised this has only just become an issue, perhaps we're seeing a greater range of delays on the iside interface so the instruction sequence leading up to the SW that outputs what we're waiting for takes longer?