### PR TITLE
Verilator warnings

### DIFF
--- a/dv/riscv_compliance/ibex_riscv_compliance.core
+++ b/dv/riscv_compliance/ibex_riscv_compliance.core
@@ -18,6 +18,11 @@ filesets:
       - rtl/riscv_testutil.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    files:
+      - lint/verilator_waiver.vlt: {file_type: vlt}
+
+
 parameters:
   RV32M:
     datatype: int
@@ -39,6 +44,7 @@ targets:
   sim:
     default_tool: verilator
     filesets:
+      - tool_verilator ? (files_verilator_waiver)
       - files_sim_verilator
     parameters:
       - RV32M

--- a/dv/riscv_compliance/lint/verilator_waiver.vlt
+++ b/dv/riscv_compliance/lint/verilator_waiver.vlt
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Lint waivers for processing riscv_compliance RTL with Verilator
+//
+// This should be used for rules applying to things like testbench
+// top-levels. For rules that apply to the actual design (files in the
+// 'rtl' directory), see verilator_waiver_rtl.vlt in the same
+// directory.
+//
+// See https://www.veripool.org/projects/verilator/wiki/Manual-verilator#CONFIGURATION-FILES
+// for documentation.
+//
+// Important: This file must included *before* any other Verilog file is read.
+// Otherwise, only global waivers are applied, but not file-specific waivers.
+
+`verilator_config
+
+// We have some boolean top-level parameters in e.g. simple_system.sv.
+// When building with fusesoc, these get set with defines like
+// -GRV32M=1 (rather than -GRV32M=1'b1), leading to warnings like:
+//
+//   Operator VAR '<varname>' expects 1 bits on the Initial value, but
+//   Initial value's CONST '32'h1' generates 32 bits.
+//
+// This signoff rule ignores errors like this. Note that it only
+// matches when you set a 1-bit value to a literal 1, so it won't hide
+// silly mistakes like setting it to 2.
+//
+lint_off -rule WIDTH -file "*/rtl/ibex_riscv_compliance.sv"
+         -match "*expects 1 bits*Initial value's CONST '32'h1'*"

--- a/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
+++ b/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
@@ -15,9 +15,9 @@ module ibex_riscv_compliance (
   input IO_RST_N
 );
 
-  parameter bit RV32E           = 0;
-  parameter bit RV32M           = 1;
-  parameter bit BranchTargetALU = 0;
+  parameter bit RV32E           = 1'b0;
+  parameter bit RV32M           = 1'b1;
+  parameter bit BranchTargetALU = 1'b0;
 
   logic clk_sys, rst_sys_n;
 

--- a/dv/riscv_compliance/rtl/riscv_testutil.sv
+++ b/dv/riscv_compliance/rtl/riscv_testutil.sv
@@ -90,8 +90,17 @@ module riscv_testutil (
     end
   end
 
-  // only word writes are supported
-  assign dev_err_o = (~dev_we_i | dev_be_i != 4'hf) & dev_req_i;
+  // The interface is write-only, and only supports 32-bit writes. If
+  // either of these checks fails, raise dev_err_o on the next cycle.
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      dev_err_o <= 1'b0;
+    end else begin
+      dev_err_o <= (~dev_we_i | dev_be_i != 4'hf) & dev_req_i;
+    end
+  end
+
+  // Since the interface is write-only, tie rdata to 0.
   assign dev_rdata_o = 32'h0;
 
 

--- a/dv/riscv_compliance/rtl/riscv_testutil.sv
+++ b/dv/riscv_compliance/rtl/riscv_testutil.sv
@@ -106,8 +106,6 @@ module riscv_testutil (
   logic [31:0] read_addr_d, read_addr_q;
   always_comb begin
     state_d = state_q;
-    host_req_o = 1'b0;
-
     unique case (state_q)
       WAIT: begin
         if (read_signature_and_terminate) begin
@@ -119,8 +117,6 @@ module riscv_testutil (
       end
 
       READ: begin
-        host_req_o = 1'b1;
-        host_addr_o = read_addr_q;
         if (host_gnt_i) begin
           read_addr_d = read_addr_q + 4;
           if (read_addr_d == end_signature_addr_q) begin
@@ -141,6 +137,11 @@ module riscv_testutil (
       end
     endcase
   end
+
+  // These are the address and read request bits, respectively of the
+  // TestUtilHost master port.
+  assign host_addr_o = read_addr_q;
+  assign host_req_o = (state_q == READ);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin

--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -17,6 +17,11 @@ filesets:
       - ibex_simple_system.cc: { file_type: cppSource }
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    files:
+      - lint/verilator_waiver.vlt: {file_type: vlt}
+
+
 parameters:
   RV32M:
     datatype: int
@@ -42,6 +47,7 @@ targets:
   sim:
     default_tool: verilator
     filesets:
+      - tool_verilator ? (files_verilator_waiver)
       - files_sim_verilator
     parameters:
       - RV32M

--- a/examples/simple_system/lint/verilator_waiver.vlt
+++ b/examples/simple_system/lint/verilator_waiver.vlt
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Lint waivers for processing simple_system RTL with Verilator
+//
+// This should be used for rules applying to things like testbench
+// top-levels. For rules that apply to the actual design (files in the
+// 'rtl' directory), see verilator_waiver_rtl.vlt in the same
+// directory.
+//
+// See https://www.veripool.org/projects/verilator/wiki/Manual-verilator#CONFIGURATION-FILES
+// for documentation.
+//
+// Important: This file must included *before* any other Verilog file is read.
+// Otherwise, only global waivers are applied, but not file-specific waivers.
+
+`verilator_config
+
+// We have some boolean top-level parameters in e.g. simple_system.sv.
+// When building with fusesoc, these get set with defines like
+// -GRV32M=1 (rather than -GRV32M=1'b1), leading to warnings like:
+//
+//   Operator VAR '<varname>' expects 1 bits on the Initial value, but
+//   Initial value's CONST '32'h1' generates 32 bits.
+//
+// This signoff rule ignores errors like this. Note that it only
+// matches when you set a 1-bit value to a literal 1, so it won't hide
+// silly mistakes like setting it to 2.
+//
+lint_off -rule WIDTH -file "*/rtl/ibex_simple_system.sv"
+         -match "*expects 1 bits*Initial value's CONST '32'h1'*"

--- a/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/examples/simple_system/rtl/ibex_simple_system.sv
@@ -18,9 +18,9 @@ module ibex_simple_system (
   input IO_RST_N
 );
 
-  parameter bit RV32E           = 0;
-  parameter bit RV32M           = 1;
-  parameter bit BranchTargetALU = 0;
+  parameter bit RV32E           = 1'b0;
+  parameter bit RV32M           = 1'b1;
+  parameter bit BranchTargetALU = 1'b0;
 
   logic clk_sys = 1'b0, rst_sys_n;
 


### PR DESCRIPTION
Fix a few last verilator warnings. The first two patches are just waivers. The third seems to be an actual bug.