### PR TITLE
Improvements in ibex_log_to_trace_csv.py

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/ibex_log_to_trace_csv.py
+++ b/dv/uvm/core_ibex/riscv_dv_extension/ibex_log_to_trace_csv.py
@@ -145,30 +145,36 @@ def check_ibex_uvm_log(uvm_log, core_name, test_name, report, write=True):
       signature
 
     """
-    pass_cnt = 0
-    fail_cnt = 0
+    passed = False
+    failed = False
+
     with open(uvm_log, "r") as log:
         for line in log:
             if 'RISC-V UVM TEST PASSED' in line:
-                pass_cnt += 1
+                passed = True
+
+            if 'RISC-V UVM TEST FAILED' in line:
+                failed = True
                 break
-            elif 'RISC-V UVM TEST FAILED' in line:
-                fail_cnt += 1
-                break
+
+    # If we saw PASSED and FAILED, that's a bit odd. But we should treat the
+    # test as having failed.
+    if failed:
+        passed = False
 
     if write:
         fd = open(report, "a+") if report else sys.stdout
 
         fd.write("%s uvm log : %s\n" % (core_name, uvm_log))
-        if pass_cnt == 1:
+        if passed:
             fd.write("%s : [PASSED]\n\n" % test_name)
-        elif fail_cnt == 1:
+        elif failed:
             fd.write("%s : [FAILED]\n\n" % test_name)
 
         if report:
             fd.close()
 
-    return pass_cnt == 1
+    return passed
 
 
 def main():

--- a/dv/uvm/core_ibex/riscv_dv_extension/ibex_log_to_trace_csv.py
+++ b/dv/uvm/core_ibex/riscv_dv_extension/ibex_log_to_trace_csv.py
@@ -5,13 +5,25 @@
 # Convert ibex log to the standard trace CSV format
 
 import argparse
+import os
 import re
 import sys
 
-sys.path.insert(0, "../../vendor/google_riscv-dv/scripts")
+_IBEX_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__),
+                                           '../../../..'))
+_DV_SCRIPTS = os.path.join(_IBEX_ROOT, 'vendor/google_riscv-dv/scripts')
+_OLD_SYS_PATH = sys.path
 
-from riscv_trace_csv import *
-from lib import *
+# Import riscv_trace_csv and lib from _DV_SCRIPTS before putting sys.path back
+# as it started.
+try:
+    sys.path.insert(0, _DV_SCRIPTS)
+
+    from riscv_trace_csv import *
+    from lib import *
+
+finally:
+    sys.path = _OLD_SYS_PATH
 
 
 INSTR_RE = re.compile(r"^\s*(?P<time>\d+)\s+(?P<cycle>\d+)\s+(?P<pc>[0-9a-f]+)\s+" \


### PR DESCRIPTION
This is a sequence of patches spurred on by the work I'm doing trying to make it easy to run simple_system binaries with Spike and then compare trace logs with Ibex.

The first patch fixes a simple bug (it wasn't possible to run the Python script except from directories exactly two components below the ibex root).

The second patch makes the command line interface a bit nicer (relevant to me, because that's how I'm running it!). Now, running without any arguments converts data from stdin to stdout (rather than exploding with a mysterious error).

The final two patches tidy things up in general, getting the code PEP8 compliant and simplifying log checking. Honestly, this is mostly just indentation changes, but there were also some dead variables to delete and I made imports explicit (which allows static analysis tools to spot when you mis-speled a variable name).