### PR TITLE
[syn] Synthesis fixes

### DIFF
--- a/syn/ibex_core_abc.nangate.sdc
+++ b/syn/ibex_core_abc.nangate.sdc
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-set_driving_cell [all_inputs] -lib_cell BUF_X2
+set_driving_cell BUF_X2
 set_load 10.0 [all_outputs]

--- a/syn/tcl/lr_synth_flow_var_setup.tcl
+++ b/syn/tcl/lr_synth_flow_var_setup.tcl
@@ -21,6 +21,7 @@ if { $lr_synth_timing_run } {
   set_flow_var cell_library_name "nangate" "Name of cell library"
   #set_flow_var sdc_file "${top_module}.sdc" "SDC file"
   set_flow_var sdc_file_in "${lr_synth_top_module}.${lr_synth_cell_library_name}.sdc" "Input SDC file"
+  set_flow_var abc_sdc_file_in "${lr_synth_top_module}_abc.${lr_synth_cell_library_name}.sdc" "Input SDC file for ABC"
   set flop_in_pin_default "*/D"
   set flop_out_pin_default "*/Q"
 

--- a/syn/tcl/yosys_run_synth.tcl
+++ b/syn/tcl/yosys_run_synth.tcl
@@ -31,7 +31,7 @@ yosys "opt"
 set yosys_abc_clk_period [expr $lr_synth_clk_period - $lr_synth_abc_clk_uprate]
 
 if { $lr_synth_timing_run } {
-  yosys "abc -liberty $lr_synth_cell_library_path -constr $lr_synth_sdc_file_out -D $yosys_abc_clk_period"
+  yosys "abc -liberty $lr_synth_cell_library_path -constr $lr_synth_abc_sdc_file_in -D $yosys_abc_clk_period"
 } else {
   yosys "abc -liberty $lr_synth_cell_library_path"
 }
@@ -43,7 +43,7 @@ if { $lr_synth_timing_run } {
   # Produce netlist that OpenSTA can use
   yosys "setundef -zero"
   yosys "splitnets"
-
+  yosys "clean"
   yosys "write_verilog -noattr -noexpr -nohex -nodec $lr_synth_sta_netlist_out"
 }
 


### PR DESCRIPTION
Correcting some small issues that cause newer versions of OpenSTA to
fail (previously it issued an error and continued).

- ABC/OpenSTA disagree how set_driving_cell command works so introduce
  seperate ABC SDC file
- Run clean before generating STA netlist, otherwise yosys generates
  some assignements to unused wires that OpenSTA's verilog parser dislikes