### PR TITLE
Re-instate an 0x in dv/uvm/core_ibex/Makefile

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -106,7 +106,7 @@ TEST_OPTS := $(COMMON_OPTS) \
 # Options used for privileged CSR test generation
 CSR_OPTS=--csr_yaml=${CSR_FILE} \
          --isa="${ISA}" \
-         --end_signature_addr=${SIGNATURE_ADDR}
+         --end_signature_addr=0x${SIGNATURE_ADDR}
 
 RISCV_DV_OPTS=--custom_target=${DV_DIR}/riscv_dv_extension \
               --isa="${ISA}" \


### PR DESCRIPTION
The --end_signature_addr argument doesn't go to Verilog; instead it
makes it through run.py (vendored-in, so hard to change) and
eventually gets inserted into some assembly code.

Before this patch,

    make ITERATIONS=1 TEST=riscv_csr_test ISS=spike SEED=123

failed with:

  out/seed-123/instr_gen/asm_tests/riscv_csr_test_0.S: Assembler messages:
  out/seed-123/instr_gen/asm_tests/riscv_csr_test_0.S:526: Error: illegal operands `li x2,8ffffffc'
  out/seed-123/instr_gen/asm_tests/riscv_csr_test_0.S:533: Error: illegal operands `li x2,8ffffffc'