### PR TITLE
[ml] add condensed test targets for ML (and constraints)

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/ml_testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/ml_testlist.yaml
@@ -30,6 +30,29 @@
 # gcc_opts        : gcc compile options
 # --------------------------------------------------------------------------------
 
+
+# --------------------------------------------------------------------------------
+# ML Parameter Constraints - riscv_rand_test
+# --------------------------------------------------------------------------------
+# A description of each generation parameter can be found in the 'Configuration'
+# section of the RISC-DV documentation
+# (https://github.com/google/riscv-dv/blob/master/docs/source/configuration.rst)
+#
+# This section will provide some constraints that must be placed on the main
+# parameter set for the riscv_rand_test to avoid failures or unexpected results
+# These constraints apply to every test that is written or used.
+# --------------------------------------------------------------------------------
+# 1)  +no_wfi must be 1 to prevent the core from hanging during tests.
+# 2)  if +no_directed_instr is 1, any directed instruction streams specified by the
+#     +stream_name_... parameters will be ignored and will not be generated.
+# 3)  +no_data_page must be 0 (default) if there are any directed streams
+#     involving memory loads and stores.
+# 4)  The +enable_misaligned_instr parameter is only used by the riscv_jal_instr
+#     directed stream, and will have no effect if this stream is disabled.
+# 5)  The +enable_unaligned_load_store parameter is only used by load/store
+#     directed instruction streams, and will have no effect if these streams
+#     are disabled.
+
 - test: riscv_rand_test
   description: >
     Random test with all useful knobs
@@ -38,6 +61,24 @@
     +num_of_sub_program=5
     +illegal_instr_ratio=5
     +hint_instr_ratio=5
+    +no_ebreak=0
+    +no_dret=0
+    +no_wfi=1
+    +set_mstatus_tw=0
+    +no_branch_jump=0
+    +no_csr_instr=0
+    +fix_sp=0
+    +enable_illegal_csr_instruction=0
+    +enable_access_invalid_csr_level=0
+    +enable_misaligned_instr=0
+    +enable_dummy_csr_write=0
+    +no_data_page=0
+    +no_directed_instr=0
+    +no_fence=0
+    +enable_unaligned_load_store=1
+    +disable_compressed_instr=0
+    +randomize_csr=0
+    +boot_mode=u
     +stream_name_0=riscv_load_store_rand_instr_stream
     +stream_freq_0=4
     +stream_name_1=riscv_loop_instr
@@ -52,16 +93,193 @@
     +stream_freq_5=4
     +stream_name_6=riscv_int_numeric_corner_stream
     +stream_freq_6=4
-    +dist_control_mode=1
-    +dist_shift=10
-    +dist_arithmetic=10
-    +dist_logical=10
-    +dist_compare=10
-    +dist_branch=10
-    +dist_synch=10
-    +dist_csr=10
+    +stream_name_7=riscv_multi_page_load_store_instr_stream
+    +stream_freq_7=4
+    +stream_name_8=riscv_load_store_rand_addr_instr_stream
+    +stream_freq_8=4
+    +stream_name_9=riscv_single_load_store_instr_stream
+    +stream_freq_9=4
+    +stream_name_10=riscv_load_store_stress_instr_stream
+    +stream_freq_10=4
   iterations: 1
   gcc_opts: >
     -mno-strict-align
   gen_test: riscv_ml_test
   rtl_test: core_ibex_base_test
+
+
+# --------------------------------------------------------------------------------
+# ML Parameter Constraints - riscv_rand_debug_test
+# --------------------------------------------------------------------------------
+# A description of each generation parameter can be found in the 'Configuration'
+# section of the RISC-DV documentation
+# (https://github.com/google/riscv-dv/blob/master/docs/source/configuration.rst)
+#
+# This section will provide some constraints that must be placed on the set of
+# parameters relating to debug ROM generation and RTL simulation to avoid
+# failures or unexpected results.
+# --------------------------------------------------------------------------------
+# 1)  +require_signature_address must be 1.
+# 2)  If +gen_debug_section is 0, none of the values of the other debug ROM
+#     parameters will matter.
+# 3)  At most 1 of the parameters +enable_ebreak_in_debug_rom, +set_dcsr_ebreak,
+#     and +enable_debug_single_step may be enabled at once.
+# 4)  +illegal_instr_ratio must be 0.
+# 5)  +no_ebreak and +no_dret must be 1.
+# 6)  +set_mstatus_tw must be 0.
+# 7)  The RTL simulation plusarg +require_signature_addr under the sim_opts
+#     section of the test entry must be enabled.
+# 8)  The RTL simulation plusarg +enable_debug_seq must be enabled.
+# 9)  The RTL simulation plusarg +max_interval controls the maximum interval
+#     between debug request assertions.
+#     NOTE: keep this value very large for the time being.
+# 10) While not a constraint, it is recommended to keep +num_debug_sub_program
+#     fairly small, as larger values can easily cause frequent test timeouts.
+
+- test: riscv_rand_debug_test
+  description: >
+    Random debug test with all useful knobs
+  gen_opts: >
+    +require_signature_addr=1
+    +gen_debug_section=1
+    +num_debug_sub_program=1
+    +enable_ebreak_in_debug_rom=0
+    +set_dcsr_ebreak=0
+    +enable_debug_single_step=1
+    +instr_cnt=10000
+    +num_of_sub_program=5
+    +illegal_instr_ratio=0
+    +hint_instr_ratio=5
+    +no_ebreak=1
+    +no_dret=1
+    +no_wfi=0
+    +set_mstatus_tw=0
+    +no_branch_jump=0
+    +no_load_store=0
+    +no_csr_instr=0
+    +fix_sp=0
+    +enable_illegal_csr_instruction=0
+    +enable_access_invalid_csr_level=0
+    +enable_misaligned_instr=1
+    +enable_dummy_csr_write=0
+    +no_data_page=0
+    +no_directed_instr=0
+    +no_fence=0
+    +enable_unaligned_load_store=1
+    +disable_compressed_instr=0
+    +randomize_csr=0
+    +boot_mode=u
+    +stream_name_0=riscv_load_store_rand_instr_stream
+    +stream_freq_0=4
+    +stream_name_1=riscv_loop_instr
+    +stream_freq_1=4
+    +stream_name_2=riscv_hazard_instr_stream
+    +stream_freq_2=4
+    +stream_name_3=riscv_load_store_hazard_instr_stream
+    +stream_freq_3=4
+    +stream_name_4=riscv_mem_region_stress_test
+    +stream_freq_4=4
+    +stream_name_5=riscv_jal_instr
+    +stream_freq_5=4
+    +stream_name_6=riscv_int_numeric_corner_stream
+    +stream_freq_6=4
+    +stream_name_7=riscv_multi_page_load_store_instr_stream
+    +stream_freq_7=4
+    +stream_name_8=riscv_load_store_rand_addr_instr_stream
+    +stream_freq_8=4
+    +stream_name_9=riscv_single_load_store_instr_stream
+    +stream_freq_9=4
+    +stream_name_10=riscv_load_store_stress_instr_stream
+    +stream_freq_10=4
+  iterations: 1
+  gcc_opts: >
+    -mno-strict-align
+  gen_test: riscv_ml_test
+  sim_opts: >
+    +require_signature_addr=1
+    +max_interval=100000
+    +enable_debug_seq=1
+  rtl_test: core_ibex_debug_intr_basic_test
+
+
+# --------------------------------------------------------------------------------
+# ML Parameter Constraints - riscv_rand_irq_test
+# --------------------------------------------------------------------------------
+# A description of each generation parameter can be found in the 'Configuration'
+# section of the RISC-DV documentation
+# (https://github.com/google/riscv-dv/blob/master/docs/source/configuration.rst)
+#
+# This section will provide some constraints that must be placed on the set of
+# parameters relating to simulations with external interrupts.
+# --------------------------------------------------------------------------------
+# 1)  +enable_interrupt and +require_signature_addr must both be 1.
+# 2)  If using Spike ISS, +enable_timer_irq must be 0, otherwise it can be
+#     randomized at will.
+# 3)  As before, +illegal_instr_ratio must be 0, +no_ebreak must be 1,
+#     and +no_dret must be 1.
+# 4)  +set_mstatus_tw must be 0.
+# 3)  One of the RTL simulation options +enable_irq_single_seq or
+#     +enable_irq_multiple_seq must be enabled.
+# 4)  The RTL simulation option +require_signature_addr must be 1.
+
+- test: riscv_rand_irq_test
+  description: >
+    Random test with all useful knobs
+  gen_opts: >
+    +require_signature_addr=1
+    +enable_interrupt=1
+    +enable_timer_irq=1
+    +instr_cnt=10000
+    +num_of_sub_program=5
+    +illegal_instr_ratio=0
+    +hint_instr_ratio=5
+    +no_ebreak=1
+    +no_dret=1
+    +no_wfi=0
+    +set_mstatus_tw=0
+    +no_branch_jump=0
+    +no_load_store=0
+    +no_csr_instr=0
+    +fix_sp=0
+    +enable_illegal_csr_instruction=0
+    +enable_access_invalid_csr_level=0
+    +enable_misaligned_instr=1
+    +enable_dummy_csr_write=0
+    +no_data_page=0
+    +no_directed_instr=0
+    +no_fence=0
+    +enable_unaligned_load_store=1
+    +disable_compressed_instr=0
+    +randomize_csr=1
+    +boot_mode=u
+    +stream_name_0=riscv_load_store_rand_instr_stream
+    +stream_freq_0=4
+    +stream_name_1=riscv_loop_instr
+    +stream_freq_1=4
+    +stream_name_2=riscv_hazard_instr_stream
+    +stream_freq_2=4
+    +stream_name_3=riscv_load_store_hazard_instr_stream
+    +stream_freq_3=4
+    +stream_name_4=riscv_mem_region_stress_test
+    +stream_freq_4=4
+    +stream_name_5=riscv_jal_instr
+    +stream_freq_5=4
+    +stream_name_6=riscv_int_numeric_corner_stream
+    +stream_freq_6=4
+    +stream_name_7=riscv_multi_page_load_store_instr_stream
+    +stream_freq_7=4
+    +stream_name_8=riscv_load_store_rand_addr_instr_stream
+    +stream_freq_8=4
+    +stream_name_9=riscv_single_load_store_instr_stream
+    +stream_freq_9=4
+    +stream_name_10=riscv_load_store_stress_instr_stream
+    +stream_freq_10=4
+  iterations: 1
+  gcc_opts: >
+    -mno-strict-align
+  gen_test: riscv_ml_test
+  sim_opts: >
+    +require_signature_addr=1
+    +enable_irq_single_seq=1
+    +enable_irq_multiple_seq=0
+  rtl_test: core_ibex_debug_intr_basic_test

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -12,7 +12,7 @@ class core_ibex_base_test extends uvm_test;
   mem_model_pkg::mem_model                        mem;
   core_ibex_vseq                                  vseq;
   bit                                             enable_irq_seq;
-  int unsigned                                    timeout_in_cycles = 10000000;
+  int unsigned                                    timeout_in_cycles = 100000000;
   // If no signature_addr handshake functionality is desired between the testbench and the generated
   // code, the test will wait for the specifield number of cycles before starting stimulus
   // sequences (irq and debug)

--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -316,7 +316,7 @@ class core_ibex_debug_intr_basic_test extends core_ibex_base_test;
         forever begin
           wait_for_core_status(IN_DEBUG_MODE);
           check_priv_mode(PRIV_LVL_M);
-          wait_ret("dret", 20000);
+          wait_ret("dret", 100000);
         end
       end
     join_none


### PR DESCRIPTION
Currently only the riscv_rand_test target fully works with RTL simulation, the other two test targets both fail RTL simulation due to some testbench error, which I think was introduced by a previous commit, will debug this issue.

Signed-off-by: Udi <udij@google.com>