### PR TITLE
Revert "Re-instate an 0x in dv/uvm/core_ibex/Makefile"

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -106,7 +106,7 @@ TEST_OPTS := $(COMMON_OPTS) \
 # Options used for privileged CSR test generation
 CSR_OPTS=--csr_yaml=${CSR_FILE} \
          --isa="${ISA}" \
-         --end_signature_addr=0x${SIGNATURE_ADDR}
+         --end_signature_addr=${SIGNATURE_ADDR}
 
 RISCV_DV_OPTS=--custom_target=${DV_DIR}/riscv_dv_extension \
               --isa="${ISA}" \


### PR DESCRIPTION
This reverts commit c32a088f0cd0bdf903d38eb9772e55fd670e08cb.

The bug fixed by this was also fixed in riscv-dv leading to two 0x being
inserted into generated .S files.

Fixes #661

I felt it was better to fix this in Ibex rather than attempting to revert things in the riscv-dv repository as there will be other downstream users effected by changes there.