### PR TITLE
Update google_riscv-dv to google/riscv-dv@3f584ad

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: 6344e951fef22b383551a85365ebb7d6aa74eb34
+    rev: 3f584adef07b7f04edda8a6ba1dfc01a14df5d98
   }
 }

--- a/vendor/google_riscv-dv/test/riscv_instr_test_lib.sv
+++ b/vendor/google_riscv-dv/test/riscv_instr_test_lib.sv
@@ -48,13 +48,12 @@ class riscv_ml_test extends riscv_instr_base_test;
 
   virtual function void randomize_cfg();
     cfg.no_fence = 0;
-    cfg.no_ebreak = 0;
     cfg.init_privileged_mode = MACHINE_MODE;
     cfg.init_privileged_mode.rand_mode(0);
     cfg.enable_unaligned_load_store = 1'b1;
     cfg.addr_translaction_rnd_order_c.constraint_mode(0);
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
-	cfg.addr_translaction_rnd_order_c.constraint_mode(1);
+    cfg.addr_translaction_rnd_order_c.constraint_mode(1);
     `uvm_info(`gfn, $sformatf("riscv_instr_gen_config is randomized:\n%0s",
                     cfg.sprint()), UVM_LOW)
   endfunction


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision 3f584adef07b7f04edda8a6ba1dfc01a14df5d98

* update ebreak generation for ML test (Udi Jonnalagadda)

Signed-off-by: Udi <udij@google.com>