### PR TITLE
update riscvOVPsim.ic for semihosting mode

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/riscvOVPsim.ic
+++ b/dv/uvm/core_ibex/riscv_dv_extension/riscvOVPsim.ic
@@ -17,5 +17,6 @@
 --override riscvOVPsim/cpu/time_undefined=F
 --override riscvOVPsim/cpu/reset_address=0x80000080
 --override riscvOVPsim/cpu/simulateexceptions=T
+--override riscvOVPsim/cpu/defaultsemihost=F
 --override riscvOVPsim/cpu/wfi_is_nop=T
 --override riscvOVPsim/cpu/tval_ii_code=T


### PR DESCRIPTION
This PR updates the riscvOVPsim ISS configuration file to disable the semihosting mode, otherwise EBREAK instructions will cause end of test to be reached.

Signed-off-by: Udi <udij@google.com>