### PR TITLE
Add Verible lint and format to fusesoc and CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,6 +128,19 @@ jobs:
     displayName: Lint Verilog source files with Verible (experimental)
 
   - bash: |
+      fusesoc --cores-root . run --no-export --target=format --tool=veribleformat lowrisc:ibex:ibex_core_tracing
+      if [ $? != 0 ]; then
+        echo -n "##vso[task.logissue type=error]"
+        echo "Verilog format with Verible failed. Run 'fusesoc --cores-root . run --no-export --target=format --tool=veribleformat lowrisc:ibex:ibex_core_tracing' to check and fix all errors."
+        echo "This flow is currently experimental and failures can be ignored."
+      fi
+      # Show diff of what verilog_format would have changed, and then revert.
+      git diff
+      git reset --hard HEAD
+    continueOnError: true
+    displayName: Format all source code with Verible format (experimental)
+
+  - bash: |
       fork_origin=$(git merge-base --fork-point origin/master)
       changed_files=$(git diff --name-only $fork_origin | grep -v '^vendor' | grep -E '\.(cpp|cc|c|h)$')
       test -z "$changed_files" || git diff -U0 $fork_origin $changed_files | clang-format-diff -p1 | tee clang-format-output

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ variables:
   VERILATOR_PATH: /opt/buildcache/verilator/$(VERILATOR_VERSION)
   RISCV_TOOLCHAIN_TAR_VERSION: 20190807-1
   RISCV_COMPLIANCE_GIT_VERSION: 844c6660ef3f0d9b96957991109dfd80cc4938e2
+  VERIBLE_VERSION: v0.0-266-g9e55307
 
 trigger:
   batch: true
@@ -55,8 +56,18 @@ jobs:
           libelf-dev \
           clang-format \
         && sudo pip3 install -U setuptools pip six \
-        && sudo pip3 install -U fusesoc
+        && sudo pip3 install -U -r python-requirements.txt
     displayName: Install dependencies
+
+  - bash: |
+      set -e
+      mkdir -p build/verible
+      cd build/verible
+      curl -Ls -o verible.tar.gz https://github.com/google/verible/releases/download/$(VERIBLE_VERSION)/verible-$(VERIBLE_VERSION)-Ubuntu-16.04-xenial-x86_64.tar.gz
+      sudo mkdir -p /tools/verible && sudo chmod 777 /tools/verible
+      tar -C /tools/verible -xf verible.tar.gz --strip-components=1
+      echo "##vso[task.setvariable variable=PATH]/tools/verible/bin:$PATH"
+    displayName: Install Verible
 
   - bash: |
       set -e
@@ -93,16 +104,28 @@ jobs:
       fusesoc --version
       verilator --version
       riscv32-unknown-elf-gcc --version
+      verilog_lint --version
     displayName: Display environment
 
   - bash: |
-      fusesoc --cores-root . run --target=lint lowrisc:ibex:ibex_core_tracing
+      fusesoc --cores-root . run --no-export --target=lint --tool=verilator lowrisc:ibex:ibex_core_tracing
       if [ $? != 0 ]; then
         echo -n "##vso[task.logissue type=error]"
-        echo "Verilog lint failed. Run 'fusesoc --cores-root . run --target=lint lowrisc:ibex:ibex_core_tracing' to check and fix all errors."
+        echo "Verilog lint with Verilator failed. Run 'fusesoc --cores-root . run --target=lint --tool=verilator lowrisc:ibex:ibex_core_tracing' to check and fix all errors."
         exit 1
       fi
     displayName: Lint Verilog source files with Verilator
+
+  - bash: |
+      fusesoc --cores-root . run --no-export --target=lint --tool=veriblelint lowrisc:ibex:ibex_core_tracing
+      if [ $? != 0 ]; then
+        echo -n "##vso[task.logissue type=error]"
+        echo "Verilog lint with Verible failed. Run 'fusesoc --cores-root . run --target=lint --tool=veriblelint lowrisc:ibex:ibex_core_tracing' to check and fix all errors."
+        echo "This flow is currently experimental and failures can be ignored."
+        exit 1
+      fi
+    continueOnError: true
+    displayName: Lint Verilog source files with Verible (experimental)
 
   - bash: |
       fork_origin=$(git merge-base --fork-point origin/master)

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -104,3 +104,7 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
+      veriblelint:
+        ruleset: default
+        rules:
+          - "-parameter-name-style"

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -108,3 +108,15 @@ targets:
         ruleset: default
         rules:
           - "-parameter-name-style"
+  format:
+    filesets:
+      - files_rtl
+    parameters:
+      - SYNTHESIS=true
+      - RVFI=true
+    default_tool: veribleformat
+    toplevel: ibex_core
+    tools:
+      veribleformat:
+        verible_format_args:
+          - "--inplace"

--- a/ibex_core_tracing.core
+++ b/ibex_core_tracing.core
@@ -79,3 +79,7 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
+      veriblelint:
+        ruleset: default
+        rules:
+          - "-parameter-name-style"

--- a/ibex_core_tracing.core
+++ b/ibex_core_tracing.core
@@ -83,3 +83,15 @@ targets:
         ruleset: default
         rules:
           - "-parameter-name-style"
+  format:
+    filesets:
+      - files_rtl
+    parameters:
+      - SYNTHESIS=true
+      - RVFI=true
+    default_tool: veribleformat
+    toplevel: ibex_core
+    tools:
+      veribleformat:
+        verible_format_args:
+          - "--inplace"

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Development version of edalize until all our changes are upstream
+git+https://github.com/lowRISC/edalize.git@ot
+
+# Development version with OT-specific changes
+git+https://github.com/lowRISC/fusesoc.git@ot


### PR DESCRIPTION
This extends the core file to be able to call Verible for lint.

This requires an updated version of edalize with
https://github.com/olofk/edalize/issues/95 fixed. For the time being, we
use the same 'ot' branches of those tools as we do in OpenTitan. Once
Verible becomes officially supported we need to ensure that released
versions of fusesoc and edalize exist, and that this requirement is
properly documented.