### PR TITLE
[doc] Fix paths in verification documentation

### DIFF
--- a/doc/verification.rst
+++ b/doc/verification.rst
@@ -160,9 +160,10 @@ against each other, since any code executed in the debug ROM and trap handlers s
 register state in the rest of the program.
 
 The entirety of this flow is controlled by the Makefile found at
-`dv/uvm/Makefile <https://github.com/lowRISC/ibex/blob/master/dv/uvm/Makefile>`_; here is a list of frequently used commands:
+`dv/uvm/core_ibex/Makefile <https://github.com/lowRISC/ibex/blob/master/dv/uvm/core_ibex/Makefile>`_; here is a list of frequently used commands:
 
 .. code-block:: bash
+   cd dv/uvm/core_ibex
 
    # Run a full regression
    make


### PR DESCRIPTION
The files moved; also add an explicit `cd` to the command listing to
help people only skimming the docs.