### PR TITLE
Explicitly pass <out> directory to VCS's UCLI TCL

### DIFF
--- a/dv/uvm/core_ibex/sim.py
+++ b/dv/uvm/core_ibex/sim.py
@@ -221,17 +221,20 @@ def get_test_sim_cmd(base_cmd, test, idx, output_dir, bin_dir, lsf_cmd):
     binary = os.path.join(bin_dir, '{}_{}.bin'.format(test_name, idx))
     desc = '{} with {}'.format(test['rtl_test'], binary)
 
+    # Do final interpolation into the test command for variables that depend on
+    # the test name or iteration number.
+    sim_cmd = subst_vars(sim_cmd,
+                         {
+                             'sim_dir': sim_dir,
+                             'rtl_test': test['rtl_test'],
+                             'binary': binary
+                         })
+
     if not os.path.exists(binary):
         raise RuntimeError('When computing simulation command for running '
                            'iteration {} of test {}, cannot find the '
                            'expected binary at {!r}.'
                            .format(idx, test_name, binary))
-
-    # Add plusargs for the test and a log file.
-    sim_cmd += (' +UVM_TESTNAME={} +bin={} +ibex_tracer_file_base={} -l {}'
-                .format(test['rtl_test'], binary,
-                        os.path.join(sim_dir, 'trace_core'),
-                        os.path.join(sim_dir, 'sim.log')))
 
     if lsf_cmd is not None:
         sim_cmd = lsf_cmd + ' ' + sim_cmd

--- a/dv/uvm/core_ibex/vcs.tcl
+++ b/dv/uvm/core_ibex/vcs.tcl
@@ -1,10 +1,20 @@
 # TCL file invoked from VCS's simv at run-time using this: -ucli -do <this file>
 
+# Since we don't necessarily run each test in a different directory,
+# we have to tell VCS where to put the waves. We do this with a
+# SIM_DIR environment variable, which we prepend to the wave name. If
+# SIM_DIR is not set, we just dump to the current directory.
+if { [info exists ::env(SIM_DIR)] } {
+    set sim_dir $::env(SIM_DIR)
+} else {
+    set sim_dir "."
+}
+
 if { [info exists ::env(VERDI_HOME)] } {
 	# Use FSDB for dumping data, but only if we have Verdi set up.
 
 	# Syntax: fsdbDumpfile FSDB_Name [Limit_Size]
-	fsdbDumpfile "waves.fsdb"
+	fsdbDumpfile "${sim_dir}/waves.fsdb"
 
 	# Syntax: fsdbDumpvars [depth] [instance] [option]*
 	##############################################################################
@@ -28,7 +38,7 @@ if { [info exists ::env(VERDI_HOME)] } {
 	fsdbDumpSVA 0 core_ibex_tb_top.dut
 } else {
 	# We don't have VERDI set up, so use VCS's standard dumping format.
-	dump -file "waves.vpd"
+	dump -file "${sim_dir}/waves.vpd"
 	dump -add { core_ibex_tb_top } -depth 0 -aggregates -scope "."
 }
 

--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -36,8 +36,11 @@
       -debug_access+all -ucli -do vcs.tcl
   sim:
     cmd: >
-      <out>/vcs_simv +vcs+lic+wait <sim_opts> <wave_opts> <cov_opts>
-        +ntb_random_seed=<seed>
+      env SIM_DIR=<sim_dir>
+        <out>/vcs_simv +vcs+lic+wait <sim_opts> <wave_opts> <cov_opts>
+          +ntb_random_seed=<seed> +UVM_TESTNAME=<rtl_test> +bin=<binary>
+          +ibex_tracer_file_base=<sim_dir>/trace_core
+          -l <sim_dir>/sim.log
     cov_opts: >
       -cm line+tgl+assert+fsm+branch
       -cm_dir <out>/test.vdb


### PR DESCRIPTION
This fixes a bug mentioned in issue #674, where dumped wave files were
ending up in dv/uvm/core_ibex, rather than a test-specific output
directory.

It turns out that this is because of my change in commit 08fc2a4,
which runs the simulator in the top core_ibex directory, rather than
changing directories each time. We have to do this to make the
parallel LSF flow work (which presumably has never actually been run,
otherwise we'd have noticed it was broken).

There are two ways I can think of getting this to work. Probably the
cleanest approach is to generate a script for each test, which looks
something like "cd test_dir; setup_stuff; run_simulator". This would
work (and is how I've seen it done in the past), but doesn't really
fit in with the string interpolation/YAML stuff we've got here.

Instead, this patch goes for a hackier approach, where we prefix the
simulation command with "env OUT_DIR=<out>" and then use the OUT_DIR
environment variable in the TCL scripts to figure out where to put the
wave file. This is kind of icky long-term, but should work for now.