### PR TITLE
Add missing dependencies in uvm/core_ibex/Makefile

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -316,13 +316,15 @@ wave-arg := $(if $(call equal,$(WAVES),1),--en_wave,)
 lsf-arg := $(if $(LSF_CMD),--lsf_cmd="$(LSF_CMD)",)
 
 $(OUT)/rtl_sim/.compile.stamp: \
-  $(compile-vars-prereq) $(all-verilog) $(risc-dv-files) sim.py | $(OUT)/rtl_sim
+  $(compile-vars-prereq) $(all-verilog) $(risc-dv-files) \
+  sim.py yaml/rtl_simulation.yaml \
+  | $(OUT)/rtl_sim
 	@./sim.py \
-     --o=${OUT} \
-     --steps=compile \
-     ${COMMON_OPTS} \
-     --simulator="${SIMULATOR}" $(cov-arg) $(wave-arg) \
-     --cmp_opts="${COMPILE_OPTS}"
+	 --o=${OUT} \
+	 --steps=compile \
+	 ${COMMON_OPTS} \
+	 --simulator="${SIMULATOR}" --simulator_yaml=yaml/rtl_simulation.yaml \
+	 $(cov-arg) $(wave-arg) --cmp_opts="${COMPILE_OPTS}"
 	$(call dump-vars,$(OUT)/rtl_sim/.compile-vars.mk,comp,$(compile-var-deps))
 	@touch $@
 
@@ -350,13 +352,15 @@ $(metadata)/rtl_sim.compile.stamp: \
 # and also on us having already compiled the test programs.
 $(metadata)/rtl_sim.run.stamp: \
   $(metadata)/rtl_sim.compile.stamp \
-  $(metadata)/instr_gen.compile.stamp $(TESTLIST) sim.py
+  $(metadata)/instr_gen.compile.stamp $(TESTLIST) \
+  sim.py yaml/rtl_simulation.yaml
 	@./sim.py \
-     --o=$(OUT-SEED) \
-     --steps=sim \
-     ${TEST_OPTS} \
-     --simulator="${SIMULATOR}" $(cov-arg) $(wave-arg) $(lsf-arg) \
-     --sim_opts="+signature_addr=${SIGNATURE_ADDR}" ${SIM_OPTS}
+	 --o=$(OUT-SEED) \
+	 --steps=sim \
+	 ${TEST_OPTS} \
+	 --simulator="${SIMULATOR}" --simulator_yaml=yaml/rtl_simulation.yaml \
+	 $(cov-arg) $(wave-arg) $(lsf-arg) \
+	 --sim_opts="+signature_addr=${SIGNATURE_ADDR}" ${SIM_OPTS}
 	@touch $@
 
 .PHONY: rtl_sim


### PR DESCRIPTION
When we run sim.py, we get commands to run the simulator from the YAML
file named by the --simulator_yaml argument, which defaults to
yaml/rtl_simulation.yaml.

This patch makes the argument explicit in the Makefile and adds a
dependency on that file for commands that read it.