### PR TITLE
[rtl/icache] Make age matrix more consistent

### DIFF
--- a/rtl/ibex_icache.sv
+++ b/rtl/ibex_icache.sv
@@ -420,7 +420,7 @@ module ibex_icache #(
 
     // Track which other fill buffers are older than this one (for age-based arbitration)
     // TODO sparsify
-    assign fill_older_d[fb]    = fill_alloc[fb] ? fill_busy_q : (fill_older_q[fb] & ~fill_done);
+    assign fill_older_d[fb]    = (fill_alloc[fb] ? fill_busy_q : fill_older_q[fb]) & ~fill_done;
 
     // A fill buffer can release once all its actions are completed
                                  // all data written to the cache (unless hit or error)


### PR DESCRIPTION
The design currently relies on fill_done remaining set in the cycle
after the fill buffer completes to ensure the fill_older_q entry gets
cleared (when a fill buffer completes in the same cycle that one is
allocated). This fix makes the behaviour a bit more consistent and easy
to reason about.