### PR TITLE
[rtl/icache] Fix PMP error logic

### DIFF
--- a/doc/icache.rst
+++ b/doc/icache.rst
@@ -215,7 +215,7 @@ Data is requested from the instruction memory with the ports prefixed by ``instr
 Note that there's one extra port on the I$, which doesn't appear at the ``ibex_core`` top-level.
 This is ``instr_pmp_err_i``.
 If the PMP block disallows a fetch for a certain address, it will squash the outgoing memory request entirely and set ``instr_pmp_err_i``.
-If that happens, the cache behaves as if the request was granted but returned some time later with an error.
+If that happens, the cache behaves as if the request was granted and stops making any further requests for that cache line.
 Note that it is possible for ``instr_gnt_i`` and ``instr_pmp_err_i`` to be high on the same cycle.
 In that case, the error signal takes precedence.
 


### PR DESCRIPTION
Instruction requests triggering PMP errors have their external request
suppressed. The beat counting logic therefore needs to know that these
requests will never receive any rvalid data responses.

This fix stops the external request counter from incrementing, and marks
all external requests complete as soon as any error is received.

The data in the cache line beyond the error is not required since the
core cannot access it without consuming the error first.