### PR TITLE
[rtl] Fix mtval for unaligned instr errors

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -19,53 +19,54 @@ module ibex_controller #(
     output logic                  ctrl_busy_o,           // core is busy processing instrs
 
     // decoder related signals
-    input  logic                  illegal_insn_i,        // decoder has an invalid instr
-    input  logic                  ecall_insn_i,          // decoder has ECALL instr
-    input  logic                  mret_insn_i,           // decoder has MRET instr
-    input  logic                  dret_insn_i,           // decoder has DRET instr
-    input  logic                  wfi_insn_i,            // decoder has WFI instr
-    input  logic                  ebrk_insn_i,           // decoder has EBREAK instr
-    input  logic                  csr_pipe_flush_i,      // do CSR-related pipeline flush
+    input  logic                  illegal_insn_i,          // decoder has an invalid instr
+    input  logic                  ecall_insn_i,            // decoder has ECALL instr
+    input  logic                  mret_insn_i,             // decoder has MRET instr
+    input  logic                  dret_insn_i,             // decoder has DRET instr
+    input  logic                  wfi_insn_i,              // decoder has WFI instr
+    input  logic                  ebrk_insn_i,             // decoder has EBREAK instr
+    input  logic                  csr_pipe_flush_i,        // do CSR-related pipeline flush
 
     // from IF-ID pipeline stage
-    input  logic                  instr_valid_i,         // instr from IF-ID reg is valid
-    input  logic [31:0]           instr_i,               // instr from IF-ID reg, for mtval
-    input  logic [15:0]           instr_compressed_i,    // instr from IF-ID reg, for mtval
-    input  logic                  instr_is_compressed_i, // instr from IF-ID reg is compressed
-    input  logic                  instr_fetch_err_i,     // instr from IF-ID reg has error
-    input  logic [31:0]           pc_id_i,               // instr from IF-ID reg address
+    input  logic                  instr_valid_i,           // instr from IF-ID reg is valid
+    input  logic [31:0]           instr_i,                 // instr from IF-ID reg, for mtval
+    input  logic [15:0]           instr_compressed_i,      // instr from IF-ID reg, for mtval
+    input  logic                  instr_is_compressed_i,   // instr from IF-ID reg is compressed
+    input  logic                  instr_fetch_err_i,       // instr from IF-ID reg has error
+    input  logic                  instr_fetch_err_plus2_i, // instr from IF-ID reg error is x32
+    input  logic [31:0]           pc_id_i,                 // instr from IF-ID reg address
 
     // to IF-ID pipeline stage
-    output logic                  instr_valid_clear_o,   // kill instr in IF-ID reg
-    output logic                  id_in_ready_o,         // ID stage is ready for new instr
-    output logic                  controller_run_o,      // Controller is in standard instruction
-                                                         // run mode
+    output logic                  instr_valid_clear_o,     // kill instr in IF-ID reg
+    output logic                  id_in_ready_o,           // ID stage is ready for new instr
+    output logic                  controller_run_o,        // Controller is in standard instruction
+                                                           // run mode
 
     // to prefetcher
-    output logic                  instr_req_o,           // start fetching instructions
-    output logic                  pc_set_o,              // jump to address set by pc_mux
-    output ibex_pkg::pc_sel_e     pc_mux_o,              // IF stage fetch address selector
-                                                         // (boot, normal, exception...)
-    output ibex_pkg::exc_pc_sel_e exc_pc_mux_o,          // IF stage selector for exception PC
-    output ibex_pkg::exc_cause_e  exc_cause_o,           // for IF stage, CSRs
+    output logic                  instr_req_o,             // start fetching instructions
+    output logic                  pc_set_o,                // jump to address set by pc_mux
+    output ibex_pkg::pc_sel_e     pc_mux_o,                // IF stage fetch address selector
+                                                           // (boot, normal, exception...)
+    output ibex_pkg::exc_pc_sel_e exc_pc_mux_o,            // IF stage selector for exception PC
+    output ibex_pkg::exc_cause_e  exc_cause_o,             // for IF stage, CSRs
 
     // LSU
-    input  logic [31:0]           lsu_addr_last_i,       // for mtval
+    input  logic [31:0]           lsu_addr_last_i,         // for mtval
     input  logic                  load_err_i,
     input  logic                  store_err_i,
-    output logic                  wb_exception_o,        // Instruction in WB taking an exception
+    output logic                  wb_exception_o,          // Instruction in WB taking an exception
 
     // jump/branch signals
-    input  logic                  branch_set_i,          // branch taken set signal
-    input  logic                  jump_set_i,            // jump taken set signal
+    input  logic                  branch_set_i,            // branch taken set signal
+    input  logic                  jump_set_i,              // jump taken set signal
 
     // interrupt signals
-    input  logic                  csr_mstatus_mie_i,     // M-mode interrupt enable bit
-    input  logic                  irq_pending_i,         // interrupt request pending
-    input  ibex_pkg::irqs_t       irqs_i,                // interrupt requests qualified with
-                                                         // mie CSR
-    input  logic                  irq_nm_i,              // non-maskeable interrupt
-    output logic                  nmi_mode_o,            // core executing NMI handler
+    input  logic                  csr_mstatus_mie_i,       // M-mode interrupt enable bit
+    input  logic                  irq_pending_i,           // interrupt request pending
+    input  ibex_pkg::irqs_t       irqs_i,                  // interrupt requests qualified with
+                                                           // mie CSR
+    input  logic                  irq_nm_i,                // non-maskeable interrupt
+    output logic                  nmi_mode_o,              // core executing NMI handler
 
     // debug signals
     input  logic                  debug_req_i,
@@ -93,10 +94,10 @@ module ibex_controller #(
     output logic                  flush_id_o,
 
     // performance monitors
-    output logic                  perf_jump_o,           // we are executing a jump
-                                                         // instruction (j, jr, jal, jalr)
-    output logic                  perf_tbranch_o         // we are executing a taken branch
-                                                         // instruction
+    output logic                  perf_jump_o,             // we are executing a jump
+                                                           // instruction (j, jr, jal, jalr)
+    output logic                  perf_tbranch_o           // we are executing a taken branch
+                                                           // instruction
 );
   import ibex_pkg::*;
 
@@ -568,7 +569,7 @@ module ibex_controller #(
           // set exception registers, priorities according to Table 3.7 of Privileged Spec v1.11
           if (instr_fetch_err) begin
             exc_cause_o = EXC_CAUSE_INSTR_ACCESS_FAULT;
-            csr_mtval_o = pc_id_i;
+            csr_mtval_o = instr_fetch_err_plus2_i ? (pc_id_i + 32'd2) : pc_id_i;
 
           end else if (illegal_insn_q) begin
             exc_cause_o = EXC_CAUSE_ILLEGAL_INSN;

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -107,6 +107,7 @@ module ibex_core #(
   logic [15:0] instr_rdata_c_id;       // Compressed instruction sampled inside IF stage
   logic        instr_is_compressed_id;
   logic        instr_fetch_err;        // Bus error on instr fetch
+  logic        instr_fetch_err_plus2;  // Instruction error is misaligned
   logic        illegal_c_insn_id;      // Illegal compressed instruction sent to ID stage
   logic [31:0] pc_if;                  // Program counter in IF stage
   logic [31:0] pc_id;                  // Program counter in ID stage
@@ -364,6 +365,7 @@ module ibex_core #(
       .instr_rdata_c_id_o       ( instr_rdata_c_id       ),
       .instr_is_compressed_id_o ( instr_is_compressed_id ),
       .instr_fetch_err_o        ( instr_fetch_err        ),
+      .instr_fetch_err_plus2_o  ( instr_fetch_err_plus2  ),
       .illegal_c_insn_id_o      ( illegal_c_insn_id      ),
       .pc_if_o                  ( pc_if                  ),
       .pc_id_o                  ( pc_id                  ),
@@ -436,6 +438,7 @@ module ibex_core #(
       .exc_cause_o                  ( exc_cause                ),
 
       .instr_fetch_err_i            ( instr_fetch_err          ),
+      .instr_fetch_err_plus2_i      ( instr_fetch_err_plus2    ),
       .illegal_c_insn_i             ( illegal_c_insn_id        ),
 
       .pc_id_i                      ( pc_id                    ),

--- a/rtl/ibex_fetch_fifo.sv
+++ b/rtl/ibex_fetch_fifo.sv
@@ -33,7 +33,8 @@ module ibex_fetch_fifo #(
     input  logic        out_ready_i,
     output logic [31:0] out_addr_o,
     output logic [31:0] out_rdata_o,
-    output logic        out_err_o
+    output logic        out_err_o,
+    output logic        out_err_plus2_o
 );
 
   // To gain extra performance DEPTH should be increased, this is due to some inefficiencies in the
@@ -50,7 +51,7 @@ module ibex_fetch_fifo #(
 
   logic                     pop_fifo;
   logic             [31:0]  rdata, rdata_unaligned;
-  logic                     err,   err_unaligned;
+  logic                     err,   err_unaligned, err_plus2;
   logic                     valid, valid_unaligned;
 
   logic                     aligned_is_compressed, unaligned_is_compressed;
@@ -92,6 +93,11 @@ module ibex_fetch_fifo #(
                                         ((valid_q[0] & err_q[0]) |
                                          (in_err_i & (~valid_q[0] | ~unaligned_is_compressed)));
 
+  // Record when an error is caused by the second half of an unaligned 32bit instruction.
+  // Only needs to be correct when unaligned and if err_unaligned is set
+  assign err_plus2       = valid_q[1] ? (err_q[1] & ~err_q[0]) :
+                                        (in_err_i & valid_q[0] & ~err_q[0]);
+
   // An uncompressed unaligned instruction is only valid if both parts are available
   assign valid_unaligned = valid_q[1] ? 1'b1 :
                                         (valid_q[0] & in_valid_i);
@@ -106,8 +112,9 @@ module ibex_fetch_fifo #(
   always_comb begin
     if (out_addr_o[1]) begin
       // unaligned case
-      out_rdata_o = rdata_unaligned;
-      out_err_o   = err_unaligned;
+      out_rdata_o     = rdata_unaligned;
+      out_err_o       = err_unaligned;
+      out_err_plus2_o = err_plus2;
 
       if (unaligned_is_compressed) begin
         out_valid_o = valid;
@@ -116,9 +123,10 @@ module ibex_fetch_fifo #(
       end
     end else begin
       // aligned case
-      out_rdata_o = rdata;
-      out_err_o   = err;
-      out_valid_o = valid;
+      out_rdata_o     = rdata;
+      out_err_o       = err;
+      out_err_plus2_o = 1'b0;
+      out_valid_o     = valid;
     end
   end
 

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -51,6 +51,7 @@ module ibex_id_stage #(
 
     input  logic                      illegal_c_insn_i,
     input  logic                      instr_fetch_err_i,
+    input  logic                      instr_fetch_err_plus2_i,
 
     input  logic [31:0]               pc_id_i,
 
@@ -421,87 +422,88 @@ module ibex_id_stage #(
   ibex_controller #(
     .WritebackStage ( WritebackStage )
   ) controller_i (
-      .clk_i                          ( clk_i                  ),
-      .rst_ni                         ( rst_ni                 ),
+      .clk_i                          ( clk_i                   ),
+      .rst_ni                         ( rst_ni                  ),
 
-      .fetch_enable_i                 ( fetch_enable_i         ),
-      .ctrl_busy_o                    ( ctrl_busy_o            ),
+      .fetch_enable_i                 ( fetch_enable_i          ),
+      .ctrl_busy_o                    ( ctrl_busy_o             ),
 
       // decoder related signals
-      .illegal_insn_i                 ( illegal_insn_o         ),
-      .ecall_insn_i                   ( ecall_insn_dec         ),
-      .mret_insn_i                    ( mret_insn_dec          ),
-      .dret_insn_i                    ( dret_insn_dec          ),
-      .wfi_insn_i                     ( wfi_insn_dec           ),
-      .ebrk_insn_i                    ( ebrk_insn              ),
-      .csr_pipe_flush_i               ( csr_pipe_flush         ),
+      .illegal_insn_i                 ( illegal_insn_o          ),
+      .ecall_insn_i                   ( ecall_insn_dec          ),
+      .mret_insn_i                    ( mret_insn_dec           ),
+      .dret_insn_i                    ( dret_insn_dec           ),
+      .wfi_insn_i                     ( wfi_insn_dec            ),
+      .ebrk_insn_i                    ( ebrk_insn               ),
+      .csr_pipe_flush_i               ( csr_pipe_flush          ),
 
       // from IF-ID pipeline
-      .instr_valid_i                  ( instr_valid_i          ),
-      .instr_i                        ( instr_rdata_i          ),
-      .instr_compressed_i             ( instr_rdata_c_i        ),
-      .instr_is_compressed_i          ( instr_is_compressed_i  ),
-      .instr_fetch_err_i              ( instr_fetch_err_i      ),
-      .pc_id_i                        ( pc_id_i                ),
+      .instr_valid_i                  ( instr_valid_i           ),
+      .instr_i                        ( instr_rdata_i           ),
+      .instr_compressed_i             ( instr_rdata_c_i         ),
+      .instr_is_compressed_i          ( instr_is_compressed_i   ),
+      .instr_fetch_err_i              ( instr_fetch_err_i       ),
+      .instr_fetch_err_plus2_i        ( instr_fetch_err_plus2_i ),
+      .pc_id_i                        ( pc_id_i                 ),
 
       // to IF-ID pipeline
-      .instr_valid_clear_o            ( instr_valid_clear_o    ),
-      .id_in_ready_o                  ( id_in_ready_o          ),
-      .controller_run_o               ( controller_run         ),
+      .instr_valid_clear_o            ( instr_valid_clear_o     ),
+      .id_in_ready_o                  ( id_in_ready_o           ),
+      .controller_run_o               ( controller_run          ),
 
       // to prefetcher
-      .instr_req_o                    ( instr_req_o            ),
-      .pc_set_o                       ( pc_set_o               ),
-      .pc_mux_o                       ( pc_mux_o               ),
-      .exc_pc_mux_o                   ( exc_pc_mux_o           ),
-      .exc_cause_o                    ( exc_cause_o            ),
+      .instr_req_o                    ( instr_req_o             ),
+      .pc_set_o                       ( pc_set_o                ),
+      .pc_mux_o                       ( pc_mux_o                ),
+      .exc_pc_mux_o                   ( exc_pc_mux_o            ),
+      .exc_cause_o                    ( exc_cause_o             ),
 
       // LSU
-      .lsu_addr_last_i                ( lsu_addr_last_i        ),
-      .load_err_i                     ( lsu_load_err_i         ),
-      .store_err_i                    ( lsu_store_err_i        ),
-      .wb_exception_o                 ( wb_exception           ),
+      .lsu_addr_last_i                ( lsu_addr_last_i         ),
+      .load_err_i                     ( lsu_load_err_i          ),
+      .store_err_i                    ( lsu_store_err_i         ),
+      .wb_exception_o                 ( wb_exception            ),
 
       // jump/branch control
-      .branch_set_i                   ( branch_set             ),
-      .jump_set_i                     ( jump_set               ),
+      .branch_set_i                   ( branch_set              ),
+      .jump_set_i                     ( jump_set                ),
 
       // interrupt signals
-      .csr_mstatus_mie_i              ( csr_mstatus_mie_i      ),
-      .irq_pending_i                  ( irq_pending_i          ),
-      .irqs_i                         ( irqs_i                 ),
-      .irq_nm_i                       ( irq_nm_i               ),
-      .nmi_mode_o                     ( nmi_mode_o             ),
+      .csr_mstatus_mie_i              ( csr_mstatus_mie_i       ),
+      .irq_pending_i                  ( irq_pending_i           ),
+      .irqs_i                         ( irqs_i                  ),
+      .irq_nm_i                       ( irq_nm_i                ),
+      .nmi_mode_o                     ( nmi_mode_o              ),
 
       // CSR Controller Signals
-      .csr_save_if_o                  ( csr_save_if_o          ),
-      .csr_save_id_o                  ( csr_save_id_o          ),
-      .csr_save_wb_o                  ( csr_save_wb_o          ),
-      .csr_restore_mret_id_o          ( csr_restore_mret_id_o  ),
-      .csr_restore_dret_id_o          ( csr_restore_dret_id_o  ),
-      .csr_save_cause_o               ( csr_save_cause_o       ),
-      .csr_mtval_o                    ( csr_mtval_o            ),
-      .priv_mode_i                    ( priv_mode_i            ),
-      .csr_mstatus_tw_i               ( csr_mstatus_tw_i       ),
+      .csr_save_if_o                  ( csr_save_if_o           ),
+      .csr_save_id_o                  ( csr_save_id_o           ),
+      .csr_save_wb_o                  ( csr_save_wb_o           ),
+      .csr_restore_mret_id_o          ( csr_restore_mret_id_o   ),
+      .csr_restore_dret_id_o          ( csr_restore_dret_id_o   ),
+      .csr_save_cause_o               ( csr_save_cause_o        ),
+      .csr_mtval_o                    ( csr_mtval_o             ),
+      .priv_mode_i                    ( priv_mode_i             ),
+      .csr_mstatus_tw_i               ( csr_mstatus_tw_i        ),
 
       // Debug Signal
-      .debug_mode_o                   ( debug_mode_o           ),
-      .debug_cause_o                  ( debug_cause_o          ),
-      .debug_csr_save_o               ( debug_csr_save_o       ),
-      .debug_req_i                    ( debug_req_i            ),
-      .debug_single_step_i            ( debug_single_step_i    ),
-      .debug_ebreakm_i                ( debug_ebreakm_i        ),
-      .debug_ebreaku_i                ( debug_ebreaku_i        ),
-      .trigger_match_i                ( trigger_match_i        ),
+      .debug_mode_o                   ( debug_mode_o            ),
+      .debug_cause_o                  ( debug_cause_o           ),
+      .debug_csr_save_o               ( debug_csr_save_o        ),
+      .debug_req_i                    ( debug_req_i             ),
+      .debug_single_step_i            ( debug_single_step_i     ),
+      .debug_ebreakm_i                ( debug_ebreakm_i         ),
+      .debug_ebreaku_i                ( debug_ebreaku_i         ),
+      .trigger_match_i                ( trigger_match_i         ),
 
       // stall signals
-      .stall_id_i                     ( stall_id               ),
-      .stall_wb_i                     ( stall_wb               ),
-      .flush_id_o                     ( flush_id               ),
+      .stall_id_i                     ( stall_id                ),
+      .stall_wb_i                     ( stall_wb                ),
+      .flush_id_o                     ( flush_id                ),
 
       // Performance Counters
-      .perf_jump_o                    ( perf_jump_o            ),
-      .perf_tbranch_o                 ( perf_tbranch_o         )
+      .perf_jump_o                    ( perf_jump_o             ),
+      .perf_tbranch_o                 ( perf_tbranch_o          )
   );
 
   assign multdiv_en_dec   = mult_en_dec | div_en_dec;

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -43,6 +43,7 @@ module ibex_if_stage #(
     output logic                  instr_is_compressed_id_o, // compressed decoder thinks this
                                                             // is a compressed instr
     output logic                  instr_fetch_err_o,        // bus error on fetch
+    output logic                  instr_fetch_err_plus2_o,  // bus error misaligned
     output logic                  illegal_c_insn_id_o,      // compressed decoder thinks this
                                                             // is an invalid instr
     output logic [31:0]           pc_if_o,
@@ -88,6 +89,7 @@ module ibex_if_stage #(
   logic       [31:0] fetch_rdata;
   logic       [31:0] fetch_addr;
   logic              fetch_err;
+  logic              fetch_err_plus2;
 
   logic       [31:0] exc_pc;
 
@@ -147,6 +149,7 @@ module ibex_if_stage #(
       .rdata_o           ( fetch_rdata                 ),
       .addr_o            ( fetch_addr                  ),
       .err_o             ( fetch_err                   ),
+      .err_plus2_o       ( fetch_err_plus2             ),
 
       // goes to instruction memory / instruction cache
       .instr_req_o       ( instr_req_o                 ),
@@ -216,6 +219,7 @@ module ibex_if_stage #(
       // To reduce fan-out and help timing from the instr_rdata_id flops they are replicated.
       instr_rdata_alu_id_o     <= instr_decompressed;
       instr_fetch_err_o        <= fetch_err;
+      instr_fetch_err_plus2_o  <= fetch_err_plus2;
       instr_rdata_c_id_o       <= fetch_rdata[15:0];
       instr_is_compressed_id_o <= instr_is_compressed_int;
       illegal_c_insn_id_o      <= illegal_c_insn;

--- a/rtl/ibex_prefetch_buffer.sv
+++ b/rtl/ibex_prefetch_buffer.sv
@@ -24,6 +24,7 @@ module ibex_prefetch_buffer (
     output logic [31:0] rdata_o,
     output logic [31:0] addr_o,
     output logic        err_o,
+    output logic        err_plus2_o,
 
 
     // goes to instruction memory / instruction cache
@@ -98,7 +99,8 @@ module ibex_prefetch_buffer (
       .out_ready_i           ( ready_i           ),
       .out_rdata_o           ( rdata_o           ),
       .out_addr_o            ( addr_o            ),
-      .out_err_o             ( err_o             )
+      .out_err_o             ( err_o             ),
+      .out_err_plus2_o       ( err_plus2_o       )
   );
 
   //////////////


### PR DESCRIPTION
mtval should record which half of the instruction caused the error
rather than just recording the PC.
An extra signal is added in the IF stage to indicate when an error is
caused by the second half of an unaligned instruction. This signal is
then used to increment the PC by 2 for mtval capture on an error.

Fixes #709