### PR TITLE
[verilator] Fix --term-after-cycles

### DIFF
--- a/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -283,10 +283,10 @@ void VerilatorSimCtrl::Run() {
   UnsetReset();
   Trace();
   while (1) {
-    if (time_ >= initial_reset_delay_cycles_ * 2) {
+    if (time_ / 2 >= initial_reset_delay_cycles_) {
       SetReset();
     }
-    if (time_ >= reset_duration_cycles_ * 2 + initial_reset_delay_cycles_ * 2) {
+    if (time_ / 2 >= reset_duration_cycles_ + initial_reset_delay_cycles_) {
       UnsetReset();
     }
 
@@ -315,7 +315,7 @@ void VerilatorSimCtrl::Run() {
                 << std::endl;
       break;
     }
-    if (term_after_cycles_ && time_ > term_after_cycles_) {
+    if (term_after_cycles_ && (time_ / 2 >= term_after_cycles_)) {
       std::cout << "Simulation timeout of " << term_after_cycles_
                 << " cycles reached, shutting down simulation." << std::endl;
       break;


### PR DESCRIPTION
The option to limit the verilator simulation's maximum number of cycles was
implemented in terms of the `time_` variable, which counts half cycles. This
patch makes the limit respect the requested number of full cycles.

The patch divides `time_` by 2, instead of multiplying `term_after_cycles_`
by 2, as that better conveys the intended semantics, and slightly increases
the range of the limit. Related computations were modified for consistency.