### PR TITLE
[rtl/icache] Fix an inconsistency in data output

### DIFF
--- a/rtl/ibex_icache.sv
+++ b/rtl/ibex_icache.sv
@@ -604,7 +604,7 @@ module ibex_icache #(
     // - Data is available from the bus this cycle (fill_rvd_arb)
     assign fill_out_req[fb]    = fill_busy_q[fb] & ~fill_stale_q[fb] & ~fill_out_done[fb] &
                                  (fill_hit_ic1[fb] | fill_hit_q[fb] |
-                                  (fill_rvd_cnt_q[fb] > fill_out_cnt_q[fb]) | fill_rvd_arb[fb]);
+                                  (fill_rvd_beat[fb] > fill_out_cnt_q[fb]) | fill_rvd_arb[fb]);
 
     // Calculate when a beat of data is output. Any ECC error squashes the output that cycle.
     assign fill_out_grant[fb]  = fill_out_arb[fb] & output_ready & ~ecc_err_ic1;


### PR DESCRIPTION
- valid_o could be asserted for one cycle then dropped when receiving
  rvalid data for a request which has branched into  the middle of a
  line.
- This fix keeps valid_o asserted by using the offset version of
  fill_rvd_cnt_q (fill_rvd_beat) to compare against fill_out_cnt_q
  (which is also offset by the branch).

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>