### PR TITLE
[rtl] Extend BT ALU to be used for all jumps

### DIFF
--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -133,7 +133,7 @@ module ibex_core #(
   logic [31:0] lsu_addr_last;
 
   // Jump and branch target and decision (EX->IF)
-  logic [31:0] jump_target_ex;
+  logic [31:0] branch_target_ex;
   logic        branch_decision;
 
   // Core busy signals
@@ -166,8 +166,8 @@ module ibex_core #(
   logic [31:0] alu_operand_a_ex;
   logic [31:0] alu_operand_b_ex;
 
-  jt_mux_sel_e jt_mux_sel_ex;
-  logic [11:0] bt_operand_imm_ex;
+  logic [31:0] bt_a_operand;
+  logic [31:0] bt_b_operand;
 
   logic [31:0] alu_adder_result_ex;    // Used to forward computed address to LSU
   logic [31:0] result_ex;
@@ -386,8 +386,8 @@ module ibex_core #(
       .icache_enable_i          ( icache_enable          ),
       .icache_inval_i           ( icache_inval           ),
 
-      // jump targets
-      .jump_target_ex_i         ( jump_target_ex         ),
+      // branch targets
+      .branch_target_ex_i       ( branch_target_ex       ),
 
       // CSRs
       .csr_mepc_i               ( csr_mepc               ), // exception return address
@@ -463,8 +463,8 @@ module ibex_core #(
       .alu_operand_a_ex_o           ( alu_operand_a_ex         ),
       .alu_operand_b_ex_o           ( alu_operand_b_ex         ),
 
-      .jt_mux_sel_ex_o              ( jt_mux_sel_ex            ),
-      .bt_operand_imm_o             ( bt_operand_imm_ex        ),
+      .bt_a_operand_o               ( bt_a_operand             ),
+      .bt_b_operand_o               ( bt_b_operand             ),
 
       .mult_en_ex_o                 ( mult_en_ex               ),
       .div_en_ex_o                  ( div_en_ex                ),
@@ -571,9 +571,8 @@ module ibex_core #(
       .alu_operand_b_i            ( alu_operand_b_ex         ),
 
       // Branch target ALU signal from ID stage
-      .jt_mux_sel_i               ( jt_mux_sel_ex            ),
-      .bt_operand_imm_i           ( bt_operand_imm_ex        ),
-      .pc_id_i                    ( pc_id                    ),
+      .bt_a_operand_i             ( bt_a_operand             ),
+      .bt_b_operand_i             ( bt_b_operand             ),
 
       // Multipler/Divider signal from ID stage
       .multdiv_operator_i         ( multdiv_operator_ex      ),
@@ -589,7 +588,7 @@ module ibex_core #(
       .alu_adder_result_ex_o      ( alu_adder_result_ex      ), // to LSU
       .result_ex_o                ( result_ex                ), // to ID
 
-      .jump_target_o              ( jump_target_ex           ), // to IF
+      .branch_target_o            ( branch_target_ex         ), // to IF
       .branch_decision_o          ( branch_decision          ), // to ID
 
       .ex_valid_o                 ( ex_valid                 )

--- a/rtl/ibex_ex_block.sv
+++ b/rtl/ibex_ex_block.sv
@@ -23,9 +23,8 @@ module ibex_ex_block #(
 
     // Branch Target ALU
     // All of these signals are unusued when BranchTargetALU == 0
-    input  ibex_pkg::jt_mux_sel_e jt_mux_sel_i,
-    input  logic [11:0]           bt_operand_imm_i,
-    input  logic [31:0]           pc_id_i,
+    input  logic [31:0]           bt_a_operand_i,
+    input  logic [31:0]           bt_b_operand_i,
 
     // Multiplier/Divider
     input  ibex_pkg::md_op_e      multdiv_operator_i,
@@ -40,7 +39,7 @@ module ibex_ex_block #(
     // Outputs
     output logic [31:0]           alu_adder_result_ex_o, // to LSU
     output logic [31:0]           result_ex_o,
-    output logic [31:0]           jump_target_o,         // to IF
+    output logic [31:0]           branch_target_o,       // to IF
     output logic                  branch_decision_o,     // to ID
 
     output logic                  ex_valid_o             // EX has valid output
@@ -74,21 +73,20 @@ module ibex_ex_block #(
 
   if (BranchTargetALU) begin : g_branch_target_alu
     logic [32:0] bt_alu_result;
+    logic        unused_bt_carry;
 
-    assign bt_alu_result = {{19{bt_operand_imm_i[11]}}, bt_operand_imm_i, 1'b0} + pc_id_i;
+    assign bt_alu_result   = bt_a_operand_i + bt_b_operand_i;
 
-    assign jump_target_o = (jt_mux_sel_i == JT_ALU) ? alu_adder_result_ex_o : bt_alu_result[31:0];
+    assign unused_bt_carry = bt_alu_result[32];
+    assign branch_target_o = bt_alu_result[31:0];
   end else begin : g_no_branch_target_alu
-    // Unused jt_mux_sel_i/bt_operand_imm_i/pc_id_i signals causes lint errors, this avoids them
-    ibex_pkg::jt_mux_sel_e unused_jt_mux_sel;
-    logic [11:0]           unused_bt_operand_imm;
-    logic [31:0]           unused_pc_id;
+    // Unused bt_operand signals cause lint errors, this avoids them
+    logic [31:0] unused_bt_a_operand, unused_bt_b_operand;
 
-    assign unused_jt_mux_sel     = jt_mux_sel_i;
-    assign unused_bt_operand_imm = bt_operand_imm_i;
-    assign unused_pc_id          = pc_id_i;
+    assign unused_bt_a_operand = bt_a_operand_i;
+    assign unused_bt_b_operand = bt_b_operand_i;
 
-    assign jump_target_o = alu_adder_result_ex_o;
+    assign branch_target_o = alu_adder_result_ex_o;
   end
 
   /////////

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -62,7 +62,7 @@ module ibex_if_stage #(
     input logic                   icache_inval_i,
 
     // jump and branch target
-    input  logic [31:0]           jump_target_ex_i,         // jump target address
+    input  logic [31:0]           branch_target_ex_i,       // branch/jump target address
 
     // CSRs
     input  logic [31:0]           csr_mepc_i,               // PC to restore after handling
@@ -128,7 +128,7 @@ module ibex_if_stage #(
   always_comb begin : fetch_addr_mux
     unique case (pc_mux_i)
       PC_BOOT: fetch_addr_n = { boot_addr_i[31:8], 8'h80 };
-      PC_JUMP: fetch_addr_n = jump_target_ex_i;
+      PC_JUMP: fetch_addr_n = branch_target_ex_i;
       PC_EXC:  fetch_addr_n = exc_pc;                       // set PC to exception handler
       PC_ERET: fetch_addr_n = csr_mepc_i;                   // restore PC when returning from EXC
       PC_DRET: fetch_addr_n = csr_depc_i;

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -142,12 +142,6 @@ typedef enum logic [2:0] {
   IMM_B_INCR_ADDR
 } imm_b_sel_e;
 
-// Only used when BranchTargetALU == 1
-typedef enum logic {
-  JT_ALU,   // Jump target from main ALU
-  JT_BT_ALU // Jump target from specialised branch ALU
-} jt_mux_sel_e;
-
 // Regfile write data selection
 typedef enum logic {
   RF_WD_EX,


### PR DESCRIPTION
- Create separate operand muxes for the branch/jump target ALU
- Complete jump instructions in one cycle when BT ALU configured

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>