### PR TITLE
[rtl] Branch signal timing fix

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -209,7 +209,7 @@ module ibex_controller #(
       exc_req_d | exc_req_lsu;
 
   // special request that can specifically occur during branch instructions
-  assign special_req_branch = (illegal_insn_d | instr_fetch_err) & (ctrl_fsm_cs != FLUSH);
+  assign special_req_branch = instr_fetch_err & (ctrl_fsm_cs != FLUSH);
 
   `ASSERT(SpecialReqBranchGivesSpecialReqAll,
     special_req_branch |-> special_req_all)


### PR DESCRIPTION
- Before this fix, the branch signal was qualified by the illegal
  instruction signal and the illegal csr signal.
- This patch removes both of these since the decoder already masks
  branches with illegal isntruction, and a branch cannot be a CSR op.
- This improves the worst path in the design significantly without the
  branch target ALU.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>