### PR TITLE
Correct PMP granularity equation

### DIFF
--- a/doc/pmp.rst
+++ b/doc/pmp.rst
@@ -6,15 +6,15 @@ Physical Memory Protection (PMP)
 The Physical Memory Protection (PMP) unit implements region-based memory access checking in-accordance with the RISC-V Privileged Specification, version 1.11.
 The following configuration parameters are available to control PMP checking:
 
-+----------------+---------------+-------------------------------------------------+
-| Parameter      | Default value | Description                                     |
-+================+===============+=================================================+
-| PMPEnable      | 0             | PMP support enabled                             |
-+----------------+---------------+-------------------------------------------------+
-| PMPNumRegions  | 4             | Number of implemented regions (1 - 16)          |
-+----------------+---------------+-------------------------------------------------+
-| PMPGranularity | 0             | Minimum match granularity 2^G\+2 bytes (0 - 31) |
-+----------------+---------------+-------------------------------------------------+
++----------------+---------------+----------------------------------------------------------+
+| Parameter      | Default value | Description                                              |
++================+===============+==========================================================+
+| PMPEnable      | 0             | PMP support enabled                                      |
++----------------+---------------+----------------------------------------------------------+
+| PMPNumRegions  | 4             | Number of implemented regions (1 - 16)                   |
++----------------+---------------+----------------------------------------------------------+
+| PMPGranularity | 0             | Minimum match granularity :math:`2^{G+2}` bytes (0 - 31) |
++----------------+---------------+----------------------------------------------------------+
 
 When PMPEnable is zero, the PMP module is not instantiated and all PMP registers read as zero (regardless of the value of PMPNumRegions)
 
@@ -30,4 +30,3 @@ PMP Granularity
 
 The PMP granularity parameter is used to reduce the size of the address matching comparators by increasing the minimum region size.
 When the granularity is greater than zero, NA4 mode is not available and will be treated as OFF mode.
-


### PR DESCRIPTION
The `+2` part should have been part of the exponent, as indicated by the
RISC-V spec.