### PR TITLE
[dv] remove return value from the compare() step

### DIFF
--- a/dv/uvm/core_ibex/sim.py
+++ b/dv/uvm/core_ibex/sim.py
@@ -556,10 +556,9 @@ def main():
         rtl_sim(sim_cmd, matched_list, seed, args.sim_opts,
                 output_dir, bin_dir, args.lsf_cmd, check_return_code)
 
-    # Compare RTL & ISS simulation result.;
+    # Compare RTL & ISS simulation result.
     if steps['compare']:
-        if not compare(matched_list, args.iss, args.o):
-            return RET_FAIL
+        compare(matched_list, args.iss, args.o)
 
     # Generate merged coverage directory and load it into appropriate GUI
     if steps['cov']:


### PR DESCRIPTION
Currently, if post_compare step fails, the entire makefile will error out, and coverage will not be generated.
Since coverage generation technically does not rely on the result of the post_compare stage, I now have each stage of the sim flow return RET_SUCCESS, to indicate that the step itself was able to run to completion; incorrect comparison results etc... will be logged to the terminal upon any failures and will now not prevent coverage from being generated.

Signed-off-by: Udi <udij@google.com>