### PR TITLE
Factor out ibex_pkg.sv into a separate core file

### DIFF
--- a/ibex_core.core
+++ b/ibex_core.core
@@ -9,8 +9,8 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
+      - lowrisc:ibex:ibex_pkg
     files:
-      - rtl/ibex_pkg.sv
       - rtl/ibex_alu.sv
       - rtl/ibex_compressed_decoder.sv
       - rtl/ibex_controller.sv

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:ibex:ibex_core:0.1"
-description: "CPU core with 2 stage pipeline implementing the RV32IMC_Zicsr ISA"
+description: "CPU core with 2 stage pipeline implementing the RV32IMC_Zicsr_Zifencei ISA"
 
 filesets:
   files_rtl:

--- a/ibex_pkg.core
+++ b/ibex_pkg.core
@@ -2,16 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:ibex:ibex_tracer:0.1"
-description: "Tracer for use with Ibex using the RVFI interface"
+name: "lowrisc:ibex:ibex_pkg:0.1"
+description: "Header package for Ibex"
+
 filesets:
   files_rtl:
-    depend:
-      - lowrisc:prim:assert
-      - lowrisc:ibex:ibex_pkg
     files:
-      - rtl/ibex_tracer_pkg.sv
-      - rtl/ibex_tracer.sv
+      - rtl/ibex_pkg.sv
     file_type: systemVerilogSource
 
 targets:


### PR DESCRIPTION
The ibex_pkg.sv file is effectively a "header" with useful defines;
we need them in ibex_tracer_pkg.sv, and in other places around Ibex.
Currently, the dependency between ibex_tracer_pkg.sv and ibex_pkg.sv
wasn't covered in a FuseSoC core file, leading to unstable behavior.

This patch adds this dependency by
- factoring out the ibex_pkg.sv file into a separate core file,
  ibex_pkg.core, and
- adding a dependency on the new ibex_pkg core to the ibex_tracer core.