### PR TITLE
[rtl/pmp] Fix PMP error prioritization

### DIFF
--- a/rtl/ibex_pmp.sv
+++ b/rtl/ibex_pmp.sv
@@ -36,8 +36,6 @@ module ibex_pmp #(
   logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_low;
   logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_both;
   logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_perm_check;
-  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   machine_access_fault;
-  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   user_access_allowed;
   logic [PMPNumChan-1:0]                      access_fault;
 
 
@@ -87,14 +85,26 @@ module ibex_pmp #(
           ((pmp_req_type_i[c] == PMP_ACC_EXEC)  & csr_pmp_cfg_i[r].exec) |
           ((pmp_req_type_i[c] == PMP_ACC_WRITE) & csr_pmp_cfg_i[r].write) |
           ((pmp_req_type_i[c] == PMP_ACC_READ)  & csr_pmp_cfg_i[r].read);
-      // In machine mode, any match to a locked region without sufficient permissions is a fault
-      assign machine_access_fault[c][r] = region_match_both[c][r] & csr_pmp_cfg_i[r].lock &
-                                          ~region_perm_check[c][r];
-      // In any other mode, any access should fault unless is matches a region
-      assign user_access_allowed[c][r]  = region_match_both[c][r] & region_perm_check[c][r];
     end
-    assign access_fault[c] = (priv_mode_i[c] == PRIV_LVL_M) ? |machine_access_fault[c] :
-                                                              ~|user_access_allowed[c];
+
+    // Access fault determination / prioritization
+    always_comb begin
+      // Default is allow for M-mode, deny for other modes
+      access_fault[c] = (priv_mode_i[c] != PRIV_LVL_M);
+
+      // PMP entries are statically prioritized, from 0 to N-1
+      // The lowest-numbered PMP entry which matches an address determines accessability
+      for (int r = PMPNumRegions-1; r >= 0; r--) begin
+        if (region_match_both[c][r]) begin
+          access_fault[c] = (priv_mode_i[c] == PRIV_LVL_M) ?
+              // For M-mode, any region which matches with the L-bit clear, or with sufficient
+              // access permissions will be allowed
+              (csr_pmp_cfg_i[r].lock & ~region_perm_check[c][r]) :
+              // For other modes, the lock bit doesn't matter
+              ~region_perm_check[c][r];
+        end
+      end
+    end
 
     assign pmp_req_err_o[c] = access_fault[c];
   end


### PR DESCRIPTION
- Region matches should be prioritized from 0 - N as stated in the RISCV
  Privileged Spec v1.11

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>