### PR TITLE
[rtl] Unify top-level parameter declaration

### DIFF
--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -10,16 +10,16 @@ module ibex_core_tracing #(
     parameter bit          PMPEnable                = 1'b0,
     parameter int unsigned PMPGranularity           = 0,
     parameter int unsigned PMPNumRegions            = 4,
-    parameter int unsigned MHPMCounterNum           = 8,
+    parameter int unsigned MHPMCounterNum           = 0,
     parameter int unsigned MHPMCounterWidth         = 40,
     parameter bit          RV32E                    = 1'b0,
     parameter bit          RV32M                    = 1'b1,
     parameter bit          BranchTargetALU          = 1'b0,
+    parameter bit          WritebackStage           = 1'b0,
     parameter              MultiplierImplementation = "fast",
     parameter bit          ICache                   = 1'b0,
     parameter bit          ICacheECC                = 1'b0,
     parameter bit          DbgTriggerEn             = 1'b0,
-    parameter bit          WritebackStage           = 1'b0,
     parameter int unsigned DmHaltAddr               = 32'h1A110800,
     parameter int unsigned DmExceptionAddr          = 32'h1A110808
 ) (


### PR DESCRIPTION
- Make parameter declaration order and default values in
  ibex_core_tracing.sv match the documentation

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>