### PR TITLE
[dv] move all SV interface includes into ibex_dv.f

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-
 package ibex_mem_intf_agent_pkg;
 
   import uvm_pkg::*;

--- a/dv/uvm/core_ibex/common/irq_agent/irq_agent_pkg.sv
+++ b/dv/uvm/core_ibex/common/irq_agent/irq_agent_pkg.sv
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-`include "irq_if.sv"
-
 package irq_agent_pkg;
 
   import uvm_pkg::*;

--- a/dv/uvm/core_ibex/env/core_ibex_env_pkg.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_env_pkg.sv
@@ -6,10 +6,6 @@
 // Core ibex environment package
 // ---------------------------------------------
 
-`include "core_ibex_dut_probe_if.sv"
-`include "core_ibex_rvfi_if.sv"
-`include "core_ibex_csr_if.sv"
-
 package core_ibex_env_pkg;
 
   import uvm_pkg::*;

--- a/dv/uvm/core_ibex/ibex_dv.f
+++ b/dv/uvm/core_ibex/ibex_dv.f
@@ -54,8 +54,13 @@ ${PRJ_DIR}/ibex/vendor/google_riscv-dv/src/riscv_signature_pkg.sv
 ${PRJ_DIR}/ibex/dv/uvm/core_ibex/common/utils/clk_if.sv
 ${PRJ_DIR}/ibex/dv/uvm/core_ibex/common/utils/dv_utils_pkg.sv
 ${PRJ_DIR}/ibex/dv/uvm/core_ibex/common/mem_model/mem_model_pkg.sv
+${PRJ_DIR}/ibex/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf.sv
 ${PRJ_DIR}/ibex/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
+${PRJ_DIR}/ibex/dv/uvm/core_ibex/common/irq_agent/irq_if.sv
 ${PRJ_DIR}/ibex/dv/uvm/core_ibex/common/irq_agent/irq_agent_pkg.sv
+${PRJ_DIR}/ibex/dv/uvm/core_ibex/env/core_ibex_dut_probe_if.sv
+${PRJ_DIR}/ibex/dv/uvm/core_ibex/env/core_ibex_rvfi_if.sv
+${PRJ_DIR}/ibex/dv/uvm/core_ibex/env/core_ibex_csr_if.sv
 ${PRJ_DIR}/ibex/dv/uvm/core_ibex/env/core_ibex_env_pkg.sv
 ${PRJ_DIR}/ibex/dv/uvm/core_ibex/tests/core_ibex_test_pkg.sv
 ${PRJ_DIR}/ibex/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv


### PR DESCRIPTION
This PR moves all SV interface includes from the relevant *_pkg.sv file into ibex_dv.f, as a follow up to #711.
In order to get the Icache testbench to compile with dvsim in #711, the ibex_mem_intf.sv file had to be removed from its `include` inside the `ibex_mem_intf_agent_pkg`, and thus had to be manually added in `ibex_dv.f` to get Ibex simulation (which don't use dvsim yet) to successfully pass.

Signed-off-by: Udi <udij@google.com>