### PR TITLE
Fix destination for dumped waves in dv/uvm

### DIFF
--- a/dv/uvm/data/common_sim_cfg.hjson
+++ b/dv/uvm/data/common_sim_cfg.hjson
@@ -44,7 +44,7 @@
   d: UVM_DEBUG
 
   // Default waves dump settings
-  dump_file:  waves.{dump}
+  dump_base:  waves
 
   // Top level simulation entities.
   sim_tops: ["-top {tb}"]
@@ -65,7 +65,7 @@
 
   // Default list of things to export to shell
   exports: [
-    DUMP_FILE: {dump_file}
+    DUMP_BASE: {dump_base}
     WAVES: {waves}
     DUT_TOP: {dut}
     TB_TOP: {tb}

--- a/dv/uvm/data/vcs/vcs_fsdb.tcl
+++ b/dv/uvm/data/vcs/vcs_fsdb.tcl
@@ -4,40 +4,40 @@
 
 # TCL file invoked from VCS's simv at run-time using this: -ucli -do <this file>
 
+set dump_waves 0
 if {[info exists ::env(WAVES)]} {
-# Use FSDB for dumping only if Verdi is set up
+    set dump_waves "$::env(WAVES)"
+}
 
-# Syntax: fsdbDumpvars [depth] [instance] [option]*
-##############################################################################
-# Option                     Description
-##############################################################################
-# +mda                       Dumps memory and MDA signals in all scopes.
-# +packedmda                 Dumps packed signals
-# +struct                    Dumps structs
-# +skip_cell_instance=mode  Enables or disables cell dumping
-# +strength                  Enables strength dumping
-# +parameter                 Dumps parameters
-# +power                     Dumps power-related signals
-# +trace_process             Dumps VHDL processes
-# +no_functions              Disables dumping of functions
-# +sva                       Dumps assertions
-# +Reg_Only                  Dumps only reg type signals
-# +IO_Only                   Dumps only IO port signals
-# +by_file=<filename>        File to specify objects to add
-# +all                       Dumps memories, MDA signals, structs, unions,power, and packed structs
-
-  if {$::env(WAVES) == 1} {
-    if { [info exists ::env(VERDI_HOME)] } {
-      fsdbDumpfile  $::env(DUMP_FILE)
-      fsdbDumpvars  0 $::env(TB_TOP) +all
-      fsdbDumpSVA   0 $::env(TB_TOP)
-    } else {
-      # Verdi is not set up, so use standard dumping format
-      set dump_file $::env(DUMP_FILE)
-      dump -file "${dump_file}"
-      dump -add { tb } -depth 0 -aggregates -scope "."
+if {"$dump_waves" == 1} {
+    # The basename (without extension) of the file where we should dump waves.
+    # Defaults to "waves".
+    set dump_base "waves"
+    if {[info exists ::(DUMP_BASE)]} {
+        set dump_base "$::env(DUMP_BASE)"
     }
-  }
+
+    # The name of the top-level testbench. Defaults to "tb" if not defined in
+    # environment
+    set tb_top "tb"
+    if {[info exists ::(TB_TOP)]} {
+        set tb_top "$::env(TB_TOP)"
+    }
+
+    if {[info exists ::env(VERDI_HOME)]} {
+        # Looks like we've got a Verdi licence. The fsdbDumpvars command tells
+        # VCS to dump everything: memories, MDA signals, structs, unions, power
+        # and packed structs.
+        puts "Dumping waves with VERDI to ${dump_base}.fsdb"
+        fsdbDumpfile  "${dump_base}.fsdb"
+        fsdbDumpvars  0 $tb_top +all
+        fsdbDumpSVA   0 $tb_top
+    } else {
+        # We don't have Verdi, so use standard dumping format (VCD+)
+        puts "Dumping waves in VCD+ format to ${dump_base}.vpd"
+        dump -file "${dump_base}.vpd"
+        dump -add "$tb_top" -depth 0 -aggregates -scope "."
+    }
 }
 
 run


### PR DESCRIPTION
The previous code correctly dumped to "waves.fsdb" if you had Verdi
installed. Unfortunately, it dumped to the same file name if you
didn't, which was rather confusing.

This patch passes a "DUMP_BASE" environment variable, rather than
"DUMP_FILE", which doesn't include the extension. Then it appends the
correct extension at runtime in the TCL, when we tell VCS what sort of
dumping to do.

The code now also checks for all environment variables before reading
them, allowing defaults if they don't exist. The defaults might not be
what you want, but a syntax error at this point causes VCS to sit
waiting for terminal input (with no stdin!), which is kind of annoying.

I've also removed the copy-pasted Verdi documentation. Apart from
anything else, this is probably copyright, so we shouldn't have a copy
in the repo!