### PR TITLE
[dv] fix timing issue in single_step test

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -739,6 +739,7 @@ class core_ibex_debug_single_step_test extends core_ibex_directed_test;
     bit [ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0] counter = 0;
     bit [ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0] next_counter = 0;
     forever begin
+      clk_vif.wait_clks(2000);
       vseq.start_debug_single_seq();
       check_next_core_status(IN_DEBUG_MODE,
                              "Core did not enter debug mode after debug stimulus", 1000);
@@ -779,7 +780,6 @@ class core_ibex_debug_single_step_test extends core_ibex_directed_test;
         wait_ret("dret", 5000);
         if (counter === 0) break;
       end
-      clk_vif.wait_clks(2000);
     end
   endtask
 


### PR DESCRIPTION
In the `riscv_debug_single_step_test` currently, we wait for 2000 clocks after each round of single stepping has been completed, which was previously fine since this meant that debug requests would start being sent out immediately at the very end of the `<init>` code section (which is the very beginning of the `<main>` code section).
This no longer applies however, since due to a restructuring of the generated program to enable PMP, there is now a jump instruction at the very end of the `<init>` section.  As the single stepping test cannot handle single stepping over branch/jump instructions as of right now, we must ensure to wait until at least this instruction has retired to start sending debug requests.
Resultantly, the `clk_vif.wait_clks(2000)` function call has now been moved to the start of each round of single stepping, which keeps the waiting time between each round the same, but provides the added effect of guaranteeing that this initial jump instruction is skipped over.

Signed-off-by: Udi <udij@google.com>