### PR TITLE
[rtl] Add fixed time execution of branches

### DIFF
--- a/doc/cs_registers.rst
+++ b/doc/cs_registers.rst
@@ -500,6 +500,11 @@ Other bit fields read as zero.
 +-------+------+------------------------------------------------------------------+
 | Bit#  | R/W  | Description                                                      |
 +-------+------+------------------------------------------------------------------+
+| 1     | WARL | **data_ind_timing:** Enable (1) or disable (0) data-independent  |
+|       |      | timing features. If the core has not been configured with        |
+|       |      | security features (SecureIbex parameter == 0), this field will   |
+|       |      | always read as zero.                                             |
++-------+------+------------------------------------------------------------------+
 | 0     | WARL | **icache_enable:** Enable (1) or disable (0) the instruction     |
 |       |      | cache. If the instruction cache has not been configured (ICache  |
 |       |      | parameter == 0), this field will always read as zero.            |

--- a/doc/integration.rst
+++ b/doc/integration.rst
@@ -23,6 +23,7 @@ Instantiation Template
       .MultiplierImplementation ( "fast"       ),
       .ICache                   ( 0            ),
       .ICacheECC                ( 0            ),
+      .SecureIbex               ( 0            ),
       .DbgTriggerEn             ( 0            ),
       .DmHaltAddr               ( 32'h1A110800 ),
       .DmExceptionAddr          ( 32'h1A110808 )
@@ -109,6 +110,9 @@ Parameters
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
 | ``ICacheECC``                | bit         | 0          | *EXPERIMENTAL* Enable SECDED ECC protection in ICache (if       |
 |                              |             |            | ICache == 1)                                                    |
++------------------------------+-------------+------------+-----------------------------------------------------------------+
+| ``SecureIbex``               | bit         | 0          | *EXPERIMENTAL* Enable various additional features targeting     |
+|                              |             |            | secure code execution.                                          |
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
 | ``DbgTriggerEn``             | bit         | 0          | Enable debug trigger support (one trigger only)                 |
 +------------------------------+-------------+------------+-----------------------------------------------------------------+

--- a/dv/cs_registers/tb/tb_cs_registers.sv
+++ b/dv/cs_registers/tb/tb_cs_registers.sv
@@ -71,6 +71,7 @@ module tb_cs_registers #(
   logic [31:0]          pc_id_i;
   logic [31:0]          pc_wb_i;
 
+  logic                 data_ind_timing_o;
   logic                 icache_enable_o;
 
   logic                 csr_save_if_i;

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -100,6 +100,12 @@ parameters:
     default: false
     description: "Enables third pipeline stage (EXPERIMENTAL)"
 
+  SecureIbex:
+    datatype: bool
+    paramtype: vlogparam
+    default: false
+    description: "Enables security hardening features (EXPERIMENTAL)"
+
 targets:
   default:
     filesets:

--- a/ibex_core_tracing.core
+++ b/ibex_core_tracing.core
@@ -77,6 +77,12 @@ parameters:
     default: false
     description: "Enables third pipeline stage (EXPERIMENTAL) [0/1]"
 
+  SecureIbex:
+    datatype: bool
+    paramtype: vlogparam
+    default: false
+    description: "Enables security hardening features (EXPERIMENTAL) [0/1]"
+
 targets:
   default:
     filesets:
@@ -100,6 +106,7 @@ targets:
       - BranchTargetALU
       - WritebackStage
       - MultiplierImplementation
+      - SecureIbex
     default_tool: verilator
     toplevel: ibex_core_tracing
     tools:

--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -18,6 +18,7 @@ lint_off -rule WIDTH -file "*/rtl/ibex_core_tracing.sv" -match "*'RV32M'*"
 lint_off -rule WIDTH -file "*/rtl/ibex_core_tracing.sv" -match "*'RV32E'*"
 lint_off -rule WIDTH -file "*/rtl/ibex_core_tracing.sv" -match "*'BranchTargetALU'*"
 lint_off -rule WIDTH -file "*/rtl/ibex_core_tracing.sv" -match "*'WritebackStage'*"
+lint_off -rule WIDTH -file "*/rtl/ibex_core_tracing.sv" -match "*'SecureIbex'*"
 
 // Filename 'ibex_register_file_ff' does not match MODULE name: ibex_register_file
 // ibex_register_file_ff and ibex_register_file_latch provide two

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -25,6 +25,7 @@ module ibex_core #(
     parameter bit          ICache                   = 1'b0,
     parameter bit          ICacheECC                = 1'b0,
     parameter bit          DbgTriggerEn             = 1'b0,
+    parameter bit          SecureIbex               = 1'b0,
     parameter int unsigned DmHaltAddr               = 32'h1A110800,
     parameter int unsigned DmExceptionAddr          = 32'h1A110808
 ) (
@@ -99,7 +100,8 @@ module ibex_core #(
 
   import ibex_pkg::*;
 
-  localparam int unsigned PMP_NUM_CHAN = 2;
+  localparam int unsigned PMP_NUM_CHAN  = 2;
+  localparam bit          DataIndTiming = SecureIbex;
 
   // IF/ID signals
   logic        instr_valid_id;
@@ -116,6 +118,7 @@ module ibex_core #(
   logic [31:0] pc_id;                  // Program counter in ID stage
   logic [31:0] pc_wb;                  // Program counter in WB stage
 
+  logic        data_ind_timing;
   logic        icache_enable;
   logic        icache_inval;
 
@@ -418,6 +421,7 @@ module ibex_core #(
       .RV32M           ( RV32M           ),
       .RV32B           ( RV32B           ),
       .BranchTargetALU ( BranchTargetALU ),
+      .DataIndTiming   ( DataIndTiming   ),
       .WritebackStage  ( WritebackStage  )
   ) id_stage_i (
       .clk_i                        ( clk                    ),
@@ -491,6 +495,7 @@ module ibex_core #(
       .priv_mode_i                  ( priv_mode_id             ),
       .csr_mstatus_tw_i             ( csr_mstatus_tw           ),
       .illegal_csr_insn_i           ( illegal_csr_insn_id      ),
+      .data_ind_timing_i            ( data_ind_timing          ),
 
       // LSU
       .lsu_req_o                    ( lsu_req                  ), // to load store unit
@@ -767,6 +772,7 @@ module ibex_core #(
 
   ibex_cs_registers #(
       .DbgTriggerEn     ( DbgTriggerEn     ),
+      .DataIndTiming    ( DataIndTiming    ),
       .ICache           ( ICache           ),
       .MHPMCounterNum   ( MHPMCounterNum   ),
       .MHPMCounterWidth ( MHPMCounterWidth ),
@@ -828,6 +834,7 @@ module ibex_core #(
       .pc_id_i                 ( pc_id                    ),
       .pc_wb_i                 ( pc_wb                    ),
 
+      .data_ind_timing_o       ( data_ind_timing          ),
       .icache_enable_o         ( icache_enable            ),
 
       .csr_save_if_i           ( csr_save_if              ),

--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -21,6 +21,7 @@ module ibex_core_tracing #(
     parameter bit          ICache                   = 1'b0,
     parameter bit          ICacheECC                = 1'b0,
     parameter bit          DbgTriggerEn             = 1'b0,
+    parameter bit          SecureIbex               = 1'b0,
     parameter int unsigned DmHaltAddr               = 32'h1A110800,
     parameter int unsigned DmExceptionAddr          = 32'h1A110808
 ) (
@@ -111,6 +112,7 @@ module ibex_core_tracing #(
     .ICacheECC                ( ICacheECC                ),
     .DbgTriggerEn             ( DbgTriggerEn             ),
     .WritebackStage           ( WritebackStage           ),
+    .SecureIbex               ( SecureIbex               ),
     .DmHaltAddr               ( DmHaltAddr               ),
     .DmExceptionAddr          ( DmExceptionAddr          )
   ) u_ibex_core (

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -14,6 +14,7 @@
 
 module ibex_cs_registers #(
     parameter bit          DbgTriggerEn     = 0,
+    parameter bit          DataIndTiming    = 1'b0,
     parameter bit          ICache           = 1'b0,
     parameter int unsigned MHPMCounterNum   = 10,
     parameter int unsigned MHPMCounterWidth = 40,
@@ -79,6 +80,7 @@ module ibex_cs_registers #(
     input  logic [31:0]          pc_wb_i,
 
     // CPU control bits
+    output logic                 data_ind_timing_o,
     output logic                 icache_enable_o,
 
     // Exception save/restore
@@ -158,7 +160,8 @@ module ibex_cs_registers #(
 
   // CPU control register fields
   typedef struct packed {
-    logic [30:0] unused_ctrl;
+    logic [31:2] unused_ctrl;
+    logic        data_ind_timing;
     logic        icache_enable;
   } CpuCtrl_t;
 
@@ -1040,6 +1043,34 @@ module ibex_cs_registers #(
   // Cast register write data
   assign cpuctrl_wdata = CpuCtrl_t'(csr_wdata_int);
 
+  // Generate fixed time execution bit
+  if (DataIndTiming) begin : gen_dit
+    logic data_ind_timing_d, data_ind_timing_q;
+
+    assign data_ind_timing_d = (csr_we_int && (csr_addr == CSR_CPUCTRL)) ?
+      cpuctrl_wdata.data_ind_timing : data_ind_timing_q;
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        data_ind_timing_q <= 1'b0; // disabled on reset
+      end else begin
+        data_ind_timing_q <= data_ind_timing_d;
+      end
+    end
+
+    assign cpuctrl_rdata.data_ind_timing = data_ind_timing_q;
+
+  end else begin : gen_no_dit
+    // tieoff for the unused bit
+    logic unused_dit;
+    assign unused_dit = cpuctrl_wdata.data_ind_timing;
+
+    // field will always read as zero if not configured
+    assign cpuctrl_rdata.data_ind_timing = 1'b0;
+  end
+
+  assign data_ind_timing_o = cpuctrl_rdata.data_ind_timing;
+
   // Generate icache enable bit
   if (ICache) begin : gen_icache_enable
     logic icache_enable_d, icache_enable_q;
@@ -1067,11 +1098,12 @@ module ibex_cs_registers #(
     assign cpuctrl_rdata.icache_enable = 1'b0;
   end
 
-  // tieoff for the currently unused bits of cpuctrl
-  logic [31:1] unused_cpuctrl;
-  assign unused_cpuctrl = {cpuctrl_wdata[31:1]};
-
   assign icache_enable_o = cpuctrl_rdata.icache_enable;
+
+  // tieoff for the currently unused bits of cpuctrl
+  logic [31:2] unused_cpuctrl;
+  assign unused_cpuctrl = {cpuctrl_wdata[31:2]};
+
 
   ////////////////
   // Assertions //


### PR DESCRIPTION
- A new parameter and a run-time control bit (SecureIbex and
  secure_mode) enable different behaviour for running security critical
  code sections.
- In the new mode, all branches act as if taken, with not-taken
  branches executing as a branch to the next instruction.
- This should give similar execution time/power characteristics
  regardless of the branch condition.
- Note that with the BranchTargetALU, branches stall an extra cycle in
  secure mode to avoid factoring the branch-taken decision into the
  branch target address mux.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>