### PR TITLE
[doc] Add note about debug system integration

### DIFF
--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -5,6 +5,16 @@ Debug Support
 
 Ibex offers support for execution-based debug according to the RISC-V Debug Specification, version 0.13.
 
+
+.. note::
+
+   Debug support in Ibex is only one of the components needed to build a System on Chip design with run-control debug support (think "the ability to attach GDB to a core over JTAG").
+   Additionally, a Debug Module and a Debug Transport Module, compliant with the RISC-V Debug Specification, are needed.
+
+   A supported open source implementation of these building blocks can be found in the `RISC-V Debug Support for PULP Cores IP block <https://github.com/pulp-platform/riscv-dbg/>`_.
+
+   The `OpenTitan project <https://github.com/lowRISC/opentitan>`_ can serve as an example of how to integrate the two components in a toplevel design.
+
 Interface
 ---------
 

--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -3,7 +3,7 @@
 Debug Support
 =============
 
-Ibex offers support for execution-based debug according to the RISC-V Debug Specification, version 0.13.
+Ibex offers support for execution-based debug according to the `RISC-V Debug Specification <https://riscv.org/specifications/debug-specification/>`_, version 0.13.
 
 
 .. note::

--- a/doc/verification.rst
+++ b/doc/verification.rst
@@ -78,7 +78,7 @@ The complete test list can be found in the file `dv/uvm/core_ibex/riscv_dv_exten
 Please note that verification is still a work in progress.
 
 Getting Started
-^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^
 
 Prerequisites & Environment Setup
 """""""""""""""""""""""""""""""""
@@ -257,4 +257,3 @@ The ``--skip-ral`` option is mandatory for building/simulating the Icache testbe
 have any CSRs, excluding this option will lead to build errors.
 ``--purge`` directs the tool to ``rm -rf`` the output directory before running the tool, this can be
 removed if not desired.
-


### PR DESCRIPTION
Ibex only provides the necessary interfaces and core-internal functionality
for run-control debug. To get a fully working,
"debuggable" toplevel design, more components are needed. Describe where to
get them from, and include OpenTitan as an exemplary integration.