### PR TITLE
Dv error changes

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/ibex_log_to_trace_csv.py
+++ b/dv/uvm/core_ibex/riscv_dv_extension/ibex_log_to_trace_csv.py
@@ -89,9 +89,12 @@ def process_ibex_sim_log(ibex_log, csv, full_trace=1):
     log and save to a standard CSV format.
     """
     logging.info("Processing ibex log : %s" % ibex_log)
-    with open(ibex_log, "r") as log_fd, open(csv, "w") as csv_fd:
-        count = _process_ibex_sim_log_fd(log_fd, csv_fd,
-                                         True if full_trace else False)
+    try:
+        with open(ibex_log, "r") as log_fd, open(csv, "w") as csv_fd:
+            count = _process_ibex_sim_log_fd(log_fd, csv_fd,
+                                             True if full_trace else False)
+    except FileNotFoundError:
+        raise RuntimeError("Logfile %s not found" % ibex_log)
 
     logging.info("Processed instruction count : %d" % count)
     if not count:

--- a/dv/uvm/core_ibex/sim.py
+++ b/dv/uvm/core_ibex/sim.py
@@ -351,9 +351,14 @@ def compare_test_run(test, idx, iss, output_dir, report):
     rtl_csv = os.path.join(rtl_dir, 'trace_core_00000000.csv')
     uvm_log = os.path.join(rtl_dir, 'sim.log')
 
-    # Convert the RTL log file to a trace CSV. On failure, this will raise an
-    # exception, so we can assume this passed.
-    process_ibex_sim_log(rtl_log, rtl_csv, 1)
+    try:
+        # Convert the RTL log file to a trace CSV.
+        process_ibex_sim_log(rtl_log, rtl_csv, 1)
+    except RuntimeError as e:
+        with open(report, 'a') as report_fd:
+            report_fd.write('Log processing failed: {}\n'.format(e))
+
+        return False
 
     # Have a look at the UVM log. We should write out a message on failure or
     # if we are stopping at this point.

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -13,6 +13,7 @@ class core_ibex_base_test extends uvm_test;
   core_ibex_vseq                                  vseq;
   bit                                             enable_irq_seq;
   int unsigned                                    timeout_in_cycles = 100000000;
+  int unsigned                                    max_quit_count  = 1;
   // If no signature_addr handshake functionality is desired between the testbench and the generated
   // code, the test will wait for the specifield number of cycles before starting stimulus
   // sequences (irq and debug)
@@ -75,6 +76,12 @@ class core_ibex_base_test extends uvm_test;
     wait_for_test_done();
     phase.drop_objection(this);
   endtask
+
+  virtual function void end_of_elaboration_phase(uvm_phase phase);
+    super.end_of_elaboration_phase(phase);
+    void'($value$plusargs("max_quit_count=%0d", max_quit_count));
+    uvm_report_server::get_server().set_max_quit_count(max_quit_count);
+  endfunction
 
   virtual function void report_phase(uvm_phase phase);
     super.report_phase(phase);


### PR DESCRIPTION
Before I added the set_max_quit_count call I had a failure (xprop related that caused several assertions to fire each cycle) that caused a ~2GB log file and a failure to dump waves (the simulation timed out which seemed to mess up the wave dump).

I set the default to 10 rather than 1 as it can be useful to let the simulation run a little past the first error if only to get another cycle or two in the waves.