### PR TITLE
[dv] Fix running on LSF

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -328,6 +328,7 @@ $(OUT)/rtl_sim/.compile.stamp: \
 	@./sim.py \
 	 --o=${OUT} \
 	 --steps=compile \
+	 --lsf_cmd="${LSF_CMD}" \
 	 ${COMMON_OPTS} \
 	 --simulator="${SIMULATOR}" --simulator_yaml=yaml/rtl_simulation.yaml \
 	 $(cov-arg) $(wave-arg) --cmp_opts="${COMPILE_OPTS}"
@@ -363,6 +364,7 @@ $(metadata)/rtl_sim.run.stamp: \
 	@./sim.py \
 	 --o=$(OUT-SEED) \
 	 --steps=sim \
+	 --lsf_cmd="${LSF_CMD}" \
 	 ${TEST_OPTS} \
 	 --simulator="${SIMULATOR}" --simulator_yaml=yaml/rtl_simulation.yaml \
 	 $(cov-arg) $(wave-arg) $(lsf-arg) \

--- a/dv/uvm/core_ibex/sim.py
+++ b/dv/uvm/core_ibex/sim.py
@@ -264,7 +264,7 @@ def run_sim_commands(command_list, use_lsf, check_return_code):
     # we have to create the output directories in advance.
     if use_lsf:
         cmds = []
-        for cmd, dirname in command_list:
+        for desc, cmd, dirname in command_list:
             os.makedirs(dirname, exist_ok=True)
             cmds.append(cmd)
         run_parallel_cmd(cmds, 600, check_return_code=check_return_code)


### PR DESCRIPTION
Minor fixes to fix running commands on LSF:
1) Adding the LSF_CMD makefile option to the compile and rtl_sim steps to actually pass in the 'bsub' command
2) Fixing a syntax error in one of the `sim.py` functions that ran whenever lsf is enabled

Signed-off-by: Udi <udij@google.com>