### PR TITLE
Switch from 'bool' to 'int' parameters in fusesoc core files

### DIFF
--- a/dv/cs_registers/tb_cs_registers.core
+++ b/dv/cs_registers/tb_cs_registers.core
@@ -59,10 +59,10 @@ scripts:
 
 parameters:
   PMPEnable:
-    datatype: bool
+    datatype: int
     paramtype: vlogparam
-    default: true
-    description: PMP enabled [true/false]
+    default: 1
+    description: PMP enabled [1/0]
   PMPNumRegions:
     datatype: int
     paramtype: vlogparam

--- a/dv/riscv_compliance/ibex_riscv_compliance.core
+++ b/dv/riscv_compliance/ibex_riscv_compliance.core
@@ -25,19 +25,19 @@ filesets:
 
 parameters:
   RV32M:
-    datatype: bool
+    datatype: int
     paramtype: vlogparam
-    default: true
+    default: 1
     description: Enable the M ISA extension (hardware multiply/divide)
   RV32E:
-    datatype: bool
+    datatype: int
     paramtype: vlogparam
-    default: false
+    default: 0
     description: Enable the E ISA extension (reduced register set)
   RV32B:
-    datatype: bool
+    datatype: int
     paramtype: vlogparam
-    default: false
+    default: 0
     description: Enable the B ISA extension (bit manipulation EXPERIMENTAL)
   MultiplierImplementation:
     datatype: str
@@ -45,14 +45,14 @@ parameters:
     description: "Multiplier implementation. Valid values: fast, slow, single-cycle"
     default: "fast"
   BranchTargetALU:
-    datatype: bool
+    datatype: int
     paramtype: vlogparam
-    default: false
+    default: 0
     description: Enables seperate branch target ALU (increasing branch performance EXPERIMENTAL)
   WritebackStage:
-    datatype: bool
+    datatype: int
     paramtype: vlogparam
-    default: false
+    default: 0
     description: Enables third pipeline stage (EXPERIMENTAL)
 
 targets:

--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -24,19 +24,19 @@ filesets:
 
 parameters:
   RV32M:
-    datatype: bool
+    datatype: int
     paramtype: vlogparam
-    default: true
+    default: 1
     description: Enable the M ISA extension (hardware multiply/divide) [0/1]
   RV32E:
-    datatype: bool
+    datatype: int
     paramtype: vlogparam
-    default: false
+    default: 0
     description: Enable the E ISA extension (reduced register set) [0/1]
   RV32B:
-    datatype: bool
+    datatype: int
     paramtype: vlogparam
-    default: false
+    default: 0
     description: Enable the B ISA extension (bit manipulation EXPERIMENTAL) [0/1]
   SRAM_INIT_FILE:
     datatype: str
@@ -48,14 +48,14 @@ parameters:
     description: "Multiplier implementation. Valid values: fast, slow, single-cycle"
     default: "fast"
   BranchTargetALU:
-    datatype: bool
+    datatype: int
     paramtype: vlogparam
-    default: false
+    default: 0
     description: Enables seperate branch target ALU (increasing branch performance EXPERIMENTAL)
   WritebackStage:
-    datatype: bool
+    datatype: int
     paramtype: vlogparam
-    default: false
+    default: 0
     description: Enables third pipeline stage (EXPERIMENTAL)
 
 targets:

--- a/ibex_configs.yaml
+++ b/ibex_configs.yaml
@@ -8,11 +8,11 @@
 # Two-stage pipeline without additional branch target ALU and 3 cycle multiplier
 # (4 cycles for mulh), resulting in 2 stall cycles for mul (3 for mulh)
 small-3cmult:
-  RV32E                    : False
-  RV32M                    : True
-  RV32B                    : False
-  BranchTargetALU          : False
-  WritebackStage           : False
+  RV32E                    : 0
+  RV32M                    : 1
+  RV32B                    : 0
+  BranchTargetALU          : 0
+  WritebackStage           : 0
   MultiplierImplementation : "fast"
 
 # ===============================
@@ -23,18 +23,18 @@ small-3cmult:
 # (2 cycles for mulh) so mul does not stall (mulh stall 1 cycles). This is the
 # maximum performance configuration.
 experimental-maxperf-1cmult:
-  RV32E                    : False
-  RV32M                    : True
-  RV32B                    : False
-  BranchTargetALU          : True
-  WritebackStage           : True
+  RV32E                    : 0
+  RV32M                    : 1
+  RV32B                    : 0
+  BranchTargetALU          : 1
+  WritebackStage           : 1
   MultiplierImplementation : "single-cycle"
 
 # maxpref-1cmult config above with bitmanip extension
 experimental-maxperf-bm-1cmult:
-  RV32E                    : False
-  RV32M                    : True
-  RV32B                    : True
-  BranchTargetALU          : True
-  WritebackStage           : True
+  RV32E                    : 0
+  RV32M                    : 1
+  RV32B                    : 1
+  BranchTargetALU          : 1
+  WritebackStage           : 1
   MultiplierImplementation : "single-cycle"

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -58,53 +58,55 @@ parameters:
     paramtype: vlogdefine
 
   RV32E:
-    datatype: bool
+    datatype: int
+    default: 0
     paramtype: vlogparam
 
   RV32M:
-    datatype: bool
+    datatype: int
+    default: 1
     paramtype: vlogparam
 
   RV32B:
-    datatype: bool
-    default: false
+    datatype: int
+    default: 0
     paramtype: vlogparam
 
   MultiplierImplementation:
     datatype: str
     paramtype: vlogparam
-    description: "Multiplier implementation. Valid values: fast, slow"
-    default: fast
+    description: "Multiplier implementation. Valid values: fast, slow, single-cycle"
+    default: "fast"
 
   ICache:
-    datatype: bool
+    datatype: int
+    default: 0
     paramtype: vlogparam
     description: "Enable instruction cache"
-    default: false
 
   ICacheECC:
-    datatype: bool
+    datatype: int
+    default: 0
     paramtype: vlogparam
     description: "Enable ECC protection in instruction cache"
-    default: false
 
   BranchTargetALU:
-    datatype: bool
+    datatype: int
+    default: 0
     paramtype: vlogparam
-    default: false
-    description: "Enables seperate branch target ALU (increasing branch performance EXPERIMENTAL)"
+    description: "Enables seperate branch target ALU (increasing branch performance EXPERIMENTAL) [0/1]"
 
   WritebackStage:
-    datatype: bool
+    datatype: int
+    default: 0
     paramtype: vlogparam
-    default: false
-    description: "Enables third pipeline stage (EXPERIMENTAL)"
+    description: "Enables third pipeline stage (EXPERIMENTAL) [0/1]"
 
   SecureIbex:
-    datatype: bool
+    datatype: int
+    default: 0
     paramtype: vlogparam
-    default: false
-    description: "Enables security hardening features (EXPERIMENTAL)"
+    description: "Enables security hardening features (EXPERIMENTAL) [0/1]"
 
 targets:
   default:

--- a/ibex_core_tracing.core
+++ b/ibex_core_tracing.core
@@ -33,18 +33,18 @@ parameters:
     paramtype: vlogdefine
 
   RV32E:
-    datatype: bool
-    default: false
+    datatype: int
+    default: 0
     paramtype: vlogparam
 
   RV32M:
-    datatype: bool
-    default: true
+    datatype: int
+    default: 1
     paramtype: vlogparam
 
   RV32B:
-    datatype: bool
-    default: false
+    datatype: int
+    default: 0
     paramtype: vlogparam
 
   MultiplierImplementation:
@@ -54,33 +54,33 @@ parameters:
     default: "fast"
 
   ICache:
-    datatype: bool
+    datatype: int
+    default: 0
     paramtype: vlogparam
     description: "Enable instruction cache"
-    default: false
 
   ICacheECC:
-    datatype: bool
+    datatype: int
+    default: 0
     paramtype: vlogparam
     description: "Enable ECC protection in instruction cache"
-    default: false
 
   BranchTargetALU:
-    datatype: bool
+    datatype: int
+    default: 0
     paramtype: vlogparam
-    default: false
     description: "Enables seperate branch target ALU (increasing branch performance EXPERIMENTAL) [0/1]"
 
   WritebackStage:
-    datatype: bool
+    datatype: int
+    default: 0
     paramtype: vlogparam
-    default: false
     description: "Enables third pipeline stage (EXPERIMENTAL) [0/1]"
 
   SecureIbex:
-    datatype: bool
+    datatype: int
+    default: 0
     paramtype: vlogparam
-    default: false
     description: "Enables security hardening features (EXPERIMENTAL) [0/1]"
 
 targets:


### PR DESCRIPTION
Fusesoc has an unfortunate bug[1] where a boolean parameter which has
default true can't be disabled. For now, just make all our boolean
parameters back into integers again. In the future, when that's fixed,
maybe we should switch things back.

[1] https://github.com/olofk/fusesoc/issues/392