### PR TITLE
[ci] Fix multi-config CI

### DIFF
--- a/ci/ibex-rtl-ci-steps.yml
+++ b/ci/ibex-rtl-ci-steps.yml
@@ -7,11 +7,14 @@ steps:
     # the CI to fail if there's an issue with the configuration file or an
     # incorrect configuration name being used
     - bash: |
-        ./util/ibex_config.py ${{ config }} fusesoc_opts
-      displayName: Display fusesoc config for ${{ config }}
+        set -e
+        IBEX_CONFIG_OPTS=`./util/ibex_config.py ${{ config }} fusesoc_opts`
+        echo $IBEX_CONFIG_OPTS
+        echo "##vso[task.setvariable variable=ibex_config_opts]" $IBEX_CONFIG_OPTS
+      displayName: Test and display fusesoc config for ${{ config }}
 
     - bash: |
-        fusesoc --cores-root . run --target=lint lowrisc:ibex:ibex_core_tracing $(./util/ibex_config.py ${{ parameters.ibex_config }} fusesoc_opts)
+        fusesoc --cores-root . run --target=lint lowrisc:ibex:ibex_core_tracing $IBEX_CONFIG_OPTS
         if [ $? != 0 ]; then
           echo -n "##vso[task.logissue type=error]"
           echo "Verilog lint failed. Run 'fusesoc --cores-root . run --target=lint lowrisc:ibex:ibex_core_tracing' to check and fix all errors."
@@ -21,7 +24,7 @@ steps:
 
     - bash: |
         # Build simulation model of Ibex
-        fusesoc --cores-root=. run --target=sim --setup --build lowrisc:ibex:ibex_riscv_compliance $(./util/ibex_config.py ${{ parameters.ibex_config }} fusesoc_opts)
+        fusesoc --cores-root=. run --target=sim --setup --build lowrisc:ibex:ibex_riscv_compliance $IBEX_CONFIG_OPTS
         if [ $? != 0 ]; then
           echo -n "##vso[task.logissue type=error]"
           echo "Unable to build Verilator model of Ibex for compliance testing."

--- a/dv/riscv_compliance/ibex_riscv_compliance.core
+++ b/dv/riscv_compliance/ibex_riscv_compliance.core
@@ -64,6 +64,7 @@ targets:
     parameters:
       - RV32M
       - RV32E
+      - RV32B
       - MultiplierImplementation
       - BranchTargetALU
       - WritebackStage

--- a/ibex_core_tracing.core
+++ b/ibex_core_tracing.core
@@ -103,6 +103,7 @@ targets:
       - SYNTHESIS=true
       - RV32M
       - RV32E
+      - RV32B
       - BranchTargetALU
       - WritebackStage
       - MultiplierImplementation

--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -16,6 +16,7 @@ lint_off -rule PINCONNECTEMPTY
 // 32 bits
 lint_off -rule WIDTH -file "*/rtl/ibex_core_tracing.sv" -match "*'RV32M'*"
 lint_off -rule WIDTH -file "*/rtl/ibex_core_tracing.sv" -match "*'RV32E'*"
+lint_off -rule WIDTH -file "*/rtl/ibex_core_tracing.sv" -match "*'RV32B'*"
 lint_off -rule WIDTH -file "*/rtl/ibex_core_tracing.sv" -match "*'BranchTargetALU'*"
 lint_off -rule WIDTH -file "*/rtl/ibex_core_tracing.sv" -match "*'WritebackStage'*"
 lint_off -rule WIDTH -file "*/rtl/ibex_core_tracing.sv" -match "*'SecureIbex'*"


### PR DESCRIPTION
This PR includes some testing bits and pieces so shouldn't be merged yet, will resubmit a version without them once I'm happy everything is working

Multi-config CI wasn't actually trying multiple configurations. This
fixes that issue and uses a less fragile method of producing fusesoc
options. They are generated once and stored in a variable so we cannot
accidentally break one or more steps by using an incorrect
ibex_config.py command in one step whilst using a correct
ibex_config.py in the display step (which is also intended to check the
ibex_config.py command is correct).