### PR TITLE
Add clocking blocks to icache core agent interface

### DIFF
--- a/dv/uvm/icache/dv/Makefile
+++ b/dv/uvm/icache/dv/Makefile
@@ -18,6 +18,7 @@ VERBOSITY=
 SEED=1
 
 ibex-top       := ../../../..
+scratch-root   := $(ibex-top)/build
 dvsim-py       := $(ibex-top)/vendor/lowrisc_ip/dvsim/dvsim.py
 dvsim-std-args := --skip-ral --scratch-root $(scratch-root)
 

--- a/dv/uvm/icache/dv/env/ibex_icache_env.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_env.sv
@@ -27,8 +27,8 @@ class ibex_icache_env extends dv_base_env #(
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
     if (cfg.en_scb) begin
-      m_ibex_icache_core_agent.monitor.analysis_port.connect(scoreboard.ibex_icache_fifo.analysis_export);
-      m_ibex_mem_intf_slave_agent.monitor.addr_ph_port.connect(scoreboard.ibex_mem_intf_slave_fifo.analysis_export);
+      m_ibex_icache_core_agent.monitor.analysis_port.connect(scoreboard.core_fifo.analysis_export);
+      m_ibex_mem_intf_slave_agent.monitor.addr_ph_port.connect(scoreboard.mem_fifo.analysis_export);
     end
     if (cfg.is_active && cfg.m_ibex_icache_core_agent_cfg.is_active) begin
       virtual_sequencer.core_sequencer_h = m_ibex_icache_core_agent.sequencer;

--- a/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
@@ -18,8 +18,8 @@ class ibex_icache_scoreboard extends dv_base_scoreboard #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    ibex_icache_fifo = new("ibex_icache_fifo", this);
-    ibex_mem_intf_slave_fifo = new("ibex_mem_intf_slave_fifo", this);
+    core_fifo = new("core_fifo", this);
+    mem_fifo = new("mem_fifo", this);
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
@@ -27,16 +27,52 @@ interface ibex_icache_core_if (input clk);
   // itself)
   logic         busy;
 
+  // A clocking block for test code that drives the interface
+  clocking driver_cb @(posedge clk);
+
+    // Drive signals on the following negedge: this isn't needed by the design, but makes it
+    // slightly easier to read dumped waves.
+    default output negedge;
+
+    output req;
+
+    output branch;
+    output branch_addr;
+
+    output ready;
+    input  valid;
+    input  err;
+
+    output enable;
+    output invalidate;
+  endclocking
+
+  // A clocking block for test code that needs to monitor the interface
+  clocking monitor_cb @(posedge clk);
+    input  req;
+    input  branch;
+    input  branch_addr;
+    input  ready;
+    input  valid;
+    input  rdata;
+    input  addr;
+    input  err;
+    input  err_plus2;
+    input  enable;
+    input  invalidate;
+    input  busy;
+  endclocking
+
   // Drive the branch pin for a single cycle, redirecting the cache to the given instruction
   // address.
   task automatic branch_to(logic [31:0] addr);
-    branch      <= 1'b1;
-    branch_addr <= addr;
+    driver_cb.branch      <= 1'b1;
+    driver_cb.branch_addr <= addr;
 
-    @(posedge clk);
+    @(driver_cb);
 
-    branch      <= 1'b0;
-    branch_addr <= 'X;
+    driver_cb.branch      <= 1'b0;
+    driver_cb.branch_addr <= 'X;
   endtask
 
   // Raise a pulse on the invalidate line for the given number of cycles.
@@ -44,24 +80,24 @@ interface ibex_icache_core_if (input clk);
   // A one-cycle pulse will start an invalidation, but testing might want a longer pulse (which the
   // cache should support)
   task automatic invalidate_pulse(int num_cycles);
-    invalidate <= 1'b1;
-    repeat (num_cycles) @(posedge clk);
-    invalidate <= 1'b0;
+    driver_cb.invalidate <= 1'b1;
+    wait_clks(num_cycles);
+    driver_cb.invalidate <= 1'b0;
   endtask
 
   // A task that waits for num_clks posedges on the clk signal
   task automatic wait_clks(int num_clks);
-    repeat (num_clks) @(posedge clk);
+    repeat (num_clks) @(driver_cb);
   endtask
 
   // Reset all the signals from the core to the cache (the other direction is controlled by the
   // DUT)
   task automatic reset();
-    req        <= 1'b0;
-    branch     <= 1'b0;
-    ready      <= 1'b0;
-    enable     <= 1'b0;
-    invalidate <= 1'b0;
+    driver_cb.req        <= 1'b0;
+    driver_cb.branch     <= 1'b0;
+    driver_cb.ready      <= 1'b0;
+    driver_cb.enable     <= 1'b0;
+    driver_cb.invalidate <= 1'b0;
   endtask
 
 endinterface


### PR DESCRIPTION
As discussed in issue #778.

The other two patches in the queue are embarrassing: it seems my "edit a long patch queue and push something near the bottom" flow missed a couple of typos which were fixed further down the list. I've checked, and you can actually run the code after this.