### PR TITLE
riviera support for riscv-dv testbench

### DIFF
--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -85,7 +85,7 @@
 
   sim:
     cmd: >
-      vsim -c <sim_opts> <cov_opts> -sv_seed <seed> -lib <out>/work +access +r+w -l <out>/logfile.log -do "run -all; endsim; quit -force" +ibex_tracer_file_base="trace_core"
+      vsim -c <sim_opts> <cov_opts> -sv_seed <seed> -lib <out>/work +access +r+w +UVM_TESTNAME=<rtl_test> +bin=<binary> +ibex_tracer_file_base="<sim_dir>/trace_core" -l <sim_dir>/sim.log -do "run -all; endsim; quit -force"
     cov_opts: >
       -acdb_file <out>/cov.acdb
 


### PR DESCRIPTION
Riviera supports riscv-dv please upadate its version to at least:
https://github.com/google/riscv-dv/commit/2e8e73bfdffc376568c71673448a4b1afdaa9bb4
and merge changes proposed in this pull request.