### PR TITLE
[dv] fix PMP compile option, update basic pmp test

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -582,5 +582,8 @@
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000
-    +num_of_sub_program=2
+    +pmp_randomize=0
+    +pmp_allow_addr_overlap=0
+    +pmp_max_offset=00021000
+    +boot_mode=u
   rtl_test: core_ibex_base_test

--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -24,7 +24,7 @@
          -Mdir=<out>/vcs_simv.csrc
          -o <out>/vcs_simv
          -debug_access+pp
-         -lca -kdb <wave_opts> <cov_opts>"
+         -lca -kdb <cmp_opts> <wave_opts> <cov_opts>"
     cov_opts: >
       -cm line+tgl+assert+fsm+branch
       -cm_tgl portsonly


### PR DESCRIPTION
Update the basic PMP test to (hopefully) solve the hanging issue by adding the new set of plusargs dictated by the new riscv_pmp_cfg generator class and adds a <cmp_opts> argument to the vcs compile command to enable compile time command substitution from the Makefile/command-line.

The <cmp_opts> argument is to enable passing in PMP-related parameters to Ibex compilation (the number of regions and granularity) as the RTL treats these as top level parameters and cannot be modified at runtime.

The basic PMP yaml test entry has some updates as well:
1) +num_of_sub_program=2 has been deleted, which causes it to be set to the generator's default value of 5
2) +pmp_randomize=0 is explicitly specified here just to provide some clarification, as I have not gotten around to creating documentation for the PMP generation class. Enabling this causes full randomization of each pmpcfg and pmpaddr CSR to create interesting test scenarios. I can easily remove this if you would like.
3) +pmp_allow_addr_overlap controls whether the automatically generated addresses written to the pmpaddr CSRs create 'overlapping' protected memory regions - this is to create test scenarios where higher number PMP configuration CSRs are matched over lower numbered PMP CSRs. As this is just a basic "sanity" PMP test, this value is set to 0 to disable this functionality.
4) +pmp_max_offset is slightly more involved. During the generator's PMP configuration routine, the address of the program's 'main' label is written to the pmpaddr0 CSR and full permissions are granted to the corresponding memory region to protect all initialization routines from faulting), but as of the current state of the generator we don't have a good way to load an address corresponding to the end of the program into the highest enabled pmpaddr CSR and then distribute the resulting address range to the remaining pmpaddr CSRs. As a result, how we do it is to pass in a large offset value from the command line, and then add this offset to the relative address stored in pmpaddr0 (the 'main' label) to get the maximum of the range covered by the PMP CSRs, and then use this offset value to distribute the remaining pmpaddr CSRs across this address range created by [main : main + pmp_max_offset].
5) +boot_mode is set to user mode to ensure that all memory requests from the I and D side go through PMP checks, as the spec states that machine mode accesses only have PMP checks applied if the L (lock) bit of the appropriate pmpcfg CSR  is set; since I disable full PMP randomization, each L bit is set to 0 so I need to boot the core into user mode to make sure that PMP checks are actually being applied to every relevant instruction.


Just as a note: the PMP configuration routine in riscv-dv is by no means complete, I will be fairly constantly updating it with features relevant to Ibex DV as well as with features requested by external users, so the plusargs in PMP tests will likely be updated as well.

Signed-off-by: Udi <udij@google.com>