### PR TITLE
[bitmanip] Add ZBS Instruction Group

### DIFF
--- a/doc/instruction_decode_execute.rst
+++ b/doc/instruction_decode_execute.rst
@@ -66,7 +66,7 @@ Other blocks use the ALU for the following tasks:
 
 Support for the RISC-V Bitmanipulation Extension (Document Version 0.92, November 8, 2019) is enabled via the parameter ``RV32B``.
 This feature is *EXPERIMENTAL* and the details of its impact are not yet documented here.
-Currently the Zbb and Zbt sub-extensions are implemented.
+Currently the Zbb, Zbs and Zbt sub-extensions are implemented.
 All instructions are carried out in a single clock cycle.
 
 .. _mult-div:

--- a/doc/integration.rst
+++ b/doc/integration.rst
@@ -92,7 +92,8 @@ Parameters
 | ``RV32M``                    | bit         | 1          | M(ultiply) extension enable                                     |
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
 | ``RV32B``                    | bit         | 0          | *EXPERIMENTAL* - B(itmanipulation) extension enable:            |
-|                              |             |            | Currently supported Z-extensions: Zbb (base)                    |
+|                              |             |            | Currently supported Z-extensions: Zbb (base), Zbs (single-bit)  |
+|                              |             |            | and Zbt (ternary)  |
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
 | ``BranchTargetALU``          | bit         | 0          | *EXPERIMENTAL* - Enables branch target ALU removing a stall     |
 |                              |             |            | cycle from taken branches                                       |

--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -36,6 +36,12 @@ lint_off -rule UNUSED -file "*/rtl/ibex_alu.sv" -match "*'shift_amt_compl'[5]*"
 // cleaner to write all bits even if not all are used
 lint_off -rule UNUSED -file "*/rtl/ibex_alu.sv" -match "*'shift_result_ext'[32]*"
 
+// Signal is not used for RV32B == 0: imd_val_q_i
+//
+// No ALU multicycle instructions exist to use the intermediate value register,
+// if bitmanipulation extension is not enabled.
+lint_off -rule UNUSED -file "*/rtl/ibex_alu.sv" -match "*'imd_val_q_i'"
+
 // Bits of signal are not used: fetch_addr_n[0]
 // cleaner to write all bits even if not all are used
 lint_off -rule UNUSED -file "*/rtl/ibex_if_stage.sv" -match "*'fetch_addr_n'[0]*"

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -566,6 +566,7 @@ module ibex_core #(
       .ready_wb_i                   ( ready_wb                 ),
       .outstanding_load_wb_i        ( outstanding_load_wb      ),
       .outstanding_store_wb_i       ( outstanding_store_wb     ),
+
       // Performance Counters
       .perf_jump_o                  ( perf_jump                ),
       .perf_branch_o                ( perf_branch              ),

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -93,7 +93,14 @@ typedef enum logic [5:0] {
   ALU_CMOV,
   ALU_CMIX,
   ALU_FSL,
-  ALU_FSR
+  ALU_FSR,
+
+  // Single-Bit Operations
+  // RV32B
+  ALU_SBSET,
+  ALU_SBCLR,
+  ALU_SBINV,
+  ALU_SBEXT
 } alu_op_e;
 
 typedef enum logic [1:0] {

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -875,7 +875,7 @@ module ibex_tracer (
         // MISC-MEM
         INSN_FENCE:      decode_fence();
         INSN_FENCEI:     decode_mnemonic("fence.i");
-        // RV32B
+        // RV32B - ZBB
         INSN_SLOI:       decode_i_shift_insn("sloi");
         INSN_SROI:       decode_i_shift_insn("sroi");
         INSN_RORI:       decode_i_shift_insn("rori");
@@ -899,7 +899,16 @@ module ibex_tracer (
         INSN_PCNT:       decode_r1_insn("pcnt");
         INSN_REV:        decode_r1_insn("rev");
         INSN_REV8:       decode_r1_insn("rev8");
-        // TERNARY BITMABIP INSTR
+        // RV32B - ZBS
+        INSN_SBCLRI:     decode_i_insn("sbclri");
+        INSN_SBSETI:     decode_i_insn("sbseti");
+        INSN_SBINVI:     decode_i_insn("sbinvi");
+        INSN_SBEXTI:     decode_i_insn("sbexti");
+        INSN_SBCLR:      decode_r_insn("sbclr");
+        INSN_SBSET:      decode_r_insn("sbset");
+        INSN_SBINV:      decode_r_insn("sbinv");
+        INSN_SBEXT:      decode_r_insn("sbext");
+        // RV32B - ZBT
         INSN_CMIX:       decode_r_cmixcmov_insn("cmix");
         INSN_CMOV:       decode_r_cmixcmov_insn("cmov");
         INSN_FSR:        decode_r_funnelshift_insn("fsr");

--- a/rtl/ibex_tracer_pkg.sv
+++ b/rtl/ibex_tracer_pkg.sv
@@ -86,6 +86,12 @@ parameter logic [31:0] INSN_REV8 =
     { 5'b01101, 2'b?, 5'b11000, 5'b? , 3'b101, 5'b?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORCB =
     { 5'b00101, 2'b?, 5'b00111, 5'b? , 3'b101, 5'b?, {OPCODE_OP_IMM} };
+// ZBS
+parameter logic [31:0] INSN_SBCLRI = { 5'b01001      , 12'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SBSETI = { 5'b00101      , 12'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SBINVI = { 5'b01101      , 12'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SBEXTI = { 5'b01001      , 12'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+
 // ZBT
 parameter logic [31:0] INSN_FSRI = { 5'b?, 1'b1, 11'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
 
@@ -105,6 +111,12 @@ parameter logic [31:0] INSN_ANDN  = { 7'b0100000, 10'b?, 3'b111, 5'b?, {OPCODE_O
 parameter logic [31:0] INSN_PACK  = { 7'b0000100, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
 parameter logic [31:0] INSN_PACKU = { 7'b0100100, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
 parameter logic [31:0] INSN_PACKH = { 7'b0000100, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
+// ZBS
+parameter logic [31:0] INSN_SBCLR = { 7'b0100100, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SBSET = { 7'b0010100, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SBINV = { 7'b0110100, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SBEXT = { 7'b0100100, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
+
 // ZBT
 parameter logic [31:0] INSN_CMIX = {5'b?, 2'b11, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
 parameter logic [31:0] INSN_CMOV = {5'b?, 2'b11, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };


### PR DESCRIPTION
This commit implements the Bit Manipulation Extension SBS instruction group: sbset[i], sbclr[i], sbinv[i] and sbext[i]. These instructions set, clear, invert or extract bit rs1[rs2] or rs1[imm] for reg-reg and reg-imm instructions respectively.

Archtectural details:

- A multiplexer is added to the shifter structure in order to chose between 32'h1, used for the single-bit instructions as summarized below, and regular operand_b input.

- Dedicated bitwise-logic blocks are introduced for multicycle shifts and cmix instructions (fsr, fsl, ror, rol), single-bit instructions (sbset, sbclr, sbinv, sbext), and stanard-ALU and zbb instructions (or, and xor, orn, andn, xnor).

Instruction details: All of the zbs instructions rely on sharing the existing shifter structure. The instructions are carried out in one cycle.

        - sbset, sbclr, sbinv:
                shift_result = 32'h1 << rs2[4:0];
                singlebit_result = rs1 [|, ^ , &~] shift_result;

        - sbext:
                shift_result = rs1 >> rs2[4:0];
                singlebit_result = {31'0,shift_resutl[0]};

As always, synthesis results are available [here](https://docs.google.com/spreadsheets/d/1dDDtzMgS5quMXtv-8z2uD--jBIHMSnaWrqj1EIDp1Nw/edit#gid=2000) (tab: zbs-rebased, design name: separatated-bwlogic). The impact on area and timing is limited. The move to separated bitwise-logic structures results in a slight trend to condserve a bit of area. Timing-wise, we see a larger fluctuation and the trend does seem to indicate a slight disadvantage of the design with seperated bitwise logic. 

A possible reason for this may be the again enlarged output multiplexer, which would have had one input for multicycle instructions, bwlogic and sb instructions in the shared-bwlogic design. Separating these structures leads to two more inputs to this mux.

However, fluctuation is reasonably small and may well be a result of random variations due to the synthesis process. However I will attempt an optimization of the output multiplexer at a later stage.

Signed-off-by: ganoam <gnoam@live.com>