### PR TITLE
Use Shared Intermediate Value Register with Multdiv Slow

### DIFF
--- a/rtl/ibex_ex_block.sv
+++ b/rtl/ibex_ex_block.sv
@@ -148,6 +148,9 @@ module ibex_ex_block #(
         .valid_o            ( multdiv_valid         ),
         .alu_operand_a_o    ( multdiv_alu_operand_a ),
         .alu_operand_b_o    ( multdiv_alu_operand_b ),
+        .imd_val_q_i        ( imd_val_q_i           ),
+        .imd_val_d_o        ( multdiv_imd_val_d     ),
+        .imd_val_we_o       ( multdiv_imd_val_we    ),
         .multdiv_ready_id_i ( multdiv_ready_id_i    ),
         .multdiv_result_o   ( multdiv_result        )
     );

--- a/rtl/ibex_multdiv_slow.sv
+++ b/rtl/ibex_multdiv_slow.sv
@@ -28,6 +28,10 @@ module ibex_multdiv_slow
     output logic [32:0]      alu_operand_a_o,
     output logic [32:0]      alu_operand_b_o,
 
+    input  logic [33:0]      imd_val_q_i,
+    output logic [33:0]      imd_val_d_o,
+    output logic             imd_val_we_o,
+
     input  logic             multdiv_ready_id_i,
 
     output logic [31:0]      multdiv_result_o,
@@ -66,6 +70,11 @@ module ibex_multdiv_slow
   assign res_adder_l       = alu_adder_ext_i[32:0];
    // (accum_window_q + op_a_shift_q)>>1
   assign res_adder_h       = alu_adder_ext_i[33:1];
+
+  // Use shared intermediate value register in id_stage for accum_window
+  assign imd_val_d_o    = accum_window_d;
+  assign imd_val_we_o   = ~multdiv_hold;
+  assign accum_window_q = imd_val_q_i;
 
   always_comb begin
     alu_operand_a_o   = accum_window_q;
@@ -147,7 +156,6 @@ module ibex_multdiv_slow
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_multdiv_state_q
     if (!rst_ni) begin
       multdiv_state_q  <= 5'h0;
-      accum_window_q   <= 33'h0;
       op_b_shift_q     <= 33'h0;
       op_a_shift_q     <= 33'h0;
       op_numerator_q   <= 32'h0;
@@ -155,7 +163,6 @@ module ibex_multdiv_slow
     end else begin
       if (~multdiv_hold) begin
         multdiv_state_q  <= multdiv_state_d;
-        accum_window_q   <= accum_window_d;
         op_b_shift_q     <= op_b_shift_d;
         op_a_shift_q     <= op_a_shift_d;
         op_numerator_q   <= op_numerator_d;


### PR DESCRIPTION
This commit adds support for the shared immediate value register in the
id_stage for the slow implementation of the multdiv module.

Register accum_window_q is now stored in the intermediate value
register.

Signed-off-by: ganoam <gnoam@live.com>