### PR TITLE
[dv] fix spurious LSF enabling

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -325,10 +325,10 @@ $(OUT)/rtl_sim/.compile.stamp: \
 	@./sim.py \
 	 --o=${OUT} \
 	 --steps=compile \
-	 --lsf_cmd="${LSF_CMD}" \
 	 ${COMMON_OPTS} \
 	 --simulator="${SIMULATOR}" --simulator_yaml=yaml/rtl_simulation.yaml \
-	 $(cov-arg) $(wave-arg) --cmp_opts="${COMPILE_OPTS}"
+	 $(cov-arg) $(wave-arg) $(lsf-arg) \
+	 --cmp_opts="${COMPILE_OPTS}"
 	$(call dump-vars,$(OUT)/rtl_sim/.compile-vars.mk,comp,$(compile-var-deps))
 	@touch $@
 
@@ -361,7 +361,6 @@ $(metadata)/rtl_sim.run.stamp: \
 	@./sim.py \
 	 --o=$(OUT-SEED) \
 	 --steps=sim \
-	 --lsf_cmd="${LSF_CMD}" \
 	 ${TEST_OPTS} \
 	 --simulator="${SIMULATOR}" --simulator_yaml=yaml/rtl_simulation.yaml \
 	 $(cov-arg) $(wave-arg) $(lsf-arg) \

--- a/dv/uvm/core_ibex/sim.py
+++ b/dv/uvm/core_ibex/sim.py
@@ -499,6 +499,13 @@ def main():
     setup_logging(args.verbose)
     parser.set_defaults(verbose=False)
 
+    # If args.lsf_cmd is an empty string return an error message and exit from
+    # the script, as doing nothing will result in arbitrary simulation timeouts
+    # and errors later on in the run flow.
+    if args.lsf_cmd == "":
+        logging.error("The LSF command passed in is an empty string.")
+        return RET_FAIL
+
     # Create the output directory
     output_dir = ("%s/rtl_sim" % args.o)
     bin_dir = ("%s/instr_gen/asm_tests" % args.o)


### PR DESCRIPTION
This fixes a small but annoying bug - when `run_sim_commands()` is called, the `lsf_cmd` argument that it takes in is always set to `True` by default even when we don't want to run on LSF, as the default value of `lsf_cmd` passed in from the top level Makefile is always `''`, which when compared to `None` will return `True`, causing seemingly random regression timeouts.
This fixes this issue by defaulting `args.lsf_cmd` to an empty string and comparing the `lsf_cmd` argument value in the `run_sim_commands` call to an empty string instead of `None`.

Signed-off-by: Udi <udij@google.com>