### PR TITLE
[dv] update directory paths for riscv-dv coverage

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -389,11 +389,12 @@ post_compare: $(OUT-SEED)/regr.log
 
 ###############################################################################
 # Generate RISCV-DV functional coverage
+# TODO(udi) - add B extension
 fcov:
 	python3 ${GEN_DIR}/cov.py \
           --core ibex \
-          --dir ${OUT}/rtl_sim \
-          -o ${OUT}/fcov \
+          --dir ${OUT-SEED}/rtl_sim \
+          -o ${OUT-SEED}/fcov \
           --isa rv32imc \
           --custom_target riscv_dv_extension
 


### PR DESCRIPTION
This PR is a minor change that simply updates source and destination directory arguments for riscv-dv functional coverage to the correct locations (in `out/seed-###` instead of just in `out/`).

Signed-off-by: Udi <udij@google.com>