### PR TITLE
Monitor and SVA assertions for core agent in icache UVM testbench

### DIFF
--- a/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
@@ -10,7 +10,7 @@ class ibex_icache_scoreboard
   // local variables
 
   // TLM agent fifos
-  uvm_tlm_analysis_fifo #(ibex_icache_core_item)     core_fifo;
+  uvm_tlm_analysis_fifo #(ibex_icache_core_bus_item) core_fifo;
   uvm_tlm_analysis_fifo #(ibex_icache_mem_resp_item) mem_fifo;
 
   `uvm_component_new
@@ -34,10 +34,10 @@ class ibex_icache_scoreboard
   endtask
 
   virtual task process_core_fifo();
-    ibex_icache_core_item item;
+    ibex_icache_core_bus_item item;
     forever begin
       core_fifo.get(item);
-      `uvm_info(`gfn, $sformatf("received ibex_icache_core item:\n%0s", item.sprint()), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("received core transaction:\n%0s", item.sprint()), UVM_HIGH)
     end
   endtask
 

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent.core
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent.core
@@ -14,6 +14,7 @@ filesets:
       - ibex_icache_core_protocol_checker.sv
       - ibex_icache_core_agent_pkg.sv
       - ibex_icache_core_item.sv: {is_include_file: true}
+      - ibex_icache_core_bus_item.sv: {is_include_file: true}
       - ibex_icache_core_agent_cfg.sv: {is_include_file: true}
       - ibex_icache_core_agent_cov.sv: {is_include_file: true}
       - ibex_icache_core_driver.sv: {is_include_file: true}

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent.core
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:dv:dv_lib
     files:
       - ibex_icache_core_if.sv
+      - ibex_icache_core_protocol_checker.sv
       - ibex_icache_core_agent_pkg.sv
       - ibex_icache_core_item.sv: {is_include_file: true}
       - ibex_icache_core_agent_cfg.sv: {is_include_file: true}

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent_pkg.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent_pkg.sv
@@ -13,6 +13,14 @@ package ibex_icache_core_agent_pkg;
     ICacheCoreTransTypeReq
   } ibex_icache_core_trans_type_e;
 
+  typedef enum {
+    ICacheCoreBusTransTypeBranch,
+    ICacheCoreBusTransTypeFetch,
+    ICacheCoreBusTransTypeInvalidate,
+    ICacheCoreBusTransTypeEnable,
+    ICacheCoreBusTransTypeBusy
+  } ibex_icache_core_bus_trans_type_e;
+
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
@@ -32,6 +40,7 @@ package ibex_icache_core_agent_pkg;
 
   // package sources
   `include "ibex_icache_core_item.sv"
+  `include "ibex_icache_core_bus_item.sv"
   `include "ibex_icache_core_agent_cfg.sv"
   `include "ibex_icache_core_agent_cov.sv"
   `include "ibex_icache_core_driver.sv"

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_bus_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_bus_item.sv
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class ibex_icache_core_bus_item extends uvm_sequence_item;
+
+  // Type of bus transaction (branch, invalidate, fetch or busy)
+  ibex_icache_core_bus_trans_type_e trans_type;
+
+  // Address. For a branch transaction, this is the address of the destination. For a fetch
+  // transaction, this is the address of the instruction fetched.
+  logic [31:0]                      address;
+
+  // 32 bits of data. Only has meaning for a fetch transaction, where it contains instruction data.
+  logic [31:0]                      insn_data;
+
+  // Error bits. Only have meaning for a fetch transaction
+  logic                             err;
+  logic                             err_plus2;
+
+  // Cache configuration (is the cache enabled?). Only has meaning for an enable transaction.
+  logic                             enable;
+
+  // Busy bit. Only has meaning for a busy transaction, where it has the new value of the busy
+  // signal.
+  logic                             busy;
+
+  `uvm_object_utils_begin(ibex_icache_core_bus_item)
+    `uvm_field_enum(ibex_icache_core_bus_trans_type_e, trans_type, UVM_DEFAULT)
+    `uvm_field_int(address,   UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int(insn_data, UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int(err,       UVM_DEFAULT)
+    `uvm_field_int(err_plus2, UVM_DEFAULT)
+    `uvm_field_int(enable,    UVM_DEFAULT)
+    `uvm_field_int(busy,      UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+endclass

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-interface ibex_icache_core_if (input clk);
+interface ibex_icache_core_if (input clk, input rst_n);
 
   // Set when core is enabled (and might request instructions soon)
   logic         req;
@@ -62,6 +62,11 @@ interface ibex_icache_core_if (input clk);
     input  invalidate;
     input  busy;
   endclocking
+
+
+  // SVA module
+  ibex_icache_core_protocol_checker checker_i (.*);
+
 
   // Drive the branch pin for a single cycle, redirecting the cache to the given instruction
   // address.

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_monitor.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_monitor.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class ibex_icache_core_monitor extends dv_base_monitor #(
-    .ITEM_T (ibex_icache_core_item),
+    .ITEM_T (ibex_icache_core_bus_item),
     .CFG_T  (ibex_icache_core_agent_cfg),
     .COV_T  (ibex_icache_core_agent_cov)
   );
@@ -12,7 +12,7 @@ class ibex_icache_core_monitor extends dv_base_monitor #(
   // the base class provides the following handles for use:
   // ibex_icache_core_agent_cfg: cfg
   // ibex_icache_core_agent_cov: cov
-  // uvm_analysis_port #(ibex_icache_core_item): analysis_port
+  // uvm_analysis_port #(ibex_icache_core_bus_item): analysis_port
 
   `uvm_component_new
 
@@ -26,17 +26,92 @@ class ibex_icache_core_monitor extends dv_base_monitor #(
 
   // collect transactions forever - already forked in dv_base_moditor::run_phase
   virtual protected task collect_trans(uvm_phase phase);
+    ibex_icache_core_bus_item trans;
+    logic                     last_inval = 0;
+    logic                     last_enable = 0;
+    logic                     last_busy = 0;
+
     forever begin
-      // TODO: detect event
+      // Collect events on positive clock edges. We collect "outputs" from the cache first, and then
+      // "inputs". This makes the scoreboard's job easier: if a branch is asserted on the same cycle
+      // as a fetch happens, the cache is being redirected at the end of the cycle, but the fetch
+      // came out of the cache at the start of the cycle. This way, the scoreboard doesn't need to
+      // do any re-ordering.
+      @(posedge cfg.vif.clk);
 
-      // TODO: sample the interface
+      // "Output" transactions
 
-      // TODO: sample the covergroups
+      // Spot whether we've received some instruction data
+      if (cfg.vif.ready & cfg.vif.valid) begin
+        trans = ibex_icache_core_bus_item::type_id::create("trans");
+        trans.trans_type = ICacheCoreBusTransTypeFetch;
+        trans.address    = cfg.vif.addr;
+        trans.insn_data  = cfg.vif.rdata;
+        trans.err        = cfg.vif.err;
+        trans.err_plus2  = cfg.vif.err_plus2;
+        trans.enable     = 0;
+        trans.busy       = 0;
+        analysis_port.write(trans);
+      end
 
-      // TODO: write trans to analysis_port
+      // Spot edges on the enable pin
+      if (cfg.vif.enable != last_enable) begin
+        trans = ibex_icache_core_bus_item::type_id::create("trans");
+        trans.trans_type = ICacheCoreBusTransTypeEnable;
+        trans.address    = 0;
+        trans.insn_data  = 0;
+        trans.err        = 0;
+        trans.err_plus2  = 0;
+        trans.enable     = cfg.vif.enable;
+        trans.busy       = 0;
+        analysis_port.write(trans);
+      end
+      last_enable = cfg.vif.enable;
 
-      // TODO: remove the line below: it is added to prevent zero delay loop in template code
-      #1us;
+      // Spot edges on the busy pin
+      if (cfg.vif.busy != last_busy) begin
+        trans = ibex_icache_core_bus_item::type_id::create("trans");
+        trans.trans_type = ICacheCoreBusTransTypeBusy;
+        trans.address    = 0;
+        trans.insn_data  = 0;
+        trans.err        = 0;
+        trans.err_plus2  = 0;
+        trans.enable     = 0;
+        trans.busy       = cfg.vif.busy;
+        analysis_port.write(trans);
+      end
+      last_busy = cfg.vif.busy;
+
+      // "Input" transactions
+
+      // Firstly, spot any branch event. There is no handshaking here: there is a branch event on
+      // this cycle if the 'branch' signal is high.
+      if (cfg.vif.branch) begin
+        trans = ibex_icache_core_bus_item::type_id::create("trans");
+        trans.trans_type = ICacheCoreBusTransTypeBranch;
+        trans.address    = cfg.vif.branch_addr;
+        trans.insn_data  = 0;
+        trans.err        = 0;
+        trans.err_plus2  = 0;
+        trans.enable     = 0;
+        trans.busy       = 0;
+        analysis_port.write(trans);
+      end
+
+      // Spot invalidate signals. These can last for several cycles, but we only care about the
+      // first cycle, so we track the last value to spot posedges.
+      if (cfg.vif.invalidate && !last_inval) begin
+        trans = ibex_icache_core_bus_item::type_id::create("trans");
+        trans.trans_type = ICacheCoreBusTransTypeInvalidate;
+        trans.address    = 0;
+        trans.insn_data  = 0;
+        trans.err        = 0;
+        trans.err_plus2  = 0;
+        trans.enable     = 0;
+        trans.busy       = 0;
+        analysis_port.write(trans);
+      end
+      last_inval = cfg.vif.invalidate;
     end
   endtask
 

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_protocol_checker.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_protocol_checker.sv
@@ -1,0 +1,142 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// An interface that contains SV assertions to check that the icache <-> core interface is being
+// driven correctly.
+//
+// This should be instantiated inside ibex_icache_core_if. The input names are the same as the
+// signals in the interface (no _i suffix), so that this can be instantiated with .*
+
+`include "prim_assert.sv"
+
+interface ibex_icache_core_protocol_checker (
+   input        clk,
+   input        rst_n,
+
+   input        req,
+
+   input        branch,
+   input [31:0] branch_addr,
+
+   input        ready,
+   input        valid,
+   input [31:0] rdata,
+   input [31:0] addr,
+   input        err,
+   input        err_plus2,
+
+   input        enable,
+   input        invalidate,
+
+   input        busy
+);
+
+  // The 'req' port
+  //
+  // The core may not assert 'ready' when 'req' is low. This is because 'req' means "core is not
+  // asleep"; the exact behaviour of instruction fetches in this mode is hard to characterise and we
+  // don't care about it because the core should never do it.
+  `ASSERT(NoReadyWithoutReq, !req |-> !ready, clk, !rst_n)
+
+  // The 'branch' and 'branch_addr' ports
+  //
+  // The branch signal tells the cache to redirect. There's no real requirement on when it can be
+  // asserted, but the address must be 16-bit aligned (i.e. the bottom bit must be zero).
+  `ASSERT(BranchAddrAligned, branch |-> !branch_addr[0], clk, !rst_n)
+
+  // The main instruction interface
+  //
+  // This uses a form of ready/valid handshaking, with a special rule that asserting branch_i
+  // cancels a transaction (so the cache can assert valid, but de-assert it if the core asserts
+  // branch_i).
+  //
+  // Note that the lower 16 bits of rdata must be stable, but the upper bits may change if this is a
+  // compressed instruction (which is the case if the bottom 2 bits are not 2'b11): the upper bits
+  // are then ignored by the core.
+  //
+  // There's no requirement on the core to hold ready until valid.
+  `ASSERT(ValidUntilReady, valid & ~(ready | branch) |=> valid,              clk, !rst_n);
+  `ASSERT(AddrStable,      valid & ~(ready | branch) |=> $stable(addr),      clk, !rst_n);
+  `ASSERT(ErrStable,       valid & ~(ready | branch) |=> $stable(err),       clk, !rst_n);
+  `ASSERT(Err2Stable,      valid & ~(ready | branch) |=> $stable(err_plus2), clk, !rst_n);
+
+  `ASSERT(LoRDataStable,
+          valid & ~(ready | branch) |=> $stable(rdata[15:0]),
+          clk, !rst_n);
+  `ASSERT(HiRDataStable,
+          valid & ~(ready | branch) & (rdata[1:0] == 2'b11) |=> $stable(rdata[15:0]),
+          clk, !rst_n);
+
+  // The core is never allowed to make a fetch from the cache when the PC is not known. To set the
+  // PC, it must issue a branch. Obviously, that means the core must branch before the first fetch
+  // after reset. Less obviously, it also means the core must branch immediately after an error
+  // (because the next PC depends on the fetched data).
+  //
+  // Rather than encoding this with a complicated SVA sequence, we define a has_addr signal that is
+  // set on branches and cleared when the core receives an error.
+  logic has_addr;
+  always @(posedge clk or negedge rst_n) begin
+    if (! rst_n) begin
+      has_addr <= 1'b0;
+    end else begin
+      if (branch) begin
+        has_addr <= 1'b1;
+      end else if (err & ready & valid) begin
+        has_addr <= 1'b0;
+      end
+    end
+  end
+
+  `ASSERT(NoFetchWithoutAddr, req |-> (branch | has_addr), clk, !rst_n)
+
+  // The err_plus2 signal means "this error was caused by the upper two bytes" and is only read when
+  // both valid and err are true. It should never be set for compressed instructions (for them, the
+  // contents of the upper two bytes are ignored).
+  `ASSERT(ErrPlus2ImpliesUncompressed,
+          valid & err & err_plus2 |-> rdata[1:0] == 2'b11,
+          clk, !rst_n)
+
+  // KNOWN assertions:
+
+  // Control lines from the core (req, branch, ready, enable, invalidate) must always have a known
+  // value
+  `ASSERT_KNOWN(ReqKnown,        req,        clk, !rst_n)
+  `ASSERT_KNOWN(BranchKnown,     branch,     clk, !rst_n)
+  `ASSERT_KNOWN(ReadyKnown,      ready,      clk, !rst_n)
+  `ASSERT_KNOWN(EnableKnown,     enable,     clk, !rst_n)
+  `ASSERT_KNOWN(InvalidateKnown, invalidate, clk, !rst_n)
+
+  // The branch_addr value must be known if branch is high
+  `ASSERT_KNOWN_IF(BranchAddrKnown, branch_addr, branch, clk, !rst_n)
+
+  // The valid line usually has a known value. The only exception is after an error (when the
+  // cache's skid buffer doesn't know whether it contains valid data; there's data iff the previous
+  // instruction was compressed, but the instruction data was 'X, so we can't check the bottom two
+  // bits).
+  //
+  // To model this, we require that valid is known whenever has_addr is true. The NoFetchWithoutAddr
+  // assertion checks that the core will never actually take any data when !has_addr.
+  `ASSERT_KNOWN_IF(ValidKnown, valid, has_addr, clk, !rst_n)
+
+  // The address of a response and its error flag must be known if valid is high (these checks are
+  // also gated by has_addr because otherwise the assertion would trigger even if valid was allowed
+  // to be 'X). The err_plus2 flag must be known if err is set.
+  `ASSERT_KNOWN_IF(RespAddrKnown, addr,      has_addr & valid,       clk, !rst_n)
+  `ASSERT_KNOWN_IF(ErrKnown,      err,       has_addr & valid,       clk, !rst_n)
+  `ASSERT_KNOWN_IF(ErrPlus2Known, err_plus2, has_addr & valid & err, clk, !rst_n)
+
+  // The lower 16 bits of a response must be known if valid is high and err is not
+  `ASSERT_KNOWN_IF(LowRDataKnown, rdata[15:0], has_addr & valid & ~err, clk, !rst_n)
+
+  // The upper 16 bits of a response must be known if valid is high, err is not and the instruction
+  // is not compressed.
+  `ASSERT_KNOWN_IF(HiRDataKnown,
+                   rdata[31:16],
+                   has_addr & valid & ~err & (rdata[1:0] == 2'b11),
+                   clk, !rst_n)
+
+  // The busy signal must always have a known value
+  `ASSERT_KNOWN(BusyKnown, busy, clk, !rst_n)
+
+endinterface

--- a/dv/uvm/icache/dv/tb/tb.sv
+++ b/dv/uvm/icache/dv/tb/tb.sv
@@ -18,7 +18,7 @@ module tb;
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
 
-  ibex_icache_core_if core_if (.clk(clk));
+  ibex_icache_core_if core_if (.clk(clk), .rst_n(rst_n));
   ibex_icache_mem_if  mem_if  (.clk(clk));
 
   // dut


### PR DESCRIPTION
Since the memory agent PR (#793) is slightly stalled, I've split out the follow-up work that adds monitors and SVA assertions. This is the code that applies to the core agent.

You should be able to build it, but it won't run to completion because there is no memory agent. I have (of course) checked that rebasing the patches from #793 on top of this patchset results in something that works.