### PR TITLE
[dv] Enable verification of the Bitmanip Extension with OVPsim and Spike

### DIFF
--- a/doc/verification.rst
+++ b/doc/verification.rst
@@ -95,12 +95,13 @@ In order to run the co-simulation flow, you'll need:
   ``--enable-misaligned`` tells Spike to simulate a core that
   handles misaligned accesses in hardware (rather than jumping to a
   trap handler).
+  In addition, Spike does not support the `RISC-V Bit Manipulation Extension <bitmanip_>`_  (Bitmanip) by default.
+  To support this draft extension implemented in Ibex, the `riscv-bitmanip branch <Spike_>`_ of Spike needs to be used.
 
-- A working RISC-V toolchain (to compile / assemble the generated
-  programs before simulating them). Either download and build the
-  `RISC-V GNU compiler toolchain <riscv-toolchain-source_>`_ or
-  (quicker) download a `pre-built toolchain
-  <riscv-toolchain-releases_>`_.
+- A working RISC-V toolchain (to compile / assemble the generated programs before simulating them).
+  Either download a `pre-built toolchain <riscv-toolchain-releases_>`_ (quicker) or download and build the `RISC-V GNU compiler toolchain <riscv-toolchain-source_>`_.
+  For the latter, the Bitmanip patches have to be manually installed to enable support for the Bitmanip draft extension.
+  For further information, checkout the `Bitmanip Extension on GitHub <bitmanip_>`_ and `how we create the pre-built toolchains <bitmanip-patches_>`_.
 
 Once these are installed, you need to set some environment variables
 to tell the RISCV-DV code where to find them:
@@ -116,10 +117,12 @@ to tell the RISCV-DV code where to find them:
 (Obviously, you only need to set ``SPIKE_PATH`` or ``OVPSIM_PATH`` if
 you have installed the corresponding instruction set simulator)
 
-.. _Spike: https://github.com/riscv/riscv-isa-sim
+.. _Spike: https://github.com/riscv/riscv-isa-sim/tree/riscv-bitmanip
 .. _OVPsim: https://github.com/riscv/riscv-ovpsim
 .. _riscv-toolchain-source: https://github.com/riscv/riscv-gnu-toolchain
 .. _riscv-toolchain-releases: https://github.com/lowRISC/lowrisc-toolchains/releases
+.. _bitmanip-patches: https://github.com/lowRISC/lowrisc-toolchains#how-to-generate-the-bitmanip-patches
+.. _bitmanip: https://github.com/riscv/riscv-bitmanip
 
 End-to-end RTL/ISS co-simulation flow
 """""""""""""""""""""""""""""""""""""

--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -40,7 +40,7 @@ ISS                 := ovpsim
 # ISS runtime options
 ISS_OPTS            :=
 # ISA
-ISA                 := rv32imc
+ISA                 := rv32imcb
 # Test name (default: full regression)
 TEST                := all
 TESTLIST            := riscv_dv_extension/testlist.yaml
@@ -394,7 +394,7 @@ fcov:
           --core ibex \
           --dir ${OUT-SEED}/rtl_sim \
           -o ${OUT-SEED}/fcov \
-          --isa rv32imc \
+          --isa rv32imcb \
           --custom_target riscv_dv_extension
 
 # Merge all output coverage directories into the <out>/rtl_sim directory

--- a/dv/uvm/core_ibex/riscv_dv_extension/riscvOVPsim.ic
+++ b/dv/uvm/core_ibex/riscv_dv_extension/riscvOVPsim.ic
@@ -1,5 +1,6 @@
 # riscOVPsim configuration file converted from YAML
 --variant RV32IMC
+--override riscvOVPsim/cpu/add_Extensions=B
 --override riscvOVPsim/cpu/misa_MXL=1
 --override riscvOVPsim/cpu/misa_MXL_mask=0x0 # 0
 --override riscvOVPsim/cpu/misa_Extensions_mask=0x0 # 0

--- a/dv/uvm/core_ibex/riscv_dv_extension/riscv_core_setting.sv
+++ b/dv/uvm/core_ibex/riscv_dv_extension/riscv_core_setting.sv
@@ -44,7 +44,7 @@ riscv_instr_name_t unsupported_instr[] = {FENCE_I};
 bit support_unaligned_load_store = 1'b1;
 
 // ISA supported by the processor
-riscv_instr_group_t supported_isa[$] = {RV32I, RV32M, RV32C};
+riscv_instr_group_t supported_isa[$] = {RV32I, RV32M, RV32C, RV32B};
 
 // Interrupt mode support
 mtvec_mode_t supported_interrupt_mode[$] = {VECTORED};

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -587,3 +587,13 @@
     +pmp_max_offset=00021000
     +boot_mode=u
   rtl_test: core_ibex_base_test
+
+- test: riscv_bitmanip_test
+  desc: >
+    Random instruction test with supported B extension instructions
+  iterations: 10
+  gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +enable_b_extension=1
+    +enable_bitmanip_groups=zbb,zbt,zbs
+  rtl_test: core_ibex_base_test

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -26,9 +26,12 @@ module core_ibex_tb_top;
   // CSR access interface
   core_ibex_csr_if csr_if(.clk(clk));
 
-  ibex_core_tracing #(.DmHaltAddr(`BOOT_ADDR + 'h0),
-                      .DmExceptionAddr(`BOOT_ADDR + 'h4),
-                      .PMPEnable(1'b1)) dut (
+  ibex_core_tracing #(
+    .DmHaltAddr(`BOOT_ADDR + 'h0),
+    .DmExceptionAddr(`BOOT_ADDR + 'h4),
+    .PMPEnable(1'b1),
+    .RV32B(1'b1)
+  ) dut (
     .clk_i(clk),
     .rst_ni(rst_n),
     .test_en_i(1'b1),


### PR DESCRIPTION
This PR enables verification of the Bitmanip Extension with OVPsim and Spike and adds a new test that can be updated in the future to also include newly added instruction groups. For Spike,
a different branch has to be used. This PR updates the documentation accordingly.

What is still missing is support for coverage. This will be later vendored in from upstream RISCV-DV.

This is related to lowRISC/ibex#703.