### PR TITLE
Add heartbeat tracking to ICache testbench

### DIFF
--- a/dv/uvm/icache/dv/env/ibex_icache_env.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_env.sv
@@ -13,6 +13,11 @@ class ibex_icache_env extends dv_base_env #(
   ibex_icache_core_agent core_agent;
   ibex_icache_mem_agent  mem_agent;
 
+  // Heartbeat tracking
+  uvm_callbacks_objection           hb_objection;
+  uvm_heartbeat                     heartbeat;
+  uvm_event                         hb_event;
+
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
@@ -23,6 +28,10 @@ class ibex_icache_env extends dv_base_env #(
 
     mem_agent = ibex_icache_mem_agent::type_id::create("mem_agent", this);
     uvm_config_db#(ibex_icache_mem_agent_cfg)::set(this, "mem_agent*", "cfg", cfg.mem_agent_cfg);
+
+    hb_objection = new("hb_objection");
+    heartbeat    = new("heartbeat", this, hb_objection);
+    hb_event     = new("hb_event");
   endfunction
 
   function void connect_phase(uvm_phase phase);
@@ -37,6 +46,28 @@ class ibex_icache_env extends dv_base_env #(
     if (cfg.is_active && cfg.mem_agent_cfg.is_active) begin
       virtual_sequencer.mem_sequencer_h = mem_agent.sequencer;
     end
+
+    // Register the heartbeat objection with both sequencers (so they know how to reset it)
+    core_agent.sequencer.register_hb(hb_objection);
+    mem_agent.sequencer.register_hb(hb_objection);
+
+    // Add each sequencer to the heartbeat object. This means that the heartbeat object expects one
+    // or more of them to set the objection each time around.
+    void'(heartbeat.set_mode(UVM_ANY_ACTIVE));
+    heartbeat.add(core_agent.sequencer);
+    heartbeat.add(mem_agent.sequencer);
   endfunction
+
+  virtual task run_phase(uvm_phase phase);
+    super.run_phase(phase);
+    // Start the heartbeat monitor. This will check (and then clear) objections each time hb_event
+    // is triggered.
+    heartbeat.start(hb_event);
+    forever begin
+      // Every 2000 clocks, check the heartbeat monitor
+      cfg.core_agent_cfg.vif.wait_clks(2000);
+      hb_event.trigger();
+    end
+  endtask
 
 endclass

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent.core
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent.core
@@ -15,6 +15,7 @@ filesets:
       - ibex_icache_core_item.sv: {is_include_file: true}
       - ibex_icache_core_agent_cfg.sv: {is_include_file: true}
       - ibex_icache_core_agent_cov.sv: {is_include_file: true}
+      - ibex_icache_core_sequencer.sv: {is_include_file: true}
       - ibex_icache_core_driver.sv: {is_include_file: true}
       - ibex_icache_core_monitor.sv: {is_include_file: true}
       - ibex_icache_core_agent.sv: {is_include_file: true}

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent_pkg.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent_pkg.sv
@@ -17,23 +17,11 @@ package ibex_icache_core_agent_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  // parameters
-
-  // local types
-  // forward declare classes to allow typedefs below
-  typedef class ibex_icache_core_item;
-  typedef class ibex_icache_core_agent_cfg;
-
-  // reuse dv_base_seqeuncer as is with the right parameter set
-  typedef dv_base_sequencer #(.ITEM_T(ibex_icache_core_item),
-                              .CFG_T (ibex_icache_core_agent_cfg)) ibex_icache_core_sequencer;
-
-  // functions
-
   // package sources
   `include "ibex_icache_core_item.sv"
   `include "ibex_icache_core_agent_cfg.sv"
   `include "ibex_icache_core_agent_cov.sv"
+  `include "ibex_icache_core_sequencer.sv"
   `include "ibex_icache_core_driver.sv"
   `include "ibex_icache_core_monitor.sv"
   `include "ibex_icache_core_agent.sv"

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_sequencer.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_sequencer.sv
@@ -2,24 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// A sequencer class for the icache memory agent.
-
-class ibex_icache_mem_sequencer
-  extends dv_base_sequencer #(.ITEM_T (ibex_icache_mem_resp_item),
-                              .CFG_T  (ibex_icache_mem_agent_cfg));
-
-  `uvm_component_utils(ibex_icache_mem_sequencer)
+class ibex_icache_core_sequencer extends dv_base_sequencer #(.ITEM_T (ibex_icache_core_item),
+                                                             .CFG_T  (ibex_icache_core_agent_cfg));
+  `uvm_component_utils(ibex_icache_core_sequencer)
   `uvm_component_new
-
-  uvm_tlm_analysis_fifo #(ibex_icache_mem_req_item) request_fifo;
 
   // An objection used for heartbeat tracking. Set with register_hb.
   uvm_callbacks_objection hb_objection;
-
-  function void build_phase(uvm_phase phase);
-    super.build_phase(phase);
-    request_fifo   = new("request_fifo", this);
-  endfunction
 
   function void register_hb (uvm_callbacks_objection obj);
     hb_objection = obj;
@@ -28,8 +17,9 @@ class ibex_icache_mem_sequencer
   virtual function void send_request(uvm_sequence_base sequence_ptr,
                                      uvm_sequence_item t,
                                      bit rerandomize = 0);
-    if (hb_objection != null)
+    if (hb_objection != null) begin
       hb_objection.raise_objection(this);
+    end
 
     super.send_request(sequence_ptr, t, rerandomize);
   endfunction

--- a/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
+++ b/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
@@ -42,7 +42,7 @@
     {
       name: ibex_icache_sanity
       uvm_test_seq: ibex_icache_sanity_vseq
-      run_opts: ["+test_timeout_ns=1000000"]
+      run_opts: ["+test_timeout_ns=100000000"]
     }
 
     // TODO: add more tests here


### PR DESCRIPTION
This pretty much follows various UVM tutorials, except that we use the
sequencers (ibex_icache_core_sequencer, ibex_icache_mem_sequencer) to
poke the heartbeat objection object if there is one.

Doing this means that we can dispense with the explicit test timeout
in the hjson file: the test will fail if there is no activity on
either interface for 2000 cycles (this number is chosen because the
longest "wait a bit" time is 1200 cycles in the core driver).