### PR TITLE
Add monitor and SVA checks to icache <-> memory interface in UVM testbench

### DIFF
--- a/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
@@ -11,7 +11,7 @@ class ibex_icache_scoreboard
 
   // TLM agent fifos
   uvm_tlm_analysis_fifo #(ibex_icache_core_bus_item) core_fifo;
-  uvm_tlm_analysis_fifo #(ibex_icache_mem_resp_item) mem_fifo;
+  uvm_tlm_analysis_fifo #(ibex_icache_mem_bus_item)  mem_fifo;
 
   `uvm_component_new
 
@@ -42,10 +42,10 @@ class ibex_icache_scoreboard
   endtask
 
   virtual task process_mem_fifo();
-    ibex_icache_mem_resp_item item;
+    ibex_icache_mem_bus_item item;
     forever begin
       mem_fifo.get(item);
-      `uvm_info(`gfn, $sformatf("received ibex_mem_intf_seq item:\n%0s", item.sprint()), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("received mem transaction:\n%0s", item.sprint()), UVM_HIGH)
     end
   endtask
 

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent.core
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent.core
@@ -15,6 +15,7 @@ filesets:
       - ibex_icache_mem_agent_pkg.sv
       - ibex_icache_mem_req_item.sv: {is_include_file: true}
       - ibex_icache_mem_resp_item.sv: {is_include_file: true}
+      - ibex_icache_mem_bus_item.sv: {is_include_file: true}
       - ibex_icache_mem_agent_cfg.sv: {is_include_file: true}
       - ibex_icache_mem_agent_cov.sv: {is_include_file: true}
       - ibex_icache_mem_driver.sv: {is_include_file: true}

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent.core
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:dv:dv_lib
     files:
       - ibex_icache_mem_if.sv
+      - ibex_icache_mem_protocol_checker.sv
       - ibex_icache_mem_agent_pkg.sv
       - ibex_icache_mem_req_item.sv: {is_include_file: true}
       - ibex_icache_mem_resp_item.sv: {is_include_file: true}

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent_pkg.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent_pkg.sv
@@ -17,6 +17,7 @@ package ibex_icache_mem_agent_pkg;
   // package sources
   `include "ibex_icache_mem_req_item.sv"
   `include "ibex_icache_mem_resp_item.sv"
+  `include "ibex_icache_mem_bus_item.sv"
   `include "ibex_icache_mem_model.sv"
   `include "ibex_icache_mem_agent_cfg.sv"
   `include "ibex_icache_mem_agent_cov.sv"

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_bus_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_bus_item.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A transaction item that represents something happening on the memory bus. A 'request' is
+// initiated by the cache and comes with an address. A 'response' comes from the memory system
+// (including possibly the PMP checker). It comes with data and error flags.
+
+class ibex_icache_mem_bus_item extends uvm_sequence_item;
+
+  // Is this a request or a response?
+  logic        is_response;
+
+  // Request address (only valid for request transactions)
+  logic [31:0] address;
+
+  // Response data and error flags (only valid for response transactions)
+  logic [31:0] rdata;
+  logic        err;
+  logic        pmp_err;
+
+  `uvm_object_utils_begin(ibex_icache_mem_bus_item)
+    `uvm_field_int(is_response, UVM_DEFAULT)
+    `uvm_field_int(address,     UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int(rdata,       UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int(err,         UVM_DEFAULT)
+    `uvm_field_int(pmp_err,     UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+endclass

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_if.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_if.sv
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-interface ibex_icache_mem_if (input clk);
+interface ibex_icache_mem_if (input clk,
+                              input rst_n);
 
   // Requests
   logic        req;
@@ -41,6 +42,9 @@ interface ibex_icache_mem_if (input clk);
     input rdata;
     input err;
   endclocking
+
+  // Interface with SVA assertions
+  ibex_icache_mem_protocol_checker checker_i (.*);
 
 
   // Reset all the signals from the memory bus to the cache (the other direction is controlled by

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_protocol_checker.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_protocol_checker.sv
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// An interface that contains SV assertions to check that the icache <-> memory interface is being
+// driven correctly.
+//
+// This should be instantiated inside ibex_icache_mem_if. The input names are the same as the
+// signals in the interface (no _i suffix), so that this can be instantiated with .*
+
+`include "prim_assert.sv"
+
+interface ibex_icache_mem_protocol_checker (
+  input        clk,
+  input        rst_n,
+
+  input        req,
+  input        gnt,
+  input [31:0] addr,
+
+  input        pmp_err,
+
+  input        rvalid,
+  input [31:0] rdata,
+  input        err
+);
+
+  // The req, gnt, pmp_err and rvalid lines should always be known
+  `ASSERT_KNOWN(ReqKnown,    req,     clk, !rst_n)
+  `ASSERT_KNOWN(GntKnown,    gnt,     clk, !rst_n)
+  `ASSERT_KNOWN(PmpErrKnown, pmp_err, clk, !rst_n)
+  `ASSERT_KNOWN(RvalidKnown, rvalid,  clk, !rst_n)
+
+  // The addr value should be known when req is asserted
+  `ASSERT_KNOWN_IF(AddrKnown, addr, req, clk, !rst_n)
+
+  // The err value should be known when rvalid is asserted and rdata should be known if err is
+  // false.
+  `ASSERT_KNOWN_IF(ErrKnown,   err,   rvalid,        clk, !rst_n)
+  `ASSERT_KNOWN_IF(RDataKnown, rdata, rvalid & ~err, clk, !rst_n)
+
+  // The 'req' signal starts a request and shouldn't drop again until granted. Similarly, requested
+  // address must be stable until the request is granted or cancelled by a PMP error.
+  `ASSERT(ReqUntilGrant, req & ~(gnt | pmp_err) |=> req,           clk, !rst_n)
+  `ASSERT(AddrStable,    req & ~(gnt | pmp_err) |=> $stable(addr), clk, !rst_n)
+
+endinterface

--- a/dv/uvm/icache/dv/tb/tb.sv
+++ b/dv/uvm/icache/dv/tb/tb.sv
@@ -19,7 +19,7 @@ module tb;
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
 
   ibex_icache_core_if core_if (.clk(clk), .rst_n(rst_n));
-  ibex_icache_mem_if  mem_if  (.clk(clk));
+  ibex_icache_mem_if  mem_if  (.clk(clk), .rst_n(rst_n));
 
   // dut
   ibex_icache dut (


### PR DESCRIPTION
The equivalent PR for the core side is PR #807. (In fact, these patches have been split, so the commit messages look rather similar).

I don't believe there are any remaining review items open on that PR that apply here. These were relevant, but are now resolved:

  1. ~~Naming of the interface that holds the assertions (see [here](https://github.com/lowRISC/ibex/pull/807#discussion_r413213740)).~~ (this naming seems ok)
  1. ~~Naming of the object that reports bus transactions (see [here](https://github.com/lowRISC/ibex/pull/807#discussion_r413201343)).~~ (renamed as requested to `ibex_icache_mem_bus_item`)