### PR TITLE
[rtl/lsu] Fix bug in pmp error clearing

### DIFF
--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -352,6 +352,7 @@ module ibex_load_store_unit
     unique case (ls_fsm_cs)
 
       IDLE: begin
+        pmp_err_d = 1'b0;
         if (lsu_req_i) begin
           data_req_o   = 1'b1;
           pmp_err_d    = data_pmp_err_i;


### PR DESCRIPTION
- pmp_err_q needs to clear once the LSU state machine returns to idle,
  otherwise it will remain set indefinely.
- Relates to #808

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>