### PR TITLE
[bitmanip] Fix bitmanip DV test failure

### DIFF
--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -441,7 +441,7 @@ module ibex_tracer (
     // fsri
     logic [5:0] shamt;
     shamt = {rvfi_insn[25:20]};
-    data_accessed = RS1 | RS3;
+    data_accessed = RS1 | RS3 | RD;
     decoded_str = $sformatf("%s\tx%0d,x%0d,x%0d,0x%0x", mnemonic, rvfi_rd_addr, rvfi_rs1_addr,
         rvfi_rs3_addr, shamt);
   endfunction


### PR DESCRIPTION
Failing to read rd in tracer for fsri caused bitmanip DV test to fail.

The bitmanip DV test is introduced in PR #809.

Signed-off-by: ganoam <gnoam@live.com>