### PR TITLE
Assorted bugfixes in the ICache UVM test code

### DIFF
--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_monitor.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_monitor.sv
@@ -41,8 +41,13 @@ class ibex_icache_core_monitor extends dv_base_monitor #(
 
       // "Output" transactions
 
-      // Spot whether we've received some instruction data
-      if (cfg.vif.ready & cfg.vif.valid) begin
+      // Spot whether we've received some instruction data.
+      //
+      // Note that we ignore anything coming back when we have branch asserted. This can happen if
+      // timing happens to work out that way or (more likely) the cycle after we've read an error,
+      // when we can keep the ready line high but also assert branch, which means we will ignore
+      // what comes back on this cycle.
+      if (cfg.vif.ready & cfg.vif.valid & ~cfg.vif.branch) begin
         trans = ibex_icache_core_bus_item::type_id::create("trans");
         trans.trans_type = ICacheCoreBusTransTypeFetch;
         trans.address    = cfg.vif.addr;

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_resp_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_resp_item.sv
@@ -18,6 +18,9 @@ class ibex_icache_mem_resp_item
   // If true, drive either a PMP error (if !is_grant) or respond later with a memory error.
   bit               err;
 
+  // The address of the memory response (only used for requests that trigger a PMP error)
+  bit [31:0]        address;
+
   // Only has an effect if is_grant. The number of cycles to wait between reading this from the
   // queue and responding with it.
   rand int unsigned delay;
@@ -42,6 +45,7 @@ class ibex_icache_mem_resp_item
   `uvm_object_utils_begin(ibex_icache_mem_resp_item)
     `uvm_field_int (is_grant, UVM_DEFAULT)
     `uvm_field_int (err,      UVM_DEFAULT)
+    `uvm_field_int (address,  UVM_DEFAULT | UVM_HEX)
     `uvm_field_int (delay,    UVM_DEFAULT)
     `uvm_field_int (rdata,    UVM_DEFAULT | UVM_HEX)
   `uvm_object_utils_end

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/seq_lib/ibex_icache_mem_resp_seq.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/seq_lib/ibex_icache_mem_resp_seq.sv
@@ -30,10 +30,6 @@ class ibex_icache_mem_resp_seq extends ibex_icache_mem_base_seq;
         resp_item.is_grant = 1'b0;
         resp_item.err      = mem_model.is_pmp_error(req_item.address);
         resp_item.rdata    = 'X;
-        `uvm_info(`gfn,
-                  $sformatf("Seen request at address 0x%08h (PMP error? %0d)",
-                            req_item.address, resp_item.err),
-                  UVM_LOW)
 
       end else begin
         // If this is a grant, take any new seed then check the memory model for a (non-PMP) error

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/seq_lib/ibex_icache_mem_resp_seq.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/seq_lib/ibex_icache_mem_resp_seq.sv
@@ -29,6 +29,7 @@ class ibex_icache_mem_resp_seq extends ibex_icache_mem_base_seq;
         // address. The other fields are ignored.
         resp_item.is_grant = 1'b0;
         resp_item.err      = mem_model.is_pmp_error(req_item.address);
+        resp_item.address  = req_item.address;
         resp_item.rdata    = 'X;
 
       end else begin
@@ -42,6 +43,7 @@ class ibex_icache_mem_resp_seq extends ibex_icache_mem_base_seq;
 
         resp_item.is_grant = 1'b1;
         resp_item.err      = mem_model.is_mem_error(req_item.address);
+        resp_item.address  = req_item.address;
         resp_item.rdata    = resp_item.err ? 'X : mem_model.read_data(req_item.address);
       end
 


### PR DESCRIPTION
These fix various bugs that I ran into when trying to get the scoreboard working properly. The most interesting patch is probably the second: it turns out that my previous plan to spot fetch requests is fragile and doesn't take the non-determinacy of delta-cycle scheduling into account. Oops!