### PR TITLE
[bitmanip] Add ZBP Instruction Group

### DIFF
--- a/doc/instruction_decode_execute.rst
+++ b/doc/instruction_decode_execute.rst
@@ -66,7 +66,7 @@ Other blocks use the ALU for the following tasks:
 
 Support for the RISC-V Bitmanipulation Extension (Document Version 0.92, November 8, 2019) is enabled via the parameter ``RV32B``.
 This feature is *EXPERIMENTAL* and the details of its impact are not yet documented here.
-Currently the Zbb, Zbs and Zbt sub-extensions are implemented.
+Currently the Zbb, Zbs, Zbp and Zbt sub-extensions are implemented.
 All instructions are carried out in a single clock cycle.
 
 .. _mult-div:

--- a/doc/integration.rst
+++ b/doc/integration.rst
@@ -93,7 +93,7 @@ Parameters
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
 | ``RV32B``                    | bit         | 0          | *EXPERIMENTAL* - B(itmanipulation) extension enable:            |
 |                              |             |            | Currently supported Z-extensions: Zbb (base), Zbs (single-bit)  |
-|                              |             |            | and Zbt (ternary)  |
+|                              |             |            | Zbp (bit permutation) and Zbt (ternary)                         |
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
 | ``BranchTargetALU``          | bit         | 0          | *EXPERIMENTAL* - Enables branch target ALU removing a stall     |
 |                              |             |            | cycle from taken branches                                       |

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -595,5 +595,5 @@
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +enable_b_extension=1
-    +enable_bitmanip_groups=zbb,zbt,zbs
+    +enable_bitmanip_groups=zbb,zbt,zbs,zbp
   rtl_test: core_ibex_base_test

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -55,9 +55,10 @@ typedef enum logic [5:0] {
   ALU_SLO,
   ALU_ROR,
   ALU_ROL,
-  ALU_REV,
-  ALU_REV8,
-  ALU_ORCB,
+  ALU_GREV,
+  ALU_GORC,
+  ALU_SHFL,
+  ALU_UNSHFL,
 
   // Comparisons
   ALU_LT,

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -893,12 +893,9 @@ module ibex_tracer (
         INSN_PACK:       decode_r_insn("pack");
         INSN_PACKH:      decode_r_insn("packh");
         INSN_PACKU:      decode_r_insn("packu");
-        INSN_ORCB:       decode_r_insn("orcb");
         INSN_CLZ:        decode_r1_insn("clz");
         INSN_CTZ:        decode_r1_insn("ctz");
         INSN_PCNT:       decode_r1_insn("pcnt");
-        INSN_REV:        decode_r1_insn("rev");
-        INSN_REV8:       decode_r1_insn("rev8");
         // RV32B - ZBS
         INSN_SBCLRI:     decode_i_insn("sbclri");
         INSN_SBSETI:     decode_i_insn("sbseti");
@@ -908,6 +905,82 @@ module ibex_tracer (
         INSN_SBSET:      decode_r_insn("sbset");
         INSN_SBINV:      decode_r_insn("sbinv");
         INSN_SBEXT:      decode_r_insn("sbext");
+        // RV32B - ZBP
+        INSN_GREV:       decode_r_insn("grev");
+        INSN_GREVI: begin
+          unique casez (rvfi_insn)
+            INSN_REV_P:  decode_r1_insn("rev.p");
+            INSN_REV2_N: decode_r1_insn("rev2.n");
+            INSN_REV_N:  decode_r1_insn("rev.n");
+            INSN_REV4_B: decode_r1_insn("rev4.b");
+            INSN_REV2_B: decode_r1_insn("rev2.b");
+            INSN_REV_B:  decode_r1_insn("rev.b");
+            INSN_REV8_H: decode_r1_insn("rev8.h");
+            INSN_REV4_H: decode_r1_insn("rev4.h");
+            INSN_REV2_H: decode_r1_insn("rev2.h");
+            INSN_REV_H:  decode_r1_insn("rev.h");
+            INSN_REV16:  decode_r1_insn("rev16");
+            INSN_REV8:   decode_r1_insn("rev8");
+            INSN_REV4:   decode_r1_insn("rev4");
+            INSN_REV2:   decode_r1_insn("rev2");
+            INSN_REV:    decode_r1_insn("rev");
+            default:     decode_i_insn("grevi");
+          endcase
+        end
+        INSN_GORC:       decode_r_insn("gorc");
+        INSN_GORCI: begin
+          unique casez (rvfi_insn)
+            INSN_ORC_P:  decode_r1_insn("orc.p");
+            INSN_ORC2_N: decode_r1_insn("orc2.n");
+            INSN_ORC_N:  decode_r1_insn("orc.n");
+            INSN_ORC4_B: decode_r1_insn("orc4.b");
+            INSN_ORC2_B: decode_r1_insn("orc2.b");
+            INSN_ORC_B:  decode_r1_insn("orc.b");
+            INSN_ORC8_H: decode_r1_insn("orc8.h");
+            INSN_ORC4_H: decode_r1_insn("orc4.h");
+            INSN_ORC2_H: decode_r1_insn("orc2.h");
+            INSN_ORC_H:  decode_r1_insn("orc.h");
+            INSN_ORC16:  decode_r1_insn("orc16");
+            INSN_ORC8:   decode_r1_insn("orc8");
+            INSN_ORC4:   decode_r1_insn("orc4");
+            INSN_ORC2:   decode_r1_insn("orc2");
+            INSN_ORC:    decode_r1_insn("orc");
+            default:     decode_i_insn("gorci");
+          endcase
+        end
+        INSN_SHFL:       decode_r_insn("shfl");
+        INSN_SHFLI: begin
+          unique casez (rvfi_insn)
+            INSN_ZIP_N:  decode_r1_insn("zip.n");
+            INSN_ZIP2_B: decode_r1_insn("zip2.b");
+            INSN_ZIP_B:  decode_r1_insn("zip.b");
+            INSN_ZIP4_H: decode_r1_insn("zip4.h");
+            INSN_ZIP2_H: decode_r1_insn("zip2.h");
+            INSN_ZIP_H:  decode_r1_insn("zip.h");
+            INSN_ZIP8:   decode_r1_insn("zip8");
+            INSN_ZIP4:   decode_r1_insn("zip4");
+            INSN_ZIP2:   decode_r1_insn("zip2");
+            INSN_ZIP:    decode_r1_insn("zip");
+            default:     decode_i_insn("shfli");
+          endcase
+        end
+        INSN_UNSHFL:       decode_r_insn("unshfl");
+        INSN_UNSHFLI: begin
+          unique casez (rvfi_insn)
+            INSN_UNZIP_N:  decode_r1_insn("unzip.n");
+            INSN_UNZIP2_B: decode_r1_insn("unzip2.b");
+            INSN_UNZIP_B:  decode_r1_insn("unzip.b");
+            INSN_UNZIP4_H: decode_r1_insn("unzip4.h");
+            INSN_UNZIP2_H: decode_r1_insn("unzip2.h");
+            INSN_UNZIP_H:  decode_r1_insn("unzip.h");
+            INSN_UNZIP8:   decode_r1_insn("unzip8");
+            INSN_UNZIP4:   decode_r1_insn("unzip4");
+            INSN_UNZIP2:   decode_r1_insn("unzip2");
+            INSN_UNZIP:    decode_r1_insn("unzip");
+            default:       decode_i_insn("unshfli");
+          endcase
+        end
+
         // RV32B - ZBT
         INSN_CMIX:       decode_r_cmixcmov_insn("cmix");
         INSN_CMOV:       decode_r_cmixcmov_insn("cmov");

--- a/rtl/ibex_tracer_pkg.sv
+++ b/rtl/ibex_tracer_pkg.sv
@@ -80,12 +80,120 @@ parameter logic [31:0] INSN_RORI = { 5'b01100        , 12'b?, 3'b101, 5'b?, {OPC
 parameter logic [31:0] INSN_CLZ  = { 12'b011000000000, 5'b? , 3'b001, 5'b?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_CTZ  = { 12'b011000000001, 5'b? , 3'b001, 5'b?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_PCNT = { 12'b011000000010, 5'b? , 3'b001, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV  =
-    { 5'b01101, 2'b?, 5'b11111, 5'b? , 3'b101, 5'b?, {OPCODE_OP_IMM} };
+// ZBP
+// grevi
+parameter logic [31:0] INSN_GREVI = { 5'b01101, 12'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+// grevi -- pseudo-instructions
+parameter logic [31:0] INSN_REV_P =
+    { 5'b01101, 2'b?, 5'b00001, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_REV2_N =
+    { 5'b01101, 2'b?, 5'b00010, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_REV_N =
+    { 5'b01101, 2'b?, 5'b00011, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_REV4_B =
+    { 5'b01101, 2'b?, 5'b00100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_REV2_B =
+    { 5'b01101, 2'b?, 5'b00110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_REV_B =
+    { 5'b01101, 2'b?, 5'b00111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_REV8_H =
+    { 5'b01101, 2'b?, 5'b01000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_REV4_H =
+    { 5'b01101, 2'b?, 5'b01100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_REV2_H =
+    { 5'b01101, 2'b?, 5'b01110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_REV_H =
+    { 5'b01101, 2'b?, 5'b01111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_REV16 =
+    { 5'b01101, 2'b?, 5'b01000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV8 =
-    { 5'b01101, 2'b?, 5'b11000, 5'b? , 3'b101, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORCB =
-    { 5'b00101, 2'b?, 5'b00111, 5'b? , 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'b?, 5'b11000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_REV4 =
+    { 5'b01101, 2'b?, 5'b11100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_REV2 =
+    { 5'b01101, 2'b?, 5'b11110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_REV =
+    { 5'b01101, 2'b?, 5'b11111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+// gorci
+parameter logic [31:0] INSN_GORCI = { 5'b00101, 12'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+// gorci -- pseudo-instructions
+parameter logic [31:0] INSN_ORC_P =
+    { 5'b00101, 2'b?, 5'b00001, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC2_N =
+    { 5'b00101, 2'b?, 5'b00010, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC_N =
+    { 5'b00101, 2'b?, 5'b00011, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC4_B =
+    { 5'b00101, 2'b?, 5'b00100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC2_B =
+    { 5'b00101, 2'b?, 5'b00110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC_B =
+    { 5'b00101, 2'b?, 5'b00111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC8_H =
+    { 5'b00101, 2'b?, 5'b01000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC4_H =
+    { 5'b00101, 2'b?, 5'b01100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC2_H =
+    { 5'b00101, 2'b?, 5'b01110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC_H =
+    { 5'b00101, 2'b?, 5'b01111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC16 =
+    { 5'b00101, 2'b?, 5'b01000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC8 =
+    { 5'b00101, 2'b?, 5'b11000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC4 =
+    { 5'b00101, 2'b?, 5'b11100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC2 =
+    { 5'b00101, 2'b?, 5'b11110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORC =
+    { 5'b00101, 2'b?, 5'b11111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+// shfli
+parameter logic [31:0] INSN_SHFLI = { 6'b000010, 11'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+// shfli -- pseudo-instructions
+parameter logic [31:0] INSN_ZIP_N =
+    { 5'b00010, 3'b?, 4'b0001, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ZIP2_B =
+    { 5'b00010, 3'b?, 4'b0010, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ZIP_B =
+    { 5'b00010, 3'b?, 4'b0011, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ZIP4_H =
+    { 5'b00010, 3'b?, 4'b0100, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ZIP2_H =
+    { 5'b00010, 3'b?, 4'b0110, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ZIP_H =
+    { 5'b00010, 3'b?, 4'b0111, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ZIP8 =
+    { 5'b00010, 3'b?, 4'b1000, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ZIP4 =
+    { 5'b00010, 3'b?, 4'b1100, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ZIP2 =
+    { 5'b00010, 3'b?, 4'b1110, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ZIP =
+    { 5'b00010, 3'b?, 4'b1111, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+// unshfli
+parameter logic [31:0] INSN_UNSHFLI = { 6'b000010, 11'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+// unshfli -- pseudo-instructions
+parameter logic [31:0] INSN_UNZIP_N =
+    { 5'b00010, 3'b?, 4'b0001, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_UNZIP2_B =
+    { 5'b00010, 3'b?, 4'b0010, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_UNZIP_B =
+    { 5'b00010, 3'b?, 4'b0011, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_UNZIP4_H =
+    { 5'b00010, 3'b?, 4'b0100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_UNZIP2_H =
+    { 5'b00010, 3'b?, 4'b0110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_UNZIP_H =
+    { 5'b00010, 3'b?, 4'b0111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_UNZIP8 =
+    { 5'b00010, 3'b?, 4'b1000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_UNZIP4 =
+    { 5'b00010, 3'b?, 4'b1100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_UNZIP2 =
+    { 5'b00010, 3'b?, 4'b1110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_UNZIP =
+    { 5'b00010, 3'b?, 4'b1111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+
 // ZBS
 parameter logic [31:0] INSN_SBCLRI = { 5'b01001      , 12'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_SBSETI = { 5'b00101      , 12'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
@@ -111,6 +219,13 @@ parameter logic [31:0] INSN_ANDN  = { 7'b0100000, 10'b?, 3'b111, 5'b?, {OPCODE_O
 parameter logic [31:0] INSN_PACK  = { 7'b0000100, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
 parameter logic [31:0] INSN_PACKU = { 7'b0100100, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
 parameter logic [31:0] INSN_PACKH = { 7'b0000100, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
+
+// ZBP
+parameter logic [31:0] INSN_GREV   = { 7'b0110100, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_GORC   = { 7'b0010100, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SHFL   = { 7'b0000100, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_UNSHFL = { 7'b0000100, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
+
 // ZBS
 parameter logic [31:0] INSN_SBCLR = { 7'b0100100, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
 parameter logic [31:0] INSN_SBSET = { 7'b0010100, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };


### PR DESCRIPTION
This commit implements the Bit Manipulation Extension ZBP instruction group: grev[i] (generalized reverse), gorc[i] (generalized or-combine) and [un]shfl[i] (generalized shuffle) and all of their pseudo-instructions.

Architectural details:
* grev / gorc: The shifter structure features only a right structure. In order to perform a left shift therefore the needs to be reversed, shifted and reversed again. The architecture 
 of the back-reversal is implemented in stages are activated using the general reverse / orcombine operand or a signal marking left-shifts.

*  shfl / unshfl: Also known as zip / unzip or interlace / operation. These instructions are implemented in their own structure using a permutation networ of 6 stages. 4 stages thereof implement the shuffle permutations. The first and the last stage is the flip stage, which effectively reverses the order of the inner stages, for unshuffle operations.

Synthesis results are available [here](https://docs.google.com/spreadsheets/d/1dDDtzMgS5quMXtv-8z2uD--jBIHMSnaWrqj1EIDp1Nw/edit#gid=1032201152). The impact on timing is negligable. Additional area consumption is 0.3-0.4 kGE.

Signed-off-by: ganoam <gnoam@live.com>