### PR TITLE
Update dv_lib to lowRISC/opentitan@1d17b122

### DIFF
--- a/vendor/lowrisc_dv_lib.lock.hjson
+++ b/vendor/lowrisc_dv_lib.lock.hjson
@@ -9,7 +9,7 @@
   upstream:
   {
     url: https://github.com/lowRISC/opentitan
-    rev: 0d7f7ac755d4e00811257027dd814edb2afca050
+    rev: 1d17b1225d324c81da522c69317335a83edd5ddb
     only_subdir: hw/dv/sv/dv_lib
   }
 }

--- a/vendor/lowrisc_ip/dv_lib/dv_base_driver.sv
+++ b/vendor/lowrisc_ip/dv_lib/dv_base_driver.sv
@@ -2,9 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class dv_base_driver #(type ITEM_T = uvm_sequence_item,
-                       type CFG_T  = dv_base_agent_cfg) extends uvm_driver #(ITEM_T);
-  `uvm_component_param_utils(dv_base_driver #())
+class dv_base_driver #(type ITEM_T     = uvm_sequence_item,
+                       type CFG_T      = dv_base_agent_cfg,
+                       type RSP_ITEM_T = ITEM_T)
+  extends uvm_driver #(.REQ(ITEM_T), .RSP(RSP_ITEM_T));
+
+  `uvm_component_param_utils(dv_base_driver #(.ITEM_T     (ITEM_T),
+                                              .CFG_T      (CFG_T),
+                                              .RSP_ITEM_T (RSP_ITEM_T)))
 
   bit   under_reset;
   CFG_T cfg;

--- a/vendor/lowrisc_ip/dv_lib/dv_base_mem.sv
+++ b/vendor/lowrisc_ip/dv_lib/dv_base_mem.sv
@@ -5,12 +5,46 @@
 // base register reg class which will be used to generate the reg mem
 class dv_base_mem extends uvm_mem;
 
+  // uvm_mem::m_access is local variable. Create it again in order to use "access" in current class
+  local string m_access;
+
   function new(string           name,
                longint unsigned size,
                int unsigned     n_bits,
                string           access = "RW",
                int              has_coverage = UVM_NO_COVERAGE);
     super.new(name, size, n_bits, access, has_coverage);
+    m_access = access;
   endfunction : new
+
+  // rewrite this function to support "WO" access type for mem
+  function void configure(uvm_reg_block  parent,
+                          string         hdl_path="");
+     if (parent == null)
+       `uvm_fatal("REG/NULL_PARENT","configure: parent argument is null")
+
+     set_parent(parent);
+
+     if (!(m_access inside {"RW", "RO", "WO"})) begin
+        `uvm_error("RegModel", {"Memory '",get_full_name(),"' can only be RW, RO or WO"})
+     end
+
+     begin
+        uvm_mem_mam_cfg cfg = new;
+
+        cfg.n_bytes      = ((get_n_bits() - 1) / 8) + 1;
+        cfg.start_offset = 0;
+        cfg.end_offset   = get_size() - 1;
+
+        cfg.mode     = uvm_mem_mam::GREEDY;
+        cfg.locality = uvm_mem_mam::BROAD;
+
+        mam = new(get_full_name(), cfg, this);
+     end
+
+     parent.add_mem(this);
+
+     if (hdl_path != "") add_hdl_path_slice(hdl_path, -1, -1);
+  endfunction: configure
 
 endclass

--- a/vendor/lowrisc_ip/dv_lib/dv_base_reg.sv
+++ b/vendor/lowrisc_ip/dv_lib/dv_base_reg.sv
@@ -62,8 +62,22 @@ class dv_base_reg extends uvm_reg;
   endfunction
 
   // post_write callback to handle reg enables
+  // TODO: create an `enable_field_access_policy` variable and set the template code during
+  // automation.
   virtual task post_write(uvm_reg_item rw);
-    if (is_enable_reg() && (rw.value[0] & 1)) set_locked_regs_access("RO");
+    dv_base_reg_field fields[$];
+    string field_access;
+    if (is_enable_reg()) begin
+      get_dv_base_reg_fields(fields);
+      field_access = fields[0].get_access();
+      case (field_access)
+        // rw.value is a dynamic array
+        "W1C": if (rw.value[0][0] == 1'b1) set_locked_regs_access("RO");
+        "W0C": if (rw.value[0][0] == 1'b0) set_locked_regs_access("RO");
+        "RO": ; // if RO, it's updated by design, need to predict in scb
+        default:`uvm_fatal(`gtn, $sformatf("enable register invalid access %s", field_access))
+      endcase
+    end
   endtask
 
 endclass

--- a/vendor/lowrisc_ip/dv_lib/dv_base_sequencer.sv
+++ b/vendor/lowrisc_ip/dv_lib/dv_base_sequencer.sv
@@ -2,9 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class dv_base_sequencer #(type ITEM_T = uvm_sequence_item,
-                          type CFG_T  = dv_base_agent_cfg) extends uvm_sequencer #(ITEM_T);
-  `uvm_component_param_utils(dv_base_sequencer #(ITEM_T, CFG_T))
+class dv_base_sequencer #(type ITEM_T     = uvm_sequence_item,
+                          type CFG_T      = dv_base_agent_cfg,
+                          type RSP_ITEM_T = ITEM_T)
+  extends uvm_sequencer #(.REQ(ITEM_T), .RSP(RSP_ITEM_T));
+
+  `uvm_component_param_utils(dv_base_sequencer #(.ITEM_T     (ITEM_T),
+                                                 .CFG_T      (CFG_T),
+                                                 .RSP_ITEM_T (RSP_ITEM_T)))
 
   CFG_T cfg;
 

--- a/vendor/lowrisc_ip/dv_lib/dv_base_test.sv
+++ b/vendor/lowrisc_ip/dv_lib/dv_base_test.sv
@@ -61,12 +61,12 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
     test_seq.set_sequencer(env.virtual_sequencer);
     `DV_CHECK_RANDOMIZE_FATAL(test_seq)
 
-    `uvm_info(`gfn, {"starting vseq ", test_seq_s}, UVM_MEDIUM)
+    `uvm_info(`gfn, {"Starting test sequence ", test_seq_s}, UVM_MEDIUM)
     phase.raise_objection(this, $sformatf("%s objection raised", `gn));
     test_seq.start(env.virtual_sequencer);
     phase.drop_objection(this, $sformatf("%s objection dropped", `gn));
     phase.phase_done.display_objections();
-    `uvm_info(`gfn, {"finished vseq ", test_seq_s}, UVM_MEDIUM)
+    `uvm_info(`gfn, {"Finished test sequence ", test_seq_s}, UVM_MEDIUM)
   endtask
 
   // TODO: add default report_phase implementation


### PR DESCRIPTION
Update code from subdir hw/dv/sv/dv_lib in upstream repository
https://github.com/lowRISC/opentitan to revision
1d17b1225d324c81da522c69317335a83edd5ddb

* [dv] Add excl for rstmgr, pwrmgr and fix top-level csr test (Weicai
  Yang)
* [dv] Allow dv_lib-based sequences to have different RSP/REQ types
  (Rupert Swarbrick)
* [dv] Support WO, RO type for mem (Weicai Yang)
* [dv,sw] SW -> DV tb self-checking mechanism - SV (Srikrishna Iyer)
* [dv/top] Fix csr rw test (Cindy Chen)

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>