### PR TITLE
Minor tweaks to make icache test sequences more interesting

### DIFF
--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_driver.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_driver.sv
@@ -143,7 +143,7 @@ class ibex_icache_core_driver
   virtual task automatic invalidate();
     int unsigned num_cycles;
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_cycles,
-                                       num_cycles dist { 0 :/ 499, [1:20] :/ 1 };)
+                                       num_cycles dist { 1 :/ 10, [2:20] :/ 1 };)
     cfg.vif.invalidate_pulse(num_cycles);
   endtask
 

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
@@ -84,7 +84,7 @@ interface ibex_icache_core_if (input clk, input rst_n);
   //
   // A one-cycle pulse will start an invalidation, but testing might want a longer pulse (which the
   // cache should support)
-  task automatic invalidate_pulse(int num_cycles);
+  task automatic invalidate_pulse(int unsigned num_cycles);
     driver_cb.invalidate <= 1'b1;
     wait_clks(num_cycles);
     driver_cb.invalidate <= 1'b0;

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_req_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_req_item.sv
@@ -45,9 +45,9 @@ class ibex_icache_core_req_item extends uvm_sequence_item;
   }
 
   constraint c_invalidate_dist {
-    // Poke the cache invalidate line one time in 500. This takes ages and we don't want to
+    // Poke the cache invalidate line one time in 50. This takes ages and we don't want to
     // accidentally spend most of the test waiting for invalidation.
-    invalidate dist { 0 :/ 499, 1 :/ 1 };
+    invalidate dist { 0 :/ 49, 1 :/ 1 };
   }
 
   constraint c_num_insns_dist {

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/seq_lib/ibex_icache_core_sanity_seq.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/seq_lib/ibex_icache_core_sanity_seq.sv
@@ -10,7 +10,7 @@ class ibex_icache_core_sanity_seq extends ibex_icache_core_base_seq;
   `uvm_object_new
 
   rand int count;
-  constraint c_count { count > 0; count < 100; }
+  constraint c_count { count inside {[800:1000]}; }
 
   task body();
     // If this is set, the next request will be constrained to have trans_type

--- a/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
+++ b/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
@@ -42,7 +42,7 @@
     {
       name: ibex_icache_sanity
       uvm_test_seq: ibex_icache_sanity_vseq
-      run_opts: ["+test_timeout_ns=100000000"]
+      run_opts: ["+test_timeout_ns=1000000000"]
     }
 
     // TODO: add more tests here


### PR DESCRIPTION
The first commit makes them longer; the second makes sure we actually see the invalidate pin toggle occasionally.