### PR TITLE
[dv] makefile:cov LSF arg fix

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -404,8 +404,8 @@ cov:
 		--steps=cov \
 		${TEST_OPTS} \
 		--simulator="${SIMULATOR}" \
-		--o="${OUT}" \
-		--lsf_cmd="${LSF_CMD}";
+		$(lsf-arg) \
+		--o="${OUT}"
 	@if [ -d "test.vdb" ]; then \
 		mv -f test.vdb ${OUT}/rtl_sim/; \
 	fi


### PR DESCRIPTION
I'd overlooked changing the hardcoded LSF_CMD argument of the `cov` target to using `$(lsf-arg)` after adding a check in sim.py to return an error if the lsf command is an empty string - this PR simply updates this to prevent spurious error signaling.

Signed-off-by: Udi <udij@google.com>