### PR TITLE
Rework choosing new seeds in icache UVM memory model

### DIFF
--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent_pkg.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent_pkg.sv
@@ -12,7 +12,11 @@ package ibex_icache_mem_agent_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  // parameters
+  typedef enum {
+    ICacheMemNewSeed,
+    ICacheMemGrant,
+    ICacheMemResponse
+  } ibex_icache_mem_trans_type_e;
 
   // package sources
   `include "ibex_icache_mem_req_item.sv"

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_bus_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_bus_item.sv
@@ -8,23 +8,20 @@
 
 class ibex_icache_mem_bus_item extends uvm_sequence_item;
 
-  // Is this a request or a response?
-  logic        is_response;
+  // What sort of transaction is this? (new seed, grant or response)
+  ibex_icache_mem_trans_type_e trans_type;
 
-  // Request address and possible new seed (only valid for request transactions)
-  logic [31:0] address;
-  bit   [31:0] seed;
+  // This holds the new seed for a 'new seed' transaction, the request address for a grant
+  // transaction and the returned rdata for a response transaction.
+  logic [31:0] data;
 
-  // Response data and error flags (only valid for response transactions)
-  logic [31:0] rdata;
+  // Response error flag (only valid for response transactions)
   logic        err;
 
   `uvm_object_utils_begin(ibex_icache_mem_bus_item)
-    `uvm_field_int(is_response, UVM_DEFAULT)
-    `uvm_field_int(address,     UVM_DEFAULT | UVM_HEX)
-    `uvm_field_int(seed,        UVM_DEFAULT | UVM_HEX)
-    `uvm_field_int(rdata,       UVM_DEFAULT | UVM_HEX)
-    `uvm_field_int(err,         UVM_DEFAULT)
+    `uvm_field_enum(ibex_icache_mem_trans_type_e, trans_type, UVM_DEFAULT)
+    `uvm_field_int(data, UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int(err,  UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_monitor.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_monitor.sv
@@ -76,11 +76,9 @@ class ibex_icache_mem_monitor
     forever begin
       if (cfg.vif.monitor_cb.rvalid) begin
         bus_trans = ibex_icache_mem_bus_item::type_id::create("bus_trans");
-        bus_trans.is_response = 1'b1;
-        bus_trans.address     = '0;
-        bus_trans.seed        = '0;
-        bus_trans.rdata       = cfg.vif.monitor_cb.rdata;
-        bus_trans.err         = cfg.vif.monitor_cb.err;
+        bus_trans.trans_type = ICacheMemResponse;
+        bus_trans.data       = cfg.vif.monitor_cb.rdata;
+        bus_trans.err        = cfg.vif.monitor_cb.err;
         analysis_port.write(bus_trans);
       end
 
@@ -88,33 +86,42 @@ class ibex_icache_mem_monitor
     end
   endtask
 
-  // This is called immediately when an address is requested and is used to drive the PMP response
+  // This is called immediately when an address is requested and is used to drive the PMP response.
+  // If we decide to choose a new seed with this transaction, the seed also gets passed to the
+  // scoreboard.
   function automatic void new_request(logic [31:0] addr);
+    ibex_icache_mem_bus_item bus_trans;
     ibex_icache_mem_req_item item = new("item");
 
     item.is_grant = 1'b0;
     item.address = addr;
-    item.seed = '0;
+    `DV_CHECK_RANDOMIZE_FATAL(item)
     request_port.write(item);
+
+    if (item.seed != 0) begin
+      bus_trans = ibex_icache_mem_bus_item::type_id::create("bus_trans");
+      bus_trans.trans_type = ICacheMemNewSeed;
+      bus_trans.data       = item.seed;
+      bus_trans.err        = '0;
+      analysis_port.write(bus_trans);
+    end
   endfunction
 
   // This is called on a clock edge when an request is granted
   function automatic void new_grant(logic [31:0] addr);
-    ibex_icache_mem_req_item        item;
+    ibex_icache_mem_req_item item;
     ibex_icache_mem_bus_item bus_trans;
 
     item = ibex_icache_mem_req_item::type_id::create("item");
     item.is_grant = 1'b1;
     item.address  = addr;
-    `DV_CHECK_RANDOMIZE_FATAL(item)
+    item.seed     = '0;
     request_port.write(item);
 
     bus_trans = ibex_icache_mem_bus_item::type_id::create("bus_trans");
-    bus_trans.is_response = 1'b0;
-    bus_trans.address     = addr;
-    bus_trans.rdata       = '0;
-    bus_trans.seed        = item.seed;
-    bus_trans.err         = 0;
+    bus_trans.trans_type = ICacheMemGrant;
+    bus_trans.data       = addr;
+    bus_trans.err        = 0;
     analysis_port.write(bus_trans);
   endfunction
 

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_req_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_req_item.sv
@@ -6,11 +6,12 @@
 // memory.
 //
 // When a request first comes in (via a posedge on the req line), it immediately generates a
-// req_item with is_grant = 0. This is used by the driver to decide whether to generate a PMP error.
+// req_item with is_grant = 0. This is used by the sequence to tell the driver whether to generate a
+// PMP error. A req_item with is_grant = 0 may also have a seed update.
 //
 // Assuming that the request wasn't squashed by a PMP error, it will be granted on some later clock
 // edge. At that point, another req_item is generated with is_grant = 1. This is added to a queue in
-// the driver and will be serviced at some later point. This item may also have a seed update.
+// the driver and will be serviced at some later point.
 
 class ibex_icache_mem_req_item extends uvm_sequence_item;
 

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/seq_lib/ibex_icache_mem_resp_seq.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/seq_lib/ibex_icache_mem_resp_seq.sv
@@ -17,34 +17,70 @@ class ibex_icache_mem_resp_seq extends ibex_icache_mem_base_seq;
   endtask
 
   task body();
+    // We pick new seeds when we spot a request (rather than when we spot a grant) to ensure that
+    // any given fetch corresponds to exactly one seed. Unfortunately, there's a race if these two
+    // things happen at one clock edge:
+    //
+    //    - Request for new address which gets a new seed
+    //    - Grant of previous request
+    //
+    // If that happens, and the event scheduler happened to schedule the monitor to spot the request
+    // before the grant, we might accidentally handle the grant with the new seed rather than the
+    // old one, which would cause confusion in the scoreboard.
+    //
+    // To avoid this problem, we keep a FIFO of pending addresses along with their corresponding
+    // seeds. When a grant message comes in, we know that we can look up the correct seed there.
+    mailbox #(bit[63:0]) pending_grants = new("pending_grants");
+
     ibex_icache_mem_req_item  req_item  = new("req_item");
     ibex_icache_mem_resp_item resp_item = new("resp_item");
+
+    bit [63:0] gnt_data;
+    bit [31:0] gnt_addr, gnt_seed;
+
+    bit [31:0] cur_seed = 0;
 
     forever begin
       // Wait for a transaction request.
       p_sequencer.request_fifo.get(req_item);
 
       if (!req_item.is_grant) begin
-        // If this is a request (not a grant), check the memory model for a PMP error at this
-        // address. The other fields are ignored.
+        // If this is a request (not a grant), take any new seed and then check the memory model for
+        // a PMP error at this address. Add the address and its corresponding seed to the list of
+        // pending grants.
+        if (req_item.seed != 32'd0) begin
+          `uvm_info(`gfn, $sformatf("New memory seed: 0x%08h", req_item.seed), UVM_HIGH)
+          cur_seed = req_item.seed;
+        end
+
         resp_item.is_grant = 1'b0;
-        resp_item.err      = mem_model.is_pmp_error(req_item.address);
+        resp_item.err      = mem_model.is_pmp_error(cur_seed, req_item.address);
         resp_item.address  = req_item.address;
         resp_item.rdata    = 'X;
 
-      end else begin
-        // If this is a grant, take any new seed then check the memory model for a (non-PMP) error
-        // at this address. On success, look up the memory data too.
+        pending_grants.put({req_item.address, cur_seed});
 
-        if (req_item.seed != 32'd0) begin
-          `uvm_info(`gfn, $sformatf("New memory seed: 0x%08h", req_item.seed), UVM_HIGH)
-          mem_model.set_seed(req_item.seed);
+      end else begin
+        // If this is a grant, search through the pending_grants mailbox to find the seed from the
+        // request that matched.
+        gnt_addr = req_item.address + 1;
+        while (pending_grants.num() > 0) begin
+          pending_grants.get(gnt_data);
+          {gnt_addr, gnt_seed} = gnt_data;
+          if (gnt_addr == req_item.address) break;
         end
 
+        // If nothing went wrong, we should have found the right item and gnt_addr should now
+        // equal req_item.address
+        `DV_CHECK_FATAL(gnt_addr == req_item.address,
+                        $sformatf("No pending grant for address 0x%08h.", req_item.address))
+
+        // Using the seed that we saw for the request, check the memory model for a (non-PMP) error
+        // at this address. On success, look up the memory data too.
         resp_item.is_grant = 1'b1;
-        resp_item.err      = mem_model.is_mem_error(req_item.address);
+        resp_item.err      = mem_model.is_mem_error(gnt_seed, req_item.address);
         resp_item.address  = req_item.address;
-        resp_item.rdata    = resp_item.err ? 'X : mem_model.read_data(req_item.address);
+        resp_item.rdata    = resp_item.err ? 'X : mem_model.read_data(gnt_seed, req_item.address);
       end
 
       // Use the response item as an entry in the sequence, randomising any delay


### PR DESCRIPTION
The flow for a memory fetch is:

  1. Cache requests data for a memory address
  2. Agent spots the request, maybe signalling a PMP error
  3. Grant line goes high, at which point the request is granted.
  4. Sometime later (in-order pipeline), agent sends a response

Occasionally, we need to pick a new seed for the backing memory.
Before this patch, we picked these seeds at point (3).

Unfortunately this was wrong in the following case:

  1. We're switching from seed S0 to seed S1.
  2. The request is spotted with seed S0 and doesn't signal a PMP error
  3. The request is granted and we switch to seed S1.
  4. We respond with data from memory based on S1, with no memory
     error either

If S1 would have caused a PMP error, the resulting fetch (no error,
but data from S1) doesn't match any possible seed and the scoreboard
gets confused.

This patch changes to picking new seeds at (2) to solve the problem.
This isn't quite enough by itself, because if a request is granted on
a clock-edge, a new request address might appear and there isn't a
guaranteed ordering in the simulation between the new request and the
old grant (both things happen at the same time). To fix this, the
response sequence now maintains a queue of requests and their
corresponding seeds to make sure that all the checks for a fetch are
done with a single seed.

The patch also gets rid of the seed state in the memory model: it
turns out that this didn't really help: the scoreboard is always
asking "what would I get with this seed?" and now the sequence is
doing something similar.