### PR TITLE
[prim] Split out primitives used by icache

### DIFF
--- a/shared/prim_generic_ram_1p.core
+++ b/shared/prim_generic_ram_1p.core
@@ -2,20 +2,16 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:ibex:ibex_icache:0.1"
-description: "IBEX_ICACHE DV sim target"
+
+name: "lowrisc:prim_generic:ram_1p"
+description: "Single port RAM"
 filesets:
   files_rtl:
-    depend:
-      - lowrisc:prim:secded
-      - lowrisc:prim:ram_1p
     files:
-      - rtl/ibex_icache.sv
+      - rtl/prim_generic_ram_1p.sv
     file_type: systemVerilogSource
 
 targets:
-  default: &default_target
+  default:
     filesets:
       - files_rtl
-    toplevel: ibex_icache
-    default_tool: vcs

--- a/shared/prim_ram_1p.core
+++ b/shared/prim_ram_1p.core
@@ -1,0 +1,16 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:ram_1p:0.1"
+description: "Single port RAM (technology independent)"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim_generic:ram_1p
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/shared/prim_secded.core
+++ b/shared/prim_secded.core
@@ -2,20 +2,19 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:ibex:ibex_icache:0.1"
-description: "IBEX_ICACHE DV sim target"
+
+name: "lowrisc:prim:secded:0.1"
+description: "SECDED ECC primitives"
 filesets:
   files_rtl:
-    depend:
-      - lowrisc:prim:secded
-      - lowrisc:prim:ram_1p
     files:
-      - rtl/ibex_icache.sv
+      - rtl/prim_secded_28_22_dec.sv
+      - rtl/prim_secded_28_22_enc.sv
+      - rtl/prim_secded_72_64_dec.sv
+      - rtl/prim_secded_72_64_enc.sv
     file_type: systemVerilogSource
 
 targets:
-  default: &default_target
+  default:
     filesets:
       - files_rtl
-    toplevel: ibex_icache
-    default_tool: vcs

--- a/shared/sim_shared.core
+++ b/shared/sim_shared.core
@@ -10,11 +10,6 @@ filesets:
       - lowrisc:prim:assert
     files:
       - ./rtl/prim_clock_gating.sv
-      - ./rtl/prim_generic_ram_1p.sv
-      - ./rtl/prim_secded_28_22_enc.sv
-      - ./rtl/prim_secded_28_22_dec.sv
-      - ./rtl/prim_secded_72_64_enc.sv
-      - ./rtl/prim_secded_72_64_dec.sv
       - ./rtl/ram_1p.sv
       - ./rtl/ram_2p.sv
       - ./rtl/bus.sv


### PR DESCRIPTION
- All primitives the icache uses are specified in distinct core files
  with names that match those existing (or about to exist) in OpenTitan
- When vendoring-in Ibex, none of those primitives need to be copied
  across, since OpenTitan will use its own versions
- Relates to lowRISC/opentitan/#1231

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>