### PR TITLE
[memutils] Make memutils work with wider RAMs

### DIFF
--- a/dv/verilator/memutil/cpp/verilator_memutil.cc
+++ b/dv/verilator/memutil/cpp/verilator_memutil.cc
@@ -45,8 +45,8 @@ bool VerilatorMemUtil::RegisterMemoryArea(const std::string name,
                                           size_t width_bit) {
   MemArea mem = {.name = name, .location = location, .width_bit = width_bit};
 
-  assert((width_bit == 32 || width_bit == 64) &&
-         "TODO: Check if width other than 32 and 64 works as expected.");
+  assert((width_bit <= 128) &&
+         "TODO: Memory loading only supported up to 128 bits.");
 
   auto ret = mem_register_.emplace(name, mem);
   if (ret.second == false) {
@@ -397,9 +397,9 @@ bool VerilatorMemUtil::MemWrite(const MemArea &m, const std::string &filepath,
     return false;
   }
 
-  if ((m.width_bit % 32) != 0) {
+  if ((m.width_bit % 8) != 0) {
     std::cerr << "ERROR: width for: " << m.name
-              << "must be a multiple of 32 (was : " << m.width_bit << ")"
+              << "must be a multiple of 8 (was : " << m.width_bit << ")"
               << std::endl;
     return false;
   }

--- a/shared/rtl/prim_generic_ram_1p.sv
+++ b/shared/rtl/prim_generic_ram_1p.sv
@@ -71,32 +71,25 @@ module prim_generic_ram_1p #(
       $readmemh(file, mem);
     endtask
 
-    // Width must be a multiple of 32bit for this function to work
-    // Note that the DPI export and function definition must both be in the same generate
-    // context to get the correct name.
-    if ((Width % 32) == 0) begin : gen_set_mem
-      // Function for setting a specific element in |mem|
-      // Returns 1 (true) for success, 0 (false) for errors.
-      export "DPI-C" function simutil_verilator_set_mem;
+    // Function for setting a specific element in |mem|
+    // Returns 1 (true) for success, 0 (false) for errors.
+    export "DPI-C" function simutil_verilator_set_mem;
 
-      function int simutil_verilator_set_mem(input int index,
-                                             input bit [Width-1:0] val);
-        if (index >= Depth) begin
-          return 0;
-        end
+    function int simutil_verilator_set_mem(input int         index,
+                                           input bit [127:0] val);
 
-        mem[index] = val;
-        return 1;
-      endfunction
-    end else begin : gen_other
-      // Function doesn't work unless Width % 32 so just return 0
-      export "DPI-C" function simutil_verilator_set_mem;
-
-      function int simutil_verilator_set_mem(input int index,
-                                             input bit [Width-1:0] val);
+      // Function will only work for memories <= 128 bits
+      if (Width > 128) begin
         return 0;
-      endfunction
-    end
+      end
+
+      if (index >= Depth) begin
+        return 0;
+      end
+
+      mem[index] = val[Width-1:0];
+      return 1;
+    endfunction
   `endif
 
   `ifdef SRAM_INIT_FILE

--- a/shared/rtl/ram_1p.sv
+++ b/shared/rtl/ram_1p.sv
@@ -56,7 +56,7 @@ module ram_1p #(
   `ifdef VERILATOR
     // Task for loading 'mem' with SystemVerilog system task $readmemh()
     export "DPI-C" task simutil_verilator_memload;
-    // Function for setting a specific 32 bit element in |mem|
+    // Function for setting a specific element in |mem|
     // Returns 1 (true) for success, 0 (false) for errors.
     export "DPI-C" function simutil_verilator_set_mem;
 
@@ -65,14 +65,13 @@ module ram_1p #(
       $readmemh(file, mem);
     endtask
 
-    // TODO: Allow 'val' to have other widths than 32 bit
-    function int simutil_verilator_set_mem(input int index,
-                                           input logic[31:0] val);
+    function int simutil_verilator_set_mem(input int         index,
+                                           input bit [127:0] val);
       if (index >= Depth) begin
         return 0;
       end
 
-      mem[index] = val;
+      mem[index] = val[31:0];
       return 1;
     endfunction
   `endif

--- a/shared/rtl/ram_2p.sv
+++ b/shared/rtl/ram_2p.sv
@@ -97,7 +97,7 @@ module ram_2p #(
   `ifdef VERILATOR
     // Task for loading 'mem' with SystemVerilog system task $readmemh()
     export "DPI-C" task simutil_verilator_memload;
-    // Function for setting a specific 32 bit element in |mem|
+    // Function for setting a specific element in |mem|
     // Returns 1 (true) for success, 0 (false) for errors.
     export "DPI-C" function simutil_verilator_set_mem;
 
@@ -106,14 +106,13 @@ module ram_2p #(
       $readmemh(file, mem);
     endtask
 
-    // TODO: Allow 'val' to have other widths than 32 bit
-    function int simutil_verilator_set_mem(input int index,
-                                           input logic[31:0] val);
+    function int simutil_verilator_set_mem(input int         index,
+                                           input bit [127:0] val);
       if (index >= Depth) begin
         return 0;
       end
 
-      mem[index] = val;
+      mem[index] = val[31:0];
       return 1;
     endfunction
   `endif


### PR DESCRIPTION
- Using the RAM width in the DPI function definition causes Verilator
  compilation failures where there are multiple memory instances with
  different widths.
- With this patch, the width of the function is fixed at 128bits, and
  the memory loader can load any width of data (+ ECC bits) that it
  likes (up to 128bits total). The RAM on the SystemVerilog side will
  discard any extra unused bits.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>