### PR TITLE
Specify "-xlrm uniq_prior_final" for VCS

### DIFF
--- a/dv/cs_registers/tb_cs_registers.core
+++ b/dv/cs_registers/tb_cs_registers.core
@@ -104,6 +104,7 @@ targets:
     tools:
       vcs:
         vcs_options:
+          - '-xlrm uniq_prior_final'
           - '../src/lowrisc_ibex_tb_cs_registers_0/build/bin/reg_dpi.so'
           - '-debug_access+all'
 

--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -24,6 +24,7 @@
          -Mdir=<out>/vcs_simv.csrc
          -o <out>/vcs_simv
          -debug_access+pp
+         -xlrm uniq_prior_final
          -lca -kdb <cmp_opts> <wave_opts> <cov_opts>"
     cov_opts: >
       -cm line+tgl+assert+fsm+branch

--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -76,6 +76,7 @@ targets:
     tools:
       vcs:
         vcs_options:
+          - '-xlrm uniq_prior_final'
           - '-debug_access+r'
       verilator:
         mode: cc


### PR DESCRIPTION
As discussed in issue #845, this tells VCS to wait for signals to
settle in combinatorial blocks before checking uniqueness in
constructs like unique case.

Otherwise things like this can cause spurious warnings:

```systemverilog
  always_comb b = ~in;

  always_comb c = in;

  always_comb begin
    unique case (1'b1)
      b: x = 1;
      c: x = 0;
      default: x = 0;  // not that it matters, but this won't happen
    endcase
  end
```

For example, on a falling edge of the `in` signal, if the processes are
executed in the order 1, 3, 2 then the unique case block will appear
to see both `b` and `c` true at the same time.