### PR TITLE
Use prim_generic_ram_1p in ram_1p

### DIFF
--- a/dv/riscv_compliance/ibex_riscv_compliance.cc
+++ b/dv/riscv_compliance/ibex_riscv_compliance.cc
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
   simctrl.SetTop(&top, &top.IO_CLK, &top.IO_RST_N,
                  VerilatorSimCtrlFlags::ResetPolarityNegative);
 
-  memutil.RegisterMemoryArea("ram", "TOP.ibex_riscv_compliance.u_ram");
+  memutil.RegisterMemoryArea("ram", "TOP.ibex_riscv_compliance.u_ram.u_ram");
   simctrl.RegisterExtension(&memutil);
 
   return simctrl.Exec(argc, argv);

--- a/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
+++ b/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
@@ -39,8 +39,10 @@ module ibex_riscv_compliance (
     TestUtilDevice
   } bus_device_e;
 
-  localparam NrDevices = 2;
-  localparam NrHosts = 3;
+  localparam int unsigned NrDevices = 2;
+  localparam int unsigned NrHosts = 3;
+  // 64 kB RAM. Must be a power of 2. Check bus configuration below when changing.
+  localparam int unsigned RamSizeWords = 64*1024/4;
 
   // host and device signals
   logic           host_req    [NrHosts];
@@ -67,7 +69,7 @@ module ibex_riscv_compliance (
   logic [31:0] cfg_device_addr_base [NrDevices];
   logic [31:0] cfg_device_addr_mask [NrDevices];
   assign cfg_device_addr_base[Ram] = 32'h0;
-  assign cfg_device_addr_mask[Ram] = ~32'hFFFF; // 64 kB
+  assign cfg_device_addr_mask[Ram] = ~32'(RamSizeWords * 4 - 1);
   assign cfg_device_addr_base[TestUtilDevice] = 32'h20000;
   assign cfg_device_addr_mask[TestUtilDevice] = ~32'h3FF; // 1 kB
 
@@ -154,7 +156,7 @@ module ibex_riscv_compliance (
 
   // SRAM block for instruction and data storage
   ram_1p #(
-      .Depth(64*1024/4)
+      .Depth(RamSizeWords)
     ) u_ram (
       .clk_i     (clk_sys),
       .rst_ni    (rst_sys_n),

--- a/shared/sim_shared.core
+++ b/shared/sim_shared.core
@@ -8,6 +8,7 @@ filesets:
   files_sim_sv:
     depend:
       - lowrisc:prim:assert
+      - lowrisc:prim_generic:ram_1p
     files:
       - ./rtl/prim_clock_gating.sv
       - ./rtl/ram_1p.sv


### PR DESCRIPTION
ram_1p is almost a copy of the single-port RAM primitive we have in
OpenTitan, called prim_ram_1p, with its generic implementation
prim_generic_ram_1p. Instead of having a copy of that file in Ibex,
consistently use the OpenTitan one.

Unfortunately, ram_1p has slightly different semantics around some
signals, especially rvalid. This commit adjusts the meanings of the
signals for now, since I don't have a way to test the Arty board
which also uses this primitive (together with the compliance test
suite). With the testing in the compliance suite I'm reasonably certain
that the Arty board will work as well.