### PR TITLE
Always assert ready in core driver for ICache UVM testbench

### DIFF
--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_driver.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_driver.sv
@@ -112,9 +112,15 @@ class ibex_icache_core_driver
   virtual task automatic read_insn();
     int unsigned delay;
 
-    // Maybe (1 time in 10) wait for a valid signal before even considering asserting ready.
-    if ($urandom_range(9) == 0)
-      wait (cfg.vif.driver_cb.valid);
+    // TODO: The icache sometimes currently requires the ready signal before it asserts valid. This
+    //       is tracked by issue #850.
+    if (0) begin
+
+      // Maybe (1 time in 10) wait for a valid signal before even considering asserting ready.
+      if ($urandom_range(9) == 0)
+        wait (cfg.vif.driver_cb.valid);
+
+    end
 
     // Then pick how long we wait before asserting that we are ready.
     //


### PR DESCRIPTION
This works around a bug tracked in issue #850.