### PR TITLE
[bitmanip] Add ZBF instruction group

### DIFF
--- a/doc/instruction_decode_execute.rst
+++ b/doc/instruction_decode_execute.rst
@@ -66,7 +66,7 @@ Other blocks use the ALU for the following tasks:
 
 Support for the RISC-V Bitmanipulation Extension (Document Version 0.92, November 8, 2019) is enabled via the parameter ``RV32B``.
 This feature is *EXPERIMENTAL* and the details of its impact are not yet documented here.
-Currently the Zbb, Zbs, Zbp, Zbe and Zbt sub-extensions are implemented.
+Currently the Zbb, Zbs, Zbp, Zbe, Zbf and Zbt sub-extensions are implemented.
 All instructions are carried out in a single clock cycle.
 
 .. _mult-div:

--- a/doc/integration.rst
+++ b/doc/integration.rst
@@ -93,8 +93,8 @@ Parameters
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
 | ``RV32B``                    | bit         | 0          | *EXPERIMENTAL* - B(itmanipulation) extension enable:            |
 |                              |             |            | Currently supported Z-extensions: Zbb (base), Zbs (single-bit)  |
-|                              |             |            | Zbp (bit permutation), Zbe (bit extract/deposit and             |
-|                              |             |            | Zbt (ternary)                                                   |
+|                              |             |            | Zbp (bit permutation), Zbe (bit extract/deposit),               |
+|                              |             |            | Zbf (bit-field place) and Zbt (ternary)                         |
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
 | ``BranchTargetALU``          | bit         | 0          | *EXPERIMENTAL* - Enables branch target ALU removing a stall     |
 |                              |             |            | cycle from taken branches                                       |

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -595,5 +595,5 @@
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +enable_b_extension=1
-    +enable_bitmanip_groups=zbb,zbt,zbs,zbe,zbp
+    +enable_bitmanip_groups=zbb,zbt,zbs,zbp,zbf,zbe
   rtl_test: core_ibex_base_test

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -346,9 +346,9 @@ module ibex_decoder #(
               end
               5'b0_1100: begin
                 unique case(instr[26:20])
-                  7'b00_00000,                                     // clz
-                  7'b00_00001,                                     // ctz
-                  7'b00_00010: illegal_insn = RV32B ? 1'b0 : 1'b1; // pcnt
+                  7'b000_0000,                                     // clz
+                  7'b000_0001,                                     // ctz
+                  7'b000_0010: illegal_insn = RV32B ? 1'b0 : 1'b1; // pcnt
                   default: illegal_insn = 1'b1;
                 endcase
               end
@@ -432,7 +432,9 @@ module ibex_decoder #(
             {7'b011_0100, 3'b101}, // grev
             {7'b001_0100, 3'b101}, // gorc
             {7'b000_0100, 3'b001}, // shfl
-            {7'b000_0100, 3'b101}: illegal_insn = RV32B ? 1'b0 : 1'b1; // unshfl
+            {7'b000_0100, 3'b101}, // unshfl
+            // RV32B zbf
+            {7'b010_0100, 3'b111}: illegal_insn = RV32B ? 1'b0 : 1'b1; // bfp
 
             // RV32M instructions
             {7'b000_0001, 3'b000}: begin // mul
@@ -881,39 +883,40 @@ module ibex_decoder #(
             {7'b000_0000, 3'b101}: alu_operator_o = ALU_SRL;   // Shift Right Logical
             {7'b010_0000, 3'b101}: alu_operator_o = ALU_SRA;   // Shift Right Arithmetic
 
-            // RV32B zbb
-            {7'b001_0000, 3'b001}: if (RV32B) alu_operator_o = ALU_SLO;   // Shift Left Ones
-            {7'b001_0000, 3'b101}: if (RV32B) alu_operator_o = ALU_SRO;   // Shift Right Ones
+            // RV32B ALU Operations
+            {7'b001_0000, 3'b001}: if (RV32B) alu_operator_o = ALU_SLO;   // slo
+            {7'b001_0000, 3'b101}: if (RV32B) alu_operator_o = ALU_SRO;   // sro
             {7'b011_0000, 3'b001}: begin
               if (RV32B) begin
-                alu_operator_o = ALU_ROL;   // Rotate Left
+                alu_operator_o = ALU_ROL;   // rol
                 alu_multicycle_o = 1'b1;
               end
             end
             {7'b011_0000, 3'b101}: begin
               if (RV32B) begin
-                alu_operator_o = ALU_ROR;   // Rotate Right
+                alu_operator_o = ALU_ROR;   // ror
                 alu_multicycle_o = 1'b1;
               end
             end
 
-            {7'b000_0101, 3'b100}: if (RV32B) alu_operator_o = ALU_MIN;    // Minimum
-            {7'b000_0101, 3'b101}: if (RV32B) alu_operator_o = ALU_MAX;    // Maximum
-            {7'b000_0101, 3'b110}: if (RV32B) alu_operator_o = ALU_MINU;   // Minimum Unsigned
-            {7'b000_0101, 3'b111}: if (RV32B) alu_operator_o = ALU_MAXU;   // Maximum Unsigned
+            {7'b000_0101, 3'b100}: if (RV32B) alu_operator_o = ALU_MIN;    // min
+            {7'b000_0101, 3'b101}: if (RV32B) alu_operator_o = ALU_MAX;    // max
+            {7'b000_0101, 3'b110}: if (RV32B) alu_operator_o = ALU_MINU;   // minu
+            {7'b000_0101, 3'b111}: if (RV32B) alu_operator_o = ALU_MAXU;   // maxu
 
-            {7'b000_0100, 3'b100}: if (RV32B) alu_operator_o = ALU_PACK;   // Pack Lower Halves
-            {7'b010_0100, 3'b100}: if (RV32B) alu_operator_o = ALU_PACKU;  // Pack Upper Halves
-            {7'b000_0100, 3'b111}: if (RV32B) alu_operator_o = ALU_PACKH;  // Pack LSB Bytes
+            {7'b000_0100, 3'b100}: if (RV32B) alu_operator_o = ALU_PACK;   // pack
+            {7'b010_0100, 3'b100}: if (RV32B) alu_operator_o = ALU_PACKU;  // packu
+            {7'b000_0100, 3'b111}: if (RV32B) alu_operator_o = ALU_PACKH;  // packh
 
-            {7'b010_0000, 3'b100}: if (RV32B) alu_operator_o = ALU_XNOR;   // Xnor
-            {7'b010_0000, 3'b110}: if (RV32B) alu_operator_o = ALU_ORN;    // Orn
-            {7'b010_0000, 3'b111}: if (RV32B) alu_operator_o = ALU_ANDN;   // Andn
+            {7'b010_0000, 3'b100}: if (RV32B) alu_operator_o = ALU_XNOR;   // xnor
+            {7'b010_0000, 3'b110}: if (RV32B) alu_operator_o = ALU_ORN;    // orn
+            {7'b010_0000, 3'b111}: if (RV32B) alu_operator_o = ALU_ANDN;   // andn
+
             // RV32B zbp
-            {7'b011_0100, 3'b101}: if (RV32B) alu_operator_o = ALU_GREV;   // Grev
-            {7'b001_0100, 3'b101}: if (RV32B) alu_operator_o = ALU_GORC;   // Grev
-            {7'b000_0100, 3'b001}: if (RV32B) alu_operator_o = ALU_SHFL;   // Shfl
-            {7'b000_0100, 3'b101}: if (RV32B) alu_operator_o = ALU_UNSHFL; // Unshfl
+            {7'b011_0100, 3'b101}: if (RV32B) alu_operator_o = ALU_GREV;   // grev
+            {7'b001_0100, 3'b101}: if (RV32B) alu_operator_o = ALU_GORC;   // grev
+            {7'b000_0100, 3'b001}: if (RV32B) alu_operator_o = ALU_SHFL;   // shfl
+            {7'b000_0100, 3'b101}: if (RV32B) alu_operator_o = ALU_UNSHFL; // unshfl
 
             // RV32B zbs
             {7'b010_0100, 3'b001}: if (RV32B) alu_operator_o = ALU_SBCLR;  // sbclr
@@ -924,6 +927,9 @@ module ibex_decoder #(
             // RV32B zbe
             {7'b010_0100, 3'b110}: if (RV32B) alu_operator_o = ALU_BDEP;   // bdep
             {7'b000_0100, 3'b110}: if (RV32B) alu_operator_o = ALU_BEXT;   // bext
+            // RV32B zbf
+            {7'b010_0100, 3'b111}: if (RV32B) alu_operator_o = ALU_BFP;    // bfp
+
             // RV32M instructions, all use the same ALU operation
             {7'b000_0001, 3'b000}: begin // mul
               alu_operator_o = ALU_ADD;

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -106,7 +106,11 @@ typedef enum logic [5:0] {
   // Bit Extract / Deposit
   // RV32B
   ALU_BEXT,
-  ALU_BDEP
+  ALU_BDEP,
+
+  // Bit Field Place
+  // RV32B
+  ALU_BFP
 } alu_op_e;
 
 typedef enum logic [1:0] {

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -991,6 +991,8 @@ module ibex_tracer (
         INSN_FSL:        decode_r_funnelshift_insn("fsl");
         INSN_FSRI:       decode_i_funnelshift_insn("fsri");
 
+        // RV32B - ZBF
+        INSN_BFP:        decode_r_insn("bfp");
         default:         decode_mnemonic("INVALID");
       endcase
     end

--- a/rtl/ibex_tracer_pkg.sv
+++ b/rtl/ibex_tracer_pkg.sv
@@ -237,6 +237,9 @@ parameter logic [31:0] INSN_CMOV = {5'b?, 2'b11, 10'b?, 3'b101, 5'b?, {OPCODE_OP
 parameter logic [31:0] INSN_FSL  = {5'b?, 2'b10, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
 parameter logic [31:0] INSN_FSR  = {5'b?, 2'b10, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
 
+// ZBF
+parameter logic [31:0] INSN_BFP  = {7'b0100100, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
+
 // LOAD & STORE
 parameter logic [31:0] INSN_LOAD    = {25'b?,                            {OPCODE_LOAD } };
 parameter logic [31:0] INSN_STORE   = {25'b?,                            {OPCODE_STORE} };


### PR DESCRIPTION
This commit implements the Bit Manipulation Extension ZBF instruction
group, which consists only of the one instruction bfp (bit-field
place).
This instruction places a field of length len < 16 from rs2 in rs1 at
offset off.

Architectureal details:

        The implementation works exactly the same as proposed by Claire
        Wolf in her reference implementation.
        1. bfp_mask = slo(o, len)
        2. bfp_result =
                (rs1 & ~(bfp_mask << off)) | (rs2 & bfp_mask) << off
                        ^------ shifter-^
        The existing shifter structure is shared for the indicated
        operation.

Impact on area:

        * When synthesizing without the B-extension, the 2 stage 
        design seems to move the timing bottleneck, leading to 
        optimizations which result in an area increase by 1 kGE, 
        when synthesized with tight timing constraints. For the 
        3 stage configuration there is no change.
        When synthesized with relaxed timing constraints there is no
        significant change in either configuration.

        * With the B-extension enabled, the area increase for tight 
        timing constraints is 1.1-1.2 kGE. For relaxed timing 
        constraints that is ~0.4kGE
        
Impact on timing: No significant impact.

Signed-off-by: ganoam <gnoam@live.com>