### PR TITLE
[config] Change default PMPNumRegions

### DIFF
--- a/dv/riscv_compliance/ibex_riscv_compliance.core
+++ b/dv/riscv_compliance/ibex_riscv_compliance.core
@@ -79,7 +79,7 @@ parameters:
 
   PMPNumRegions:
     datatype: int
-    default: 0
+    default: 4
     paramtype: vlogparam
     description: "Number of PMP regions"
 

--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -78,7 +78,7 @@ parameters:
 
   PMPNumRegions:
     datatype: int
-    default: 0
+    default: 4
     paramtype: vlogparam
     description: "Number of PMP regions"
 

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -122,7 +122,7 @@ parameters:
 
   PMPNumRegions:
     datatype: int
-    default: 0
+    default: 4
     paramtype: vlogparam
     description: "Number of PMP regions"
 

--- a/ibex_core_tracing.core
+++ b/ibex_core_tracing.core
@@ -97,7 +97,7 @@ parameters:
 
   PMPNumRegions:
     datatype: int
-    default: 0
+    default: 4
     paramtype: vlogparam
     description: "Number of PMP regions"
 


### PR DESCRIPTION
Change default to 4 rather than 0. Makes no difference when PMPEnable==0
and gets rid of lint failures due to 0 array referencing (0 is an
unsupported value for this parameter).

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>