### PR TITLE
Move seed updates into sequence in ICache memory agent

### DIFF
--- a/dv/uvm/icache/dv/env/ibex_icache_env.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_env.sv
@@ -39,6 +39,7 @@ class ibex_icache_env extends dv_base_env #(
     if (cfg.en_scb) begin
       core_agent.monitor.analysis_port.connect(scoreboard.core_fifo.analysis_export);
       mem_agent.monitor.analysis_port.connect(scoreboard.mem_fifo.analysis_export);
+      mem_agent.driver.analysis_port.connect(scoreboard.seed_fifo.analysis_export);
     end
     if (cfg.is_active && cfg.core_agent_cfg.is_active) begin
       virtual_sequencer.core_sequencer_h = core_agent.sequencer;

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent_pkg.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent_pkg.sv
@@ -12,12 +12,6 @@ package ibex_icache_mem_agent_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  typedef enum {
-    ICacheMemNewSeed,
-    ICacheMemGrant,
-    ICacheMemResponse
-  } ibex_icache_mem_trans_type_e;
-
   // package sources
   `include "ibex_icache_mem_req_item.sv"
   `include "ibex_icache_mem_resp_item.sv"

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_bus_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_bus_item.sv
@@ -8,20 +8,20 @@
 
 class ibex_icache_mem_bus_item extends uvm_sequence_item;
 
-  // What sort of transaction is this? (new seed, grant or response)
-  ibex_icache_mem_trans_type_e trans_type;
+  // What sort of transaction is this? (grant or response)
+  bit          is_grant;
 
-  // This holds the new seed for a 'new seed' transaction, the request address for a grant
-  // transaction and the returned rdata for a response transaction.
+  // This holds the request address for a grant transaction and the returned rdata for a response
+  // transaction.
   logic [31:0] data;
 
   // Response error flag (only valid for response transactions)
   logic        err;
 
   `uvm_object_utils_begin(ibex_icache_mem_bus_item)
-    `uvm_field_enum(ibex_icache_mem_trans_type_e, trans_type, UVM_DEFAULT)
-    `uvm_field_int(data, UVM_DEFAULT | UVM_HEX)
-    `uvm_field_int(err,  UVM_DEFAULT)
+    `uvm_field_int(is_grant, UVM_DEFAULT)
+    `uvm_field_int(data,     UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int(err,      UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_driver.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_driver.sv
@@ -20,13 +20,19 @@ class ibex_icache_mem_driver
   mailbox #(ibex_icache_mem_resp_item) rdata_queue;
   mailbox #(bit [31:0])                pmp_queue;
 
+  // An analysis port that gets hooked up to the scoreboard. This isn't used to report on actual bus
+  // traffic (that's done by the monitor, as usual) but is used to report on new memory seeds, which
+  // the scoreboard needs to know about, but don't in themselves cause any bus traffic.
+  uvm_analysis_port #(bit [31:0]) analysis_port;
+
   `uvm_component_utils(ibex_icache_mem_driver)
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    rdata_queue = new("rdata_queue");
-    pmp_queue   = new("pmp_queue");
+    rdata_queue   = new("rdata_queue");
+    pmp_queue     = new("pmp_queue");
+    analysis_port = new("analysis_port", this);
   endfunction
 
   virtual task reset_signals();
@@ -73,8 +79,15 @@ class ibex_icache_mem_driver
 
       // Is this a request or a grant?
       if (!req.is_grant) begin
-        // If a request, it's ignored unless it causes a PMP error. In that case, we push the
-        // address onto pmp_queue.
+        // A request has two effects.
+        //
+        //   1. If this is a new seed then we need to tell the scoreboard about it.
+        //
+        //   2. If it causes a PMP error, we push the address onto pmp_queue (which will be handled
+        //      by drive_pmp).
+        if (req.seed != 32'd0) begin
+          analysis_port.write(req.seed);
+        end
         if (req.err) begin
           pmp_queue.put(req.address);
         end

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_req_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_req_item.sv
@@ -7,7 +7,7 @@
 //
 // When a request first comes in (via a posedge on the req line), it immediately generates a
 // req_item with is_grant = 0. This is used by the sequence to tell the driver whether to generate a
-// PMP error. A req_item with is_grant = 0 may also have a seed update.
+// PMP error.
 //
 // Assuming that the request wasn't squashed by a PMP error, it will be granted on some later clock
 // edge. At that point, another req_item is generated with is_grant = 1. This is added to a queue in
@@ -18,20 +18,9 @@ class ibex_icache_mem_req_item extends uvm_sequence_item;
   bit               is_grant;
   logic [31:0]      address;
 
-  rand bit [31:0]   seed;
-
-  // Change the memory seed roughly one time in 500 reads
-  constraint c_seed_dist {
-    seed dist {
-      32'd0            :/ 499,
-      [1:32'hffffffff] :/ 1
-    };
-  }
-
   `uvm_object_utils_begin(ibex_icache_mem_req_item)
     `uvm_field_int (is_grant, UVM_DEFAULT)
     `uvm_field_int (address,  UVM_DEFAULT | UVM_HEX)
-    `uvm_field_int (seed,     UVM_DEFAULT | UVM_HEX)
   `uvm_object_utils_end
 
   `uvm_object_new


### PR DESCRIPTION
The previous code kind of worked, but we were making the "should I
make a new seed" decision in the monitor, rather than the sequence.
The problem is that this is difficult to customize with other test
sequences (they sit adjacent to the monitor in the class hierarchy,
not above it).

The new code seems a little cleaner. We generate new seeds in the
sequence (which is in charge of keeping track of the current seed
anyway). These new seeds get passed to the driver, which has an
analysis port by which it can tell the scoreboard about them. Note
that we have to pass them from the driver, rather than the monitor,
because the new seed doesn't directly appear on the interface.

The rest of the changes are simplifying the ibex_icache_mem_bus_item
class, which now only has two modes and removing the seed field from
the ibex_icache_mem_req_item class.