### PR TITLE
[bitmanip] Add ZBC instruction group

### DIFF
--- a/doc/instruction_decode_execute.rst
+++ b/doc/instruction_decode_execute.rst
@@ -66,7 +66,7 @@ Other blocks use the ALU for the following tasks:
 
 Support for the RISC-V Bitmanipulation Extension (Document Version 0.92, November 8, 2019) is enabled via the parameter ``RV32B``.
 This feature is *EXPERIMENTAL* and the details of its impact are not yet documented here.
-Currently the Zbb, Zbs, Zbp, Zbe, Zbf and Zbt sub-extensions are implemented.
+Currently the Zbb, Zbs, Zbp, Zbe, Zbf, Zbc and Zbt sub-extensions are implemented.
 All instructions are carried out in a single clock cycle.
 
 .. _mult-div:

--- a/doc/integration.rst
+++ b/doc/integration.rst
@@ -94,7 +94,8 @@ Parameters
 | ``RV32B``                    | bit         | 0          | *EXPERIMENTAL* - B(itmanipulation) extension enable:            |
 |                              |             |            | Currently supported Z-extensions: Zbb (base), Zbs (single-bit)  |
 |                              |             |            | Zbp (bit permutation), Zbe (bit extract/deposit),               |
-|                              |             |            | Zbf (bit-field place) and Zbt (ternary)                         |
+|                              |             |            | Zbf (bit-field place) Zbc (carry-less multiplication)
+|                              |             |            | and Zbt (ternary)                                               |
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
 | ``BranchTargetALU``          | bit         | 0          | *EXPERIMENTAL* - Enables branch target ALU removing a stall     |
 |                              |             |            | cycle from taken branches                                       |

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -595,5 +595,5 @@
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +enable_b_extension=1
-    +enable_bitmanip_groups=zbb,zbt,zbs,zbp,zbf,zbe
+    +enable_bitmanip_groups=zbb,zbt,zbs,zbp,zbf,zbe,zbc
   rtl_test: core_ibex_base_test

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -437,7 +437,11 @@ module ibex_decoder #(
             {7'b000_0100, 3'b001}, // shfl
             {7'b000_0100, 3'b101}, // unshfl
             // RV32B zbf
-            {7'b010_0100, 3'b111}: illegal_insn = RV32B ? 1'b0 : 1'b1; // bfp
+            {7'b010_0100, 3'b111}, // bfp
+            // RV32B zbc
+            {7'b000_0101, 3'b001}, // clmul
+            {7'b000_0101, 3'b010}, // clmulr
+            {7'b000_0101, 3'b011}: illegal_insn = RV32B ? 1'b0 : 1'b1; // clmulh
 
             // RV32M instructions
             {7'b000_0001, 3'b000}: begin // mul
@@ -928,6 +932,11 @@ module ibex_decoder #(
             {7'b001_0100, 3'b001}: if (RV32B) alu_operator_o = ALU_SBSET;  // sbset
             {7'b011_0100, 3'b001}: if (RV32B) alu_operator_o = ALU_SBINV;  // sbinv
             {7'b010_0100, 3'b101}: if (RV32B) alu_operator_o = ALU_SBEXT;  // sbext
+
+            // RV32B zbc
+            {7'b000_0101, 3'b001}: if (RV32B) alu_operator_o = ALU_CLMUL;  // clmul
+            {7'b000_0101, 3'b010}: if (RV32B) alu_operator_o = ALU_CLMULR; // clmulr
+            {7'b000_0101, 3'b011}: if (RV32B) alu_operator_o = ALU_CLMULH; // clmulh
 
             // RV32B zbe
             {7'b010_0100, 3'b110}: if (RV32B) alu_operator_o = ALU_BDEP;   // bdep

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -115,7 +115,13 @@ typedef enum logic [5:0] {
 
   // Bit Field Place
   // RV32B
-  ALU_BFP
+  ALU_BFP,
+
+  // Carry-less Multiply
+  // RV32B
+  ALU_CLMUL,
+  ALU_CLMULR,
+  ALU_CLMULH
 } alu_op_e;
 
 typedef enum logic [1:0] {

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -1013,6 +1013,12 @@ module ibex_tracer (
 
         // RV32B - ZBF
         INSN_BFP:        decode_r_insn("bfp");
+
+        // RV32B - ZBC
+        INSN_CLMUL:      decode_r_insn("clmul");
+        INSN_CLMULR:     decode_r_insn("clmulr");
+        INSN_CLMULH:     decode_r_insn("clmulh");
+
         default:         decode_mnemonic("INVALID");
       endcase
     end

--- a/rtl/ibex_tracer_pkg.sv
+++ b/rtl/ibex_tracer_pkg.sv
@@ -246,6 +246,11 @@ parameter logic [31:0] INSN_FSR  = {5'b?, 2'b10, 10'b?, 3'b101, 5'b?, {OPCODE_OP
 // ZBF
 parameter logic [31:0] INSN_BFP  = {7'b0100100, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
 
+// ZBC
+parameter logic [31:0] INSN_CLMUL  = {7'b0000101, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_CLMULR = {7'b0000101, 10'b?, 3'b010, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_CLMULH = {7'b0000101, 10'b?, 3'b011, 5'b?, {OPCODE_OP} };
+
 // LOAD & STORE
 parameter logic [31:0] INSN_LOAD    = {25'b?,                            {OPCODE_LOAD } };
 parameter logic [31:0] INSN_STORE   = {25'b?,                            {OPCODE_STORE} };


### PR DESCRIPTION
This commit implements the Bit Manipulation Extension ZBC instruction
group: clmul[rh] (carry-less multiply [reverse][high])

Carry-less multiplication can be understood as multiplication based on
the addition interpreted as the bit-wise xor operation.

Example: 1101 X 1011 = 1111111:

      1011 X 1101
      -----------
             1101
        xor 1101
        ---------
            10111
       xor 0000
       ----------
           010111
      xor 1101
      -----------
          1111111

Architectural details:
        
        A 32 x 32-bit array
        `[ operand_b[i] ? (operand_a << i) : '0 for i in 0 ... 31 ]`
        is generated. The entries of the array are pairwise 'xor-ed'
        together in a 5-stage binary tree.

The area increase when synthesized with relaxed timing constraints is
1.6-1.7kGE.

Timing figures are improve by 0.1 ns for the 3-stage configuration and
worsen by 0.04ns for the 2-stage implementation. This suggests
fluctuations due to the heuristic nature of the synthesis tools.

Signed-off-by: ganoam <gnoam@live.com>