### PR TITLE
[rtl] Add speculative branch signal

### DIFF
--- a/doc/icache.rst
+++ b/doc/icache.rst
@@ -247,6 +247,11 @@ On cycles where ``branch_i`` is not asserted, the address counter will be increm
 This increment depends on the instruction data (visible at ``rdata_o``): it will be 2 if the instruction is compressed and 4 otherwise.
 Since the contents of ``rdata_o`` are not specified if an instruction fetch has caused an error, the core must signal a branch before accepting another instruction after it sees ``err_o``.
 
+There is an additional branch signal ``branch_spec_i`` which is a speculative version of the actual branch signal.
+Internally, ``branch_spec_i`` is used to setup address multiplexing as it is available earlier in the cycle.
+In cases where ``branch_spec_i`` is high, but ``branch_i`` is low, any lookup that might have been made that cycle is suppressed.
+Note that if ``branch_i`` is high, ``branch_spec_i`` must also be high.
+
 Because a single instruction can span two 32bit memory addresses, an extra signal (``err_plus2_o``) indicates when an error is caused by the second half of an unaligned uncompressed instruction.
 This signal is only valid when ``valid_o`` and ``err_o`` are set, and will only be set for uncompressed instructions.
 The core uses this signal to record the correct address in the ``mtval`` CSR upon an error.

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -45,6 +45,7 @@ module ibex_controller #(
     // to prefetcher
     output logic                  instr_req_o,             // start fetching instructions
     output logic                  pc_set_o,                // jump to address set by pc_mux
+    output logic                  pc_set_spec_o,           // speculative branch
     output ibex_pkg::pc_sel_e     pc_mux_o,                // IF stage fetch address selector
                                                            // (boot, normal, exception...)
     output ibex_pkg::exc_pc_sel_e exc_pc_mux_o,            // IF stage selector for exception PC
@@ -58,6 +59,7 @@ module ibex_controller #(
 
     // jump/branch signals
     input  logic                  branch_set_i,            // branch taken set signal
+    input  logic                  branch_set_spec_i,       // speculative branch signal
     input  logic                  jump_set_i,              // jump taken set signal
 
     // interrupt signals
@@ -299,6 +301,7 @@ module ibex_controller #(
     // helping timing.
     pc_mux_o              = PC_BOOT;
     pc_set_o              = 1'b0;
+    pc_set_spec_o         = 1'b0;
 
     exc_pc_mux_o          = EXC_PC_IRQ;
     exc_cause_o           = EXC_CAUSE_INSN_ADDR_MISA; // = 6'h00
@@ -326,6 +329,7 @@ module ibex_controller #(
         instr_req_o   = 1'b0;
         pc_mux_o      = PC_BOOT;
         pc_set_o      = 1'b1;
+        pc_set_spec_o = 1'b1;
         if (fetch_enable_i) begin
           ctrl_fsm_ns = BOOT_SET;
         end
@@ -336,6 +340,7 @@ module ibex_controller #(
         instr_req_o   = 1'b1;
         pc_mux_o      = PC_BOOT;
         pc_set_o      = 1'b1;
+        pc_set_spec_o = 1'b1;
 
         ctrl_fsm_ns = FIRST_FETCH;
       end
@@ -414,11 +419,16 @@ module ibex_controller #(
           halt_if     = 1'b1;
         end
 
-        if ((branch_set_i || jump_set_i) && ~special_req_branch) begin
+        if ((branch_set_i || jump_set_i) && !special_req_branch) begin
           pc_set_o       = 1'b1;
 
           perf_tbranch_o = branch_set_i;
           perf_jump_o    = jump_set_i;
+        end
+
+        // pc_set signal excluding branch taken condition
+        if ((branch_set_spec_i || jump_set_i) && !special_req_branch) begin
+          pc_set_spec_o = 1'b1;
         end
 
         // If entering debug mode or handling an IRQ the core needs to wait
@@ -455,6 +465,7 @@ module ibex_controller #(
 
         if (handle_irq) begin
           pc_set_o         = 1'b1;
+          pc_set_spec_o    = 1'b1;
 
           csr_save_if_o    = 1'b1;
           csr_save_cause_o = 1'b1;
@@ -490,6 +501,7 @@ module ibex_controller #(
         if (debug_single_step_i || debug_req_i || trigger_match_i) begin
           flush_id         = 1'b1;
           pc_set_o         = 1'b1;
+          pc_set_spec_o    = 1'b1;
 
           csr_save_if_o    = 1'b1;
           debug_csr_save_o = 1'b1;
@@ -518,10 +530,11 @@ module ibex_controller #(
         //
         // for 1. do not update dcsr and dpc, for 2. do so [Debug Spec v0.13.2, p.39]
         // jump to debug exception handler in debug memory
-        flush_id     = 1'b1;
-        pc_mux_o     = PC_EXC;
-        pc_set_o     = 1'b1;
-        exc_pc_mux_o = EXC_PC_DBD;
+        flush_id      = 1'b1;
+        pc_mux_o      = PC_EXC;
+        pc_set_o      = 1'b1;
+        pc_set_spec_o = 1'b1;
+        exc_pc_mux_o  = EXC_PC_DBD;
 
         // update dcsr and dpc
         if (ebreak_into_debug && !debug_mode_q) begin // ebreak with forced entry
@@ -554,6 +567,7 @@ module ibex_controller #(
         // exc_req_lsu is high for one clock cycle only (in DECODE)
         if (exc_req_q || store_err_q || load_err_q) begin
           pc_set_o         = 1'b1;
+          pc_set_spec_o    = 1'b1;
           pc_mux_o         = PC_EXC;
           exc_pc_mux_o     = debug_mode_q ? EXC_PC_DBG_EXC : EXC_PC_EXC;
 
@@ -598,6 +612,7 @@ module ibex_controller #(
                * [Debug Spec v0.13.2, p.42]
                */
               pc_set_o         = 1'b0;
+              pc_set_spec_o    = 1'b0;
               csr_save_id_o    = 1'b0;
               csr_save_cause_o = 1'b0;
               ctrl_fsm_ns      = DBG_TAKEN_ID;
@@ -629,6 +644,7 @@ module ibex_controller #(
           if (mret_insn) begin
             pc_mux_o              = PC_ERET;
             pc_set_o              = 1'b1;
+            pc_set_spec_o         = 1'b1;
             csr_restore_mret_id_o = 1'b1;
             if (nmi_mode_q) begin
               nmi_mode_d          = 1'b0; // exit NMI mode
@@ -636,6 +652,7 @@ module ibex_controller #(
           end else if (dret_insn) begin
             pc_mux_o              = PC_DRET;
             pc_set_o              = 1'b1;
+            pc_set_spec_o         = 1'b1;
             debug_mode_d          = 1'b0;
             csr_restore_dret_id_o = 1'b1;
           end else if (wfi_insn) begin
@@ -720,5 +737,8 @@ module ibex_controller #(
   `ASSERT(IbexCtrlStateValid, ctrl_fsm_cs inside {
       RESET, BOOT_SET, WAIT_SLEEP, SLEEP, FIRST_FETCH, DECODE, FLUSH,
       IRQ_TAKEN, DBG_TAKEN_IF, DBG_TAKEN_ID})
+
+  // The speculative branch signal should be set whenever the actual branch signal is set
+  `ASSERT(IbexSpecImpliesSetPC, pc_set_o |-> pc_set_spec_o)
 
 endmodule

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -138,6 +138,7 @@ module ibex_core #(
   logic        instr_first_cycle_id;
   logic        instr_valid_clear;
   logic        pc_set;
+  logic        pc_set_spec;
   pc_sel_e     pc_mux_id;                      // Mux selector for next PC
   exc_pc_sel_e exc_pc_mux_id;                  // Mux selector for exception PC
   exc_cause_e  exc_cause;                      // Exception cause
@@ -408,6 +409,7 @@ module ibex_core #(
       // control signals
       .instr_valid_clear_i      ( instr_valid_clear      ),
       .pc_set_i                 ( pc_set                 ),
+      .pc_set_spec_i            ( pc_set_spec            ),
       .pc_mux_i                 ( pc_mux_id              ),
       .exc_pc_mux_i             ( exc_pc_mux_id          ),
       .exc_cause                ( exc_cause              ),
@@ -476,6 +478,7 @@ module ibex_core #(
       .id_in_ready_o                ( id_in_ready              ),
       .instr_req_o                  ( instr_req_int            ),
       .pc_set_o                     ( pc_set                   ),
+      .pc_set_spec_o                ( pc_set_spec              ),
       .pc_mux_o                     ( pc_mux_id                ),
       .exc_pc_mux_o                 ( exc_pc_mux_id            ),
       .exc_cause_o                  ( exc_cause                ),

--- a/rtl/ibex_icache.sv
+++ b/rtl/ibex_icache.sv
@@ -31,6 +31,7 @@ module ibex_icache #(
 
     // Set the cache's address counter
     input  logic                branch_i,
+    input  logic                branch_spec_i,
     input  logic [31:0]         addr_i,
 
     // IF stage interface: Pass fetched instructions to the core
@@ -84,6 +85,7 @@ module ibex_icache #(
   logic [ADDR_W-1:0]                   prefetch_addr_d, prefetch_addr_q;
   logic                                prefetch_addr_en;
   // Cache pipelipe IC0 signals
+  logic                                branch_suppress;
   logic                                lookup_throttle;
   logic                                lookup_req_ic0;
   logic [ADDR_W-1:0]                   lookup_addr_ic0;
@@ -223,8 +225,8 @@ module ibex_icache #(
   assign lookup_throttle  = (fb_fill_level > FB_THRESHOLD[$clog2(NUM_FB)-1:0]);
 
   assign lookup_req_ic0   = req_i & ~&fill_busy_q & (branch_i | ~lookup_throttle) & ~ecc_write_req;
-  assign lookup_addr_ic0  = branch_i ? addr_i :
-                                       prefetch_addr_q;
+  assign lookup_addr_ic0  = branch_spec_i ? addr_i :
+                                            prefetch_addr_q;
   assign lookup_index_ic0 = lookup_addr_ic0[INDEX_HI:LINE_W];
 
   // Cache write
@@ -233,9 +235,13 @@ module ibex_icache #(
   assign fill_tag_ic0   = {(~inval_prog_q & ~ecc_write_req),fill_ram_req_addr[ADDR_W-1:INDEX_HI+1]};
   assign fill_wdata_ic0 = fill_ram_req_data;
 
+  // Suppress a new lookup on a not-taken branch (as the address will be incorrect)
+  assign branch_suppress   = branch_spec_i & ~branch_i;
+
   // Arbitrated signals - lookups have highest priority
-  assign lookup_grant_ic0  = lookup_req_ic0;
-  assign fill_grant_ic0    = fill_req_ic0 & ~lookup_req_ic0 & ~inval_prog_q & ~ecc_write_req;
+  assign lookup_grant_ic0  = lookup_req_ic0 & ~branch_suppress;
+  assign fill_grant_ic0    = fill_req_ic0 & (~lookup_req_ic0 | branch_suppress) & ~inval_prog_q &
+                             ~ecc_write_req;
   // Qualified lookup grant to mask ram signals in IC1 if access was not made
   assign lookup_actual_ic0 = lookup_grant_ic0 & icache_enable_i & ~inval_prog_q;
 

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -48,6 +48,7 @@ module ibex_id_stage #(
 
     // IF and ID stage signals
     output logic                      pc_set_o,
+    output logic                      pc_set_spec_o,
     output ibex_pkg::pc_sel_e         pc_mux_o,
     output ibex_pkg::exc_pc_sel_e     exc_pc_mux_o,
     output ibex_pkg::exc_cause_e      exc_cause_o,
@@ -190,6 +191,7 @@ module ibex_id_stage #(
   logic        wb_exception;
 
   logic        branch_in_dec;
+  logic        branch_spec, branch_set_spec;
   logic        branch_set, branch_set_d;
   logic        branch_taken;
   logic        jump_in_dec;
@@ -530,6 +532,7 @@ module ibex_id_stage #(
       // to prefetcher
       .instr_req_o                    ( instr_req_o             ),
       .pc_set_o                       ( pc_set_o                ),
+      .pc_set_spec_o                  ( pc_set_spec_o           ),
       .pc_mux_o                       ( pc_mux_o                ),
       .exc_pc_mux_o                   ( exc_pc_mux_o            ),
       .exc_cause_o                    ( exc_cause_o             ),
@@ -542,6 +545,7 @@ module ibex_id_stage #(
 
       // jump/branch control
       .branch_set_i                   ( branch_set              ),
+      .branch_set_spec_i              ( branch_set_spec         ),
       .jump_set_i                     ( jump_set                ),
 
       // interrupt signals
@@ -618,7 +622,8 @@ module ibex_id_stage #(
   if (BranchTargetALU && !DataIndTiming) begin : g_branch_set_direct
     // Branch set fed straight to controller with branch target ALU
     // (condition pass/fail used same cycle as generated instruction request)
-    assign branch_set = branch_set_d;
+    assign branch_set      = branch_set_d;
+    assign branch_set_spec = branch_spec;
   end else begin : g_branch_set_flop
     // Branch set flopped without branch target ALU, or in fixed time execution mode
     // (condition pass/fail used next cycle where branch target is calculated)
@@ -635,7 +640,9 @@ module ibex_id_stage #(
     // Branches always take two cycles in fixed time execution mode, with or without the branch
     // target ALU (to avoid a path from the branch decision into the branch target ALU operand
     // muxing).
-    assign branch_set = (BranchTargetALU && !data_ind_timing_i) ? branch_set_d : branch_set_q;
+    assign branch_set      = (BranchTargetALU && !data_ind_timing_i) ? branch_set_d : branch_set_q;
+    // Use the speculative branch signal when BTALU is enabled
+    assign branch_set_spec = (BranchTargetALU && !data_ind_timing_i) ? branch_spec : branch_set_q;
   end
 
   // Branch condition is calculated in the first cycle and flopped for use in the second cycle
@@ -694,6 +701,7 @@ module ibex_id_stage #(
     stall_branch            = 1'b0;
     stall_alu               = 1'b0;
     branch_set_d            = 1'b0;
+    branch_spec             = 1'b0;
     jump_set                = 1'b0;
     perf_branch_o           = 1'b0;
 
@@ -729,6 +737,8 @@ module ibex_id_stage #(
                                   MULTI_CYCLE : FIRST_CYCLE;
               stall_branch  = (~BranchTargetALU & branch_decision_i) | data_ind_timing_i;
               branch_set_d  = branch_decision_i | data_ind_timing_i;
+              // Speculative branch (excludes branch_decision_i)
+              branch_spec   = 1'b1;
               perf_branch_o = 1'b1;
             end
             jump_in_dec: begin

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -56,6 +56,7 @@ module ibex_if_stage #(
     // control signals
     input  logic                  instr_valid_clear_i,      // clear instr valid bit in IF-ID
     input  logic                  pc_set_i,                 // set the PC to a new value
+    input  logic                  pc_set_spec_i,
     input  ibex_pkg::pc_sel_e     pc_mux_i,                 // selector for PC multiplexer
     input  ibex_pkg::exc_pc_sel_e exc_pc_mux_i,             // selects ISR address
     input  ibex_pkg::exc_cause_e  exc_cause,                // selects ISR address for
@@ -164,6 +165,7 @@ module ibex_if_stage #(
         .req_i             ( req_i                       ),
 
         .branch_i          ( branch_req                  ),
+        .branch_spec_i     ( pc_set_spec_i               ),
         .addr_i            ( {fetch_addr_n[31:1], 1'b0}  ),
 
         .ready_i           ( fetch_ready                 ),
@@ -194,6 +196,7 @@ module ibex_if_stage #(
         .req_i             ( req_i                       ),
 
         .branch_i          ( branch_req                  ),
+        .branch_spec_i     ( pc_set_spec_i               ),
         .addr_i            ( {fetch_addr_n[31:1], 1'b0}  ),
 
         .ready_i           ( fetch_ready                 ),

--- a/rtl/ibex_prefetch_buffer.sv
+++ b/rtl/ibex_prefetch_buffer.sv
@@ -16,6 +16,7 @@ module ibex_prefetch_buffer (
     input  logic        req_i,
 
     input  logic        branch_i,
+    input  logic        branch_spec_i,
     input  logic [31:0] addr_i,
 
 
@@ -42,6 +43,7 @@ module ibex_prefetch_buffer (
 
   localparam int unsigned NUM_REQS  = 2;
 
+  logic                branch_suppress;
   logic                valid_new_req, valid_req;
   logic                valid_req_d, valid_req_q;
   logic                discard_req_d, discard_req_q;
@@ -107,8 +109,13 @@ module ibex_prefetch_buffer (
   // Requests //
   //////////////
 
+  // Suppress a new request on a not-taken branch (as the external address will be incorrect)
+  assign branch_suppress = branch_spec_i & ~branch_i;
+
   // Make a new request any time there is space in the FIFO, and space in the request queue
-  assign valid_new_req = req_i & (fifo_ready | branch_i) & ~rdata_outstanding_q[NUM_REQS-1];
+  assign valid_new_req = ~branch_suppress & req_i & (fifo_ready | branch_i) &
+                         ~rdata_outstanding_q[NUM_REQS-1];
+
   assign valid_req = valid_req_q | valid_new_req;
 
   // If a request address triggers a PMP error, the external bus request is suppressed. We might
@@ -159,7 +166,7 @@ module ibex_prefetch_buffer (
   // Update on a branch or as soon as a request is issued
   assign fetch_addr_en = branch_i | (valid_new_req & ~valid_req_q);
 
-  assign fetch_addr_d = (branch_i ? addr_i : 
+  assign fetch_addr_d = (branch_i ? addr_i :
                                     {fetch_addr_q[31:2], 2'b00}) +
                         // Current address + 4
                         {{29{1'b0}},(valid_new_req & ~valid_req_q),2'b00};
@@ -171,9 +178,9 @@ module ibex_prefetch_buffer (
   end
 
   // Address mux
-  assign instr_addr = valid_req_q ? stored_addr_q :
-                      branch_i    ? addr_i :
-                                    fetch_addr_q;
+  assign instr_addr = valid_req_q   ? stored_addr_q :
+                      branch_spec_i ? addr_i :
+                                      fetch_addr_q;
 
   assign instr_addr_w_aligned = {instr_addr[31:2], 2'b00};
 


### PR DESCRIPTION
- Drive a speculative version of the branch signal into the IF stage to
  drive address muxing
- The speculative signal is the same as the regular branch signal but
  assumes all conditional branches are taken
- This breaks the timing path from branch condition calculation into
  address muxing (and therefore PMP error calculation)
- When the branch is not taken, any external request we might otherwise
  have made is suppressed
- This has a minor performance cost (0.8% without I$, ~0% with I$)

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>