### PR TITLE
added missing cmp_opts to Riviera compilation options

### DIFF
--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -79,6 +79,7 @@
     cmd:
       - "vlib <out>/work"
       - "vlog -work <out>/work
+        <cmp_opts>
         +incdir+<ALDEC_PATH>/vlib/uvm-1.2/src
         +define+UVM
         -l uvm_1_2


### PR DESCRIPTION
Hey!
In this pull request I added missing `cmp_opts` to Riviera compilation options