### PR TITLE
Update google_riscv-dv to google/riscv-dv@7b38e54

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: e6a63ff19ddf162a89379f9e03f76345c3558ecc
+    rev: 7b38e54c5e833f147edc03717b3fd711be923026
   }
 }

--- a/vendor/google_riscv-dv/src/riscv_instr_gen_config.sv
+++ b/vendor/google_riscv-dv/src/riscv_instr_gen_config.sv
@@ -229,6 +229,8 @@ class riscv_instr_gen_config extends uvm_object;
   rand int               single_step_iterations;
   // Enable mstatus.tw bit - causes u-mode WFI to raise illegal instruction exceptions
   bit                    set_mstatus_tw;
+  // Enable users to set mstatus.mprv to enable privilege checks on memory accesses.
+  bit                    set_mstatus_mprv;
   // Stack space allocated to each program, need to be enough to store necessary context
   // Example: RA, SP, T0
   int                    min_stack_len_per_program = 10 * (XLEN/8);
@@ -324,9 +326,9 @@ class riscv_instr_gen_config extends uvm_object;
   }
 
   constraint mstatus_c {
-    // This is default disabled at setup phase. It can be enabled in the exception and interrupt
-    // handling routine
-    mstatus_mprv == 1'b0;
+    if (set_mstatus_mprv) {
+      mstatus_mprv == 1'b1;
+    }
     if (SATP_MODE == BARE) {
       mstatus_mxr == 0;
       mstatus_sum == 0;
@@ -492,6 +494,7 @@ class riscv_instr_gen_config extends uvm_object;
     `uvm_field_int(enable_debug_single_step, UVM_DEFAULT)
     `uvm_field_int(single_step_iterations, UVM_DEFAULT)
     `uvm_field_int(set_mstatus_tw, UVM_DEFAULT)
+    `uvm_field_int(set_mstatus_mprv, UVM_DEFAULT)
     `uvm_field_int(max_branch_step, UVM_DEFAULT)
     `uvm_field_int(max_directed_instr_stream_seq, UVM_DEFAULT)
     `uvm_field_int(enable_floating_point, UVM_DEFAULT)
@@ -551,6 +554,7 @@ class riscv_instr_gen_config extends uvm_object;
     get_bool_arg_value("+set_dcsr_ebreak=", set_dcsr_ebreak);
     get_bool_arg_value("+enable_debug_single_step=", enable_debug_single_step);
     get_bool_arg_value("+set_mstatus_tw=", set_mstatus_tw);
+    get_bool_arg_value("+set_mstatus_mprv=", set_mstatus_mprv);
     get_bool_arg_value("+enable_floating_point=", enable_floating_point);
     get_bool_arg_value("+enable_vector_extension=", enable_vector_extension);
     get_bool_arg_value("+enable_b_extension=", enable_b_extension);

--- a/vendor/google_riscv-dv/yaml/simulator.yaml
+++ b/vendor/google_riscv-dv/yaml/simulator.yaml
@@ -119,3 +119,18 @@
       vsim -c <sim_opts> -sv_seed <seed> <cov_opts> -do <cwd>/riviera_sim.tcl
     cov_opts: >
       -acdb_file <out>/cov.acdb
+
+- tool: xlm
+  compile:
+    cmd:
+      - "xrun -64bit -access +rwc -f <cwd>/files.f
+              +incdir+<setting>
+              +incdir+<user_extension>
+              -q -sv -uvm -vlog_ext +.vh -I.
+              -uvmhome CDNS-1.2
+              -elaborate
+              -l <out>/compile.log <cmp_opts>
+              -xmlibdirpath <out>"
+  sim:
+    cmd: >
+      xrun -R -xmlibdirpath <out> <sim_opts> -svseed <seed> -svrnc rand_struct -nokey


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision 7b38e54c5e833f147edc03717b3fd711be923026

* add cmdline configuration of mstatus.mprv (Udi Jonnalagadda)
* Add Xcelium support (google/riscv-dv#579) (Tudor Timi)

Signed-off-by: Udi <udij@google.com>