### PR TITLE
[bitmanip] Add ZBR instruction group

### DIFF
--- a/doc/instruction_decode_execute.rst
+++ b/doc/instruction_decode_execute.rst
@@ -66,8 +66,9 @@ Other blocks use the ALU for the following tasks:
 
 Support for the RISC-V Bitmanipulation Extension (Document Version 0.92, November 8, 2019) is enabled via the parameter ``RV32B``.
 This feature is *EXPERIMENTAL* and the details of its impact are not yet documented here.
-Currently the Zbb, Zbs, Zbp, Zbe, Zbf, Zbc and Zbt sub-extensions are implemented.
-All instructions are carried out in a single clock cycle.
+Currently the Zbb, Zbs, Zbp, Zbe, Zbf, Zbc, Zbr and Zbt sub-extensions are implemented.
+The rotate instructions `ror` and `rol` (Zbb), ternary instructions `cmov`, `cmix`, `fsl` and `fsr` as well as cyclic redundancy checks `crc32[c]` (Zbr) are completed in 2 cycles. All remaining instructions complete in one cycle.
+
 
 .. _mult-div:
 

--- a/doc/integration.rst
+++ b/doc/integration.rst
@@ -94,8 +94,8 @@ Parameters
 | ``RV32B``                    | bit         | 0          | *EXPERIMENTAL* - B(itmanipulation) extension enable:            |
 |                              |             |            | Currently supported Z-extensions: Zbb (base), Zbs (single-bit)  |
 |                              |             |            | Zbp (bit permutation), Zbe (bit extract/deposit),               |
-|                              |             |            | Zbf (bit-field place) Zbc (carry-less multiplication)
-|                              |             |            | and Zbt (ternary)                                               |
+|                              |             |            | Zbf (bit-field place) Zbc (carry-less multiplication)           |
+|                              |             |            | Zbr (cyclic redundancy check) and Zbt (ternary)                 |
 +------------------------------+-------------+------------+-----------------------------------------------------------------+
 | ``BranchTargetALU``          | bit         | 0          | *EXPERIMENTAL* - Enables branch target ALU removing a stall     |
 |                              |             |            | cycle from taken branches                                       |

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -595,5 +595,5 @@
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +enable_b_extension=1
-    +enable_bitmanip_groups=zbb,zbt,zbs,zbp,zbf,zbe,zbc
+    +enable_bitmanip_groups=zbb,zbt,zbs,zbp,zbf,zbe,zbc,zbr
   rtl_test: core_ibex_base_test

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -346,11 +346,17 @@ module ibex_decoder #(
               end
               5'b0_1100: begin
                 unique case(instr[26:20])
-                  7'b00_00000,                                     // clz
-                  7'b00_00001,                                     // ctz
-                  7'b00_00010,                                     // pcnt
-                  7'b00_00100,                                     // sext.b
-                  7'b00_00101: illegal_insn = RV32B ? 1'b0 : 1'b1; // sext.h
+                  7'b000_0000,                                     // clz
+                  7'b000_0001,                                     // ctz
+                  7'b000_0010,                                     // pcnt
+                  7'b000_0100,                                     // sext.b
+                  7'b000_0101,                                     // sext.h
+                  7'b001_0000,                                     // crc32.b
+                  7'b001_0001,                                     // crc32.h
+                  7'b001_0010,                                     // crc32.w
+                  7'b001_1000,                                     // crc32c.b
+                  7'b001_1001,                                     // crc32c.h
+                  7'b001_1010: illegal_insn = RV32B ? 1'b0 : 1'b1; // crc32c.w
 
                   default: illegal_insn = 1'b1;
                 endcase
@@ -775,11 +781,35 @@ module ibex_decoder #(
                 5'b0_0001: if (instr_alu[26] == 0) alu_operator_o = ALU_SHFL;
                 5'b0_1100: begin
                   unique case (instr_alu[26:20])
-                    7'b000_0000: alu_operator_o = ALU_CLZ;   // Count Leading Zeros
-                    7'b000_0001: alu_operator_o = ALU_CTZ;   // Count Trailing Zeros
-                    7'b000_0010: alu_operator_o = ALU_PCNT;  // Count Set Bits
-                    7'b000_0100: alu_operator_o = ALU_SEXTB; // Sign-extend Byte
-                    7'b000_0101: alu_operator_o = ALU_SEXTH; // Sign-extend Half-word
+                    7'b000_0000: alu_operator_o = ALU_CLZ;      // clz
+                    7'b000_0001: alu_operator_o = ALU_CTZ;      // ctz
+                    7'b000_0010: alu_operator_o = ALU_PCNT;     // pcnt
+                    7'b000_0100: alu_operator_o = ALU_SEXTB;    // sext.b
+                    7'b000_0101: alu_operator_o = ALU_SEXTH;    // sext.h
+                    7'b001_0000: begin
+                      alu_operator_o = ALU_CRC32_B;  // crc32.b
+                      alu_multicycle_o = 1'b1;
+                    end
+                    7'b001_0001: begin
+                      alu_operator_o = ALU_CRC32_H;  // crc32.h
+                      alu_multicycle_o = 1'b1;
+                    end
+                    7'b001_0010: begin
+                      alu_operator_o = ALU_CRC32_W;  // crc32.w
+                      alu_multicycle_o = 1'b1;
+                    end
+                    7'b001_1000: begin
+                      alu_operator_o = ALU_CRC32C_B; // crc32c.b
+                      alu_multicycle_o = 1'b1;
+                    end
+                    7'b001_1001: begin
+                      alu_operator_o = ALU_CRC32C_H; // crc32c.h
+                      alu_multicycle_o = 1'b1;
+                    end
+                    7'b001_1010: begin
+                      alu_operator_o = ALU_CRC32C_W; // crc32c.w
+                      alu_multicycle_o = 1'b1;
+                    end
                     default: ;
                   endcase
                 end

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -121,7 +121,15 @@ typedef enum logic [5:0] {
   // RV32B
   ALU_CLMUL,
   ALU_CLMULR,
-  ALU_CLMULH
+  ALU_CLMULH,
+
+  // Cyclic Redundancy Check
+  ALU_CRC32_B,
+  ALU_CRC32C_B,
+  ALU_CRC32_H,
+  ALU_CRC32C_H,
+  ALU_CRC32_W,
+  ALU_CRC32C_W
 } alu_op_e;
 
 typedef enum logic [1:0] {

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -1019,6 +1019,14 @@ module ibex_tracer (
         INSN_CLMULR:     decode_r_insn("clmulr");
         INSN_CLMULH:     decode_r_insn("clmulh");
 
+        // RV32B - ZBR
+        INSN_CRC32_B:    decode_r1_insn("crc32.b");
+        INSN_CRC32_H:    decode_r1_insn("crc32.h");
+        INSN_CRC32_W:    decode_r1_insn("crc32.w");
+        INSN_CRC32C_B:   decode_r1_insn("crc32c.b");
+        INSN_CRC32C_H:   decode_r1_insn("crc32c.h");
+        INSN_CRC32C_W:   decode_r1_insn("crc32c.w");
+
         default:         decode_mnemonic("INVALID");
       endcase
     end

--- a/rtl/ibex_tracer_pkg.sv
+++ b/rtl/ibex_tracer_pkg.sv
@@ -251,6 +251,14 @@ parameter logic [31:0] INSN_CLMUL  = {7'b0000101, 10'b?, 3'b001, 5'b?, {OPCODE_O
 parameter logic [31:0] INSN_CLMULR = {7'b0000101, 10'b?, 3'b010, 5'b?, {OPCODE_OP} };
 parameter logic [31:0] INSN_CLMULH = {7'b0000101, 10'b?, 3'b011, 5'b?, {OPCODE_OP} };
 
+// ZBR
+parameter logic [31:0] INSN_CRC32_B  = {7'b0110000, 5'b10000, 5'b?, 3'b001, 5'b?,  {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32_H  = {7'b0110000, 5'b10001, 5'b?, 3'b001, 5'b?,  {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32_W  = {7'b0110000, 5'b10010, 5'b?, 3'b001, 5'b?,  {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32C_B = {7'b0110000, 5'b11000, 5'b?, 3'b001, 5'b?,  {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32C_H = {7'b0110000, 5'b11001, 5'b?, 3'b001, 5'b?,  {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32C_W = {7'b0110000, 5'b11010, 5'b?, 3'b001, 5'b?,  {OPCODE_OP_IMM} };
+
 // LOAD & STORE
 parameter logic [31:0] INSN_LOAD    = {25'b?,                            {OPCODE_LOAD } };
 parameter logic [31:0] INSN_STORE   = {25'b?,                            {OPCODE_STORE} };


### PR DESCRIPTION
This commit implements the Bit Manipulation Extension ZBR instruction
group: crc32[c].[bhw].

CRC-32 (CRC-32/ISO-HDLC) and CRC-32C (CRC-32/ISCSI) are directly
implemented. The CRC operation solves the following equation using
binary polynomial arithmetic:
```
rev(rd)(x) = rev(rs1)(x) * x**n mod {1, P}(x)
```
where {1,P}(x) denotes the crc polynomial. Using barret reduction one
can write this as
```
rd = (rs1 >> n) ^ rev(rev( (rs1 << (32-1)) cx rev(mu)) cx P)
                      ^-- cycle 0--------------------^
     ^-- cycle 1 ------------------------------------------^
```
Where `cx` denotes carry-less multiplication and `mu = polydiv(x**64,
{1,P})`, omitting the MSB (bit 32).

The implementation increases area consumption by ~0.6kGE for synthesis
with relaxed timing constraints. With tight timing constraints that is
~1.6kGE. There is no significant impact on frequency.

Signed-off-by: ganoam <gnoam@live.com>