### PR TITLE
[DV] Tie test_en_i to zero

### DIFF
--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -57,7 +57,7 @@ module core_ibex_tb_top;
   ) dut (
     .clk_i          (clk                  ),
     .rst_ni         (rst_n                ),
-    .test_en_i      (1'b1                 ),
+    .test_en_i      (1'b0                 ),
     .hart_id_i      (32'b0                ),
     .boot_addr_i    (`BOOT_ADDR           ), // align with spike boot address
     .irq_software_i (irq_vif.irq_software ),


### PR DESCRIPTION
- test_en_i is a DFT feature that shouldn't be enabled for normal
  runtime testing
- Only really affects the clock gate in the design, but is needed for
  running tests with the latch-based register file

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>