### PR TITLE
Fix deprecation warning in ibex_config.py

### DIFF
--- a/util/ibex_config.py
+++ b/util/ibex_config.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import collections
+import collections.abc
 import os
 import shlex
 import sys
@@ -39,7 +39,7 @@ def _verify_config(name, config_dict):
         ConfigException: An issue was found with config_dict
     """
 
-    if not isinstance(config_dict, collections.Mapping):
+    if not isinstance(config_dict, collections.abc.Mapping):
         raise ConfigException('Config ' + name +
                               ' must have dictionary giving parameters')
 


### PR DESCRIPTION
Fix a deprecation, to be removed in Python 3.10.

See https://docs.python.org/3/library/collections.html:
"Deprecated since version 3.3, will be removed in version 3.10: Moved
Collections Abstract Base Classes to the collections.abc module. For
backwards compatibility, they continue to be visible in this module
through Python 3.9."