### PR TITLE
[rtl] Fix PMP NA4 address matching

### DIFF
--- a/rtl/ibex_pmp.sv
+++ b/rtl/ibex_pmp.sv
@@ -32,9 +32,10 @@ module ibex_pmp #(
   // Access Checking Signals
   logic [33:0]                                region_start_addr [PMPNumRegions];
   logic [33:PMPGranularity+2]                 region_addr_mask  [PMPNumRegions];
-  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_high;
-  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_low;
-  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_both;
+  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_gt;
+  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_lt;
+  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_eq;
+  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_all;
   logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_perm_check;
   logic [PMPNumChan-1:0]                      access_fault;
 
@@ -71,16 +72,30 @@ module ibex_pmp #(
 
   for (genvar c = 0; c < PMPNumChan; c++) begin : g_access_check
     for (genvar r = 0; r < PMPNumRegions; r++) begin : g_regions
-      // TOR Region high/low matching is reused for all match types
       // Comparators are sized according to granularity
-      assign region_match_low[c][r]     = pmp_req_addr_i[c][33:PMPGranularity+2] >=
-                                          (region_start_addr[r][33:PMPGranularity+2] &
-                                           region_addr_mask[r]);
-      assign region_match_high[c][r]    = (pmp_req_addr_i[c][33:PMPGranularity+2] &
-                                           region_addr_mask[r]) <
-                                          csr_pmp_addr_i[r][33:PMPGranularity+2];
-      assign region_match_both[c][r]    = region_match_low[c][r] & region_match_high[c][r] &
-                                          (csr_pmp_cfg_i[r].mode != PMP_MODE_OFF);
+      assign region_match_eq[c][r] = (pmp_req_addr_i[c][33:PMPGranularity+2] &
+                                      region_addr_mask[r]) ==
+                                     (region_start_addr[r][33:PMPGranularity+2] &
+                                      region_addr_mask[r]);
+      assign region_match_gt[c][r] = pmp_req_addr_i[c][33:PMPGranularity+2] >
+                                     region_start_addr[r][33:PMPGranularity+2];
+      assign region_match_lt[c][r] = pmp_req_addr_i[c][33:PMPGranularity+2] <
+                                     csr_pmp_addr_i[r][33:PMPGranularity+2];
+
+      always_comb begin
+        region_match_all[c][r] = 1'b0;
+        unique case (csr_pmp_cfg_i[r].mode)
+          PMP_MODE_OFF   : region_match_all[c][r] = 1'b0;
+          PMP_MODE_NA4   : region_match_all[c][r] = region_match_eq[c][r];
+          PMP_MODE_NAPOT : region_match_all[c][r] = region_match_eq[c][r];
+          PMP_MODE_TOR   : begin
+            region_match_all[c][r] = (region_match_eq[c][r] | region_match_gt[c][r]) &
+                                     region_match_lt[c][r];
+          end
+          default        : region_match_all[c][r] = 1'b0;
+        endcase
+      end
+
       // Check specific required permissions
       assign region_perm_check[c][r] =
           ((pmp_req_type_i[c] == PMP_ACC_EXEC)  & csr_pmp_cfg_i[r].exec) |
@@ -96,7 +111,7 @@ module ibex_pmp #(
       // PMP entries are statically prioritized, from 0 to N-1
       // The lowest-numbered PMP entry which matches an address determines accessability
       for (int r = PMPNumRegions-1; r >= 0; r--) begin
-        if (region_match_both[c][r]) begin
+        if (region_match_all[c][r]) begin
           access_fault[c] = (priv_mode_i[c] == PRIV_LVL_M) ?
               // For M-mode, any region which matches with the L-bit clear, or with sufficient
               // access permissions will be allowed


### PR DESCRIPTION
- Apply address masking to the bottom address bit for NA4 as well as
  NAPOT
- Relates to #902

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>