### PR TITLE
[ibex/dv] Add several PMP tests

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -575,17 +575,72 @@
   sim_opts: >
     +require_signature_addr=1
 
-- test: riscv_pmp_test
+- test: riscv_pmp_basic_test
   desc: >
-    Random PMP settings
-  iterations: 1
+    Basic PMP test - all PMP regions will be configured to default setting,
+    enabling all forms of accesses, expect that no exception will be thrown.
+    Randomize mstatus.mprv.
+  iterations: 10
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000
-    +pmp_randomize=0
-    +pmp_allow_addr_overlap=0
-    +pmp_max_offset=00021000
-    +boot_mode=u
+    +pmp_max_offset=00024000
+  rtl_test: core_ibex_base_test
+
+- test: riscv_pmp_disable_all_regions_test
+  desc: >
+    Disable all permissions from PMP regions, randomize the boot mode,
+    and randomize mstatus.mprv.
+    Expect that all appropriate faults are taken, and that the core
+    finishes executing successfully.
+  iterations: 20
+  gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +instr_cnt=6000
+    +pmp_max_offset=00024000
+    +pmp_region_1=X:0,W:0,R:0
+    +pmp_region_2=X:0,W:0,R:0
+    +pmp_region_3=X:0,W:0,R:0
+    +pmp_region_4=X:0,W:0,R:0
+    +pmp_region_5=X:0,W:0,R:0
+    +pmp_region_6=X:0,W:0,R:0
+    +pmp_region_7=X:0,W:0,R:0
+    +pmp_region_8=X:0,W:0,R:0
+    +pmp_region_9=X:0,W:0,R:0
+    +pmp_region_10=X:0,W:0,R:0
+    +pmp_region_11=X:0,W:0,R:0
+    +pmp_region_12=X:0,W:0,R:0
+    +pmp_region_13=X:0,W:0,R:0
+    +pmp_region_14=X:0,W:0,R:0
+    +pmp_region_15=X:0,W:0,R:0
+  rtl_test: core_ibex_base_test
+
+- test: riscv_pmp_out_of_bounds_test
+  desc: >
+    Default PMP settings - enable all regions with full permissions.
+    Randomize mstatus.mprv and the boot mode.
+    Insert streams of memory instructions that access addresses out of PMP boundaries.
+  iterations: 25
+  gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +instr_cnt=6000
+    +pmp_max_offset=00024000
+    +directed_instr_0=riscv_load_store_rand_addr_instr_stream,50
+  rtl_test: core_ibex_base_test
+
+- test: riscv_pmp_full_random_test
+  desc: >
+    Completely randomize the boot mode, mstatus.mprv, and all PMP configuration,
+    and allow PMP regions to overlap.
+    A large number of iterations will be required since this introduces a huge
+    state space of configurations.
+  iterations: 100
+  gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +instr_cnt=6000
+    +pmp_max_offset=00024000
+    +pmp_randomize=1
+    +pmp_allow_addr_overlap=1
   rtl_test: core_ibex_base_test
 
 - test: riscv_bitmanip_test


### PR DESCRIPTION
This PR adds 3 new PMP tests, and updates the existing PMP test in the Ibex testlist.

1) `riscv_pmp_basic_test` - this updates the existing Ibex-specific PMP sanity test, where every PMP region is given full x/w/r permissions and operates in TOR address matching mode, as a result the core should be able to successfully execute every instruction fetch and memory load/store without any faults being raised.

2) `riscv_pmp_disable_all_regions_test` - In this test, all x/w/r permissions are stripped from every PMP region and TOR address matching is enabled by default for every region. We should see every fetch from IMEM and every load/store from DMEM raise an exception to trap into the custom exception handler.

3) `riscv_pmp_out_of_bounds_test` - In this test, default PMP settings are used (full permissions granted to every region), but the random assembly program is injected with directed instructions that access memory locations that are not contained by any PMP region. If the core is in M-mode, we ensure that the core successfully executes these instructions, but if the core is in U-mode, we ensure that the core raises an exception.

4) `riscv_pmp_full_random_test` - In this test, we completely randomize all PMP regions (their corresponding addresses, address matching modes, and all access privileges). This is extremely useful due to the huge size of the state space created by all PMP-related parameters and can help efficiently uncover any hidden edge case scenarios, hence the large number of iterations of this test.

A few notes:
- We use the standard post-comparison flow where Ibex trace logs are fully compared to OVPsim trace logs for correctness checking, no new reference model needs to be created since OVPsim already fully supports PMP functionality.
- No new functionality in the testbench needs to be added to support PMP testing, pretty much all of the work lies within the riscv-dv domain, hence no new parameter values under the `sim_opts` section of each YAML target.

Signed-off-by: Udi <udij@google.com>