### PR TITLE
Add missing Python dependency on premailer library

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -10,3 +10,6 @@ git+https://github.com/lowRISC/fusesoc.git@ot
 
 pyyaml
 mako
+
+# Needed by dvsim.py (not actually used in Ibex)
+premailer


### PR DESCRIPTION
This dependency gets pulled in with dvsim.py since OpenTitan [commit
1aff665d2](https://github.com/lowRISC/opentitan/commit/1aff665d27d93ce0108cc80c200b52f0936d6878), vendored in with Ibex commit 1bbcce0.