### PR TITLE
[rtl] Make speculative branch optional

### DIFF
--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -108,6 +108,11 @@ module ibex_core #(
   localparam int unsigned PMP_NUM_CHAN      = 2;
   localparam bit          DataIndTiming     = SecureIbex;
   localparam bit          DummyInstructions = SecureIbex;
+  // Speculative branch option, trades-off performance against timing.
+  // Setting this to 1 eases branch target critical paths significantly but reduces performance
+  // by ~3% (based on Coremark/MHz score).
+  // Set by default in the max PMP config which has the tightest budget for branch target timing.
+  localparam bit          SpecBranch        = PMPEnable & (PMPNumRegions == 16);
 
   // IF/ID signals
   logic        dummy_instr_id;
@@ -449,6 +454,7 @@ module ibex_core #(
       .RV32B           ( RV32B           ),
       .BranchTargetALU ( BranchTargetALU ),
       .DataIndTiming   ( DataIndTiming   ),
+      .SpecBranch      ( SpecBranch      ),
       .WritebackStage  ( WritebackStage  )
   ) id_stage_i (
       .clk_i                        ( clk                      ),

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -22,6 +22,7 @@ module ibex_id_stage #(
     parameter bit RV32B           = 0,
     parameter bit DataIndTiming   = 1'b0,
     parameter bit BranchTargetALU = 0,
+    parameter bit SpecBranch      = 0,
     parameter bit WritebackStage  = 0
 ) (
     input  logic                      clk_i,
@@ -747,7 +748,7 @@ module ibex_id_stage #(
               stall_branch  = (~BranchTargetALU & branch_decision_i) | data_ind_timing_i;
               branch_set_d  = branch_decision_i | data_ind_timing_i;
               // Speculative branch (excludes branch_decision_i)
-              branch_spec   = 1'b1;
+              branch_spec   = SpecBranch ? 1'b1 : branch_decision_i;
               perf_branch_o = 1'b1;
             end
             jump_in_dec: begin


### PR DESCRIPTION
- The speculative branch behaviour causes a performance degradation of
  around 3% in the max config. This change enables that behaviour only
  the maximum PMP config, which is where it is most needed for timing
  closure.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>