### PR TITLE
Fix syn include path

### DIFF
--- a/formal/Makefile
+++ b/formal/Makefile
@@ -14,7 +14,7 @@ OUTDIR   := build
 # Source directory relative to this Makefile
 SRC_DIR  := ../rtl
 # Include directory relative to this Makefile
-INC_DIR  := ../shared/rtl
+INC_DIR  := ../vendor/lowrisc_ip/prim/rtl/
 
 # SystemVerilog sources of Ibex
 SRCS_SV ?= $(SRC_DIR)/ibex_alu.sv 		\

--- a/syn/syn_yosys.sh
+++ b/syn/syn_yosys.sh
@@ -31,15 +31,9 @@ for file in ../rtl/*.sv; do
   sv2v \
     --define=SYNTHESIS \
     ../rtl/*_pkg.sv \
-    -I../shared/rtl \
+    -I../vendor/lowrisc_ip/prim/rtl/ \
     $file \
     > $LR_SYNTH_OUT_DIR/generated/${module}.v
-
-  # TODO: eventually remove below hack. It removes "unsigned" from params
-  # because Yosys doesn't support unsigned parameters
-  sed -i 's/parameter unsigned/parameter/g'   $LR_SYNTH_OUT_DIR/generated/${module}.v
-  sed -i 's/localparam unsigned/localparam/g' $LR_SYNTH_OUT_DIR/generated/${module}.v
-  sed -i 's/reg unsigned/reg/g'   $LR_SYNTH_OUT_DIR/generated/${module}.v
 done
 
 # remove generated *pkg.v files (they are empty files and not needed)


### PR DESCRIPTION
This location was changed in 8b42024cd5ce5f76a0589a6143917d19fe9dd3d2. I've also taken the liberty of removing a hack that A) doesn't work with BSD `sed` implementations; and B) is no longer necessary.