### PR TITLE
Add backward_line icache test sequence

### DIFF
--- a/dv/uvm/icache/data/ibex_icache_testplan.hjson
+++ b/dv/uvm/icache/data/ibex_icache_testplan.hjson
@@ -81,7 +81,7 @@
     }
 
     {
-      name: backward_line
+      name: back_line
       desc: '''Check the cache fills correctly from the middle of a line
 
             With the cache enabled, branch to an arbitrary address, read a few
@@ -95,7 +95,7 @@
             spot if there are any bugs that cause it to cache bogus data just
             before the original branch target.'''
       milestone: V2
-      tests: []
+      tests: ["ibex_icache_back_line"]
     }
 
     {

--- a/dv/uvm/icache/dv/env/ibex_icache_env.core
+++ b/dv/uvm/icache/dv/env/ibex_icache_env.core
@@ -24,6 +24,7 @@ filesets:
       - seq_lib/ibex_icache_caching_vseq.sv: {is_include_file: true}
       - seq_lib/ibex_icache_invalidation_vseq.sv: {is_include_file: true}
       - seq_lib/ibex_icache_oldval_vseq.sv: {is_include_file: true}
+      - seq_lib/ibex_icache_back_line_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/dv/uvm/icache/dv/env/seq_lib/ibex_icache_back_line_vseq.sv
+++ b/dv/uvm/icache/dv/env/seq_lib/ibex_icache_back_line_vseq.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class ibex_icache_back_line_vseq extends ibex_icache_base_vseq;
+
+  `uvm_object_utils(ibex_icache_back_line_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    // The base class creates a sequence for the core and memory agents in its pre_start method. We
+    // want to override its decision and use a different sequence for the core
+    ibex_icache_core_base_seq::type_id::
+      set_inst_override(ibex_icache_core_back_line_seq::get_type(), "*");
+
+    super.pre_start();
+  endtask : pre_start
+
+endclass : ibex_icache_back_line_vseq

--- a/dv/uvm/icache/dv/env/seq_lib/ibex_icache_vseq_list.sv
+++ b/dv/uvm/icache/dv/env/seq_lib/ibex_icache_vseq_list.sv
@@ -8,3 +8,4 @@
 `include "ibex_icache_caching_vseq.sv"
 `include "ibex_icache_invalidation_vseq.sv"
 `include "ibex_icache_oldval_vseq.sv"
+`include "ibex_icache_back_line_vseq.sv"

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent.core
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent.core
@@ -23,6 +23,7 @@ filesets:
       - ibex_icache_core_monitor.sv: {is_include_file: true}
       - ibex_icache_core_agent.sv: {is_include_file: true}
       - seq_lib/ibex_icache_core_base_seq.sv: {is_include_file: true}
+      - seq_lib/ibex_icache_core_back_line_seq.sv: {is_include_file: true}
       - seq_lib/ibex_icache_core_seq_list.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/seq_lib/ibex_icache_core_back_line_seq.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/seq_lib/ibex_icache_core_back_line_seq.sv
@@ -1,0 +1,54 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class ibex_icache_core_back_line_seq extends ibex_icache_core_base_seq;
+
+  `uvm_object_utils(ibex_icache_core_back_line_seq)
+  `uvm_object_new
+
+  bit        req_phase = 0;
+  bit [31:0] last_branch;
+
+  protected virtual task run_req(ibex_icache_core_req_item req, ibex_icache_core_rsp_item rsp);
+    bit [31:0] min_addr, max_addr;
+
+    start_item(req);
+
+    // The allowed address range depends on the phase. In the first phase, we behave like the normal
+    // caching sequence: pick something somewhere near the base address. In the second phase, we go
+    // "back a bit" from the previous address.
+    if (!req_phase) begin
+      min_addr = base_addr;
+      max_addr = base_addr + 64;
+    end else begin
+      min_addr = last_branch - 16;
+      max_addr = last_branch;
+    end
+
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(
+       req,
+
+       // Lots of branches!
+       req.trans_type == ICacheCoreTransTypeBranch;
+
+       // Constrain branch targets
+       req.branch_addr inside {[min_addr:max_addr]};
+
+       // Ask for at most 5 insns in either phase (in the first phase, this means we have a chance
+       // of jumping back when the cache isn't ready yet).
+       num_insns <= 5;
+
+       // The cache should always be enabled and never invalidated
+       enable == 1'b1;
+       invalidate == 1'b0;
+    )
+
+    finish_item(req);
+    get_response(rsp);
+
+    last_branch = req.branch_addr;
+    req_phase = !req_phase;
+  endtask
+
+endclass : ibex_icache_core_back_line_seq

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/seq_lib/ibex_icache_core_base_seq.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/seq_lib/ibex_icache_core_base_seq.sv
@@ -74,7 +74,7 @@ class ibex_icache_core_base_seq extends dv_base_seq #(
   endtask
 
   // Generate and run a single item using class parameters
-  protected task run_req(ibex_icache_core_req_item req, ibex_icache_core_rsp_item rsp);
+  protected virtual task run_req(ibex_icache_core_req_item req, ibex_icache_core_rsp_item rsp);
     start_item(req);
 
     if (constrain_branches && insns_since_branch >= 100)

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/seq_lib/ibex_icache_core_seq_list.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/seq_lib/ibex_icache_core_seq_list.sv
@@ -3,3 +3,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 `include "ibex_icache_core_base_seq.sv"
+`include "ibex_icache_core_back_line_seq.sv"

--- a/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
+++ b/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
@@ -65,6 +65,11 @@
       uvm_test_seq: ibex_icache_oldval_vseq
       uvm_test: ibex_icache_oldval_test
     }
+
+    {
+      name: ibex_icache_back_line
+      uvm_test_seq: ibex_icache_back_line_vseq
+    }
   ]
 
   // List of regressions.
@@ -74,7 +79,8 @@
       tests: ["ibex_icache_sanity",
               "ibex_icache_passthru",
               "ibex_icache_caching",
-              "ibex_icache_invalidation"]
+              "ibex_icache_invalidation",
+              "ibex_icache_back_line"]
     }
   ]
 }


### PR DESCRIPTION
This turns out to be reasonably easy to plumb in: derive from the core
sequence base class, overriding its run_req method (once I've
remembered to make it virtual). Then pick the right core sequence by
adding a factory override in the vseq.