### PR TITLE
Wire in the branch_spec signal properly in ICache testbench

### DIFF
--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
@@ -9,6 +9,7 @@ interface ibex_icache_core_if (input clk, input rst_n);
 
   // Branch request
   logic         branch;
+  logic         branch_spec;
   logic [31:0]  branch_addr;
 
   // Passing instructions back to the core
@@ -37,6 +38,7 @@ interface ibex_icache_core_if (input clk, input rst_n);
     output req;
 
     output branch;
+    output branch_spec;
     output branch_addr;
 
     output ready;
@@ -51,6 +53,7 @@ interface ibex_icache_core_if (input clk, input rst_n);
   clocking monitor_cb @(posedge clk);
     input  req;
     input  branch;
+    input  branch_spec;
     input  branch_addr;
     input  ready;
     input  valid;
@@ -72,11 +75,13 @@ interface ibex_icache_core_if (input clk, input rst_n);
   // address.
   task automatic branch_to(logic [31:0] addr);
     driver_cb.branch      <= 1'b1;
+    driver_cb.branch_spec <= 1'b1;
     driver_cb.branch_addr <= addr;
 
     @(driver_cb);
 
     driver_cb.branch      <= 1'b0;
+    driver_cb.branch_spec <= 1'b0;
     driver_cb.branch_addr <= 'X;
   endtask
 
@@ -98,11 +103,12 @@ interface ibex_icache_core_if (input clk, input rst_n);
   // Reset all the signals from the core to the cache (the other direction is controlled by the
   // DUT)
   task automatic reset();
-    driver_cb.req        <= 1'b0;
-    driver_cb.branch     <= 1'b0;
-    driver_cb.ready      <= 1'b0;
-    driver_cb.enable     <= 1'b0;
-    driver_cb.invalidate <= 1'b0;
+    driver_cb.req         <= 1'b0;
+    driver_cb.branch      <= 1'b0;
+    driver_cb.branch_spec <= 1'b0;
+    driver_cb.ready       <= 1'b0;
+    driver_cb.enable      <= 1'b0;
+    driver_cb.invalidate  <= 1'b0;
   endtask
 
 endinterface

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_protocol_checker.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_protocol_checker.sv
@@ -17,6 +17,7 @@ interface ibex_icache_core_protocol_checker (
    input        req,
 
    input        branch,
+   input        branch_spec,
    input [31:0] branch_addr,
 
    input        ready,
@@ -44,6 +45,11 @@ interface ibex_icache_core_protocol_checker (
   // The branch signal tells the cache to redirect. There's no real requirement on when it can be
   // asserted, but the address must be 16-bit aligned (i.e. the bottom bit must be zero).
   `ASSERT(BranchAddrAligned, branch |-> !branch_addr[0], clk, !rst_n)
+
+  // The 'branch' and 'branch_spec' ports
+  //
+  // The branch_spec signal is used in internal muxing and must be true if branch is true.
+  `ASSERT(BranchImpliesSpec, branch |-> branch_spec, clk, !rst_n)
 
   // The main instruction interface
 

--- a/dv/uvm/icache/dv/tb/tb.sv
+++ b/dv/uvm/icache/dv/tb/tb.sv
@@ -29,7 +29,7 @@ module tb;
     // Connect icache <-> core interface
     .req_i           (core_if.req),
     .branch_i        (core_if.branch),
-    .branch_spec_i   (core_if.branch), // TODO - drive this from TB
+    .branch_spec_i   (core_if.branch_spec),
     .addr_i          (core_if.branch_addr),
     .ready_i         (core_if.ready),
     .valid_o         (core_if.valid),


### PR DESCRIPTION
This should have no functional change - it's still set iff branch is
set - but the logic now lies in the UVM code, rather than the
structural code in tb.sv.