### PR TITLE
Add interface-level functional coverage to icache tests

### DIFF
--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent_cov.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent_cov.sv
@@ -8,11 +8,70 @@ class ibex_icache_core_agent_cov extends dv_base_agent_cov #(ibex_icache_core_ag
   // the base class provides the following handles for use:
   // ibex_icache_core_agent_cfg: cfg
 
-  // covergroups
+  // A covergroup that spots a pair of fetches with no intermediate branch.
+  //
+  // addr1 will always be addr0 + 2 or addr0 + 4 (possibly with a wraparound), depending on the
+  // contents of the first fetch.
+  //
+  // We want to see both increments, and also a wrap-around.
+  covergroup inc_fetch_cg with function sample (bit compressed, bit wraparound);
+    cmp:  coverpoint compressed;
+    wrap: coverpoint wraparound;
+    all:  cross cmp, wrap;
+  endgroup : inc_fetch_cg
+
+  // Branch destinations, binned into "near zero", "near top" and "the rest"
+  covergroup branch_dest_cg with function sample (bit [31:0] addr);
+    coverpoint addr {
+      bins zero = { 0 };
+      bins low  = { [2:16] };
+      bins high = { [32'hfffffff0:32'hfffffffc] };
+      bins top  = { 32'hfffffffe };
+      bins mid  = default;
+    }
+  endgroup : branch_dest_cg
+
+  // A covergroup tracking properties of fetches.
+  covergroup fetch_cg with function sample (bit err, bit err_plus2, bit enable);
+    coverpoint enable;
+    coverpoint err;
+    coverpoint err_plus2;
+
+    // Cross err with err_plus2: the latter only has any effect when err is true, so we should make
+    // sure we see the combination. Bin together (False, False) and (False, True) because they have
+    // the same meaning.
+    errs: cross err, err_plus2 {
+      bins no_err = binsof(err) intersect {0};
+    }
+  endgroup : fetch_cg
+
+  // Tracking when a branch cancels a valid result, recording whether or not this happens at the
+  // same time as ready is high.
+  covergroup cancelled_valid_cg with function sample (bit ready);
+    coverpoint ready;
+  endgroup : cancelled_valid_cg
+
+  // Track the combination of branch_spec and branch. The branch signal implies branch_spec, but the
+  // converse is not true. This covergroup is sampled when branch_spec is high.
+  covergroup branch_spec_cg with function sample (bit branch);
+    coverpoint branch;
+  endgroup : branch_spec_cg
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // instantiate all covergroups here
+    inc_fetch_cg = new();
+    branch_dest_cg = new();
+    fetch_cg = new();
+    cancelled_valid_cg = new();
+    branch_spec_cg = new();
   endfunction : new
+
+  // Called on an "incrementing" pair of fetches: two fetches with no branch in between. addr0/addr1
+  // should be the address of the first/second fetch, respectively.
+  function automatic void on_inc_fetches(bit [31:0] addr0, bit [31:0] addr1);
+    bit compressed = (addr1 == addr0 + 2);
+    bit wrap       = addr1 < addr0;
+    inc_fetch_cg.sample(compressed, wrap);
+  endfunction
 
 endclass

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
@@ -111,4 +111,28 @@ interface ibex_icache_core_if (input clk, input rst_n);
     driver_cb.invalidate  <= 1'b0;
   endtask
 
+
+  // Coverage properties
+
+  // Spot a valid signal being cancelled. This happens when valid was high and the core hasn't taken
+  // the corresponding data, but we assert the branch line and the cache doesn't yet have the data
+  // at the requested address.
+  //
+  // We also track whether rdy was high on the cycle where the branch got cancelled, and pass it
+  // back to a covergroup.
+  sequence cancelled_valid;
+    @(posedge clk)
+      $rose(valid)
+      ##1
+      (valid & ~ready) [*0:$]
+      ##1
+      (branch, cover_cancelled_valid());
+  endsequence : cancelled_valid
+  cover property (cancelled_valid);
+
+  bit cancelled_valid_trig = 0;
+  function void cover_cancelled_valid();
+    cancelled_valid_trig = ~cancelled_valid_trig;
+  endfunction
+
 endinterface

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
@@ -9,6 +9,7 @@ interface ibex_icache_core_if (input clk, input rst_n);
 
   // Branch request
   logic         branch;
+  logic         branch_spec;
   logic [31:0]  branch_addr;
 
   // Passing instructions back to the core
@@ -37,6 +38,7 @@ interface ibex_icache_core_if (input clk, input rst_n);
     output req;
 
     output branch;
+    output branch_spec;
     output branch_addr;
 
     output ready;
@@ -51,6 +53,7 @@ interface ibex_icache_core_if (input clk, input rst_n);
   clocking monitor_cb @(posedge clk);
     input  req;
     input  branch;
+    input  branch_spec;
     input  branch_addr;
     input  ready;
     input  valid;
@@ -72,11 +75,13 @@ interface ibex_icache_core_if (input clk, input rst_n);
   // address.
   task automatic branch_to(logic [31:0] addr);
     driver_cb.branch      <= 1'b1;
+    driver_cb.branch_spec <= 1'b1;
     driver_cb.branch_addr <= addr;
 
     @(driver_cb);
 
     driver_cb.branch      <= 1'b0;
+    driver_cb.branch_spec <= 1'b0;
     driver_cb.branch_addr <= 'X;
   endtask
 
@@ -98,11 +103,12 @@ interface ibex_icache_core_if (input clk, input rst_n);
   // Reset all the signals from the core to the cache (the other direction is controlled by the
   // DUT)
   task automatic reset();
-    driver_cb.req        <= 1'b0;
-    driver_cb.branch     <= 1'b0;
-    driver_cb.ready      <= 1'b0;
-    driver_cb.enable     <= 1'b0;
-    driver_cb.invalidate <= 1'b0;
+    driver_cb.req         <= 1'b0;
+    driver_cb.branch      <= 1'b0;
+    driver_cb.branch_spec <= 1'b0;
+    driver_cb.ready       <= 1'b0;
+    driver_cb.enable      <= 1'b0;
+    driver_cb.invalidate  <= 1'b0;
   endtask
 
 endinterface

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_protocol_checker.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_protocol_checker.sv
@@ -17,6 +17,7 @@ interface ibex_icache_core_protocol_checker (
    input        req,
 
    input        branch,
+   input        branch_spec,
    input [31:0] branch_addr,
 
    input        ready,
@@ -44,6 +45,11 @@ interface ibex_icache_core_protocol_checker (
   // The branch signal tells the cache to redirect. There's no real requirement on when it can be
   // asserted, but the address must be 16-bit aligned (i.e. the bottom bit must be zero).
   `ASSERT(BranchAddrAligned, branch |-> !branch_addr[0], clk, !rst_n)
+
+  // The 'branch' and 'branch_spec' ports
+  //
+  // The branch_spec signal is used in internal muxing and must be true if branch is true.
+  `ASSERT(BranchImpliesSpec, branch |-> branch_spec, clk, !rst_n)
 
   // The main instruction interface
 

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent_cov.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent_cov.sv
@@ -10,11 +10,15 @@ class ibex_icache_mem_agent_cov
   // the base class provides the following handles for use:
   // ibex_icache_mem_agent_cfg: cfg
 
-  // covergroups
+  // Spot the gnt and pmp_err signal being high at the same time (the error should take precedence).
+  // This is sampled when gnt is high and tracks whether pmp_err is high too.
+  covergroup gnt_err_cg with function sample(bit pmp_err);
+    coverpoint pmp_err;
+  endgroup : gnt_err_cg
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // instantiate all covergroups here
+    gnt_err_cg = new();
   endfunction : new
 
 endclass

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_monitor.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_monitor.sv
@@ -84,6 +84,7 @@ class ibex_icache_mem_monitor
       if (cfg.vif.monitor_cb.req && cfg.vif.monitor_cb.gnt && !cfg.vif.monitor_cb.pmp_err) begin
         new_grant(cfg.vif.monitor_cb.addr);
       end
+      if (cfg.en_cov && cfg.vif.monitor_cb.gnt) cov.gnt_err_cg.sample(cfg.vif.monitor_cb.pmp_err);
 
       @(cfg.vif.monitor_cb);
     end

--- a/dv/uvm/icache/dv/tb/tb.sv
+++ b/dv/uvm/icache/dv/tb/tb.sv
@@ -29,7 +29,7 @@ module tb;
     // Connect icache <-> core interface
     .req_i           (core_if.req),
     .branch_i        (core_if.branch),
-    .branch_spec_i   (core_if.branch), // TODO - drive this from TB
+    .branch_spec_i   (core_if.branch_spec),
     .addr_i          (core_if.branch_addr),
     .ready_i         (core_if.ready),
     .valid_o         (core_if.valid),


### PR DESCRIPTION
This doesn't define points for interesting behaviours that we're trying to hit with special tests in the testplan (I'll do that in a follow-up). It also doesn't define points for uarch coverage, which will use slightly different machinery.

This PR depends on PR #935 for the first patch: let's review that commit there, rather than here, if necessary.

@tomroberts-lowrisc: Can you think of any other sensible interface-level coverage points that we should define? I'd have thought that most "weird timing" coverage points should be uarch-level, because it will be easier to describe them there, but maybe I've missed something?