### PR TITLE
[rtl] Use gated clock for wb_stage and rf

### DIFF
--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -705,7 +705,7 @@ module ibex_core #(
   ibex_wb_stage #(
     .WritebackStage ( WritebackStage )
   ) wb_stage_i (
-    .clk_i                      ( clk_i                    ),
+    .clk_i                      ( clk                      ),
     .rst_ni                     ( rst_ni                   ),
     .en_wb_i                    ( en_wb                    ),
     .instr_type_wb_i            ( instr_type_wb            ),
@@ -740,7 +740,7 @@ module ibex_core #(
       .DataWidth         (32),
       .DummyInstructions (DummyInstructions)
   ) register_file_i (
-      .clk_i            ( clk_i          ),
+      .clk_i            ( clk            ),
       .rst_ni           ( rst_ni         ),
 
       .test_en_i        ( test_en_i      ),


### PR DESCRIPTION
Corrects a typo, ibex_wb_stage and ibex_register_file were being
supplied with the ungated clk.