### PR TITLE
Add ECC UVM tests for the ICache

### DIFF
--- a/dv/uvm/icache/data/ibex_icache_testplan.hjson
+++ b/dv/uvm/icache/data/ibex_icache_testplan.hjson
@@ -118,7 +118,7 @@
             bit error. Check that the invalid cached data is correctly
             ignored.'''
       milestone: V2
-      tests: []
+      tests: ["ibex_icache_ecc"]
     }
 
     {

--- a/dv/uvm/icache/doc/tb.svg
+++ b/dv/uvm/icache/doc/tb.svg
@@ -7,15 +7,15 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
-   viewBox="0 0 1051 671"
-   stroke-miterlimit="10"
-   id="svg1659"
-   sodipodi:docname="tb.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   style="fill:none;stroke:none;stroke-linecap:square;stroke-miterlimit:10"
+   height="721"
    width="1051"
-   height="671"
-   style="fill:none;stroke:none;stroke-linecap:square;stroke-miterlimit:10">
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="tb.svg"
+   id="svg1659"
+   stroke-miterlimit="10"
+   viewBox="0 0 1051 721"
+   version="1.1">
   <metadata
      id="metadata1665">
     <rdf:RDF>
@@ -31,497 +31,338 @@
   <defs
      id="defs1663">
     <marker
-       inkscape:stockid="Arrow1Lend"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="Arrow1Lend"
+       inkscape:isstock="true"
        style="overflow:visible"
-       inkscape:isstock="true">
+       id="Arrow1Lend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
       <path
-         id="path7702"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         inkscape:connector-curvature="0"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         inkscape:connector-curvature="0" />
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path7702" />
     </marker>
   </defs>
   <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1043"
-     id="namedview1661"
-     showgrid="true"
-     inkscape:zoom="1.0440636"
-     inkscape:cx="531.97562"
-     inkscape:cy="326.55768"
-     inkscape:window-x="1920"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="g2507"
-     fit-margin-top="0"
-     fit-margin-left="0"
+     inkscape:guide-bbox="true"
+     showguides="true"
+     inkscape:document-rotation="0"
+     fit-margin-bottom="0"
      fit-margin-right="0"
-     fit-margin-bottom="0">
+     fit-margin-left="0"
+     fit-margin-top="0"
+     inkscape:current-layer="svg1659"
+     inkscape:window-maximized="1"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:cy="334.71118"
+     inkscape:cx="375.46262"
+     inkscape:zoom="0.73826445"
+     showgrid="true"
+     id="namedview1661"
+     inkscape:window-height="1043"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff">
     <inkscape:grid
-       type="xygrid"
+       originy="-109.5"
+       originx="-49.500001"
        id="grid1791"
-       originx="-49.499996"
-       originy="-109.5" />
+       type="xygrid" />
   </sodipodi:namedview>
   <clipPath
      id="p.0">
     <path
-       d="M 0,0 H 1086 V 817 H 0 Z"
-       id="path1438"
+       style="clip-rule:nonzero"
        inkscape:connector-curvature="0"
-       style="clip-rule:nonzero" />
+       id="path1438"
+       d="M 0,0 H 1086 V 817 H 0 Z" />
   </clipPath>
   <path
-     style="fill:#000000;fill-opacity:0;fill-rule:evenodd"
-     inkscape:connector-curvature="0"
+     d="M -49.500001,-36.500001 H 1036.5 V 780.5 H -49.500001 Z"
      id="path1441"
-     d="M -49.499996,-36.5 H 1036.5 v 817 H -49.499996 Z" />
-  <path
-     style="fill:#000000;fill-opacity:0;fill-rule:evenodd"
      inkscape:connector-curvature="0"
+     style="fill:#000000;fill-opacity:0;fill-rule:evenodd" />
+  <path
+     d="m 399.76248,507.2441 c 0,12.49915 -57.79852,51.22955 -103.7601,24.99829 -45.96161,-26.23126 -80.0863,-117.42416 -103.7601,-208.61664 -23.6738,-91.1925 -36.89667,-182.3845 -61.95644,-208.6167 -25.05978,-26.232181 -61.956441,12.49548 -61.956441,24.99097"
      id="path1497"
-     d="m 399.76248,507.2441 c 0,12.49915 -57.79852,51.22955 -103.7601,24.99829 -45.96161,-26.23126 -80.0863,-117.42416 -103.7601,-208.61664 -23.6738,-91.1925 -36.89667,-182.3845 -61.95644,-208.6167 -25.05978,-26.23218 -61.956436,12.49548 -61.956436,24.99097" />
-  <path
-     style="fill:#000000;fill-opacity:0;fill-rule:evenodd"
      inkscape:connector-curvature="0"
+     style="fill:#000000;fill-opacity:0;fill-rule:evenodd" />
+  <path
+     d="m 241.68896,288.44882 c 12.51828,0 12.82883,64.17889 25.03653,121.89743 12.20767,57.71851 36.31247,108.97662 66.52112,121.8974 30.20862,12.92078 66.52112,-12.49585 66.52112,-24.9917"
      id="path1539"
-     d="m 241.68896,288.44882 c 12.51828,0 12.82883,64.17889 25.03653,121.89743 12.20767,57.71851 36.31247,108.97662 66.52112,121.8974 30.20862,12.92078 66.52112,-12.49585 66.52112,-24.9917" />
-  <path
-     style="fill:#000000;fill-opacity:0;fill-rule:evenodd"
      inkscape:connector-curvature="0"
+     style="fill:#000000;fill-opacity:0;fill-rule:evenodd" />
+  <path
+     d="m 241.68896,220.05774 c 12.51828,0 12.82883,82.41611 25.03653,156.09299 12.20767,73.67688 36.31247,138.61453 66.52112,156.09299 30.20862,17.47839 66.52112,-12.50244 66.52112,-25.00488"
      id="path1543"
-     d="m 241.68896,220.05774 c 12.51828,0 12.82883,82.41611 25.03653,156.09299 12.20767,73.67688 36.31247,138.61453 66.52112,156.09299 30.20862,17.47839 66.52112,-12.50244 66.52112,-25.00488" />
-  <path
-     style="fill:#000000;fill-opacity:0;fill-rule:evenodd"
      inkscape:connector-curvature="0"
+     style="fill:#000000;fill-opacity:0;fill-rule:evenodd" />
+  <path
+     d="M 27.429129,672.96063 C 14.929114,672.96063 0.66137928,576.83465 2.4290953,480.70868 4.1968113,384.58267 21.999984,288.4567 41.570868,288.4567"
      id="path1579"
-     d="M 27.429134,672.96063 C 14.929119,672.96063 0.66138378,576.83465 2.4290998,480.70868 4.1968158,384.58267 21.999989,288.4567 41.570873,288.4567" />
-  <path
-     style="fill:#000000;fill-opacity:0;fill-rule:evenodd"
      inkscape:connector-curvature="0"
+     style="fill:#000000;fill-opacity:0;fill-rule:evenodd" />
+  <path
+     d="m 567.7257,12.017604 h 454.0787 V 256.0491 H 567.7257 Z"
      id="path1593"
-     d="m 567.7257,12.017605 h 454.0787 V 256.0491 H 567.7257 Z" />
-  <path
-     style="fill:#000000;fill-opacity:0;fill-rule:evenodd"
      inkscape:connector-curvature="0"
+     style="fill:#000000;fill-opacity:0;fill-rule:evenodd" />
+  <path
+     d="M 565.26904,260.10367 H 1024.2611 V 497.39502 H 565.26904 Z"
      id="path1615"
-     d="M 565.26904,260.10367 H 1024.2611 V 497.39502 H 565.26904 Z" />
-  <path
-     style="fill:#000000;fill-opacity:0;fill-rule:evenodd"
      inkscape:connector-curvature="0"
+     style="fill:#000000;fill-opacity:0;fill-rule:evenodd" />
+  <path
+     d="m 399.76248,507.2441 c 0,12.50079 -36.3114,47.04083 -66.51877,25.00159 C 303.03634,510.20644 278.93298,431.58785 266.72497,341.94964 254.51696,252.31142 254.20434,151.65357 241.68371,151.65357"
      id="path1653"
-     d="m 399.76248,507.2441 c 0,12.50079 -36.3114,47.04083 -66.51877,25.00159 C 303.03634,510.20644 278.93298,431.58785 266.72497,341.94964 254.51696,252.31142 254.20434,151.65357 241.68371,151.65357" />
+     inkscape:connector-curvature="0"
+     style="fill:#000000;fill-opacity:0;fill-rule:evenodd" />
   <rect
-     ry="90.000008"
-     rx="90"
-     y="10.5"
-     x="10.500019"
-     height="640"
-     width="530"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fff8e3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="rect2206"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fff8e3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666794px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#f18080;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="274.93945"
-     y="42.595207"
-     id="text1777"><tspan
-       sodipodi:role="line"
-       id="tspan1775"
-       x="274.93945"
-       y="42.595207"
-       style="fill:#000000;fill-opacity:1">ibex_icache_base_test</tspan></text>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="575.61847"
-     y="295.76044"
-     id="text8237"><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="295.76044"
-       id="tspan8151"><tspan
-         x="575.61847"
-         y="295.76044"
-         id="tspan8147">Square boxes: SV modules / interfaces (static)</tspan><tspan
-         dx="0"
-         x="904.83722"
-         y="295.76044"
-         id="tspan8149" /></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="315.76044"
-       id="tspan8157"><tspan
-         x="575.61847"
-         y="315.76044"
-         id="tspan8153">Rounded boxes: SV classes (UVM; dynamically created)</tspan><tspan
-         dx="0"
-         x="976.93097"
-         y="315.76044"
-         id="tspan8155" /></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="335.76044"
-       id="tspan8163"><tspan
-         x="575.61847"
-         y="335.76044"
-         id="tspan8159">Square box with cut corner: Code block (a UVM phase)</tspan><tspan
-         dx="0"
-         x="967.14966"
-         y="335.76044"
-         id="tspan8161" /></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="355.76044"
-       id="tspan8167"><tspan
-         x="575.61847"
-         y="355.76044"
-         id="tspan8165" /></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="375.76044"
-       id="tspan8171"><tspan
-         x="575.61847"
-         y="375.76044"
-         id="tspan8169">Nesting shows fields in classes, so there is an object of type </tspan></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="395.76041"
-       id="tspan8175"><tspan
-         x="575.61847"
-         y="395.76041"
-         id="tspan8173">ibex_icache_env inside the object of type </tspan></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="415.76041"
-       id="tspan8181"><tspan
-         x="575.61847"
-         y="415.76041"
-         id="tspan8177">ibex_icache_base_test.</tspan><tspan
-         dx="0"
-         x="742.93097"
-         y="415.76041"
-         id="tspan8179" /></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="435.76041"
-       id="tspan8185"><tspan
-         x="575.61847"
-         y="435.76041"
-         id="tspan8183" /></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="455.76041"
-       id="tspan8189"><tspan
-         x="575.61847"
-         y="455.76041"
-         id="tspan8187">The color of the box for a class shows the base class. For </tspan></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="475.76041"
-       id="tspan8195"><tspan
-         x="575.61847"
-         y="475.76041"
-         id="tspan8191">example, interfaces are pink; agents are green.</tspan><tspan
-         dx="0"
-         x="910.21222"
-         y="475.76041"
-         id="tspan8193" /></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="495.76041"
-       id="tspan8199"><tspan
-         x="575.61847"
-         y="495.76041"
-         id="tspan8197" /></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="515.76038"
-       id="tspan8203"><tspan
-         x="575.61847"
-         y="515.76038"
-         id="tspan8201">Many classes have handles (always called cfg) to the test's </tspan></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="535.76038"
-       id="tspan8207"><tspan
-         x="575.61847"
-         y="535.76038"
-         id="tspan8205">ibex_icache_env_cfg object. To denote this, those classes are </tspan></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="555.76038"
-       id="tspan8213"><tspan
-         x="575.61847"
-         y="555.76038"
-         id="tspan8209">connected by a dotted line to the ibex_icache_env_cfg class.</tspan><tspan
-         dx="0"
-         x="1006.2747"
-         y="555.76038"
-         id="tspan8211" /></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="575.76038"
-       id="tspan8217"><tspan
-         x="575.61847"
-         y="575.76038"
-         id="tspan8215" /></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="595.76038"
-       id="tspan8221"><tspan
-         x="575.61847"
-         y="595.76038"
-         id="tspan8219">The virtual sequence object created in the run phase has a </tspan></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="615.76038"
-       id="tspan8225"><tspan
-         x="575.61847"
-         y="615.76038"
-         id="tspan8223">p_sequencer handle to the ibex_icache_virtual_sequencer </tspan></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="635.76038"
-       id="tspan8231"><tspan
-         x="575.61847"
-         y="635.76038"
-         id="tspan8227">inside the environment (not shown).</tspan><tspan
-         dx="0"
-         x="829.24347"
-         y="635.76038"
-         id="tspan8229" /></tspan><tspan
-       sodipodi:role="line"
-       x="575.61847"
-       y="635.76038"
-       id="tspan8235"><tspan
-         x="575.61847"
-         y="655.76038"
-         id="tspan8233" /></tspan></text>
-  <g
-     id="g2617"
-     transform="translate(-49.499996,-36.5)">
-    <rect
-       ry="40"
-       rx="40"
-       y="107"
-       x="70"
-       height="310"
-       width="239.99998"
-       id="rect1908"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fff2cc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    <text
-       transform="scale(1.0069205,0.99312707)"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:19.8625412px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#f18080;fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="189.25031"
-       y="140.77362"
-       id="text1785"><tspan
-         sodipodi:role="line"
-         id="tspan1783"
-         x="189.25031"
-         y="140.77362"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.99999994px">ibex_icache_env</tspan></text>
-    <g
-       transform="translate(-5,-39.999999)"
-       id="g1896">
-      <rect
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffe599;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         id="rect1831"
-         width="229.99998"
-         height="36.322979"
-         x="80"
-         y="205.67702"
-         ry="10"
-         rx="9.999999" />
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="194.49219"
-         y="228.39612"
-         id="text1789"><tspan
-           sodipodi:role="line"
-           id="tspan1787"
-           x="194.49219"
-           y="228.39612">ibex_icache_env_cov</tspan></text>
-    </g>
-    <g
-       transform="translate(-4.9999695,-36.322967)"
-       id="g1901">
-      <rect
-         rx="9.999999"
-         ry="10"
-         y="247"
-         x="79.999992"
-         height="36.322979"
-         width="229.99998"
-         id="rect1852"
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffe599;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-      <text
-         id="text1856"
-         y="269.71912"
-         x="194.98438"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         xml:space="preserve"><tspan
-           y="269.71912"
-           x="194.98438"
-           id="tspan1854"
-           sodipodi:role="line">ibex_icache_scoreboard</tspan></text>
-    </g>
-    <g
-       transform="translate(-5,-31.322968)"
-       id="g1906">
-      <rect
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffe599;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         id="rect1876"
-         width="229.99998"
-         height="36.322979"
-         x="80"
-         y="287"
-         ry="10"
-         rx="9.999999" />
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="194.98438"
-         y="309.71912"
-         id="text1880"><tspan
-           sodipodi:role="line"
-           id="tspan1878"
-           x="194.98438"
-           y="309.71912">ibex_icache_virtual_sequencer</tspan></text>
-    </g>
-    <g
-       transform="translate(0,-45)"
-       id="g2036">
-      <rect
-         rx="9.999999"
-         ry="10"
-         y="355.67703"
-         x="75"
-         height="36.322979"
-         width="229.99998"
-         id="rect2008"
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-      <text
-         id="text2012"
-         y="378.39615"
-         x="189.98438"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         xml:space="preserve"><tspan
-           y="378.39615"
-           x="189.98438"
-           id="tspan2010"
-           sodipodi:role="line">ibex_icache_core_agent</tspan></text>
-    </g>
-    <g
-       id="g2044">
-      <rect
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         id="rect2038"
-         width="229.99998"
-         height="36.322979"
-         x="75"
-         y="355.67703"
-         ry="10"
-         rx="9.999999" />
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="189.98438"
-         y="378.39615"
-         id="text2042"><tspan
-           sodipodi:role="line"
-           id="tspan2040"
-           x="189.98438"
-           y="378.39615">ibex_icache_mem_agent</tspan></text>
-    </g>
-  </g>
-  <rect
-     ry="40"
+     width="530"
+     height="700"
+     x="10.500014"
+     y="10.499999"
      rx="40"
-     y="70.5"
-     x="290.5"
-     height="310"
-     width="239.99998"
-     id="rect2074"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffe599;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     ry="40.000004" />
   <text
-     xml:space="preserve"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666794px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#f18080;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="410.48175"
+     id="text1777"
+     y="42.595207"
+     x="274.93945"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.6667px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#f18080;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     xml:space="preserve"><tspan
+       style="fill:#000000;fill-opacity:1"
+       y="42.595207"
+       x="274.93945"
+       id="tspan1775"
+       sodipodi:role="line">ibex_icache_base_test</tspan></text>
+  <text
+     id="text8237"
+     y="295.76044"
+     x="575.61847"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     xml:space="preserve"><tspan
+       id="tspan8151"
+       y="295.76044"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8147"
+         y="295.76044"
+         x="575.61847">Square boxes: SV modules / interfaces (static)</tspan><tspan
+         id="tspan8149"
+         y="295.76044"
+         x="904.83722"
+         dx="0" /></tspan><tspan
+       id="tspan8157"
+       y="315.76044"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8153"
+         y="315.76044"
+         x="575.61847">Rounded boxes: SV classes (UVM; dynamically created)</tspan><tspan
+         id="tspan8155"
+         y="315.76044"
+         x="976.93097"
+         dx="0" /></tspan><tspan
+       id="tspan8163"
+       y="335.76044"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8159"
+         y="335.76044"
+         x="575.61847">Square box with cut corner: Code block (a UVM phase)</tspan><tspan
+         id="tspan8161"
+         y="335.76044"
+         x="967.14966"
+         dx="0" /></tspan><tspan
+       id="tspan8167"
+       y="355.76044"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8165"
+         y="355.76044"
+         x="575.61847" /></tspan><tspan
+       id="tspan8171"
+       y="375.76044"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8169"
+         y="375.76044"
+         x="575.61847">Nesting shows fields in classes, so there is an object of type </tspan></tspan><tspan
+       id="tspan8175"
+       y="395.76041"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8173"
+         y="395.76041"
+         x="575.61847">ibex_icache_env inside the object of type </tspan></tspan><tspan
+       id="tspan8181"
+       y="415.76041"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8177"
+         y="415.76041"
+         x="575.61847">ibex_icache_base_test.</tspan><tspan
+         id="tspan8179"
+         y="415.76041"
+         x="742.93097"
+         dx="0" /></tspan><tspan
+       id="tspan8185"
+       y="435.76041"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8183"
+         y="435.76041"
+         x="575.61847" /></tspan><tspan
+       id="tspan8189"
+       y="455.76041"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8187"
+         y="455.76041"
+         x="575.61847">The color of the box for a class shows the base class. For </tspan></tspan><tspan
+       id="tspan8195"
+       y="475.76041"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8191"
+         y="475.76041"
+         x="575.61847">example, interfaces are pink; agents are green.</tspan><tspan
+         id="tspan8193"
+         y="475.76041"
+         x="910.21222"
+         dx="0" /></tspan><tspan
+       id="tspan8199"
+       y="495.76041"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8197"
+         y="495.76041"
+         x="575.61847" /></tspan><tspan
+       id="tspan8203"
+       y="515.76038"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8201"
+         y="515.76038"
+         x="575.61847">Many classes have handles (always called cfg) to the test's </tspan></tspan><tspan
+       id="tspan8207"
+       y="535.76038"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8205"
+         y="535.76038"
+         x="575.61847">ibex_icache_env_cfg object. To denote this, those classes are </tspan></tspan><tspan
+       id="tspan8213"
+       y="555.76038"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8209"
+         y="555.76038"
+         x="575.61847">connected by a dotted line to the ibex_icache_env_cfg class.</tspan><tspan
+         id="tspan8211"
+         y="555.76038"
+         x="1006.2747"
+         dx="0" /></tspan><tspan
+       id="tspan8217"
+       y="575.76038"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8215"
+         y="575.76038"
+         x="575.61847" /></tspan><tspan
+       id="tspan8221"
+       y="595.76038"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8219"
+         y="595.76038"
+         x="575.61847">The virtual sequence object created in the run phase has a </tspan></tspan><tspan
+       id="tspan8225"
+       y="615.76038"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8223"
+         y="615.76038"
+         x="575.61847">p_sequencer handle to the ibex_icache_virtual_sequencer </tspan></tspan><tspan
+       id="tspan8231"
+       y="635.76038"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8227"
+         y="635.76038"
+         x="575.61847">inside the environment (not shown).</tspan><tspan
+         id="tspan8229"
+         y="635.76038"
+         x="829.24347"
+         dx="0" /></tspan><tspan
+       id="tspan8235"
+       y="635.76038"
+       x="575.61847"
+       sodipodi:role="line"><tspan
+         id="tspan8233"
+         y="655.76038"
+         x="575.61847" /></tspan></text>
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffe599;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="rect2074"
+     width="239.99998"
+     height="430"
+     x="290.5"
+     y="70.5"
+     rx="25"
+     ry="25" />
+  <text
+     id="text2078"
      y="103.84506"
-     id="text2078"><tspan
-       sodipodi:role="line"
-       id="tspan2076"
-       x="410.48175"
+     x="410.48175"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.6667px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#f18080;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     xml:space="preserve"><tspan
+       style="fill:#000000;fill-opacity:1"
        y="103.84506"
-       style="fill:#000000;fill-opacity:1">ibex_icache_env_cfg</tspan></text>
+       x="410.48175"
+       id="tspan2076"
+       sodipodi:role="line">ibex_icache_env_cfg</tspan></text>
   <g
-     transform="translate(215.5,-76.5)"
-     id="g2086">
-    <rect
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f4cccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       id="rect2080"
-       width="229.99998"
-       height="36.322979"
-       x="80"
-       y="205.67702"
-       ry="10"
-       rx="9.999999" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="194.49219"
-       y="228.39612"
-       id="text2084"><tspan
-         sodipodi:role="line"
-         id="tspan2082"
-         x="194.49219"
-         y="228.39612">ibex_icache_core_if</tspan></text>
-  </g>
-  <g
-     id="g2116"
-     transform="translate(220.5,-81.5)">
+     id="g2086"
+     transform="translate(215.5,-76.500001)">
     <rect
        rx="9.999999"
        ry="10"
-       y="355.67703"
-       x="75"
+       y="205.67702"
+       x="80"
        height="36.322979"
        width="229.99998"
-       id="rect2110"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       id="rect2080"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f4cccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <text
-       id="text2114"
-       y="378.39615"
-       x="189.98438"
+       id="text2084"
+       y="228.39612"
+       x="194.49219"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        xml:space="preserve"><tspan
-         y="378.39615"
-         x="189.98438"
-         id="tspan2112"
-         sodipodi:role="line">ibex_icache_core_agent_cfg</tspan></text>
+         y="228.39612"
+         x="194.49219"
+         id="tspan2082"
+         sodipodi:role="line">ibex_icache_core_if</tspan></text>
   </g>
   <g
-     transform="translate(220.5,-36.5)"
-     id="g2124">
+     transform="translate(220.5,-15.177032)"
+     id="g2116">
     <rect
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       id="rect2118"
+       id="rect2110"
        width="229.99998"
        height="36.322979"
        x="75"
@@ -533,300 +374,656 @@
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="189.98438"
        y="378.39615"
-       id="text2122"><tspan
+       id="text2114"><tspan
          sodipodi:role="line"
-         id="tspan2120"
+         id="tspan2112"
          x="189.98438"
-         y="378.39615">ibex_icache_mem_agent_cfg</tspan></text>
+         y="378.39615">ibex_icache_core_agent_cfg</tspan></text>
   </g>
   <g
-     id="g2196"
-     transform="translate(215.5,-31.5)">
+     id="g1140">
     <rect
        rx="9.999999"
        ry="10"
-       y="205.67702"
-       x="80"
+       y="385.5"
+       x="295.5"
        height="36.322979"
        width="229.99998"
+       id="rect2118"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <text
+       id="text2122"
+       y="408.21912"
+       x="410.48438"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         y="408.21912"
+         x="410.48438"
+         id="tspan2120"
+         sodipodi:role="line">ibex_icache_mem_agent_cfg</tspan></text>
+  </g>
+  <g
+     transform="translate(215.5,-31.500001)"
+     id="g2196">
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f4cccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect2190"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f4cccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       width="229.99998"
+       height="36.322979"
+       x="80"
+       y="205.67702"
+       ry="10"
+       rx="9.999999" />
     <text
-       id="text2194"
-       y="228.39612"
-       x="194.49219"
+       xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       xml:space="preserve"><tspan
-         y="228.39612"
-         x="194.49219"
+       x="194.49219"
+       y="228.39612"
+       id="text2194"><tspan
+         sodipodi:role="line"
          id="tspan2192"
-         sodipodi:role="line">ibex_icache_mem_if</tspan></text>
+         x="194.49219"
+         y="228.39612">ibex_icache_mem_if</tspan></text>
   </g>
   <g
-     id="g2204"
-     transform="translate(215.5,13.5)">
+     transform="translate(215.5,13.499999)"
+     id="g2204">
     <rect
-       rx="9.999999"
-       ry="10"
-       y="205.67702"
-       x="80"
-       height="36.322979"
-       width="229.99998"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f4cccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect2198"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f4cccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       width="229.99998"
+       height="36.322979"
+       x="80"
+       y="205.67702"
+       ry="10"
+       rx="9.999999" />
     <text
-       id="text2202"
-       y="228.39612"
-       x="194.49219"
+       xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       xml:space="preserve"><tspan
-         y="228.39612"
-         x="194.49219"
+       x="194.49219"
+       y="228.39612"
+       id="text2202"><tspan
+         sodipodi:role="line"
          id="tspan2200"
-         sodipodi:role="line">clk_reset_if</tspan></text>
+         x="194.49219"
+         y="228.39612">clk_reset_if</tspan></text>
   </g>
   <text
-     xml:space="preserve"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.33333397px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="30.500004"
+     id="text2330"
      y="510.5"
-     id="text2330"><tspan
-       sodipodi:role="line"
+     x="30.5"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     xml:space="preserve"><tspan
+       y="510.5"
+       x="30.5"
        id="tspan2328"
-       x="30.500004"
-       y="525.27972" /></text>
+       sodipodi:role="line" /></text>
   <flowRoot
-     xml:space="preserve"
+     transform="translate(-49.500001,-36.500001)"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.6667px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="flowRoot2332"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.66666698px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     transform="translate(-49.499996,-36.5)"><flowRegion
-       id="flowRegion2334"
-       style="text-align:start;text-anchor:start"><rect
-         id="rect2336"
-         width="440"
-         height="120"
-         x="80"
+     xml:space="preserve"><flowRegion
+       style="text-align:start;text-anchor:start"
+       id="flowRegion2334"><rect
+         style="text-align:start;text-anchor:start"
          y="537"
-         style="text-align:start;text-anchor:start" /></flowRegion><flowPara
-       id="flowPara2338" /></flowRoot>  <g
-     id="g2521"
-     transform="translate(-49.499996,-36.5)">
+         x="80"
+         height="120"
+         width="440"
+         id="rect2336" /></flowRegion><flowPara
+       id="flowPara2338" /></flowRoot>
+  <g
+     transform="translate(-49.500001,63.499999)"
+     id="g2521">
     <path
-       sodipodi:nodetypes="cccccc"
-       d="m 70,447 h 470 l 40,50 V 617 H 70 Z"
-       id="path1559"
+       style="fill:#cfe2f3;fill-rule:evenodd;stroke:#000000;stroke-opacity:1"
        inkscape:connector-curvature="0"
-       style="fill:#cfe2f3;fill-rule:evenodd;stroke:#000000;stroke-opacity:1" />
+       id="path1559"
+       d="m 70,447 h 470 l 40,50 V 617 H 70 Z"
+       sodipodi:nodetypes="cccccc" />
     <g
        id="g2507">
       <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.33333397px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="90"
+         id="text2326"
          y="471.74084"
-         id="text2326"><tspan
-           sodipodi:role="line"
-           id="tspan2324"
-           x="90"
-           y="471.74084">run_phase:</tspan></text>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.66666698px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="90"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="471.74084"
+           x="90"
+           id="tspan2324"
+           sodipodi:role="line">run_phase:</tspan></text>
+      <text
+         id="text8251"
          y="497.8609"
-         id="text8251"><tspan
-           sodipodi:role="line"
-           x="90"
+         x="90"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.6667px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           id="tspan8241"
            y="497.8609"
-           id="tspan8241"><tspan
-             x="90"
+           x="90"
+           sodipodi:role="line"><tspan
+             id="tspan8239"
              y="497.8609"
-             id="tspan8239">In the UVM run phase, the dv_base_test class (from which the </tspan></tspan><tspan
-           sodipodi:role="line"
-           x="90"
+             x="90">In the UVM run phase, the dv_base_test class (from which the </tspan></tspan><tspan
+           id="tspan8245"
            y="517.8609"
-           id="tspan8245"><tspan
-             x="90"
-             y="517.8609"
-             id="tspan8243">ibex_icache_base_test class derives) creates and runs the sequence </tspan></tspan><tspan
-           sodipodi:role="line"
            x="90"
+           sodipodi:role="line"><tspan
+             id="tspan8243"
+             y="517.8609"
+             x="90">ibex_icache_base_test class derives) creates and runs the sequence </tspan></tspan><tspan
+           id="tspan8249"
            y="537.8609"
-           id="tspan8249"><tspan
-             x="90"
+           x="90"
+           sodipodi:role="line"><tspan
+             id="tspan8247"
              y="537.8609"
-             id="tspan8247">named by the +UVM_TEST_SEQ plusarg.</tspan></tspan></text>
+             x="90">named by the +UVM_TEST_SEQ plusarg.</tspan></tspan></text>
     </g>
     <g
        id="g2499">
       <rect
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fff3cd;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         id="rect2348"
-         width="470"
-         height="39.940208"
-         x="90"
-         y="557"
+         ry="15.181121"
          rx="20"
-         ry="15.181121" />
+         y="557"
+         x="90"
+         height="39.940208"
+         width="470"
+         id="rect2348"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fff3cd;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="324.9772"
+         id="text2352"
          y="581.76636"
-         id="text2352"><tspan
-           sodipodi:role="line"
-           id="tspan2350"
+         x="324.9772"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.6667px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="581.76636"
            x="324.9772"
-           y="581.76636">ibex_icache_base_vseq</tspan></text>
+           id="tspan2350"
+           sodipodi:role="line">ibex_icache_base_vseq</tspan></text>
     </g>
   </g>
   <text
-     xml:space="preserve"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="575.61847"
+     id="text2356"
      y="265.32785"
-     id="text2356"><tspan
-       sodipodi:role="line"
-       id="tspan2354"
-       x="575.61847"
+     x="575.61847"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.6667px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     xml:space="preserve"><tspan
+       style="text-align:start;text-anchor:start"
        y="265.32785"
-       style="text-align:start;text-anchor:start">Legend:</tspan></text>
+       x="575.61847"
+       id="tspan2354"
+       sodipodi:role="line">Legend:</tspan></text>
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
-     d="m 290.5,105.5 c -15,0 -35,30 -35,30"
+     sodipodi:nodetypes="cc"
+     inkscape:connector-curvature="0"
      id="path1998"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cc" />
-  <path
-     sodipodi:nodetypes="cc"
-     inkscape:connector-curvature="0"
-     id="path2402"
-     d="m 290.5,105.5 c -15,0 -35,75 -35,75"
+     d="m 290.5,105.5 c -15,0 -35,30 -35,30"
      style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
   <path
      style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
-     d="m 290.5,105.5 c -15,0 -35,120 -35,120"
-     id="path2404"
+     d="m 290.5,105.5 c -15,0 -35,75 -35,75"
+     id="path2402"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc" />
   <path
      sodipodi:nodetypes="cc"
      inkscape:connector-curvature="0"
-     id="path2406"
-     d="m 290.5,105.5 c -15,0 -30,10 -30,10"
+     id="path2404"
+     d="m 290.5,105.5 c -15,0 -35,120 -35,120"
      style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 290.5,105.5 c -15,0 -30,10 -30,10"
+     id="path2406"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc" />
   <rect
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#dad2ea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="rect2619"
-     width="470"
-     height="219.99998"
-     x="570.5"
-     y="10.499996"
+     ry="0"
      rx="0"
-     ry="0" />
-  <rect
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="rect7655"
-     width="180"
-     height="150"
-     x="840.5"
-     y="60.500008" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.33333397px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="930.08954"
-     y="141.69531"
-     id="text7659"><tspan
-       sodipodi:role="line"
-       x="930.08954"
-       y="141.69531"
-       id="tspan7970">ICache</tspan></text>
+     y="10.499995"
+     x="570.5"
+     height="219.99998"
+     width="470"
+     id="rect2619"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#dad2ea;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <g
-     id="g7675"
-     transform="translate(-49.499996,-149)">
-    <rect
-       y="222"
-       x="640"
-       height="35"
-       width="170"
-       id="rect7666"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fce6ce;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    <text
-       id="text7670"
-       y="244.05762"
-       x="724.40332"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.33333397px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       xml:space="preserve"><tspan
-         y="244.05762"
-         x="724.40332"
-         id="tspan7668"
-         sodipodi:role="line">core_if</tspan></text>
-  </g>
-  <g
-     id="g7683"
-     transform="translate(-49.499996,-104)">
+     transform="translate(-49.500001,-149)"
+     id="g7675">
     <rect
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fce6ce;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       id="rect7677"
+       id="rect7666"
        width="170"
        height="35"
        x="640"
        y="222" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.33333397px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="724.40332"
        y="244.05762"
-       id="text7681"><tspan
+       id="text7670"><tspan
          sodipodi:role="line"
-         id="tspan7679"
+         id="tspan7668"
          x="724.40332"
-         y="244.05762">mem_if</tspan></text>
+         y="244.05762">core_if</tspan></text>
   </g>
   <g
-     transform="translate(-49.499996,-59)"
-     id="g7691">
+     transform="translate(-49.500001,-104)"
+     id="g7683">
     <rect
        y="222"
        x="640"
        height="35"
        width="170"
-       id="rect7685"
+       id="rect7677"
        style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fce6ce;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <text
-       id="text7689"
+       id="text7681"
        y="244.05762"
        x="724.40332"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.33333397px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        xml:space="preserve"><tspan
          y="244.05762"
          x="724.40332"
+         id="tspan7679"
+         sodipodi:role="line">mem_if</tspan></text>
+  </g>
+  <g
+     id="g7691"
+     transform="translate(-49.500001,-59.000001)">
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fce6ce;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect7685"
+       width="170"
+       height="35"
+       x="640"
+       y="222" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="724.40332"
+       y="244.05762"
+       id="text7689"><tspan
+         sodipodi:role="line"
          id="tspan7687"
-         sodipodi:role="line">clk_rst_if</tspan></text>
+         x="724.40332"
+         y="244.05762">clk_rst_if</tspan></text>
   </g>
   <path
-     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 765.5,90.5 10,-15 v 10 h 50 v -10 l 10,15 -10,15 v -10 h -50 v 10 z"
+     inkscape:connector-curvature="0"
      id="path7693"
+     d="m 765.5,90.499999 10,-15 v 10 h 50 v -10 l 10,15 L 825.5,105.5 V 95.499999 h -50 V 105.5 Z"
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 765.5,135.5 10,-15 v 10 h 50 v -10 l 10,15 -10,15 v -10 h -50 v 10 z"
+     id="path7695"
      inkscape:connector-curvature="0" />
   <path
      inkscape:connector-curvature="0"
-     id="path7695"
-     d="m 765.5,135.5 10,-15 v 10 h 50 v -10 l 10,15 -10,15 v -10 h -50 v 10 z"
-     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-  <path
-     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
-     d="m 765.5,183 h 70"
      id="path7697"
-     inkscape:connector-curvature="0" />
+     d="m 765.5,183 h 70"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Lend)" />
   <text
-     xml:space="preserve"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.33333397px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="612.0202"
+     id="text7968"
      y="45.608871"
-     id="text7968"><tspan
-       sodipodi:role="line"
-       id="tspan7966"
+     x="612.0202"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     xml:space="preserve"><tspan
+       y="45.608871"
        x="612.0202"
-       y="45.608871">tb.sv</tspan></text>
+       id="tspan7966"
+       sodipodi:role="line">tb.sv</tspan></text>
+  <g
+     id="g1295">
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect7655"
+       width="180"
+       height="150"
+       x="840.5"
+       y="60.500008" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="930.08527"
+       y="109.6452"
+       id="text7659"><tspan
+         sodipodi:role="line"
+         x="930.08527"
+         y="109.6452"
+         id="tspan7970">ICache</tspan></text>
+    <g
+       id="g1040"
+       transform="translate(-7.5000083,5.2941127)">
+      <rect
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fce6ce;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         id="rect1032"
+         width="120.00001"
+         height="24.705883"
+         x="885.5"
+         y="155.79411" />
+      <rect
+         y="150.5"
+         x="880.5"
+         height="24.705883"
+         width="120.00001"
+         id="rect1030"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fce6ce;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <rect
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fce6ce;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         id="rect1028"
+         width="120.00001"
+         height="24.705883"
+         x="875.5"
+         y="145.5" />
+      <rect
+         y="140.5"
+         x="870.5"
+         height="24.705883"
+         width="120.00001"
+         id="rect993"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fce6ce;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <text
+         id="text997"
+         y="157.41055"
+         x="930.11914"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="157.41055"
+           x="930.11914"
+           id="tspan995"
+           sodipodi:role="line">ecc_if</tspan></text>
+    </g>
+  </g>
+  <g
+     transform="translate(3.9999955)"
+     id="g1065">
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f4cccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect1057"
+       width="209.99998"
+       height="33.164459"
+       x="307.5"
+       y="276.177"
+       ry="10"
+       rx="9.999999" />
+    <rect
+       rx="9.999999"
+       ry="10"
+       y="272.177"
+       x="303.5"
+       height="33.164459"
+       width="209.99998"
+       id="rect1055"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f4cccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f4cccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect1053"
+       width="209.99998"
+       height="33.164459"
+       x="299.5"
+       y="268.177"
+       ry="10"
+       rx="9.999999" />
+    <rect
+       rx="9.999999"
+       ry="10"
+       y="264.177"
+       x="295.5"
+       height="33.164459"
+       width="209.99998"
+       id="rect1042"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f4cccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <text
+       id="text1046"
+       y="284.96625"
+       x="399.95312"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         y="284.96625"
+         x="399.95312"
+         id="tspan1044"
+         sodipodi:role="line">ibex_icache_ecc_if</tspan></text>
+  </g>
+  <g
+     id="g1135">
+    <rect
+       rx="9.999999"
+       ry="10"
+       y="444.5"
+       x="311.5"
+       height="33.164459"
+       width="209.99998"
+       id="rect1067"
+       style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1" />
+    <rect
+       style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+       id="rect1069"
+       width="209.99998"
+       height="33.164459"
+       x="307.5"
+       y="440.5"
+       ry="10"
+       rx="9.999999" />
+    <rect
+       rx="9.999999"
+       ry="10"
+       y="436.5"
+       x="303.5"
+       height="33.164459"
+       width="209.99998"
+       id="rect1071"
+       style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1" />
+    <rect
+       style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+       id="rect1073"
+       width="209.99998"
+       height="33.164459"
+       x="299.5"
+       y="432.5"
+       ry="10"
+       rx="9.999999" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="403.95312"
+       y="453.28925"
+       id="text1077"><tspan
+         sodipodi:role="line"
+         id="tspan1075"
+         x="403.95312"
+         y="453.28925">ibex_icache_ecc_agent_cfg</tspan></text>
+  </g>
+  <g
+     id="g1188">
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#fff2cc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect1908"
+       width="239.99998"
+       height="430"
+       x="20.5"
+       y="70.5"
+       rx="25"
+       ry="25.000002" />
+    <text
+       id="text1785"
+       y="104.02103"
+       x="140.09052"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.6667px;line-height:19.8625px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#f18080;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"
+       transform="scale(1.0069205,0.99312707)"><tspan
+         style="fill:#000000;fill-opacity:1;stroke-width:1px"
+         y="104.02103"
+         x="140.09052"
+         id="tspan1783"
+         sodipodi:role="line">ibex_icache_env</tspan></text>
+    <g
+       id="g1896"
+       transform="translate(-54.500001,-76.5)">
+      <rect
+         rx="9.999999"
+         ry="10"
+         y="205.67702"
+         x="80"
+         height="36.322979"
+         width="229.99998"
+         id="rect1831"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffe599;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <text
+         id="text1789"
+         y="228.39612"
+         x="194.49219"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="228.39612"
+           x="194.49219"
+           id="tspan1787"
+           sodipodi:role="line">ibex_icache_env_cov</tspan></text>
+    </g>
+    <g
+       id="g1901"
+       transform="translate(-54.499971,-72.822968)">
+      <rect
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffe599;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         id="rect1852"
+         width="229.99998"
+         height="36.322979"
+         x="79.999992"
+         y="247"
+         ry="10"
+         rx="9.999999" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="194.98438"
+         y="269.71912"
+         id="text1856"><tspan
+           sodipodi:role="line"
+           id="tspan1854"
+           x="194.98438"
+           y="269.71912">ibex_icache_scoreboard</tspan></text>
+    </g>
+    <g
+       id="g1906"
+       transform="translate(-54.500001,-67.822969)">
+      <rect
+         rx="9.999999"
+         ry="10"
+         y="287"
+         x="80"
+         height="36.322979"
+         width="229.99998"
+         id="rect1876"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffe599;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <text
+         id="text1880"
+         y="309.71912"
+         x="194.98438"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="309.71912"
+           x="194.98438"
+           id="tspan1878"
+           sodipodi:role="line">ibex_icache_virtual_sequencer</tspan></text>
+    </g>
+    <g
+       id="g2036"
+       transform="translate(-49.500001,-16.500001)">
+      <rect
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         id="rect2008"
+         width="229.99998"
+         height="36.322979"
+         x="75"
+         y="355.67703"
+         ry="10"
+         rx="9.999999" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="189.98438"
+         y="378.39615"
+         id="text2012"><tspan
+           sodipodi:role="line"
+           id="tspan2010"
+           x="189.98438"
+           y="378.39615">ibex_icache_core_agent</tspan></text>
+    </g>
+    <g
+       id="g2044"
+       transform="translate(-49.500001,28.499999)">
+      <rect
+         rx="9.999999"
+         ry="10"
+         y="355.67703"
+         x="75"
+         height="36.322979"
+         width="229.99998"
+         id="rect2038"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <text
+         id="text2042"
+         y="378.39615"
+         x="189.98438"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="378.39615"
+           x="189.98438"
+           id="tspan2040"
+           sodipodi:role="line">ibex_icache_mem_agent</tspan></text>
+    </g>
+    <g
+       id="g1154"
+       transform="translate(-270)">
+      <rect
+         rx="9.999999"
+         ry="10"
+         y="444.5"
+         x="311.5"
+         height="33.164459"
+         width="209.99998"
+         id="rect1142"
+         style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1" />
+      <rect
+         style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+         id="rect1144"
+         width="209.99998"
+         height="33.164459"
+         x="307.5"
+         y="440.5"
+         ry="10"
+         rx="9.999999" />
+      <rect
+         rx="9.999999"
+         ry="10"
+         y="436.5"
+         x="303.5"
+         height="33.164459"
+         width="209.99998"
+         id="rect1146"
+         style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1" />
+      <rect
+         style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#d9ead3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+         id="rect1148"
+         width="209.99998"
+         height="33.164459"
+         x="299.5"
+         y="432.5"
+         ry="10"
+         rx="9.999999" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="403.95312"
+         y="453.28925"
+         id="text1152"><tspan
+           sodipodi:role="line"
+           id="tspan1150"
+           x="403.95312"
+           y="453.28925">ibex_icache_ecc_agent</tspan></text>
+    </g>
+  </g>
 </svg>

--- a/dv/uvm/icache/dv/env/ibex_icache_env.core
+++ b/dv/uvm/icache/dv/env/ibex_icache_env.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:dv:dv_lib
       - lowrisc:dv:ibex_icache_core_agent
       - lowrisc:dv:ibex_icache_mem_agent
+      - lowrisc:dv:ibex_icache_ecc_agent
     files:
       - ibex_icache_env_pkg.sv
       - ibex_icache_env_cfg.sv: {is_include_file: true}
@@ -26,6 +27,7 @@ filesets:
       - seq_lib/ibex_icache_oldval_vseq.sv: {is_include_file: true}
       - seq_lib/ibex_icache_back_line_vseq.sv: {is_include_file: true}
       - seq_lib/ibex_icache_many_errors_vseq.sv: {is_include_file: true}
+      - seq_lib/ibex_icache_ecc_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/dv/uvm/icache/dv/env/ibex_icache_env.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_env.sv
@@ -13,6 +13,9 @@ class ibex_icache_env extends dv_base_env #(
   ibex_icache_core_agent core_agent;
   ibex_icache_mem_agent  mem_agent;
 
+  ibex_icache_ecc_agent  ecc_tag_agents[];
+  ibex_icache_ecc_agent  ecc_data_agents[];
+
   // Heartbeat tracking
   uvm_callbacks_objection           hb_objection;
   uvm_heartbeat                     heartbeat;
@@ -29,6 +32,23 @@ class ibex_icache_env extends dv_base_env #(
     mem_agent = ibex_icache_mem_agent::type_id::create("mem_agent", this);
     uvm_config_db#(ibex_icache_mem_agent_cfg)::set(this, "mem_agent*", "cfg", cfg.mem_agent_cfg);
 
+    // If ECC is enabled, create ECC agents for the RAMs. We have already created config objects for
+    // them (the test called create_ecc_agent_cfgs in its build_phase method), so we just have to
+    // make an agent for each config. In practice, there will be the same number of tag and data
+    // agents, but this code doesn't really care.
+    ecc_tag_agents  = new[cfg.ecc_tag_agent_cfgs.size()];
+    for (int unsigned i = 0; i < cfg.ecc_tag_agent_cfgs.size(); i++) begin
+      string tname = $sformatf("ecc_tag_agents[%0d]", i);
+      ecc_tag_agents[i] = ibex_icache_ecc_agent::type_id::create(tname, this);
+      uvm_config_db#(ibex_icache_ecc_agent_cfg)::set(this, {tname, "*"}, "cfg", cfg.ecc_tag_agent_cfgs[i]);
+    end
+    ecc_data_agents  = new[cfg.ecc_data_agent_cfgs.size()];
+    for (int unsigned i = 0; i < cfg.ecc_data_agent_cfgs.size(); i++) begin
+      string dname = $sformatf("ecc_data_agents[%0d]", i);
+      ecc_data_agents[i] = ibex_icache_ecc_agent::type_id::create(dname, this);
+      uvm_config_db#(ibex_icache_ecc_agent_cfg)::set(this, {dname, "*"}, "cfg", cfg.ecc_data_agent_cfgs[i]);
+    end
+
     hb_objection = new("hb_objection");
     heartbeat    = new("heartbeat", this, hb_objection);
     hb_event     = new("hb_event");
@@ -43,15 +63,37 @@ class ibex_icache_env extends dv_base_env #(
       mem_agent.monitor.analysis_port.connect(scoreboard.mem_fifo.analysis_export);
       core_agent.driver.analysis_port.connect(scoreboard.seed_fifo.analysis_export);
     end
-    if (cfg.is_active && cfg.mem_agent_cfg.is_active && cfg.core_agent_cfg.is_active) begin
-      core_agent.driver.analysis_port.connect(mem_agent.sequencer.seed_fifo.analysis_export);
-    end
 
-    if (cfg.is_active && cfg.core_agent_cfg.is_active) begin
-      virtual_sequencer.core_sequencer_h = core_agent.sequencer;
-    end
-    if (cfg.is_active && cfg.mem_agent_cfg.is_active) begin
-      virtual_sequencer.mem_sequencer_h = mem_agent.sequencer;
+    // If we are active, wire up each active agent to a sequencer in the virtual sequencer.
+    if (cfg.is_active) begin
+      if (cfg.mem_agent_cfg.is_active && cfg.core_agent_cfg.is_active) begin
+        core_agent.driver.analysis_port.connect(mem_agent.sequencer.seed_fifo.analysis_export);
+      end
+
+      if (cfg.core_agent_cfg.is_active) begin
+        virtual_sequencer.core_sequencer_h = core_agent.sequencer;
+      end
+      if (cfg.mem_agent_cfg.is_active) begin
+        virtual_sequencer.mem_sequencer_h = mem_agent.sequencer;
+      end
+
+      // We assume that either all ECC tag/data agents are active or none of them are.
+      `DV_CHECK_EQ_FATAL(cfg.ecc_tag_agent_cfgs.size(), ecc_tag_agents.size())
+      if ((cfg.ecc_tag_agent_cfgs.size() > 0) && (cfg.ecc_tag_agent_cfgs[0].is_active)) begin
+        virtual_sequencer.ecc_tag_sequencers = new[cfg.ecc_tag_agent_cfgs.size()];
+        foreach (ecc_tag_agents[i]) begin
+          `DV_CHECK_FATAL(cfg.ecc_tag_agent_cfgs[i].is_active);
+          virtual_sequencer.ecc_tag_sequencers[i] = ecc_tag_agents[i].sequencer;
+        end
+      end
+      `DV_CHECK_EQ_FATAL(cfg.ecc_data_agent_cfgs.size(), ecc_data_agents.size())
+      if ((cfg.ecc_data_agent_cfgs.size() > 0) && (cfg.ecc_data_agent_cfgs[0].is_active)) begin
+        virtual_sequencer.ecc_data_sequencers = new[cfg.ecc_data_agent_cfgs.size()];
+        foreach (ecc_data_agents[i]) begin
+          `DV_CHECK_FATAL(cfg.ecc_data_agent_cfgs[i].is_active);
+          virtual_sequencer.ecc_data_sequencers[i] = ecc_data_agents[i].sequencer;
+        end
+      end
     end
 
     // Register the heartbeat objection with both sequencers (so they know how to reset it)

--- a/dv/uvm/icache/dv/env/ibex_icache_env_cfg.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_env_cfg.sv
@@ -4,6 +4,9 @@
 
 class ibex_icache_env_cfg extends dv_base_env_cfg;
 
+  // If set, the scoreboard won't check caching ratios
+  bit disable_caching_ratio_test = 0;
+
   // ext component cfgs
   rand ibex_icache_core_agent_cfg   core_agent_cfg;
   rand ibex_icache_mem_agent_cfg    mem_agent_cfg;
@@ -14,9 +17,17 @@ class ibex_icache_env_cfg extends dv_base_env_cfg;
     clk_freq_mhz == ClkFreq50Mhz;
   }
 
+  // Config objects for ECC components (see create_ecc_agent_cfgs). Since these are created after
+  // initialization, they won't get randomized automatically, so we do that manually at the bottom
+  // of create_ecc_agent_cfgs.
+  ibex_icache_ecc_agent_cfg         ecc_tag_agent_cfgs[];
+  ibex_icache_ecc_agent_cfg         ecc_data_agent_cfgs[];
+
   `uvm_object_utils_begin(ibex_icache_env_cfg)
-    `uvm_field_object(core_agent_cfg, UVM_DEFAULT)
-    `uvm_field_object(mem_agent_cfg,  UVM_DEFAULT)
+    `uvm_field_object      (core_agent_cfg,      UVM_DEFAULT)
+    `uvm_field_object      (mem_agent_cfg,       UVM_DEFAULT)
+    `uvm_field_array_object(ecc_tag_agent_cfgs,  UVM_DEFAULT)
+    `uvm_field_array_object(ecc_data_agent_cfgs, UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
@@ -24,6 +35,22 @@ class ibex_icache_env_cfg extends dv_base_env_cfg;
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     core_agent_cfg = ibex_icache_core_agent_cfg::type_id::create("core_agent_cfg");
     mem_agent_cfg  = ibex_icache_mem_agent_cfg::type_id::create ("mem_agent_cfg");
+  endfunction
+
+  // Create tag and data ECC agents for each way. If ECC is disabled, this should still be called,
+  // but with num_ecc_ways = 0.
+  function automatic void create_ecc_agent_cfgs(int unsigned num_ecc_ways);
+    ecc_tag_agent_cfgs = new[num_ecc_ways];
+    ecc_data_agent_cfgs = new[num_ecc_ways];
+    for (int unsigned i = 0; i < num_ecc_ways; i++) begin
+      string tname = $sformatf("ecc_tag_agent_cfgs[%0d]", i);
+      string dname = $sformatf("ecc_data_agent_cfgs[%0d]", i);
+      ecc_tag_agent_cfgs[i] = ibex_icache_ecc_agent_cfg::type_id::create(tname);
+      ecc_data_agent_cfgs[i] = ibex_icache_ecc_agent_cfg::type_id::create(dname);
+
+      `DV_CHECK_RANDOMIZE_FATAL(ecc_tag_agent_cfgs[i])
+      `DV_CHECK_RANDOMIZE_FATAL(ecc_data_agent_cfgs[i])
+    end
   endfunction
 
 endclass

--- a/dv/uvm/icache/dv/env/ibex_icache_env_pkg.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_env_pkg.sv
@@ -9,6 +9,7 @@ package ibex_icache_env_pkg;
   import dv_utils_pkg::*;
   import ibex_icache_core_agent_pkg::*;
   import ibex_icache_mem_agent_pkg::*;
+  import ibex_icache_ecc_agent_pkg::*;
   import dv_lib_pkg::*;
 
   // macro includes

--- a/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
@@ -607,6 +607,9 @@ class ibex_icache_scoreboard
     bit [31:0]   window_width;
     int unsigned fetch_ratio_pc;
 
+    // Ignore instructions if this check is disabled in the configuration
+    if (cfg.disable_caching_ratio_test) return;
+
     if (err) begin
       window_reset();
       return;

--- a/dv/uvm/icache/dv/env/ibex_icache_virtual_sequencer.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_virtual_sequencer.sv
@@ -9,6 +9,9 @@ class ibex_icache_virtual_sequencer
   ibex_icache_core_sequencer core_sequencer_h;
   ibex_icache_mem_sequencer  mem_sequencer_h;
 
+  ibex_icache_ecc_sequencer  ecc_tag_sequencers[];
+  ibex_icache_ecc_sequencer  ecc_data_sequencers[];
+
   `uvm_component_new
 
 endclass

--- a/dv/uvm/icache/dv/env/seq_lib/ibex_icache_base_vseq.sv
+++ b/dv/uvm/icache/dv/env/seq_lib/ibex_icache_base_vseq.sv
@@ -11,12 +11,19 @@ class ibex_icache_base_vseq
   `uvm_object_utils(ibex_icache_base_vseq)
   `uvm_object_new
 
-  // The two actual sequences. We don't subclass them in subclasses of this virtual sequence, but we
-  // might want to set control knobs. To allow this, we construct the sequences in pre_start.
+  // Should we generate ECC errors in the underlying SRAM objects?
+  bit enable_ecc_errors = 0;
+
+  // The core and memory sequences. We don't subclass them in subclasses of this virtual sequence,
+  // but we might want to set control knobs. To allow this, we construct the sequences in pre_start.
   // Subclasses should override pre_start, call this super to construct the sequence, and then set
   // any control knobs they need.
   ibex_icache_core_base_seq core_seq;
   ibex_icache_mem_resp_seq  mem_seq;
+
+  // ECC sequences. The arrays are created in pre_start and are nonempty if ECC errors are enabled.
+  ibex_icache_ecc_base_seq  ecc_tag_seqs[];
+  ibex_icache_ecc_base_seq  ecc_data_seqs[];
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init();
@@ -26,22 +33,55 @@ class ibex_icache_base_vseq
     super.pre_start();
     `uvm_create_on(core_seq, p_sequencer.core_sequencer_h)
     `uvm_create_on(mem_seq, p_sequencer.mem_sequencer_h)
+
+    // If enable_ecc_errors then create any ECC sequences we need (one for each sequencer in
+    // p_sequencer.ecc_tag_sequencers and p_sequencer.ecc_data_sequencers).
+    ecc_tag_seqs = new[enable_ecc_errors ? p_sequencer.ecc_tag_sequencers.size() : 0];
+    foreach (ecc_tag_seqs[i]) begin
+      `uvm_create_on(ecc_tag_seqs[i], p_sequencer.ecc_tag_sequencers[i])
+    end
+    ecc_data_seqs = new[enable_ecc_errors ? p_sequencer.ecc_data_sequencers.size() : 0];
+    foreach (ecc_data_seqs[i]) begin
+      `uvm_create_on(ecc_data_seqs[i], p_sequencer.ecc_data_sequencers[i])
+    end
   endtask : pre_start
 
   virtual task body();
-    // Start the core and memory sequences. We use fork/join_any so that we don't wait for the
-    // memory sequence (which is reactive so will never finish).
     fork
+      // The core sequence blocks until it has run all its items.
       begin
         `DV_CHECK_RANDOMIZE_FATAL(core_seq)
         core_seq.start(p_sequencer.core_sequencer_h);
       end
-      begin
-        `DV_CHECK_RANDOMIZE_FATAL(mem_seq)
-        mem_seq.start(p_sequencer.mem_sequencer_h);
-      end
+
+      // These sequences will never end. We wrap them all up together in a fork/join so that we can
+      // fork/join_none any ECC sequences (which yield immediately so that we can start them in a
+      // loop), but still have a process that never yields, to use as a child for the surrounding
+      // fork/join_any.
+      fork
+        begin
+          `DV_CHECK_RANDOMIZE_FATAL(mem_seq)
+          mem_seq.start(p_sequencer.mem_sequencer_h);
+        end
+        foreach (ecc_tag_seqs[i]) begin
+          start_ecc_body(ecc_tag_seqs[i], p_sequencer.ecc_tag_sequencers[i]);
+        end
+        foreach (ecc_data_seqs[i]) begin
+          start_ecc_body(ecc_data_seqs[i], p_sequencer.ecc_data_sequencers[i]);
+        end
+      join
     join_any
+
   endtask : body
+
+  // Randomize and then run a given (never ending) ECC sequence on the given sequencer. Returns
+  // immediately (so you can start sequences in a loop).
+  protected task start_ecc_body(ibex_icache_ecc_base_seq seq, ibex_icache_ecc_sequencer sqr);
+    `DV_CHECK_RANDOMIZE_FATAL(seq);
+    fork begin
+      seq.start(sqr);
+    end join_none
+  endtask
 
   virtual task dut_shutdown();
     // check for pending ibex_icache operations and wait for them to complete

--- a/dv/uvm/icache/dv/env/seq_lib/ibex_icache_ecc_vseq.sv
+++ b/dv/uvm/icache/dv/env/seq_lib/ibex_icache_ecc_vseq.sv
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that injects ECC errors and checks we deal with them correctly.
+//
+// This is based on the caching vseq, which means we should see lots of cache hits (some of which
+// will be corrupt).
+
+class ibex_icache_ecc_vseq extends ibex_icache_caching_vseq;
+
+  `uvm_object_utils(ibex_icache_ecc_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    enable_ecc_errors = 1'b1;
+    super.pre_start();
+  endtask : pre_start
+
+endclass : ibex_icache_ecc_vseq

--- a/dv/uvm/icache/dv/env/seq_lib/ibex_icache_vseq_list.sv
+++ b/dv/uvm/icache/dv/env/seq_lib/ibex_icache_vseq_list.sv
@@ -10,3 +10,4 @@
 `include "ibex_icache_oldval_vseq.sv"
 `include "ibex_icache_back_line_vseq.sv"
 `include "ibex_icache_many_errors_vseq.sv"
+`include "ibex_icache_ecc_vseq.sv"

--- a/dv/uvm/icache/dv/ibex_icache_ecc_agent/README.md
+++ b/dv/uvm/icache/dv/ibex_icache_ecc_agent/README.md
@@ -1,0 +1,3 @@
+# ICache ECC Agent
+
+This very simple agent can be used to inject single-bit and double-bit errors on the interface of a `prim_ram_1p`, used for checking ECC error detection.

--- a/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_agent.core
+++ b/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_agent.core
@@ -1,0 +1,28 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:ibex_icache_ecc_agent:0.1"
+description: "IBEX_ICACHE DV UVM agent"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_utils
+      - lowrisc:dv:dv_lib
+    files:
+      - ibex_icache_ecc_if.sv
+      - ibex_icache_ecc_agent_pkg.sv
+      - ibex_icache_ecc_item.sv: {is_include_file: true}
+      - ibex_icache_ecc_bus_item.sv: {is_include_file: true}
+      - ibex_icache_ecc_agent_cfg.sv: {is_include_file: true}
+      - ibex_icache_ecc_driver.sv: {is_include_file: true}
+      - ibex_icache_ecc_monitor.sv: {is_include_file: true}
+      - ibex_icache_ecc_agent.sv: {is_include_file: true}
+      - seq_lib/ibex_icache_ecc_base_seq.sv: {is_include_file: true}
+      - seq_lib/ibex_icache_ecc_seq_list.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_agent.sv
+++ b/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_agent.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class ibex_icache_ecc_agent extends dv_base_agent #(
+  .CFG_T          (ibex_icache_ecc_agent_cfg),
+  .DRIVER_T       (ibex_icache_ecc_driver),
+  .SEQUENCER_T    (ibex_icache_ecc_sequencer),
+  .MONITOR_T      (ibex_icache_ecc_monitor)
+);
+
+  `uvm_component_utils(ibex_icache_ecc_agent)
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // get ibex_icache_ecc_if handle
+    if (!uvm_config_db#(virtual ibex_icache_ecc_if)::get(this, "", "vif", cfg.vif)) begin
+      `uvm_fatal(`gfn, "failed to get ibex_icache_ecc_if handle from uvm_config_db")
+    end
+  endfunction
+
+endclass

--- a/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_agent_cfg.sv
+++ b/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_agent_cfg.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class ibex_icache_ecc_agent_cfg extends dv_base_agent_cfg;
+
+  // Knobs
+  bit          error_prob_pc = 10;
+
+  // interface handle used by driver, monitor & the sequencer, via cfg handle
+  virtual ibex_icache_ecc_if vif;
+
+  `uvm_object_utils_begin(ibex_icache_ecc_agent_cfg)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+endclass

--- a/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_agent_pkg.sv
+++ b/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_agent_pkg.sv
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package ibex_icache_ecc_agent_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import dv_lib_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  typedef class ibex_icache_ecc_item;
+  typedef class ibex_icache_ecc_agent_cfg;
+
+  typedef dv_base_sequencer #(.ITEM_T(ibex_icache_ecc_item),
+                              .CFG_T (ibex_icache_ecc_agent_cfg)) ibex_icache_ecc_sequencer;
+
+  // package sources
+  `include "ibex_icache_ecc_item.sv"
+  `include "ibex_icache_ecc_bus_item.sv"
+  `include "ibex_icache_ecc_agent_cfg.sv"
+  `include "ibex_icache_ecc_driver.sv"
+  `include "ibex_icache_ecc_monitor.sv"
+  `include "ibex_icache_ecc_agent.sv"
+  `include "ibex_icache_ecc_seq_list.sv"
+
+endpackage: ibex_icache_ecc_agent_pkg

--- a/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_bus_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_bus_item.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// An item that represents a transaction seen on the interface.
+//
+// Since the interface is a bit weird here (bound in with forced data), we just report the address
+// and data of each read transaction together with its XOR mask.
+
+class ibex_icache_ecc_bus_item extends uvm_sequence_item;
+
+  logic [31:0]  addr;
+  logic [127:0] bad_bit_mask;
+  logic [127:0] sram_rdata;
+
+  `uvm_object_utils_begin(ibex_icache_ecc_bus_item)
+    `uvm_field_int (bad_bit_mask, UVM_DEFAULT | UVM_HEX)
+    `uvm_field_int (sram_rdata,   UVM_DEFAULT | UVM_HEX)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+endclass

--- a/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_driver.sv
+++ b/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_driver.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class ibex_icache_ecc_driver
+  extends dv_base_driver #(.ITEM_T (ibex_icache_ecc_item),
+                           .CFG_T  (ibex_icache_ecc_agent_cfg));
+
+  `uvm_component_utils(ibex_icache_ecc_driver)
+  `uvm_component_new
+
+  virtual task reset_signals();
+    cfg.vif.reset();
+  endtask
+
+  virtual task get_and_drive();
+    forever begin
+      seq_item_port.get_next_item(req);
+      `uvm_info(`gfn, $sformatf("rcvd item:\n%0s", req.sprint()), UVM_LOW)
+
+      cfg.vif.wait_reads(req.delay);
+      if (req.two_bits) begin
+        cfg.vif.corrupt_read_1(req.bit_pos0);
+      end else begin
+        cfg.vif.corrupt_read_2(req.bit_pos0, req.bit_pos1);
+      end
+
+      seq_item_port.item_done();
+    end
+  endtask
+
+endclass

--- a/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_if.sv
+++ b/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_if.sv
@@ -1,0 +1,90 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// An interface that gets bound into a badbit_ram_1p with .*
+
+interface ibex_icache_ecc_if
+  (input logic          clk_i,
+   input logic          req_i,
+   input logic          write_i,
+   input logic [31:0]   width,
+   input logic [31:0]   addr,
+   input logic [127:0]  rdata,
+   output logic [127:0] bad_bit_mask);
+
+  // The address for the last monitored req transaction
+  logic [31:0]  last_addr = 'x;
+
+  bit rst_n = 1'b1;
+
+  // Start a process that will drive the rst_n line low until the next clock, but return
+  // immediately. If rst_n is already low, does nothing.
+  task automatic reset();
+    if (!rst_n) return;
+    rst_n = 1'b0;
+    fork
+      begin
+        @(posedge clk_i);
+        rst_n = 1'b1;
+      end
+    join_none
+  endtask
+
+  // Wait until a cycle with req_i & ~write_i (signalling the start of a read).
+  //
+  // Returns early on reset.
+  task automatic wait_for_read_start();
+    while (rst_n && !(req_i & ~write_i)) @(posedge clk_i);
+  endtask
+
+  // Wait for num_reads complete reads. Ends on the clock posedge where the last read's data is
+  // returned.
+  //
+  // Returns early on reset.
+  task automatic wait_reads(int unsigned num_reads);
+    repeat (num_reads) begin
+      wait_for_read_start();
+      if (!rst_n) break;
+      @(posedge clk_i);
+    end
+  endtask
+
+  // Set a bit to be toggled on the next read
+  task static corrupt_read_1(int unsigned pos);
+    wait_for_read_start();
+    if (!rst_n) return;
+
+    bad_bit_mask = 128'b1 << (pos % width);
+    @(posedge clk_i);
+    bad_bit_mask = 0;
+  endtask
+
+  // Set two bits to be toggled on the next read
+  task static corrupt_read_2(int unsigned pos0, int unsigned pos1);
+    wait_for_read_start();
+    if (!rst_n) return;
+
+    bad_bit_mask = (128'b1 << (pos0 % width)) | (128'b1 << (pos1 % width));
+    @(posedge clk_i);
+    bad_bit_mask = 0;
+  endtask
+
+  // Wait for a read, setting last_addr accordingly.
+  //
+  // This can be called re-entrantly, despite writing last_addr (it will just write the same value
+  // more than once).
+  //
+  // Returns early on reset.
+  task automatic wait_read();
+    wait_for_read_start();
+    if (!rst_n) return;
+    last_addr = addr;
+    @(posedge clk_i);
+  endtask
+
+  initial begin
+    bad_bit_mask = 0;
+  end
+
+endinterface

--- a/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_item.sv
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence item that represents a bit twiddle.
+//
+// The item will wait <delay> other reads before taking effect. When it does take effect, it toggles
+// 1 or 2 bits in the read value. If <two_bits> is true, the bits at positions <bit_pos0> and
+// <bit_pos1> will be toggled. Otherwise, just the bit at <bit_pos0> will be.
+//
+// <bit_pos0> and <bit_pos1> are interpreted modulo the interface width in the driver, so don't need
+// constraining.
+
+class ibex_icache_ecc_item extends uvm_sequence_item;
+
+  rand bit          two_bits;
+  rand int unsigned bit_pos0;
+  rand int unsigned bit_pos1;
+  rand int unsigned delay;
+
+  `uvm_object_utils_begin(ibex_icache_ecc_item)
+    `uvm_field_int (two_bits, UVM_DEFAULT)
+    `uvm_field_int (bit_pos0, UVM_DEFAULT)
+    `uvm_field_int (bit_pos1, UVM_DEFAULT)
+    `uvm_field_int (delay,    UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+endclass

--- a/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_monitor.sv
+++ b/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_monitor.sv
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class ibex_icache_ecc_monitor extends dv_base_monitor #(
+    .ITEM_T (ibex_icache_ecc_bus_item),
+    .CFG_T  (ibex_icache_ecc_agent_cfg)
+  );
+  `uvm_component_utils(ibex_icache_ecc_monitor)
+
+  // the base class provides the following handles for use:
+  // ibex_icache_ecc_agent_cfg: cfg
+  // ibex_icache_ecc_agent_cov: cov
+  // uvm_analysis_port #(ibex_icache_ecc_bus_item): analysis_port
+
+  `uvm_component_new
+
+  // collect transactions forever - already forked in dv_base_moditor::run_phase
+  virtual protected task collect_trans(uvm_phase phase);
+    ibex_icache_ecc_bus_item trans;
+    forever begin
+      cfg.vif.wait_read();
+      // If this isn't a reset pulse, we have a read transaction. Report it.
+      if (!cfg.vif.rst_n) begin
+        trans = ibex_icache_ecc_bus_item::type_id::create("trans");
+        trans.addr         = cfg.vif.last_addr;
+        trans.bad_bit_mask = cfg.vif.bad_bit_mask;
+        trans.sram_rdata   = cfg.vif.rdata;
+        analysis_port.write(trans);
+      end
+      @(posedge cfg.vif.clk_i);
+    end
+  endtask
+
+endclass

--- a/dv/uvm/icache/dv/ibex_icache_ecc_agent/seq_lib/ibex_icache_ecc_base_seq.sv
+++ b/dv/uvm/icache/dv/ibex_icache_ecc_agent/seq_lib/ibex_icache_ecc_base_seq.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class ibex_icache_ecc_base_seq
+  extends dv_base_seq #(.REQ         (ibex_icache_ecc_item),
+                        .CFG_T       (ibex_icache_ecc_agent_cfg),
+                        .SEQUENCER_T (ibex_icache_ecc_sequencer));
+  `uvm_object_utils(ibex_icache_ecc_base_seq)
+
+  `uvm_object_new
+
+  virtual task body();
+    forever begin
+      req = ibex_icache_ecc_item::type_id::create("req");
+      start_item(req);
+      `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+                                     req.delay dist {0       :/ 1,
+                                                     [1:20]  :/ 1,
+                                                     [21:50] :/ 1};)
+      finish_item(req);
+    end
+  endtask
+
+endclass

--- a/dv/uvm/icache/dv/ibex_icache_ecc_agent/seq_lib/ibex_icache_ecc_seq_list.sv
+++ b/dv/uvm/icache/dv/ibex_icache_ecc_agent/seq_lib/ibex_icache_ecc_seq_list.sv
@@ -1,0 +1,5 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "ibex_icache_ecc_base_seq.sv"

--- a/dv/uvm/icache/dv/ibex_icache_sim.core
+++ b/dv/uvm/icache/dv/ibex_icache_sim.core
@@ -20,6 +20,7 @@ targets:
   sim:
     parameters:
       - ICacheECC
+      - PRIM_DEFAULT_IMPL=prim_pkg::ImplBadbit
     filesets:
       - files_rtl
       - files_dv
@@ -32,3 +33,9 @@ parameters:
     default: 0
     paramtype: vlogparam
     description: "Enable ECC protection in instruction cache"
+
+  PRIM_DEFAULT_IMPL:
+    datatype: str
+    paramtype: vlogdefine
+    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
+    default: prim_pkg::ImplBadbit

--- a/dv/uvm/icache/dv/ibex_icache_sim.core
+++ b/dv/uvm/icache/dv/ibex_icache_sim.core
@@ -18,8 +18,17 @@ filesets:
 
 targets:
   sim:
+    parameters:
+      - ICacheECC
     filesets:
       - files_rtl
       - files_dv
     toplevel: tb
     default_tool: vcs
+
+parameters:
+  ICacheECC:
+    datatype: int
+    default: 0
+    paramtype: vlogparam
+    description: "Enable ECC protection in instruction cache"

--- a/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
+++ b/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
@@ -81,6 +81,12 @@
       uvm_test_seq: ibex_icache_many_errors_vseq
       uvm_test: ibex_icache_many_errors_test
     }
+
+    {
+      name: ibex_icache_ecc
+      uvm_test_seq: ibex_icache_ecc_vseq
+      uvm_test: ibex_icache_ecc_test
+    }
   ]
 
   // List of regressions.
@@ -92,8 +98,8 @@
               "ibex_icache_caching",
               "ibex_icache_invalidation",
               "ibex_icache_back_line",
-              "ibex_icache_many_errors"]
+              "ibex_icache_many_errors",
+              "ibex_icache_ecc"]
     }
   ]
 }
-

--- a/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
+++ b/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
@@ -20,10 +20,15 @@
   // Testplan hjson file.
   testplan: "{proj_root}/dv/uvm/icache/data/ibex_icache_testplan.hjson"
 
-
   // Import additional common sim cfg files.
-  import_cfgs: [// Project wide common sim cfg file
-                "{proj_root}/dv/uvm/data/common_sim_cfg.hjson"]
+  import_cfgs: [
+      // Project wide common sim cfg file
+      "{proj_root}/dv/uvm/data/common_sim_cfg.hjson",
+
+      // Configuration options that should apply after the settings in
+      // common_sim_cfg.
+      "{proj_root}/dv/uvm/icache/dv/late_cfg.hjson"
+  ]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/dv/uvm/icache/dv/late_cfg.hjson
+++ b/dv/uvm/icache/dv/late_cfg.hjson
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Set any fusesoc parameters by appending to sv_flist_gen_opts
+  //
+  // We want to enable ICache ECC (needed for the ECC test below)
+  sv_flist_gen_opts: ["--ICacheECC=1"]
+}

--- a/dv/uvm/icache/dv/prim_badbit/README.md
+++ b/dv/uvm/icache/dv/prim_badbit/README.md
@@ -1,0 +1,11 @@
+Badbit RAM
+==========
+
+This is an SRAM wrapper that allows a testbench to force bit errors onthe read interface.
+
+This works as a dummy technology library.
+Instantiate it by adding setting `PRIM_DEFAULT_IMPL` to prim_pkg::ImplBadbit (see the README.md in the prim directory for details).
+To use it, bind a module or interface into an instance of `prim_badbit_ram_1p` and force the value of `bad_bit_mask`, which is XOR'd with rdata.
+
+To make this easier to use, we don't vary the width of `bad_bit_mask` with the `Width` parameter: it's a constant 128.
+This means that the bound interface doesn't need to be parameterised.

--- a/dv/uvm/icache/dv/prim_badbit/prim_badbit_ram_1p.core
+++ b/dv/uvm/icache/dv/prim_badbit/prim_badbit_ram_1p.core
@@ -1,0 +1,20 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_badbit:ram_1p"
+description: "Single-port RAM which allows a bound interface to inject errors"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim_generic:ram_1p
+      - lowrisc:prim:assert
+    files:
+      - prim_badbit_ram_1p.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/dv/uvm/icache/dv/prim_badbit/prim_badbit_ram_1p.sv
+++ b/dv/uvm/icache/dv/prim_badbit/prim_badbit_ram_1p.sv
@@ -1,0 +1,81 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Single-port SRAM model which allows a test to corrupt read responses from the underlying memory.
+//
+// To use this, instantiate it then bind in a module or interface that has bad_bit_mask as an
+// output. A nonzero bit in bad_bit_mask will cause the corresponding bit to be flipped in the
+// response.
+
+`include "prim_assert.sv"
+
+module prim_badbit_ram_1p #(
+  parameter  int Width           = 32,   // bit
+  parameter  int Depth           = 128,
+  parameter  int DataBitsPerMask = 1,    // Number of data bits per bit of write mask
+  parameter      MemInitFile     = "",   // VMEM file to initialize the memory with
+
+  localparam int Aw              = $clog2(Depth)  // derived parameter
+) (
+  input  logic             clk_i,
+
+  input  logic             req_i,
+  input  logic             write_i,
+  input  logic [Aw-1:0]    addr_i,
+  input  logic [Width-1:0] wdata_i,
+  input  logic [Width-1:0] wmask_i,
+  output logic [Width-1:0] rdata_o // Read data. Data is returned one cycle after req_i is high.
+);
+
+  logic [Width-1:0] sram_rdata;
+
+  prim_generic_ram_1p #(
+    .Width           (Width),
+    .Depth           (Depth),
+    .DataBitsPerMask (DataBitsPerMask),
+    .MemInitFile     (MemInitFile)
+  ) u_mem (
+    .clk_i   (clk_i),
+
+    .req_i   (req_i),
+    .write_i (write_i),
+    .addr_i  (addr_i),
+    .wdata_i (wdata_i),
+    .wmask_i (wmask_i),
+    .rdata_o (sram_rdata)
+  );
+
+  // This module doesn't work with Verilator (because of the wired-or). Because we define the
+  // "badbit" ram as a technology library, it gets picked up and parsed by any tool using the Ibex
+  // repo. Rather than telling Verilator to ignore the whole lot (which causes NOTFOUNDMODULE
+  // warnings), we just hide the actual guts.
+`ifdef VERILATOR
+  assign rdata_o = sram_rdata;
+`else
+  // Making bad_bit_mask a constant size makes this easier to use (because you don't need to faff
+  // around with parameterised interfaces in your UVM database). Check that rdata_o is actually
+  // controllable. Similarly, we make the address a constant width: make sure that's large enough.
+  `ASSERT_INIT(WidthSmallEnough, Width <= 128)
+  `ASSERT_INIT(AddrSmallEnough, Aw <= 32)
+
+  // Make the Width parameter easily accessible to bound-in modules.
+  logic [31:0] width;
+  assign width = Width;
+
+  // Similarly, extend addr and sram_rdata (the un-fiddled value)
+  logic [31:0]  addr;
+  logic [127:0] rdata;
+  assign addr  = {{32-Aw{1'b0}}, addr_i};
+  assign rdata = {{128-Width{1'b0}}, sram_rdata};
+
+  // To inject errors, bind in an interface with bad_bit_mask as an output and assign one of the
+  // bits in bad_bit_mask[Width-1:0] to one. The wired-OR together with an assignment to zero means
+  // this acts like a weak pull-down.
+  wor [127:0] bad_bit_mask;
+  assign bad_bit_mask = 128'b0;
+
+  assign rdata_o = sram_rdata ^ bad_bit_mask;
+`endif // VERILATOR
+
+endmodule

--- a/dv/uvm/icache/dv/tb/tb.sv
+++ b/dv/uvm/icache/dv/tb/tb.sv
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-module tb #(
-  parameter bit ICacheECC = 1'b0
-);
+module tb #(parameter bit ICacheECC = 1'b0);
   // dep packages
   import uvm_pkg::*;
   import dv_utils_pkg::*;
@@ -55,12 +53,45 @@ module tb #(
     .instr_rvalid_i  (mem_if.rvalid)
   );
 
+  // If the ICacheECC parameter is set in the DUT, generate another interface for each tag ram and
+  // each data ram, binding them into the RAMs themselves. ECC tests can use these to insert errors
+  // into memory lookups.
+  generate if (dut.ICacheECC) begin : gen_ecc
+    for (genvar w = 0; w < dut.NumWays; w++) begin : gen_ecc_ifs
+      bind dut.gen_rams[w].tag_bank.gen_badbit.u_impl_badbit  ibex_icache_ecc_if tag_bank_if (.*);
+      bind dut.gen_rams[w].data_bank.gen_badbit.u_impl_badbit ibex_icache_ecc_if data_bank_if (.*);
+
+      initial begin
+        uvm_config_db#(virtual ibex_icache_ecc_if)::
+          set(null,
+              $sformatf("*.env.ecc_tag_agents[%0d]*", w),
+              "vif",
+              dut.gen_rams[w].tag_bank.gen_badbit.u_impl_badbit.tag_bank_if);
+
+        uvm_config_db#(virtual ibex_icache_ecc_if)::
+          set(null,
+              $sformatf("*.env.ecc_data_agents[%0d]*", w),
+              "vif",
+              dut.gen_rams[w].data_bank.gen_badbit.u_impl_badbit.data_bank_if);
+      end
+    end
+  end
+  endgenerate
+
   initial begin
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
+
+    // Store virtual interfaces into the UVM config database. ECC interfaces are done separately
+    // above because otherwise you have to repeat the (verbose) generate loop.
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual ibex_icache_core_if)::set(null, "*.env.core_agent*", "vif", core_if);
     uvm_config_db#(virtual ibex_icache_mem_if)::set(null, "*.env.mem_agent*", "vif", mem_if);
+
+    // Record the number of (ECC) ways in the config database. The top-level environment's config
+    // will use this to decide how many agents to create.
+    uvm_config_db#(int unsigned)::set(null, "*", "num_ecc_ways", dut.ICacheECC ? dut.NumWays : 0);
+
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end

--- a/dv/uvm/icache/dv/tb/tb.sv
+++ b/dv/uvm/icache/dv/tb/tb.sv
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-module tb;
+module tb #(
+  parameter bit ICacheECC = 1'b0
+);
   // dep packages
   import uvm_pkg::*;
   import dv_utils_pkg::*;
@@ -22,7 +24,9 @@ module tb;
   ibex_icache_mem_if  mem_if  (.clk(clk), .rst_n(rst_n));
 
   // dut
-  ibex_icache dut (
+  ibex_icache #(
+    .ICacheECC (ICacheECC)
+  ) dut (
     .clk_i           (clk),
     .rst_ni          (rst_n),
 

--- a/dv/uvm/icache/dv/tests/ibex_icache_base_test.sv
+++ b/dv/uvm/icache/dv/tests/ibex_icache_base_test.sv
@@ -15,8 +15,19 @@ class ibex_icache_base_test extends dv_base_test #(
   // ibex_icache_env:     env
 
   virtual function void build_phase(uvm_phase phase);
+    int unsigned num_ecc_ways;
+    if (!uvm_config_db#(int unsigned)::get(this, "", "num_ecc_ways", num_ecc_ways)) begin
+      `uvm_fatal(`gfn, "failed to get num_ecc_ways from uvm_config_db")
+    end
+
     super.build_phase(phase);
+
     cfg.has_ral = 1'b0;
+
+    // Create config objects for each of the ECC agents. We can't do that in the config object
+    // itself (because that's not a component, so doesn't have access to the uvm_config_db).
+    cfg.create_ecc_agent_cfgs(num_ecc_ways);
+
   endfunction
 
   // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in

--- a/dv/uvm/icache/dv/tests/ibex_icache_ecc_test.sv
+++ b/dv/uvm/icache/dv/tests/ibex_icache_ecc_test.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class ibex_icache_ecc_test extends ibex_icache_base_test;
+
+  `uvm_component_utils(ibex_icache_ecc_test)
+  `uvm_component_new
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+
+    // Tell the scoreboard not to track cache hit ratios. This test corrupts data in the ICache's
+    // memory. The corruptions are spotted, and behave as if the cache missed. This (obviously)
+    // lowers the cache hit rate, so we don't want the test to make sure it's high enough.
+    cfg.disable_caching_ratio_test = 1'b1;
+  endfunction
+
+endclass : ibex_icache_ecc_test

--- a/dv/uvm/icache/dv/tests/ibex_icache_test.core
+++ b/dv/uvm/icache/dv/tests/ibex_icache_test.core
@@ -13,6 +13,7 @@ filesets:
       - ibex_icache_base_test.sv: {is_include_file: true}
       - ibex_icache_oldval_test.sv: {is_include_file: true}
       - ibex_icache_many_errors_test.sv: {is_include_file: true}
+      - ibex_icache_ecc_test.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/dv/uvm/icache/dv/tests/ibex_icache_test_pkg.sv
+++ b/dv/uvm/icache/dv/tests/ibex_icache_test_pkg.sv
@@ -20,5 +20,6 @@ package ibex_icache_test_pkg;
   `include "ibex_icache_base_test.sv"
   `include "ibex_icache_oldval_test.sv"
   `include "ibex_icache_many_errors_test.sv"
+  `include "ibex_icache_ecc_test.sv"
 
 endpackage


### PR DESCRIPTION
There are three commits in this PR. The first just turns ECC on. This is a little tricky to do in `dvsim.py`, not sure whether there's a neater approach.

The other commits add ECC testing by allowing the SRAMs inside the icache to sometimes respond with single-bit errors. Commit 2 does the "design-side" work: it defines a RAM wrapper that can be asked to stomp on bits and instantiates it between the icache and the underlying RAMs. Commit 3 does the "UVM-side" work. We make an agent for each RAM, binding its interface into the design to allow it to change the internal signals. These agents' sequencers only get given sequences if ECC errors are enabled, which we currently just do in a new 'ibex_icache_ecc' test.