### PR TITLE
Initial addition of riscv-trace-spec signals to ibex_core

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,6 +24,7 @@ Ibex User Manual
    tracer
    rvfi
    verification
+   riscv_trace
    examples
    concierge
 

--- a/doc/riscv_trace.rst
+++ b/doc/riscv_trace.rst
@@ -13,30 +13,30 @@ Signals implemented until now are shown in the table below:
 Trace Signals
 -------------
 
-+--------------------+---------------------+-------------------------------------------------------------+
-|   Signal Name      |          Bits       |                         Description                         |
-+====================+=====================+=============================================================+
-| rv_trace_itype     |           3         | 0: Final instruction in block is none of other itype codes; |
-|                    |                     | 1: Exception. An exception that traps occurred              |
-|                    |                     | following the final retired instruction in the block;       |
-|                    |                     | 2: Interrupt. An interrupt that traps occurred              |
-|                    |                     | following the final retired instruction in the block;       |
-|                    |                     | 3: Exception or interrupt return;  (not yet implemented)    |
-|                    |                     | 4: Nontaken branch;                                         |
-|                    |                     | 5: Taken branch;                                            |
-|                    |                     | 6: Uninferable jump                (not yet implemented)    |
-+--------------------+---------------------+-------------------------------------------------------------+
-| rv_trace_iaddr     |          32         | Contains the value of the address all the time.             |
-+--------------------+---------------------+-------------------------------------------------------------+
-| rv_trace_cause     |          7          | ucause/mcause CSR                                           |
-+--------------------+---------------------+-------------------------------------------------------------+
-| rv_trace_tval      |          32         | Associated trap value, e.g. address of                      |
-|                    |                     | exceptions, as written to the utval/mtval CSR               |
-+--------------------+---------------------+-------------------------------------------------------------+
-| rv_trace_priv      |          2          | Privilege level for all instructions retired on this cycle. |
-+--------------------+---------------------+-------------------------------------------------------------+
-| rv_trace_iretire   |          1          | The trace signals are valid (1), or not (0).                |                         
-+--------------------+---------------------+-------------------------------------------------------------+
++--------------------+----------+-------------------------------------------------------------+
+|   Signal Name      |   Bits   |                         Description                         |
++====================+==========+=============================================================+
+| rv_trace_itype     |    3     | 0: Final instruction in block is none of other itype codes; |
+|                    |          | 1: Exception. An exception that traps occurred              |
+|                    |          | following the final retired instruction in the block;       |
+|                    |          | 2: Interrupt. An interrupt that traps occurred              |
+|                    |          | following the final retired instruction in the block;       |
+|                    |          | 3: Exception or interrupt return;  (not yet implemented)    |
+|                    |          | 4: Nontaken branch;                                         |
+|                    |          | 5: Taken branch;                                            |
+|                    |          | 6: Uninferable jump                (not yet implemented)    |
++--------------------+----------+-------------------------------------------------------------+
+| rv_trace_iaddr     |   32     | Contains the value of the address all the time.             |
++--------------------+----------+-------------------------------------------------------------+
+| rv_trace_cause     |    7     | ucause/mcause CSR                                           |
++--------------------+----------+-------------------------------------------------------------+
+| rv_trace_tval      |   32     | Associated trap value, e.g. address of                      |
+|                    |          | exceptions, as written to the utval/mtval CSR               |
++--------------------+----------+-------------------------------------------------------------+
+| rv_trace_priv      |    2     | Privilege level for all instructions retired on this cycle. |
++--------------------+----------+-------------------------------------------------------------+
+| rv_trace_iretire   |    1     | The trace signals are valid (1), or not (0).                |                         
++--------------------+----------+-------------------------------------------------------------+
 
 Parameters
 ----------

--- a/doc/riscv_trace.rst
+++ b/doc/riscv_trace.rst
@@ -26,12 +26,12 @@ Trace Signals
 |                    |          | 5: Taken branch;                                            |
 |                    |          | 6: Uninferable jump                (not yet implemented)    |
 +--------------------+----------+-------------------------------------------------------------+
-| rv_trace_iaddr     |   32     | Contains the value of the address all the time.             |
+| rv_trace_iaddr     |   32     | Address of the retired instruction                          |
 +--------------------+----------+-------------------------------------------------------------+
-| rv_trace_cause     |    7     | ucause/mcause CSR                                           |
+| rv_trace_cause     |    6     | Interrupt or exception cause                                |
 +--------------------+----------+-------------------------------------------------------------+
 | rv_trace_tval      |   32     | Associated trap value, e.g. address of                      |
-|                    |          | exceptions, as written to the utval/mtval CSR               |
+|                    |          | exceptions, as written to the mtval CSR                     |
 +--------------------+----------+-------------------------------------------------------------+
 | rv_trace_priv      |    2     | Privilege level for all instructions retired on this cycle. |
 +--------------------+----------+-------------------------------------------------------------+

--- a/doc/riscv_trace.rst
+++ b/doc/riscv_trace.rst
@@ -21,7 +21,7 @@ Trace Signals
 |                    |          | following the final retired instruction in the block;       |
 |                    |          | 2: Interrupt. An interrupt that traps occurred              |
 |                    |          | following the final retired instruction in the block;       |
-|                    |          | 3: Exception or interrupt return;  (not yet implemented)    |
+|                    |          | 3: Exception or interrupt return;                           |
 |                    |          | 4: Nontaken branch;                                         |
 |                    |          | 5: Taken branch;                                            |
 |                    |          | 6: Uninferable jump                (not yet implemented)    |

--- a/doc/riscv_trace.rst
+++ b/doc/riscv_trace.rst
@@ -1,0 +1,54 @@
+.. _riscv_trace:                                                                                         
+
+
+RISC-V Trace Interface
+======================
+
+Ibex implements an instruction trace interface compatible with the `RISC-V Trace Specification, version 1.0, as released on March 20, 2020 <https://github.com/riscv/riscv-trace-spec/>`_. 
+This interface exports needed internal signals as ibex_core outputs to be used to encode the trace packets to be logged.
+
+Signals implemented until now are shown in the table below:
+
+
+Trace Signals
+-------------
+
++--------------------+---------------------+-------------------------------------------------------------+
+|   Signal Name      |          Bits       |                         Description                         |
++====================+=====================+=============================================================+
+| rv_trace_itype     |           3         | 0: Final instruction in block is none of other itype codes; |
+|                    |                     | 1: Exception. An exception that traps occurred              |
+|                    |                     | following the final retired instruction in the block;       |
+|                    |                     | 2: Interrupt. An interrupt that traps occurred              |
+|                    |                     | following the final retired instruction in the block;       |
+|                    |                     | 3: Exception or interrupt return;  (not yet implemented)    |
+|                    |                     | 4: Nontaken branch;                                         |
+|                    |                     | 5: Taken branch;                                            |
+|                    |                     | 6: Uninferable jump                (not yet implemented)    |
++--------------------+---------------------+-------------------------------------------------------------+
+| rv_trace_iaddr     |          32         | Contains the value of the address all the time.             |
++--------------------+---------------------+-------------------------------------------------------------+
+| rv_trace_cause     |          7          | ucause/mcause CSR                                           |
++--------------------+---------------------+-------------------------------------------------------------+
+| rv_trace_tval      |          32         | Associated trap value, e.g. address of                      |
+|                    |                     | exceptions, as written to the utval/mtval CSR               |
++--------------------+---------------------+-------------------------------------------------------------+
+| rv_trace_priv      |          2          | Privilege level for all instructions retired on this cycle. |
++--------------------+---------------------+-------------------------------------------------------------+
+| rv_trace_iretire   |          1          | The trace signals are valid (1), or not (0).                |                         
++--------------------+---------------------+-------------------------------------------------------------+
+
+Parameters
+----------
+
+Referring to Table 7.1 in the RISC-V Trace Specification v1.0, here are the parameters specified in the the implemented interface:
+
++----------------+-------+
+| Parameter      | Value |
++----------------+-------+ 
+| itype_width_p  |   3   |
++----------------+-------+
+| ecause_width_p |   6   |
++----------------+-------+
+| ecause_choice_p|   1   |
++----------------+-------+

--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -26,6 +26,7 @@ parameters:
   RV_TRACE:
     datatype: bool
     paramtype: vlogdefine
+    description: "RISC-V trace interface implementation"
 
   RV32M:
     datatype: int

--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -23,6 +23,10 @@ filesets:
 
 
 parameters:
+  RV_TRACE:
+    datatype: bool
+    paramtype: vlogdefine
+
   RV32M:
     datatype: int
     paramtype: vlogparam
@@ -103,6 +107,7 @@ targets:
       - PMPGranularity
       - PMPNumRegions
       - SRAM_INIT_FILE
+      - RV_TRACE
     tools:
       vcs:
         vcs_options:

--- a/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/examples/simple_system/rtl/ibex_simple_system.sv
@@ -192,6 +192,15 @@ module ibex_simple_system (
 
       .debug_req_i           ('b0),
 
+`ifdef RV_TRACE
+      .rv_trace_itype        (),
+      .rv_trace_iaddr        (),
+      .rv_trace_cause        (),
+      .rv_trace_tval         (),
+      .rv_trace_priv         (),
+      .rv_trace_iretire      (),
+`endif
+
       .fetch_enable_i        ('b1),
       .core_sleep_o          ()
     );

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -57,6 +57,10 @@ parameters:
     datatype: bool
     paramtype: vlogdefine
 
+  RV_TRACE:
+    datatype: bool
+    paramtype: vlogdefine
+
   SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
@@ -145,6 +149,7 @@ targets:
       - files_check_tool_requirements
     parameters:
       - SYNTHESIS=true
+      - RV_TRACE=true
       - RVFI=true
     default_tool: verilator
     toplevel: ibex_core
@@ -165,6 +170,7 @@ targets:
       - files_rtl
     parameters:
       - SYNTHESIS=true
+      - RV_TRACE=true
       - RVFI=true
     default_tool: veribleformat
     toplevel: ibex_core

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -60,6 +60,7 @@ parameters:
   RV_TRACE:
     datatype: bool
     paramtype: vlogdefine
+    description: "RISC-V trace interface implementation"
 
   SYNTHESIS:
     datatype: bool

--- a/ibex_core_tracing.core
+++ b/ibex_core_tracing.core
@@ -31,6 +31,7 @@ parameters:
   RV_TRACE:
     datatype: bool
     paramtype: vlogdefine
+    description: "RISC-V trace interface implementation"
 
   SYNTHESIS:
     datatype: bool

--- a/ibex_core_tracing.core
+++ b/ibex_core_tracing.core
@@ -28,6 +28,10 @@ parameters:
     paramtype: vlogdefine
     default: true
 
+  RV_TRACE:
+    datatype: bool
+    paramtype: vlogdefine
+
   SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
@@ -119,6 +123,7 @@ targets:
       - files_lint
     parameters:
       - RVFI=true
+      - RV_TRACE=true
       - SYNTHESIS=true
       - RV32M
       - RV32E
@@ -149,6 +154,7 @@ targets:
       - files_rtl
     parameters:
       - SYNTHESIS=true
+      - RV_TRACE=true
       - RVFI=true
     default_tool: veribleformat
     toplevel: ibex_core

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -1322,12 +1322,12 @@ module ibex_core #(
 
   localparam RV_TRACE_STAGES = WritebackStage ? 2 : 1;
 
-  logic [31:0] rv_trace_iaddr_stage    [RV_TRACE_STAGES-1:0];
-  logic [31:0] rv_trace_tval_stage     [RV_TRACE_STAGES-1:0];
-  logic        rv_trace_iretire_stage  [RV_TRACE_STAGES-1:0];
-  logic [2:0]  rv_trace_itype_stage    [RV_TRACE_STAGES-1:0];
-  logic [5:0]  rv_trace_cause_stage    [RV_TRACE_STAGES-1:0];
-  logic [1:0]  rv_trace_priv_stage     [RV_TRACE_STAGES-1:0];
+  logic [31:0]     rv_trace_iaddr_stage    [RV_TRACE_STAGES-1:0];
+  logic [31:0]     rv_trace_tval_stage     [RV_TRACE_STAGES-1:0];
+  logic            rv_trace_iretire_stage  [RV_TRACE_STAGES-1:0];
+  rv_trace_type_e  rv_trace_itype_stage    [RV_TRACE_STAGES-1:0];
+  logic [5:0]      rv_trace_cause_stage    [RV_TRACE_STAGES-1:0];
+  logic [1:0]      rv_trace_priv_stage     [RV_TRACE_STAGES-1:0];
 
   logic        rv_trace_iretire_d      [RV_TRACE_STAGES-1:0];
   logic        rv_trace_perf_branch_d  [RV_TRACE_STAGES-1:0];
@@ -1368,19 +1368,19 @@ module ibex_core #(
 	rv_trace_cause_stage[i]   <= exc_cause;
 
 	if ( rv_trace_perf_tbranch_d[i] == 1 ) begin
-          rv_trace_itype_stage[i] <= 3'd5;
+          rv_trace_itype_stage[i] <= RV_TRACE_ITYPE_T_BRAN;
         end else if ( rv_trace_perf_branch_d[i] == 1 ) begin
-          rv_trace_itype_stage[i] <= 3'd4;
+          rv_trace_itype_stage[i] <= RV_TRACE_ITYPE_N_BRAN;
         end else if ( pc_mux_id == PC_ERET ) begin // return from interrupt
-              rv_trace_itype_stage[i] <= 3'd3; 
+          rv_trace_itype_stage[i] <= RV_TRACE_ITYPE_IE_RET; 
         end else if ( exc_cause > 0 ) begin
           if ( exc_cause[5] == 1 ) begin // => inter
-            rv_trace_itype_stage[i] <= 3'd2;
+            rv_trace_itype_stage[i] <= RV_TRACE_ITYPE_INTER;
           end else begin // => exce
-            rv_trace_itype_stage[i] <= 3'd1;
+            rv_trace_itype_stage[i] <= RV_TRACE_ITYPE_EXCEP;
           end 
         end else begin
-	  rv_trace_itype_stage[i] <= 3'd0; 
+	  rv_trace_itype_stage[i] <= RV_TRACE_ITYPE_OTHER; 
         end
         if (i == 0) begin
           if (instr_id_done) begin

--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -64,6 +64,16 @@ module ibex_core_tracing #(
     input  logic [14:0] irq_fast_i,
     input  logic        irq_nm_i,       // non-maskeable interrupt
 
+`ifdef RV_TRACE
+    // riscv_trace_spec signals 
+    output logic [2:0]  rv_trace_itype,
+    output logic [31:0] rv_trace_iaddr,
+    output logic [6:0]  rv_trace_cause,
+    output logic [31:0] rv_trace_tval,
+    output logic [1:0]  rv_trace_priv, 
+    output logic        rv_trace_iretire,
+`endif
+
     // Debug Interface
     input  logic        debug_req_i,
 
@@ -179,6 +189,15 @@ module ibex_core_tracing #(
     .rvfi_mem_wmask,
     .rvfi_mem_rdata,
     .rvfi_mem_wdata,
+
+`ifdef RV_TRACE
+    .rv_trace_itype,
+    .rv_trace_iaddr,
+    .rv_trace_cause,
+    .rv_trace_tval,
+    .rv_trace_priv,
+    .rv_trace_iretire,
+`endif
 
     .fetch_enable_i,
     .core_sleep_o

--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -68,7 +68,7 @@ module ibex_core_tracing #(
     // riscv_trace_spec signals 
     output logic [2:0]  rv_trace_itype,
     output logic [31:0] rv_trace_iaddr,
-    output logic [6:0]  rv_trace_cause,
+    output logic [5:0]  rv_trace_cause,
     output logic [31:0] rv_trace_tval,
     output logic [1:0]  rv_trace_priv, 
     output logic        rv_trace_iretire,

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -491,4 +491,15 @@ parameter int unsigned CSR_MEIX_BIT      = 11;
 parameter int unsigned CSR_MFIX_BIT_LOW  = 16;
 parameter int unsigned CSR_MFIX_BIT_HIGH = 30;
 
+// RV_TRACE types of address discontinuity
+typedef enum logic [2:0] {
+  RV_TRACE_ITYPE_OTHER   = 3'd0,
+  RV_TRACE_ITYPE_EXCEP   = 3'd1,
+  RV_TRACE_ITYPE_INTER   = 3'd2,
+  RV_TRACE_ITYPE_IE_RET  = 3'd3,
+  RV_TRACE_ITYPE_N_BRAN  = 3'd4,
+  RV_TRACE_ITYPE_T_BRAN  = 3'd5,
+  RV_TRACE_ITYPE_N_INF_J = 3'd6
+} rv_trace_type_e;
+   
 endpackage


### PR DESCRIPTION
The mandatory signals defined by the riscv-trace-spec are added to ibex_core outputs. 
They are also connected initially to some signals from the ibex core. 
These signals are to be checked and corrected as more understanding is gained. 