### PR TITLE
Tweak ICache tests to fill functional coverage defined so far

### DIFF
--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_driver.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_driver.sv
@@ -59,11 +59,17 @@ class ibex_icache_core_driver
     // Drive the enable state
     cfg.vif.driver_cb.enable <= req.enable;
 
+    // Maybe drive the ready line high while the branch happens. This should have no effect, but is
+    // allowed by the interface so we should make sure it happens occasionally. The signal will be
+    // controlled properly by read_insns afterwards.
+    cfg.vif.driver_cb.ready <= $urandom_range(16) == 0;
+
     // Branch, invalidate and set new seed immediately. When the branch has finished, read num_insns
     // instructions and wiggle the branch_spec line until everything is done.
     fork
       begin
         cfg.vif.branch_to(req.branch_addr);
+        cfg.vif.driver_cb.ready <= 1'b0;
         fork
           read_insns(rsp, req.num_insns);
           drive_branch_spec();

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
@@ -122,11 +122,9 @@ interface ibex_icache_core_if (input clk, input rst_n);
   // back to a covergroup.
   sequence cancelled_valid;
     @(posedge clk)
-      $rose(valid)
+      (valid & ~ready)
       ##1
-      (valid & ~ready) [*0:$]
-      ##1
-      (branch, cover_cancelled_valid());
+      (~valid, cover_cancelled_valid());
   endsequence : cancelled_valid
   cover property (cancelled_valid);
 

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_monitor.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_monitor.sv
@@ -21,13 +21,15 @@ class ibex_icache_core_monitor extends dv_base_monitor #(
   endfunction
 
   task run_phase(uvm_phase phase);
-    super.run_phase(phase);
-
     if (cfg.en_cov) begin
       fork
         process_cancelled_valid();
       join_none
     end
+
+    super.run_phase(phase);
+
+    disable fork;
   endtask
 
   // collect transactions forever - already forked in dv_base_moditor::run_phase

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/seq_lib/ibex_icache_core_back_line_seq.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/seq_lib/ibex_icache_core_back_line_seq.sv
@@ -20,9 +20,9 @@ class ibex_icache_core_back_line_seq extends ibex_icache_core_base_seq;
     // "back a bit" from the previous address.
     if (!req_phase) begin
       min_addr = base_addr;
-      max_addr = base_addr + 64;
+      max_addr = top_restricted_addr;
     end else begin
-      min_addr = last_branch - 16;
+      min_addr = last_branch < 16 ? 0 : last_branch - 16;
       max_addr = last_branch;
     end
 


### PR DESCRIPTION
There are 4 patches in the series.

1. Make it more likely that a branch will land at the edge of the address space (to check wrapping)
1. Allow the ready signal to be high when a branch hits (this has no effect, but is allowed by the spec, so we may as well do it sometimes).
1. Make the "cancelled_valid" sequence spot what it was supposed to spot
1. Fix the wiring downstream of the "cancelled_valid" sequence (I was turning on the monitor after the run phase had completed, which meant it didn't see very much!).