### PR TITLE
Install requirements for documentation builds

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -16,3 +16,6 @@ premailer
 
 # Recurse to get any requirements from riscv-dv
 -r vendor/google_riscv-dv/requirements.txt
+
+# Documentation build requirements
+-r doc/requirements.txt


### PR DESCRIPTION
A couple more Python requirements are needed to build documentation, but
we don't include them in the main requirements.txt yet. Keep them
separate for RTD to use, but also include them in the main requirements
for our developers to use.