### PR TITLE
[dv/ibex] Update riscv_core_setting to match latest version of riscv-dv

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/riscv_core_setting.sv
+++ b/dv/uvm/core_ibex/riscv_dv_extension/riscv_core_setting.sv
@@ -20,11 +20,19 @@
 // XLEN
 parameter int XLEN = 32;
 
+// GPR setting
+parameter int NUM_FLOAT_GPR = 0;
+parameter int NUM_GPR = 32;
+parameter int NUM_VEC_GPR = 0;
+
 // Vector extension parameters - not used in Ibex
 parameter int VECTOR_EXTENSION_ENABLE = 0;
 parameter int VLEN = 512;
 parameter int ELEN = 64;
 parameter int SLEN = 64;
+parameter int VELEN = 4;
+parameter int SELEN = 8;
+parameter int MAX_LMUL = 8;
 
 // Number of harts
 parameter int NUM_HARTS = 1;


### PR DESCRIPTION
This PR just adds some required (but mostly unused) parameters to `riscv_core_setting.sv` to match the updated version of the instruction generator - required to allow the Ibex DV environment to compile successfully.

The vector parameters are not used, since Ibex does not support the vector instruction set; same with `num_float_gpr` and `num_vec_gpr`, as Ibex also does not support the floating point instruction set.