### PR TITLE
Enable ICache ECC in the way dvsim.py requires

### DIFF
--- a/dv/uvm/icache/dv/ibex_icache_sim.core
+++ b/dv/uvm/icache/dv/ibex_icache_sim.core
@@ -19,7 +19,6 @@ filesets:
 targets:
   sim:
     parameters:
-      - ICacheECC
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplBadbit
     filesets:
       - files_rtl
@@ -28,12 +27,6 @@ targets:
     default_tool: vcs
 
 parameters:
-  ICacheECC:
-    datatype: int
-    default: 0
-    paramtype: vlogparam
-    description: "Enable ECC protection in instruction cache"
-
   PRIM_DEFAULT_IMPL:
     datatype: str
     paramtype: vlogdefine

--- a/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
+++ b/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
@@ -23,11 +23,22 @@
   // Import additional common sim cfg files.
   import_cfgs: [
       // Project wide common sim cfg file
-      "{proj_root}/dv/uvm/data/common_sim_cfg.hjson",
+      "{proj_root}/dv/uvm/data/common_sim_cfg.hjson"
+  ]
 
-      // Configuration options that should apply after the settings in
-      // common_sim_cfg.
-      "{proj_root}/dv/uvm/icache/dv/late_cfg.hjson"
+  build_modes: [
+    {
+      name: default
+      en_build_modes: ["{tool}_icache_ecc"]
+    }
+    {
+      name: vcs_icache_ecc
+      build_opts: ["-gv tb.ICacheECC=1"]
+    }
+    {
+      name: riviera_icache_ecc
+      run_opts: ["-gICacheECC=1"]
+    }
   ]
 
   // Default iterations for all tests - each test entry can override this.

--- a/dv/uvm/icache/dv/late_cfg.hjson
+++ b/dv/uvm/icache/dv/late_cfg.hjson
@@ -1,9 +1,0 @@
-// Copyright lowRISC contributors.
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
-{
-  // Set any fusesoc parameters by appending to sv_flist_gen_opts
-  //
-  // We want to enable ICache ECC (needed for the ECC test below)
-  sv_flist_gen_opts: ["--ICacheECC=1"]
-}


### PR DESCRIPTION
It seems that dvsim.py doesn't actually use fusesoc to do things like
pass parameters. Instead, we have to set the tool-specific options in
the hjson file by hand.

Fixes issue #964.