### PR TITLE
[ibex/dv] Add clocking blocks to Ibex interfaces

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf.sv
@@ -2,10 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-interface ibex_mem_intf#(parameter int ADDR_WIDTH = 32,
-                         parameter int DATA_WIDTH = 32);
+interface ibex_mem_intf#(
+  parameter int ADDR_WIDTH = 32,
+  parameter int DATA_WIDTH = 32
+) (
+  input clk
+);
 
-  logic                    clock;
   logic                    reset;
   logic                    request;
   logic                    grant;
@@ -16,5 +19,52 @@ interface ibex_mem_intf#(parameter int ADDR_WIDTH = 32,
   logic [DATA_WIDTH-1:0]   wdata;
   logic [DATA_WIDTH-1:0]   rdata;
   logic                    error;
+
+  clocking host_driver_cb @(posedge clk);
+    input   reset;
+    output  request;
+    input   grant;
+    output  addr;
+    output  we;
+    output  be;
+    input   rvalid;
+    output  wdata;
+    input   rdata;
+    input   error;
+  endclocking
+
+  clocking device_driver_cb @(posedge clk);
+    input   reset;
+    input   request;
+    output  grant;
+    input   addr;
+    input   we;
+    input   be;
+    output  rvalid;
+    input   wdata;
+    output  rdata;
+    output  error;
+  endclocking
+
+  clocking monitor_cb @(posedge clk);
+    input reset;
+    input request;
+    input grant;
+    input addr;
+    input we;
+    input be;
+    input rvalid;
+    input wdata;
+    input rdata;
+    input error;
+  endclocking
+
+  task automatic wait_clks(input int num);
+    repeat (num) @(posedge clk);
+  endtask
+
+  task automatic wait_neg_clks(input int num);
+    repeat (num) @(negedge clk);
+  endtask
 
 endinterface : ibex_mem_intf

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_slave_driver.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_slave_driver.sv
@@ -27,12 +27,12 @@ class ibex_mem_intf_slave_driver extends uvm_driver #(ibex_mem_intf_seq_item);
 
   virtual task run_phase(uvm_phase phase);
     reset_signals();
-    wait(vif.reset === 1'b0);
+    wait (vif.device_driver_cb.reset === 1'b0);
     forever begin
       fork : drive_stimulus
         send_grant();
         get_and_drive();
-        wait(vif.reset === 1'b1);
+        wait (vif.device_driver_cb.reset === 1'b1);
       join_any
       // Will only be reached after mid-test reset
       disable drive_stimulus;
@@ -52,26 +52,26 @@ class ibex_mem_intf_slave_driver extends uvm_driver #(ibex_mem_intf_seq_item);
       end
     end while (req != null);
     reset_signals();
-    wait(vif.reset === 1'b0);
+    wait (vif.device_driver_cb.reset === 1'b0);
   endtask
 
   virtual protected task reset_signals();
-    vif.rvalid  <= 1'b0;
-    vif.grant   <= 1'b0;
-    vif.rdata   <= 'b0;
-    vif.error   <= 1'b0;
+    vif.device_driver_cb.rvalid  <= 1'b0;
+    vif.device_driver_cb.grant   <= 1'b0;
+    vif.device_driver_cb.rdata   <= 'b0;
+    vif.device_driver_cb.error   <= 1'b0;
   endtask : reset_signals
 
   virtual protected task get_and_drive();
-    wait(vif.reset === 1'b0);
+    wait (vif.device_driver_cb.reset === 1'b0);
     fork
       begin
         forever begin
           ibex_mem_intf_seq_item req, req_c;
-          @(posedge vif.clock);
+          vif.wait_clks(1);
           seq_item_port.get_next_item(req);
           $cast(req_c, req.clone());
-          if(~vif.reset) begin
+          if(~vif.device_driver_cb.reset) begin
             rdata_queue.put(req_c);
           end
           seq_item_port.item_done();
@@ -86,8 +86,8 @@ class ibex_mem_intf_slave_driver extends uvm_driver #(ibex_mem_intf_seq_item);
   virtual protected task send_grant();
     int gnt_delay;
     forever begin
-      while(vif.request !== 1'b1) begin
-        @(negedge vif.clock);
+      while(vif.device_driver_cb.request !== 1'b1) begin
+        vif.wait_neg_clks(1);
       end
       if (!std::randomize(gnt_delay) with {
         gnt_delay dist {
@@ -98,11 +98,11 @@ class ibex_mem_intf_slave_driver extends uvm_driver #(ibex_mem_intf_seq_item);
       }) begin
         `uvm_fatal(`gfn, $sformatf("Cannot randomize grant"))
       end
-      repeat(gnt_delay) @(negedge vif.clock);
-      if(~vif.reset) begin
-        vif.grant = 1'b1;
-        @(negedge vif.clock);
-        vif.grant = 1'b0;
+      vif.wait_neg_clks(gnt_delay);
+      if(~vif.device_driver_cb.reset) begin
+        vif.device_driver_cb.grant <= 1'b1;
+        vif.wait_neg_clks(1);
+        vif.device_driver_cb.grant <= 1'b0;
       end
     end
   endtask : send_grant
@@ -110,17 +110,17 @@ class ibex_mem_intf_slave_driver extends uvm_driver #(ibex_mem_intf_seq_item);
   virtual protected task send_read_data();
     ibex_mem_intf_seq_item tr;
     forever begin
-      @(posedge vif.clock);
-      vif.rvalid <=  1'b0;
-      vif.rdata  <= 'x;
-      vif.error  <= 1'b0;
+      vif.wait_clks(1);
+      vif.device_driver_cb.rvalid <=  1'b0;
+      vif.device_driver_cb.rdata  <= 'x;
+      vif.device_driver_cb.error  <= 1'b0;
       rdata_queue.get(tr);
-      if(vif.reset) continue;
-      repeat(tr.rvalid_delay) @(posedge vif.clock);
-      if(~vif.reset) begin
-        vif.rvalid <=  1'b1;
-        vif.error  <=  tr.error;
-        vif.rdata  <=  tr.data;
+      if(vif.device_driver_cb.reset) continue;
+      vif.wait_clks(tr.rvalid_delay);
+      if(~vif.device_driver_cb.reset) begin
+        vif.device_driver_cb.rvalid <=  1'b1;
+        vif.device_driver_cb.error  <=  tr.error;
+        vif.device_driver_cb.rdata  <=  tr.data;
       end
     end
   endtask : send_read_data

--- a/dv/uvm/core_ibex/common/irq_agent/irq_if.sv
+++ b/dv/uvm/core_ibex/common/irq_agent/irq_if.sv
@@ -2,12 +2,34 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-interface irq_if;
-  logic        clock;
+interface irq_if(input clk);
   logic        reset;
   logic        irq_software;
   logic        irq_timer;
   logic        irq_external;
   logic [14:0] irq_fast;
   logic        irq_nm;       // non-maskeable interrupt
+
+  clocking driver_cb @(posedge clk);
+    input   reset;
+    output  irq_software;
+    output  irq_timer;
+    output  irq_external;
+    output  irq_fast;
+    output  irq_nm;
+  endclocking
+
+  clocking monitor_cb @(posedge clk);
+    input reset;
+    input irq_software;
+    input irq_timer;
+    input irq_external;
+    input irq_fast;
+    input irq_nm;
+  endclocking
+
+  task automatic wait_clks(input int num);
+    repeat (num) @(posedge clk);
+  endtask
+
 endinterface

--- a/dv/uvm/core_ibex/common/irq_agent/irq_master_driver.sv
+++ b/dv/uvm/core_ibex/common/irq_agent/irq_master_driver.sv
@@ -22,7 +22,7 @@ class irq_master_driver extends uvm_driver #(irq_seq_item);
     forever begin
       fork : drive_irq
         get_and_drive();
-        wait(vif.reset === 1'b1);
+        wait (vif.driver_cb.reset === 1'b1);
       join_any
       // Will only reach here on mid-test reset
       disable drive_irq;
@@ -43,7 +43,7 @@ class irq_master_driver extends uvm_driver #(irq_seq_item);
   endtask
 
   virtual protected task get_and_drive();
-    wait(vif.reset === 1'b0);
+    wait (vif.driver_cb.reset === 1'b0);
     forever begin
       seq_item_port.try_next_item(req);
       if (req != null) begin
@@ -52,30 +52,30 @@ class irq_master_driver extends uvm_driver #(irq_seq_item);
         drive_seq_item(rsp);
         seq_item_port.item_done(rsp);
       end else begin
-        @(posedge vif.clock);
+        vif.wait_clks(1);
       end
     end
   endtask : get_and_drive
 
   virtual protected task reset_signals();
-    @(negedge vif.reset);
+    @(negedge vif.driver_cb.reset);
     drive_reset_value();
   endtask : reset_signals
 
   virtual protected task drive_seq_item (irq_seq_item trans);
-    vif.irq_software <= trans.irq_software;
-    vif.irq_timer    <= trans.irq_timer;
-    vif.irq_external <= trans.irq_external;
-    vif.irq_fast     <= trans.irq_fast;
-    vif.irq_nm       <= trans.irq_nm;
+    vif.driver_cb.irq_software <= trans.irq_software;
+    vif.driver_cb.irq_timer    <= trans.irq_timer;
+    vif.driver_cb.irq_external <= trans.irq_external;
+    vif.driver_cb.irq_fast     <= trans.irq_fast;
+    vif.driver_cb.irq_nm       <= trans.irq_nm;
   endtask : drive_seq_item
 
   task drive_reset_value();
-    vif.irq_software <= '0;
-    vif.irq_timer    <= '0;
-    vif.irq_external <= '0;
-    vif.irq_fast     <= '0;
-    vif.irq_nm       <= '0;
+    vif.driver_cb.irq_software <= '0;
+    vif.driver_cb.irq_timer    <= '0;
+    vif.driver_cb.irq_external <= '0;
+    vif.driver_cb.irq_fast     <= '0;
+    vif.driver_cb.irq_nm       <= '0;
   endtask : drive_reset_value
 
 endclass : irq_master_driver

--- a/dv/uvm/core_ibex/env/core_ibex_csr_if.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_csr_if.sv
@@ -9,4 +9,13 @@ interface core_ibex_csr_if(input logic clk);
   logic [31:0]              csr_wdata;
   logic [31:0]              csr_rdata;
   ibex_pkg::csr_op_e        csr_op;
+
+  clocking csr_cb @(posedge clk);
+    input csr_access;
+    input csr_addr;
+    input csr_wdata;
+    input csr_rdata;
+    input csr_op;
+  endclocking
+
 endinterface

--- a/dv/uvm/core_ibex/env/core_ibex_dut_probe_if.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_dut_probe_if.sv
@@ -16,6 +16,20 @@ interface core_ibex_dut_probe_if(input logic clk);
   logic                 debug_req;
   ibex_pkg::priv_lvl_e  priv_mode;
 
+  clocking dut_cb @(posedge clk);
+    output fetch_enable;
+    output debug_req;
+    input reset;
+    input illegal_instr;
+    input ecall;
+    input wfi;
+    input ebreak;
+    input dret;
+    input mret;
+    input core_sleep;
+    input priv_mode;
+  endclocking
+
   initial begin
     debug_req = 1'b0;
   end

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -12,9 +12,9 @@ module core_ibex_tb_top;
   logic fetch_enable;
 
   clk_if         ibex_clk_if(.clk(clk), .rst_n(rst_n));
-  irq_if         irq_vif();
-  ibex_mem_intf  data_mem_vif();
-  ibex_mem_intf  instr_mem_vif();
+  irq_if         irq_vif(.clk(clk));
+  ibex_mem_intf  data_mem_vif(.clk(clk));
+  ibex_mem_intf  instr_mem_vif(.clk(clk));
 
 
   // DUT probe interface
@@ -89,10 +89,8 @@ module core_ibex_tb_top;
   );
 
   // Data load/store vif connection
-  assign data_mem_vif.clock     = clk;
   assign data_mem_vif.reset     = ~rst_n;
   // Instruction fetch vif connnection
-  assign instr_mem_vif.clock    = clk;
   assign instr_mem_vif.reset    = ~rst_n;
   assign instr_mem_vif.we       = 0;
   assign instr_mem_vif.be       = 0;
@@ -118,7 +116,6 @@ module core_ibex_tb_top;
   assign rvfi_if.mem_rdata      = dut.rvfi_mem_rdata;
   assign rvfi_if.mem_wdata      = dut.rvfi_mem_wdata;
   // Irq interface connections
-  assign irq_vif.clock          = clk;
   assign irq_vif.reset          = ~rst_n;
   // Dut_if interface connections
   assign dut_if.ecall           = dut.u_ibex_core.id_stage_i.controller_i.ecall_insn;

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -68,10 +68,10 @@ class core_ibex_base_test extends uvm_test;
     enable_irq_seq = cfg.enable_irq_single_seq || cfg.enable_irq_multiple_seq;
     phase.raise_objection(this);
     run = phase;
-    dut_vif.fetch_enable = 1'b0;
+    dut_vif.dut_cb.fetch_enable <= 1'b0;
     clk_vif.wait_clks(100);
     load_binary_to_mem();
-    dut_vif.fetch_enable = 1'b1;
+    dut_vif.dut_cb.fetch_enable <= 1'b1;
     send_stimulus();
     wait_for_test_done();
     phase.drop_objection(this);
@@ -116,11 +116,11 @@ class core_ibex_base_test extends uvm_test;
   virtual task wait_for_test_done();
     fork
       begin
-        wait (dut_vif.ecall === 1'b1);
+        wait (dut_vif.dut_cb.ecall === 1'b1);
         vseq.stop();
         `uvm_info(`gfn, "ECALL instruction is detected, test done", UVM_LOW)
         // De-assert fetch enable to finish the test
-        dut_vif.fetch_enable = 1'b0;
+        dut_vif.dut_cb.fetch_enable <= 1'b0;
         fork
           check_perf_stats();
           // Wait some time for the remaining instruction to finish

--- a/dv/uvm/core_ibex/tests/core_ibex_seq_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_seq_lib.sv
@@ -131,15 +131,15 @@ class debug_seq extends core_base_seq#(irq_seq_item);
     if (!uvm_config_db#(virtual core_ibex_dut_probe_if)::get(null, "", "dut_if", dut_vif)) begin
       `uvm_fatal(get_full_name(), "Cannot get dut_if")
     end
-    dut_vif.debug_req <= 1'b0;
+    dut_vif.dut_cb.debug_req <= 1'b0;
     super.body();
   endtask
 
   virtual task send_req();
     `uvm_info(get_full_name(), "Sending debug request", UVM_HIGH)
-    dut_vif.debug_req <= 1'b1;
+    dut_vif.dut_cb.debug_req <= 1'b1;
     clk_vif.wait_clks(50);
-    dut_vif.debug_req <= 1'b0;
+    dut_vif.dut_cb.debug_req <= 1'b0;
   endtask
 
 endclass


### PR DESCRIPTION
This PR simply adds clocking blocks to all major Ibex interface agents and updates all interface accesses to use these clocking blocks to enforce clock synchronization.

@tomroberts-lowrisc this should address #954. I tested the `riscv_dret_test` and other similar tests that you noticed some arbitrary errors in, and they all seem to pass successfully with these changes

A few notes about some parts of this PR:

- `ibex_mem_intf` has two driver clocking blocks added, one for host side and one for device side. This is because our Ibex testbench currently provides both host and device agents for the Ibex I/D-side interfaces (of course we only use the reactive device agents in the main testbench). If you feel the host agents should be removed, I can do this in a later PR.
- `csr_if` has only one clocking block - this is because the signals bound to this interface are only ever sampled, never driven (these are signals internal to the CSR 'register file').
- `dut_if` has only one clocking block as well - this is because `fetch_enable` and `debug_req` are only ever driven, never sampled, and the remaining signals are only sampled, never driven (these are signals internal to the `ibex_controller`, so we can make do with a single clocking block here.
- some utility tasks have been added to some interfaces to wait for a specified number of clock cycles - no other significant changes are present in this PR apart from this.