### PR TITLE
[top_pkg] Fix style lint warnings

### DIFF
--- a/dv/uvm/icache/dv/top_pkg.sv
+++ b/dv/uvm/icache/dv/top_pkg.sv
@@ -5,21 +5,21 @@
 
 package top_pkg;
 
-localparam TL_AW=32;
-localparam TL_DW=32;    // = TL_DBW * 8; TL_DBW must be a power-of-two
-localparam TL_AIW=8;    // a_source, d_source
-localparam TL_DIW=1;    // d_sink
-localparam TL_DUW=16;   // d_user
-localparam TL_DBW=(TL_DW>>3);
-localparam TL_SZW=$clog2($clog2(TL_DBW)+1);
-localparam FLASH_BANKS=2;
-localparam FLASH_PAGES_PER_BANK=256;
-localparam FLASH_WORDS_PER_PAGE=256;
-localparam FLASH_BYTES_PER_WORD=4;
-localparam FLASH_BKW = $clog2(FLASH_BANKS);
-localparam FLASH_PGW = $clog2(FLASH_PAGES_PER_BANK);
-localparam FLASH_WDW = $clog2(FLASH_WORDS_PER_PAGE);
-localparam FLASH_AW = FLASH_BKW + FLASH_PGW + FLASH_WDW;
-localparam FLASH_DW = FLASH_BYTES_PER_WORD * 8;
+localparam int TL_AW=32;
+localparam int TL_DW=32;    // = TL_DBW * 8; TL_DBW must be a power-of-two
+localparam int TL_AIW=8;    // a_source, d_source
+localparam int TL_DIW=1;    // d_sink
+localparam int TL_DUW=16;   // d_user
+localparam int TL_DBW=(TL_DW>>3);
+localparam int TL_SZW=$clog2($clog2(TL_DBW)+1);
+localparam int FLASH_BANKS=2;
+localparam int FLASH_PAGES_PER_BANK=256;
+localparam int FLASH_WORDS_PER_PAGE=256;
+localparam int FLASH_BYTES_PER_WORD=4;
+localparam int FLASH_BKW = $clog2(FLASH_BANKS);
+localparam int FLASH_PGW = $clog2(FLASH_PAGES_PER_BANK);
+localparam int FLASH_WDW = $clog2(FLASH_WORDS_PER_PAGE);
+localparam int FLASH_AW = FLASH_BKW + FLASH_PGW + FLASH_WDW;
+localparam int FLASH_DW = FLASH_BYTES_PER_WORD * 8;
 
 endpackage

--- a/rtl/ibex_alu.sv
+++ b/rtl/ibex_alu.sv
@@ -591,9 +591,9 @@ module ibex_alu #(
     `define _N(stg) (16 >> stg)
 
     // bext / bdep control bit generation
-    for (genvar stg=0; stg<5; stg++) begin
+    for (genvar stg=0; stg<5; stg++) begin : gen_stage
       // number of segs: 2** stg
-      for (genvar seg=0; seg<2**stg; seg++) begin
+      for (genvar seg=0; seg<2**stg; seg++) begin : gen_segment
 
         assign lrotc_stage[stg][2*`_N(stg)*(seg+1)-1 : 2*`_N(stg)*seg] =
             {{`_N(stg){1'b0}},{`_N(stg){1'b1}}} <<
@@ -611,7 +611,7 @@ module ibex_alu #(
     end
     `undef _N
 
-    for (genvar stg=0; stg<5; stg++) begin
+    for (genvar stg=0; stg<5; stg++) begin : gen_zbe_mask
       assign butterfly_zbe_mask_not[stg] =
           ~(butterfly_zbe_mask_l[stg] | butterfly_zbe_mask_r[stg]);
     end
@@ -708,17 +708,17 @@ module ibex_alu #(
     // Shuffle / Unshuffle //
     /////////////////////////
 
-    localparam logic [31:0] SHUFFLE_MASK_L [0:3] =
-        '{32'h00ff_0000, 32'h0f00_0f00, 32'h3030_3030, 32'h4444_4444};
-    localparam logic [31:0] SHUFFLE_MASK_R [0:3] =
-        '{32'h0000_ff00, 32'h00f0_00f0, 32'h0c0c_0c0c, 32'h2222_2222};
+    localparam logic [31:0] SHUFFLE_MASK_L [4] =
+        '{32'h4444_4444, 32'h3030_3030, 32'h0f00_0f00, 32'h00ff_0000};
+    localparam logic [31:0] SHUFFLE_MASK_R [4] =
+        '{32'h2222_2222, 32'h0c0c_0c0c, 32'h00f0_00f0, 32'h0000_ff00};
 
-    localparam logic [31:0] FLIP_MASK_L [0:3] =
-        '{32'h2200_1100, 32'h0044_0000, 32'h4411_0000, 32'h1100_0000};
-    localparam logic [31:0] FLIP_MASK_R [0:3] =
-        '{32'h0088_0044, 32'h0000_2200, 32'h0000_8822, 32'h0000_0088};
+    localparam logic [31:0] FLIP_MASK_L [4] =
+        '{32'h1100_0000, 32'h4411_0000, 32'h0044_0000, 32'h2200_1100};
+    localparam logic [31:0] FLIP_MASK_R [4] =
+        '{32'h0000_0088, 32'h0000_8822, 32'h0000_2200, 32'h0088_0044};
 
-    logic [31:0] SHUFFLE_MASK_NOT [0:3];
+    logic [31:0] SHUFFLE_MASK_NOT [4];
     for(genvar i = 0; i < 4; i++) begin : gen_shuffle_mask_not
       assign SHUFFLE_MASK_NOT[i] = ~(SHUFFLE_MASK_L[i] | SHUFFLE_MASK_R[i]);
     end

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -715,6 +715,7 @@ module ibex_controller #(
               exc_cause_o = EXC_CAUSE_LOAD_ACCESS_FAULT;
               csr_mtval_o = lsu_addr_last_i;
             end
+            default: ;
           endcase
         end else begin
           // special instructions and pipeline flushes

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -778,7 +778,7 @@ module ibex_core #(
   assign outstanding_load_id  = id_stage_i.instr_executing & id_stage_i.lsu_req_dec & ~id_stage_i.lsu_we;
   assign outstanding_store_id = id_stage_i.instr_executing & id_stage_i.lsu_req_dec &  id_stage_i.lsu_we;
 
-  if (WritebackStage) begin
+  if (WritebackStage) begin : gen_wb_stage
     // When the writeback stage is present a load/store could be in ID or WB. A Load/store in ID can
     // see a response before it moves to WB when it is unaligned otherwise we should only see
     // a response when load/store is in WB.
@@ -790,7 +790,7 @@ module ibex_core #(
 
     // When writing back the result of a load, the load must have made it to writeback
     `ASSERT(NoMemRFWriteWithoutPendingLoad, rf_we_lsu |-> outstanding_load_wb, clk_i, !rst_ni)
-  end else begin
+  end else begin : gen_no_wb_stage
     // Without writeback stage only look into whether load or store is in ID to determine if
     // a response is expected.
     assign outstanding_load_resp  = outstanding_load_id;
@@ -975,33 +975,33 @@ module ibex_core #(
   // second stage. RVFI outputs are all straight from flops. So 2 stage pipeline requires a single
   // set of flops (instr_info => RVFI_out), 3 stage pipeline requires two sets (instr_info => wb
   // => RVFI_out)
-  localparam RVFI_STAGES = WritebackStage ? 2 : 1;
+  localparam int RVFI_STAGES = WritebackStage ? 2 : 1;
 
-  logic        rvfi_stage_valid     [RVFI_STAGES-1:0];
-  logic [63:0] rvfi_stage_order     [RVFI_STAGES-1:0];
-  logic [31:0] rvfi_stage_insn      [RVFI_STAGES-1:0];
-  logic        rvfi_stage_trap      [RVFI_STAGES-1:0];
-  logic        rvfi_stage_halt      [RVFI_STAGES-1:0];
-  logic        rvfi_stage_intr      [RVFI_STAGES-1:0];
-  logic [ 1:0] rvfi_stage_mode      [RVFI_STAGES-1:0];
-  logic [ 1:0] rvfi_stage_ixl       [RVFI_STAGES-1:0];
-  logic [ 4:0] rvfi_stage_rs1_addr  [RVFI_STAGES-1:0];
-  logic [ 4:0] rvfi_stage_rs2_addr  [RVFI_STAGES-1:0];
-  logic [ 4:0] rvfi_stage_rs3_addr  [RVFI_STAGES-1:0];
-  logic [31:0] rvfi_stage_rs1_rdata [RVFI_STAGES-1:0];
-  logic [31:0] rvfi_stage_rs2_rdata [RVFI_STAGES-1:0];
-  logic [31:0] rvfi_stage_rs3_rdata [RVFI_STAGES-1:0];
-  logic [ 4:0] rvfi_stage_rd_addr   [RVFI_STAGES-1:0];
-  logic [31:0] rvfi_stage_rd_wdata  [RVFI_STAGES-1:0];
-  logic [31:0] rvfi_stage_pc_rdata  [RVFI_STAGES-1:0];
-  logic [31:0] rvfi_stage_pc_wdata  [RVFI_STAGES-1:0];
-  logic [31:0] rvfi_stage_mem_addr  [RVFI_STAGES-1:0];
-  logic [ 3:0] rvfi_stage_mem_rmask [RVFI_STAGES-1:0];
-  logic [ 3:0] rvfi_stage_mem_wmask [RVFI_STAGES-1:0];
-  logic [31:0] rvfi_stage_mem_rdata [RVFI_STAGES-1:0];
-  logic [31:0] rvfi_stage_mem_wdata [RVFI_STAGES-1:0];
+  logic        rvfi_stage_valid     [RVFI_STAGES];
+  logic [63:0] rvfi_stage_order     [RVFI_STAGES];
+  logic [31:0] rvfi_stage_insn      [RVFI_STAGES];
+  logic        rvfi_stage_trap      [RVFI_STAGES];
+  logic        rvfi_stage_halt      [RVFI_STAGES];
+  logic        rvfi_stage_intr      [RVFI_STAGES];
+  logic [ 1:0] rvfi_stage_mode      [RVFI_STAGES];
+  logic [ 1:0] rvfi_stage_ixl       [RVFI_STAGES];
+  logic [ 4:0] rvfi_stage_rs1_addr  [RVFI_STAGES];
+  logic [ 4:0] rvfi_stage_rs2_addr  [RVFI_STAGES];
+  logic [ 4:0] rvfi_stage_rs3_addr  [RVFI_STAGES];
+  logic [31:0] rvfi_stage_rs1_rdata [RVFI_STAGES];
+  logic [31:0] rvfi_stage_rs2_rdata [RVFI_STAGES];
+  logic [31:0] rvfi_stage_rs3_rdata [RVFI_STAGES];
+  logic [ 4:0] rvfi_stage_rd_addr   [RVFI_STAGES];
+  logic [31:0] rvfi_stage_rd_wdata  [RVFI_STAGES];
+  logic [31:0] rvfi_stage_pc_rdata  [RVFI_STAGES];
+  logic [31:0] rvfi_stage_pc_wdata  [RVFI_STAGES];
+  logic [31:0] rvfi_stage_mem_addr  [RVFI_STAGES];
+  logic [ 3:0] rvfi_stage_mem_rmask [RVFI_STAGES];
+  logic [ 3:0] rvfi_stage_mem_wmask [RVFI_STAGES];
+  logic [31:0] rvfi_stage_mem_rdata [RVFI_STAGES];
+  logic [31:0] rvfi_stage_mem_wdata [RVFI_STAGES];
 
-  logic        rvfi_stage_valid_d   [RVFI_STAGES-1:0];
+  logic        rvfi_stage_valid_d   [RVFI_STAGES];
 
   assign rvfi_valid     = rvfi_stage_valid    [RVFI_STAGES-1];
   assign rvfi_order     = rvfi_stage_order    [RVFI_STAGES-1];
@@ -1027,7 +1027,7 @@ module ibex_core #(
   assign rvfi_mem_rdata = rvfi_stage_mem_rdata[RVFI_STAGES-1];
   assign rvfi_mem_wdata = rvfi_stage_mem_wdata[RVFI_STAGES-1];
 
-  if (WritebackStage) begin
+  if (WritebackStage) begin : gen_rvfi_wb_stage
     logic unused_instr_new_id;
 
     assign unused_instr_new_id = instr_new_id;
@@ -1054,7 +1054,7 @@ module ibex_core #(
         rvfi_instr_new_wb_q <= instr_id_done;
       end
     end
-  end else begin
+  end else begin : gen_rvfi_no_wb_stage
     // Without writeback stage first RVFI stage is output stage so simply valid the cycle after
     // instruction leaves ID/EX (and so has retired)
     assign rvfi_stage_valid_d[0] = instr_id_done & ~dummy_instr_id;

--- a/rtl/ibex_counter.sv
+++ b/rtl/ibex_counter.sv
@@ -44,8 +44,8 @@ module ibex_counter #(
 
 `ifdef FPGA_XILINX
   // Set DSP pragma for supported xilinx FPGAs
-  localparam dsp_pragma = CounterWidth < 49  ? "yes" : "no";
-  (* use_dsp = dsp_pragma *) logic [CounterWidth-1:0] counter_q;
+  localparam int DspPragma = CounterWidth < 49  ? "yes" : "no";
+  (* use_dsp = DspPragma *) logic [CounterWidth-1:0] counter_q;
 
   // DSP output register requires synchronous reset.
   `define COUNTER_FLOP_RST posedge clk_i

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -137,12 +137,12 @@ module ibex_cs_registers #(
     priv_lvl_e mpp;
     logic      mprv;
     logic      tw;
-  } Status_t;
+  } status_t;
 
   typedef struct packed {
     logic      mpie;
     priv_lvl_e mpp;
-  } StatusStk_t;
+  } status_stk_t;
 
   typedef struct packed {
       x_debug_ver_e xdebugver;
@@ -160,7 +160,7 @@ module ibex_cs_registers #(
       logic         nmip;
       logic         step;
       priv_lvl_e    prv;
-  } Dcsr_t;
+  } dcsr_t;
 
   // CPU control register fields
   typedef struct packed {
@@ -169,14 +169,14 @@ module ibex_cs_registers #(
     logic        dummy_instr_en;
     logic        data_ind_timing;
     logic        icache_enable;
-  } CpuCtrl_t;
+  } cpu_ctrl_t;
 
   // Interrupt and exception control signals
   logic [31:0] exception_pc;
 
   // CSRs
   priv_lvl_e   priv_lvl_q, priv_lvl_d;
-  Status_t     mstatus_q, mstatus_d;
+  status_t     mstatus_q, mstatus_d;
   irqs_t       mie_q, mie_d;
   logic [31:0] mscratch_q, mscratch_d;
   logic [31:0] mepc_q, mepc_d;
@@ -184,14 +184,14 @@ module ibex_cs_registers #(
   logic [31:0] mtval_q, mtval_d;
   logic [31:0] mtvec_q, mtvec_d;
   irqs_t       mip;
-  Dcsr_t       dcsr_q, dcsr_d;
+  dcsr_t       dcsr_q, dcsr_d;
   logic [31:0] depc_q, depc_d;
   logic [31:0] dscratch0_q, dscratch0_d;
   logic [31:0] dscratch1_q, dscratch1_d;
 
   // CSRs for recoverable NMIs
   // NOTE: these CSRS are nonstandard, see https://github.com/riscv/riscv-isa-manual/issues/261
-  StatusStk_t  mstack_q, mstack_d;
+  status_stk_t mstack_q, mstack_d;
   logic [31:0] mstack_epc_q, mstack_epc_d;
   logic  [5:0] mstack_cause_q, mstack_cause_d;
 
@@ -221,7 +221,7 @@ module ibex_cs_registers #(
   logic [31:0] tmatch_value_rdata;
 
   // CPU control bits
-  CpuCtrl_t    cpuctrl_rdata, cpuctrl_wdata;
+  cpu_ctrl_t   cpuctrl_rdata, cpuctrl_wdata;
 
   // CSR update logic
   logic [31:0] csr_wdata_int;
@@ -685,7 +685,7 @@ module ibex_cs_registers #(
       mepc_q         <= '0;
       mcause_q       <= '0;
       mtval_q        <= '0;
-      mtvec_q        <= 32'b01;
+      mtvec_q        <= 32'h0000_0001;
       dcsr_q         <= '{
           xdebugver: XDEBUGVER_STD,
           cause:     DBG_CAUSE_NONE, // 3'h0
@@ -1054,7 +1054,7 @@ module ibex_cs_registers #(
   // CPU control fields
   assign cpuctrl_rdata.unused_ctrl = '0;
   // Cast register write data
-  assign cpuctrl_wdata = CpuCtrl_t'(csr_wdata_int);
+  assign cpuctrl_wdata = cpu_ctrl_t'(csr_wdata_int);
 
   // Generate fixed time execution bit
   if (DataIndTiming) begin : gen_dit


### PR DESCRIPTION
This fixes several style lint warnings in Ibex. Note that the `top_pkg` from Ibex seems to override the `top_pkg` from OpenTitan (hence we get all these duplicate warnings about missing parameter types in https://reports.opentitan.org/hw/ip/rv_core_ibex/lint/veriblelint/latest/results.html). This is another instance of https://github.com/lowRISC/opentitan/issues/1231 and we should resolve this.

Signed-off-by: Michael Schaffner <msf@google.com>