### PR TITLE
Fix Pointer Authentication lint errors

### DIFF
--- a/examples/sw/simple_system/pa_test/pa_test.c
+++ b/examples/sw/simple_system/pa_test/pa_test.c
@@ -5,56 +5,58 @@
 #include "simple_system_common.h"
 
 #define PMP_NAPOT 0x18
-#define PMP_R     0x01
-#define PMP_W     0x02
-#define PMP_X     0x04
+#define PMP_R 0x01
+#define PMP_W 0x02
+#define PMP_X 0x04
 
 #define MSTATUS_MPP_M (3 << 11)
 #define MSTATUS_MPP_U (0 << 11)
 
-
-typedef struct  {
+typedef struct {
   uintptr_t pointer0;
   uintptr_t pointer1;
 } auth_ptr_t;
 
-
 void setup_pakey() {
   // Set the key for PA in CSR
   uint32_t key = 0xdeadbeef;
-  asm volatile ("csrw 0x7c2, %[key];"
-                "csrw 0x7c3, %[key];"
-                "csrw 0x7c4, %[key];"
-                "csrw 0x7c5, %[key];"
-                : : [key] "r" (key) :);
+  asm volatile(
+      "csrw 0x7c2, %[key];"
+      "csrw 0x7c3, %[key];"
+      "csrw 0x7c4, %[key];"
+      "csrw 0x7c5, %[key];"
+      :
+      : [key] "r"(key)
+      :);
 }
 
 void setup_pmp() {
   // 0x00000000 ~ 0x0FFFFFFF is accessible
-  uint32_t base_addr  = 0x0;
-  uint32_t size       = 1 << 30;
+  uint32_t base_addr = 0x0;
+  uint32_t size = 1 << 30;
   uint32_t napot_size = (size / 2) - 1;
   uint32_t pmpaddr = (base_addr + napot_size) >> 2;
   uint32_t pmpcfg = PMP_NAPOT | PMP_R | PMP_W | PMP_X;
-  asm volatile ("csrw pmpaddr0, %0;"
-                "csrw pmpcfg0, %1;"
-                : : "r" (pmpaddr), "r" (pmpcfg) :);
+  asm volatile(
+      "csrw pmpaddr0, %0;"
+      "csrw pmpcfg0, %1;"
+      :
+      : "r"(pmpaddr), "r"(pmpcfg)
+      :);
 }
 
-
 auth_ptr_t pac(auth_ptr_t ptr, uint32_t context) {
-  asm volatile (".insn r 0x0b, 0, 0, %[pointer1], %[pointer0], %[context];"
-                : [pointer0] "+r"  (ptr.pointer0), [pointer1] "=r" (ptr.pointer1)
-                : [context] "r" (context)
-  );
+  asm volatile(".insn r 0x0b, 0, 0, %[pointer1], %[pointer0], %[context];"
+               : [pointer0] "+r"(ptr.pointer0), [pointer1] "=r"(ptr.pointer1)
+               : [context] "r"(context));
   return ptr;
 }
 
 auth_ptr_t aut(auth_ptr_t ptr, uint32_t context) {
-  asm volatile (".insn r4 0x0b, 1, 0, %[pointer0], %[pointer0], %[pointer1], %[context];"
-                : [pointer0] "+r" (ptr.pointer0)
-                : [pointer1] "r" (ptr.pointer1), [context] "r" (context)
-  );
+  asm volatile(
+      ".insn r4 0x0b, 1, 0, %[pointer0], %[pointer0], %[pointer1], %[context];"
+      : [pointer0] "+r"(ptr.pointer0)
+      : [pointer1] "r"(ptr.pointer1), [context] "r"(context));
   return ptr;
 }
 
@@ -67,14 +69,13 @@ void print_auth_ptr(auth_ptr_t ptr) {
   putchar('\n');
 }
 
-
 // Test for pac and aut instruction
 void test_pointer_authentication() {
-  auth_ptr_t ptr = { .pointer0 = 0x1000, .pointer1 = 0x0 };
+  auth_ptr_t ptr = {.pointer0 = 0x1000, .pointer1 = 0x0};
   const uint32_t context = 0xffff;
 
   // Execute PAC instruction
-  auth_ptr_t pac_ptr = pac(ptr,     context);
+  auth_ptr_t pac_ptr = pac(ptr, context);
   print_auth_ptr(pac_ptr);
 
   // Execute AUT instruction
@@ -90,12 +91,13 @@ void test_pointer_authentication() {
 // Test whether pmp error occurs when accessing with unauthenticated pointer
 void test_pmp_error() {
   const int data = 'A';
-  auth_ptr_t ptr = { .pointer0 = (uintptr_t)&data, .pointer1 = 0x0 };
+  auth_ptr_t ptr = {.pointer0 = (uintptr_t)&data, .pointer1 = 0x0};
   const uint32_t context = 0xffff;
 
   auth_ptr_t pac_ptr = pac(ptr, context);
   // Access data using unauthenticated pointer
-  *(int*)pac_ptr.pointer0 = 'B'; // <- Error occurs due to use of unauthenticated pointer
+  *(int *)pac_ptr.pointer0 =
+      'B';  // <- Error occurs due to use of unauthenticated pointer
 }
 
 void test() {
@@ -106,18 +108,19 @@ void test() {
   sim_halt();
 }
 
-
 int main(int argc, char **argv) {
   setup_pakey();
   setup_pmp();
 
   // from M mode to U mode
   uint32_t mstatus;
-  asm volatile ("csrr %0, mstatus" : "=r" (mstatus));
+  asm volatile("csrr %0, mstatus" : "=r"(mstatus));
   mstatus = (mstatus & ~MSTATUS_MPP_M) | MSTATUS_MPP_U;
-  asm volatile ("csrw mstatus, %0;"
-                "csrw mepc, %1;"
-                "mret;"
-                 : : "r" (mstatus), "r" (test));
+  asm volatile(
+      "csrw mstatus, %0;"
+      "csrw mepc, %1;"
+      "mret;"
+      :
+      : "r"(mstatus), "r"(test));
   return 0;
 }

--- a/rtl/ibex_cipher.sv
+++ b/rtl/ibex_cipher.sv
@@ -59,9 +59,9 @@ module ibex_cipher (
       end
 
       C_OUTPUT: begin
+        out_data_o  = data_q[31:0] ^ data_q[63:32];
+        out_valid_o = 1'b1;
         if (out_ready_i) begin
-          out_data_o  = data_q[31:0] ^ data_q[63:32];
-          out_valid_o = 1'b1;
           c_fsm_d     = C_INPUT;
         end
       end


### PR DESCRIPTION
We have some lint errors below in Pointer Authentication. I fixed it.
- Bits of signal are not used
- Case values incompletely covered
- Signal unoptimizable: Feedback to clock or circular logic
- Run clang-format on pa_test.c