### PR TITLE
Fix hazard detection issues for Pointer Authentication 

### DIFF
--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -621,8 +621,8 @@ module ibex_core #(
       .instr_id_done_compressed_o   ( instr_id_done_compressed ),
 
       // Pointer Authentication
-      .pac_en_dec_o                 ( pa_pac_en                ),
-      .aut_en_dec_o                 ( pa_aut_en                ),
+      .pac_en_id_o                  ( pa_pac_en                ),
+      .aut_en_id_o                  ( pa_aut_en                ),
       .pa_data0_o                   ( pa_data0                 ),
       .pa_data1_o                   ( pa_data1                 ),
       .pa_ready_id_o                ( pa_ready_id              ),

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -602,6 +602,8 @@ module ibex_decoder #(
       ////////////////////////////
 
       OPCODE_PA: begin // Custom Operations for Pointer Authentication
+        rf_ren_a_o = 1'b1;
+        rf_ren_b_o = 1'b1;
         unique case (instr[14:12])
           3'b000: begin // PAC
             pac_en_dec_o   = (PointerAuthentication) ? 1'b1 : 1'b0;


### PR DESCRIPTION
With the writeback stage enabled we execute the PAC/AUT instruction before the required data is written to the register file. For example, when the load instruction precedes AUT instruction, AUT instruction is started before the loaded data is written to the register file. It is a problem that the hazard detection (`stall_ld_hz`) using `rf_ren_a/b_o` was not active for PAC/AUT instruction. So, I change codes to set `rf_ren_a/b_o` in the decoder.  Also, I change codes not to activate `pa_pac_en` or `pa_aut_en` when load hazard occurs. 

I show how the waveform changes before and after. I build with this command (`fusesoc --cores-root=.run --target=sim --setup --build lowrisc:ibex:ibex_simple_system --RV32M=1 --RV32E=0 --PMPEnable=1 --PointerAuthentication= 1 --WritebackStage=1`) and run `examples/sw/simple_system/pa_test/pa_test.c`. The figure below shows the waveforms of the LOAD and AUT instruction. You can see that `stall_ld_hz` is not active in the before figure. Also, you can see that `stall_ld_hz` is active and `pa_aut_en` is low until the load hazard ends In the after figure.

![ibex_pa_fix_ld_hz](https://user-images.githubusercontent.com/19609323/85434744-78e7e380-b5c1-11ea-83e4-ffb819235812.jpg)
