### PR TITLE
[doc] Add bitmanip spec to introduction page

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -21,6 +21,7 @@ It follows these specifications:
 * `RISC-V Instruction Set Manual, Volume II: Privileged Architecture, document version 20190608-Base-Ratified (June 8, 2019) <https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMFDQC-and-Priv-v1.11/riscv-privileged-20190608.pdf>`_.
   Ibex implements the Machine ISA version 1.11.
 * `RISC-V External Debug Support, version 0.13.2 <https://content.riscv.org/wp-content/uploads/2019/03/riscv-debug-release.pdf>`_
+* `RISC-V Bit Manipulation Extension, version 0.92 (November 8, 2019) <https://github.com/riscv/riscv-bitmanip/blob/master/bitmanip-0.92.pdf>`_
 
 Many features in the RISC-V specification are optional, and Ibex can be parametrized to enable or disable some of them.
 


### PR DESCRIPTION
We list all specifications we implement, even optional ones. Add
Bitmanip there as well.

Fixes #966