### PR TITLE
Fix Verible lint issues

### DIFF
--- a/rtl/ibex_alu.sv
+++ b/rtl/ibex_alu.sv
@@ -622,17 +622,17 @@ module ibex_alu #(
       // Shuffle / Unshuffle //
       /////////////////////////
 
-      localparam logic [31:0] SHUFFLE_MASK_L [0:3] =
+      localparam logic [31:0] SHUFFLE_MASK_L [4] =
           '{32'h00ff_0000, 32'h0f00_0f00, 32'h3030_3030, 32'h4444_4444};
-      localparam logic [31:0] SHUFFLE_MASK_R [0:3] =
+      localparam logic [31:0] SHUFFLE_MASK_R [4] =
           '{32'h0000_ff00, 32'h00f0_00f0, 32'h0c0c_0c0c, 32'h2222_2222};
 
-      localparam logic [31:0] FLIP_MASK_L [0:3] =
+      localparam logic [31:0] FLIP_MASK_L [4] =
           '{32'h2200_1100, 32'h0044_0000, 32'h4411_0000, 32'h1100_0000};
-      localparam logic [31:0] FLIP_MASK_R [0:3] =
+      localparam logic [31:0] FLIP_MASK_R [4] =
           '{32'h0088_0044, 32'h0000_2200, 32'h0000_8822, 32'h0000_0088};
 
-      logic [31:0] SHUFFLE_MASK_NOT [0:3];
+      logic [31:0] SHUFFLE_MASK_NOT [4];
       for(genvar i = 0; i < 4; i++) begin : gen_shuffle_mask_not
         assign SHUFFLE_MASK_NOT[i] = ~(SHUFFLE_MASK_L[i] | SHUFFLE_MASK_R[i]);
       end
@@ -1047,7 +1047,7 @@ module ibex_alu #(
           default:     clmul_result = clmul_result_raw;
         endcase
       end
-    end else begin
+    end else begin : gen_alu_rvb_notfull
       assign shuffle_result       = '0;
       assign butterfly_result     = '0;
       assign invbutterfly_result  = '0;

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -85,11 +85,11 @@ module ibex_tracer (
   logic        insn_is_compressed;
 
   // Data items accessed during this instruction
-  localparam RS1 = (1 << 0);
-  localparam RS2 = (1 << 1);
-  localparam RS3 = (1 << 2);
-  localparam RD  = (1 << 3);
-  localparam MEM = (1 << 4);
+  localparam logic [4:0] RS1 = (1 << 0);
+  localparam logic [4:0] RS2 = (1 << 1);
+  localparam logic [4:0] RS3 = (1 << 2);
+  localparam logic [4:0] RD  = (1 << 3);
+  localparam logic [4:0] MEM = (1 << 4);
   logic [4:0] data_accessed;
 
   function automatic void printbuffer_dumpline();
@@ -130,10 +130,10 @@ module ibex_tracer (
     if ((data_accessed & MEM) != 0) begin
       $fwrite(file_handle, " PA:0x%08x", rvfi_mem_addr);
 
-      if (rvfi_mem_rmask != 4'b000) begin
+      if (rvfi_mem_rmask != 4'b0000) begin
         $fwrite(file_handle, " store:0x%08x", rvfi_mem_wdata);
       end
-      if (rvfi_mem_wmask != 4'b000) begin
+      if (rvfi_mem_wmask != 4'b0000) begin
         $fwrite(file_handle, " load:0x%08x", rvfi_mem_rdata);
       end
     end

--- a/rtl/ibex_tracer_pkg.sv
+++ b/rtl/ibex_tracer_pkg.sv
@@ -11,50 +11,50 @@ parameter logic [1:0] OPCODE_C1 = 2'b01;
 parameter logic [1:0] OPCODE_C2 = 2'b10;
 
 // instruction masks (for tracer)
-parameter logic [31:0] INSN_LUI     = { 25'b?,                           {OPCODE_LUI  } };
-parameter logic [31:0] INSN_AUIPC   = { 25'b?,                           {OPCODE_AUIPC} };
-parameter logic [31:0] INSN_JAL     = { 25'b?,                           {OPCODE_JAL  } };
-parameter logic [31:0] INSN_JALR    = { 17'b?,             3'b000, 5'b?, {OPCODE_JALR } };
+parameter logic [31:0] INSN_LUI     = { 25'h?,                           {OPCODE_LUI  } };
+parameter logic [31:0] INSN_AUIPC   = { 25'h?,                           {OPCODE_AUIPC} };
+parameter logic [31:0] INSN_JAL     = { 25'h?,                           {OPCODE_JAL  } };
+parameter logic [31:0] INSN_JALR    = { 17'h?,             3'b000, 5'h?, {OPCODE_JALR } };
 
 // BRANCH
-parameter logic [31:0] INSN_BEQ     = { 17'b?,             3'b000, 5'b?, {OPCODE_BRANCH} };
-parameter logic [31:0] INSN_BNE     = { 17'b?,             3'b001, 5'b?, {OPCODE_BRANCH} };
-parameter logic [31:0] INSN_BLT     = { 17'b?,             3'b100, 5'b?, {OPCODE_BRANCH} };
-parameter logic [31:0] INSN_BGE     = { 17'b?,             3'b101, 5'b?, {OPCODE_BRANCH} };
-parameter logic [31:0] INSN_BLTU    = { 17'b?,             3'b110, 5'b?, {OPCODE_BRANCH} };
-parameter logic [31:0] INSN_BGEU    = { 17'b?,             3'b111, 5'b?, {OPCODE_BRANCH} };
-parameter logic [31:0] INSN_BALL    = { 17'b?,             3'b010, 5'b?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSN_BEQ     = { 17'h?,             3'b000, 5'h?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSN_BNE     = { 17'h?,             3'b001, 5'h?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSN_BLT     = { 17'h?,             3'b100, 5'h?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSN_BGE     = { 17'h?,             3'b101, 5'h?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSN_BLTU    = { 17'h?,             3'b110, 5'h?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSN_BGEU    = { 17'h?,             3'b111, 5'h?, {OPCODE_BRANCH} };
+parameter logic [31:0] INSN_BALL    = { 17'h?,             3'b010, 5'h?, {OPCODE_BRANCH} };
 
 // OPIMM
-parameter logic [31:0] INSN_ADDI    = { 17'b?,             3'b000, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SLTI    = { 17'b?,             3'b010, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SLTIU   = { 17'b?,             3'b011, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_XORI    = { 17'b?,             3'b100, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORI     = { 17'b?,             3'b110, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ANDI    = { 17'b?,             3'b111, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SLLI    = { 7'b0000000, 10'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SRLI    = { 7'b0000000, 10'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SRAI    = { 7'b0100000, 10'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ADDI    = { 17'h?,             3'b000, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SLTI    = { 17'h?,             3'b010, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SLTIU   = { 17'h?,             3'b011, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_XORI    = { 17'h?,             3'b100, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ORI     = { 17'h?,             3'b110, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ANDI    = { 17'h?,             3'b111, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SLLI    = { 7'b0000000, 10'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SRLI    = { 7'b0000000, 10'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SRAI    = { 7'b0100000, 10'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 
 // OP
-parameter logic [31:0] INSN_ADD     = { 7'b0000000, 10'b?, 3'b000, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SUB     = { 7'b0100000, 10'b?, 3'b000, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SLL     = { 7'b0000000, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SLT     = { 7'b0000000, 10'b?, 3'b010, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SLTU    = { 7'b0000000, 10'b?, 3'b011, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_XOR     = { 7'b0000000, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SRL     = { 7'b0000000, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SRA     = { 7'b0100000, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_OR      = { 7'b0000000, 10'b?, 3'b110, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_AND     = { 7'b0000000, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_ADD     = { 7'b0000000, 10'h?, 3'b000, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SUB     = { 7'b0100000, 10'h?, 3'b000, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SLL     = { 7'b0000000, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SLT     = { 7'b0000000, 10'h?, 3'b010, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SLTU    = { 7'b0000000, 10'h?, 3'b011, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_XOR     = { 7'b0000000, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SRL     = { 7'b0000000, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SRA     = { 7'b0100000, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_OR      = { 7'b0000000, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_AND     = { 7'b0000000, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
 
 // SYSTEM
-parameter logic [31:0] INSN_CSRRW   = { 17'b?,             3'b001, 5'b?, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_CSRRS   = { 17'b?,             3'b010, 5'b?, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_CSRRC   = { 17'b?,             3'b011, 5'b?, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_CSRRWI  = { 17'b?,             3'b101, 5'b?, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_CSRRSI  = { 17'b?,             3'b110, 5'b?, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_CSRRCI  = { 17'b?,             3'b111, 5'b?, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSN_CSRRW   = { 17'h?,             3'b001, 5'h?, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSN_CSRRS   = { 17'h?,             3'b010, 5'h?, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSN_CSRRC   = { 17'h?,             3'b011, 5'h?, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSN_CSRRWI  = { 17'h?,             3'b101, 5'h?, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSN_CSRRSI  = { 17'h?,             3'b110, 5'h?, {OPCODE_SYSTEM} };
+parameter logic [31:0] INSN_CSRRCI  = { 17'h?,             3'b111, 5'h?, {OPCODE_SYSTEM} };
 parameter logic [31:0] INSN_ECALL   = { 12'b000000000000,         13'b0, {OPCODE_SYSTEM} };
 parameter logic [31:0] INSN_EBREAK  = { 12'b000000000001,         13'b0, {OPCODE_SYSTEM} };
 parameter logic [31:0] INSN_MRET    = { 12'b001100000010,         13'b0, {OPCODE_SYSTEM} };
@@ -62,241 +62,241 @@ parameter logic [31:0] INSN_DRET    = { 12'b011110110010,         13'b0, {OPCODE
 parameter logic [31:0] INSN_WFI     = { 12'b000100000101,         13'b0, {OPCODE_SYSTEM} };
 
 // RV32M
-parameter logic [31:0] INSN_DIV     = { 7'b0000001, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_DIVU    = { 7'b0000001, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_REM     = { 7'b0000001, 10'b?, 3'b110, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_REMU    = { 7'b0000001, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PMUL    = { 7'b0000001, 10'b?, 3'b000, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PMUH    = { 7'b0000001, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PMULHSU = { 7'b0000001, 10'b?, 3'b010, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PMULHU  = { 7'b0000001, 10'b?, 3'b011, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_DIV     = { 7'b0000001, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_DIVU    = { 7'b0000001, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_REM     = { 7'b0000001, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_REMU    = { 7'b0000001, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_PMUL    = { 7'b0000001, 10'h?, 3'b000, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_PMUH    = { 7'b0000001, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_PMULHSU = { 7'b0000001, 10'h?, 3'b010, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_PMULHU  = { 7'b0000001, 10'h?, 3'b011, 5'h?, {OPCODE_OP} };
 
 // RV32B
 // ZBB
-parameter logic [31:0] INSN_SLOI = { 5'b00100        , 12'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SROI = { 5'b00100        , 12'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_RORI = { 5'b01100        , 12'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CLZ  = { 12'b011000000000, 5'b?,  3'b001, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CTZ  = { 12'b011000000001, 5'b?,  3'b001, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_PCNT = { 12'b011000000010, 5'b?,  3'b001, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SEXTB = { 12'b011000000100, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SEXTH = { 12'b011000000101, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SLOI = { 5'b00100        , 12'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SROI = { 5'b00100        , 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_RORI = { 5'b01100        , 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CLZ  = { 12'b011000000000, 5'h?,  3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CTZ  = { 12'b011000000001, 5'h?,  3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_PCNT = { 12'b011000000010, 5'h?,  3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SEXTB = { 12'b011000000100, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SEXTH = { 12'b011000000101, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 // sext -- pseudoinstruction: andi rd, rs 255
-parameter logic [31:0] INSN_ZEXTB = { 4'b0000, 8'b11111111, 5'b?, 3'b111, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_ZEXTB = { 4'b0000, 8'b11111111, 5'h?, 3'b111, 5'h?, {OPCODE_OP_IMM} };
 // sext -- pseudoinstruction: pack rd, rs zero
-parameter logic [31:0] INSN_ZEXTH = { 7'b0000100, 5'b00000, 5'b?, 3'b100, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_ZEXTH = { 7'b0000100, 5'b00000, 5'h?, 3'b100, 5'h?, {OPCODE_OP} };
 
-parameter logic [31:0] INSN_SLO   = { 7'b0010000, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SRO   = { 7'b0010000, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_ROL   = { 7'b0110000, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_ROR   = { 7'b0110000, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_MIN   = { 7'b0000101, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_MAX   = { 7'b0000101, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_MINU  = { 7'b0000101, 10'b?, 3'b110, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_MAXU  = { 7'b0000101, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_XNOR  = { 7'b0100000, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_ORN   = { 7'b0100000, 10'b?, 3'b110, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_ANDN  = { 7'b0100000, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PACK  = { 7'b0000100, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PACKU = { 7'b0100100, 10'b?, 3'b100, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PACKH = { 7'b0000100, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SLO   = { 7'b0010000, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SRO   = { 7'b0010000, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_ROL   = { 7'b0110000, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_ROR   = { 7'b0110000, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_MIN   = { 7'b0000101, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_MAX   = { 7'b0000101, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_MINU  = { 7'b0000101, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_MAXU  = { 7'b0000101, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_XNOR  = { 7'b0100000, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_ORN   = { 7'b0100000, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_ANDN  = { 7'b0100000, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_PACK  = { 7'b0000100, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_PACKU = { 7'b0100100, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_PACKH = { 7'b0000100, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
 
 // ZBS
-parameter logic [31:0] INSN_SBCLRI = { 5'b01001, 12'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SBSETI = { 5'b00101, 12'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SBINVI = { 5'b01101, 12'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SBEXTI = { 5'b01001, 12'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SBCLRI = { 5'b01001, 12'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SBSETI = { 5'b00101, 12'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SBINVI = { 5'b01101, 12'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SBEXTI = { 5'b01001, 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 
-parameter logic [31:0] INSN_SBCLR = { 7'b0100100, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SBSET = { 7'b0010100, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SBINV = { 7'b0110100, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SBEXT = { 7'b0100100, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SBCLR = { 7'b0100100, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SBSET = { 7'b0010100, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SBINV = { 7'b0110100, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SBEXT = { 7'b0100100, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
 
 // ZBP
 // grevi
-parameter logic [31:0] INSN_GREVI = { 5'b01101, 12'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_GREVI = { 5'b01101, 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 // grevi -- pseudo-instructions
 parameter logic [31:0] INSN_REV_P =
-    { 5'b01101, 2'b?, 5'b00001, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b00001, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV2_N =
-    { 5'b01101, 2'b?, 5'b00010, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b00010, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV_N =
-    { 5'b01101, 2'b?, 5'b00011, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b00011, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV4_B =
-    { 5'b01101, 2'b?, 5'b00100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b00100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV2_B =
-    { 5'b01101, 2'b?, 5'b00110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b00110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV_B =
-    { 5'b01101, 2'b?, 5'b00111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b00111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV8_H =
-    { 5'b01101, 2'b?, 5'b01000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b01000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV4_H =
-    { 5'b01101, 2'b?, 5'b01100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b01100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV2_H =
-    { 5'b01101, 2'b?, 5'b01110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b01110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV_H =
-    { 5'b01101, 2'b?, 5'b01111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b01111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV16 =
-    { 5'b01101, 2'b?, 5'b01000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b01000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV8 =
-    { 5'b01101, 2'b?, 5'b11000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b11000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV4 =
-    { 5'b01101, 2'b?, 5'b11100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b11100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV2 =
-    { 5'b01101, 2'b?, 5'b11110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b11110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_REV =
-    { 5'b01101, 2'b?, 5'b11111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b01101, 2'h?, 5'b11111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 // gorci
-parameter logic [31:0] INSN_GORCI = { 5'b00101, 12'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_GORCI = { 5'b00101, 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 // gorci -- pseudo-instructions
 parameter logic [31:0] INSN_ORC_P =
-    { 5'b00101, 2'b?, 5'b00001, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b00001, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC2_N =
-    { 5'b00101, 2'b?, 5'b00010, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b00010, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC_N =
-    { 5'b00101, 2'b?, 5'b00011, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b00011, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC4_B =
-    { 5'b00101, 2'b?, 5'b00100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b00100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC2_B =
-    { 5'b00101, 2'b?, 5'b00110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b00110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC_B =
-    { 5'b00101, 2'b?, 5'b00111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b00111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC8_H =
-    { 5'b00101, 2'b?, 5'b01000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b01000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC4_H =
-    { 5'b00101, 2'b?, 5'b01100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b01100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC2_H =
-    { 5'b00101, 2'b?, 5'b01110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b01110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC_H =
-    { 5'b00101, 2'b?, 5'b01111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b01111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC16 =
-    { 5'b00101, 2'b?, 5'b01000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b01000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC8 =
-    { 5'b00101, 2'b?, 5'b11000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b11000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC4 =
-    { 5'b00101, 2'b?, 5'b11100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b11100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC2 =
-    { 5'b00101, 2'b?, 5'b11110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b11110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ORC =
-    { 5'b00101, 2'b?, 5'b11111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00101, 2'h?, 5'b11111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 // shfli
-parameter logic [31:0] INSN_SHFLI = { 6'b000010, 11'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_SHFLI = { 6'b000010, 11'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 // shfli -- pseudo-instructions
 parameter logic [31:0] INSN_ZIP_N =
-    { 5'b00010, 3'b?, 4'b0001, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b0001, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ZIP2_B =
-    { 5'b00010, 3'b?, 4'b0010, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b0010, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ZIP_B =
-    { 5'b00010, 3'b?, 4'b0011, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b0011, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ZIP4_H =
-    { 5'b00010, 3'b?, 4'b0100, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b0100, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ZIP2_H =
-    { 5'b00010, 3'b?, 4'b0110, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b0110, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ZIP_H =
-    { 5'b00010, 3'b?, 4'b0111, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b0111, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ZIP8 =
-    { 5'b00010, 3'b?, 4'b1000, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b1000, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ZIP4 =
-    { 5'b00010, 3'b?, 4'b1100, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b1100, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ZIP2 =
-    { 5'b00010, 3'b?, 4'b1110, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b1110, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_ZIP =
-    { 5'b00010, 3'b?, 4'b1111, 5'b?, 3'b001, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b1111, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 // unshfli
-parameter logic [31:0] INSN_UNSHFLI = { 6'b000010, 11'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_UNSHFLI = { 6'b000010, 11'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 // unshfli -- pseudo-instructions
 parameter logic [31:0] INSN_UNZIP_N =
-    { 5'b00010, 3'b?, 4'b0001, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b0001, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_UNZIP2_B =
-    { 5'b00010, 3'b?, 4'b0010, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b0010, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_UNZIP_B =
-    { 5'b00010, 3'b?, 4'b0011, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b0011, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_UNZIP4_H =
-    { 5'b00010, 3'b?, 4'b0100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b0100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_UNZIP2_H =
-    { 5'b00010, 3'b?, 4'b0110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b0110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_UNZIP_H =
-    { 5'b00010, 3'b?, 4'b0111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b0111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_UNZIP8 =
-    { 5'b00010, 3'b?, 4'b1000, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b1000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_UNZIP4 =
-    { 5'b00010, 3'b?, 4'b1100, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b1100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_UNZIP2 =
-    { 5'b00010, 3'b?, 4'b1110, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b1110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_UNZIP =
-    { 5'b00010, 3'b?, 4'b1111, 5'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+    { 5'b00010, 3'h?, 4'b1111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 
-parameter logic [31:0] INSN_GREV   = { 7'b0110100, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_GORC   = { 7'b0010100, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SHFL   = { 7'b0000100, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_UNSHFL = { 7'b0000100, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_GREV   = { 7'b0110100, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_GORC   = { 7'b0010100, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_SHFL   = { 7'b0000100, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_UNSHFL = { 7'b0000100, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
 
 // ZBE
-parameter logic [31:0] INSN_BDEP = {7'b0100100, 10'b?, 3'b110, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_BEXT = {7'b0000100, 10'b?, 3'b110, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_BDEP = {7'b0100100, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_BEXT = {7'b0000100, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
 
 // ZBT
-parameter logic [31:0] INSN_FSRI = { 5'b?, 1'b1, 11'b?, 3'b101, 5'b?, {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_FSRI = { 5'h?, 1'b1, 11'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 
-parameter logic [31:0] INSN_CMIX = {5'b?, 2'b11, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_CMOV = {5'b?, 2'b11, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_FSL  = {5'b?, 2'b10, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_FSR  = {5'b?, 2'b10, 10'b?, 3'b101, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_CMIX = {5'h?, 2'b11, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_CMOV = {5'h?, 2'b11, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_FSL  = {5'h?, 2'b10, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_FSR  = {5'h?, 2'b10, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
 
 // ZBF
-parameter logic [31:0] INSN_BFP  = {7'b0100100, 10'b?, 3'b111, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_BFP  = {7'b0100100, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
 
 // ZBC
-parameter logic [31:0] INSN_CLMUL  = {7'b0000101, 10'b?, 3'b001, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_CLMULR = {7'b0000101, 10'b?, 3'b010, 5'b?, {OPCODE_OP} };
-parameter logic [31:0] INSN_CLMULH = {7'b0000101, 10'b?, 3'b011, 5'b?, {OPCODE_OP} };
+parameter logic [31:0] INSN_CLMUL  = {7'b0000101, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_CLMULR = {7'b0000101, 10'h?, 3'b010, 5'h?, {OPCODE_OP} };
+parameter logic [31:0] INSN_CLMULH = {7'b0000101, 10'h?, 3'b011, 5'h?, {OPCODE_OP} };
 
 // ZBR
-parameter logic [31:0] INSN_CRC32_B  = {7'b0110000, 5'b10000, 5'b?, 3'b001, 5'b?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32_H  = {7'b0110000, 5'b10001, 5'b?, 3'b001, 5'b?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32_W  = {7'b0110000, 5'b10010, 5'b?, 3'b001, 5'b?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32C_B = {7'b0110000, 5'b11000, 5'b?, 3'b001, 5'b?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32C_H = {7'b0110000, 5'b11001, 5'b?, 3'b001, 5'b?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32C_W = {7'b0110000, 5'b11010, 5'b?, 3'b001, 5'b?,  {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32_B  = {7'b0110000, 5'b10000, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32_H  = {7'b0110000, 5'b10001, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32_W  = {7'b0110000, 5'b10010, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32C_B = {7'b0110000, 5'b11000, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32C_H = {7'b0110000, 5'b11001, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
+parameter logic [31:0] INSN_CRC32C_W = {7'b0110000, 5'b11010, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
 
 // LOAD & STORE
-parameter logic [31:0] INSN_LOAD    = {25'b?,                            {OPCODE_LOAD } };
-parameter logic [31:0] INSN_STORE   = {25'b?,                            {OPCODE_STORE} };
+parameter logic [31:0] INSN_LOAD    = {25'h?,                            {OPCODE_LOAD } };
+parameter logic [31:0] INSN_STORE   = {25'h?,                            {OPCODE_STORE} };
 
 // MISC-MEM
-parameter logic [31:0] INSN_FENCE   = { 17'b?,             3'b000, 5'b?, {OPCODE_MISC_MEM} };
-parameter logic [31:0] INSN_FENCEI  = { 17'b0,             3'b001, 5'b0, {OPCODE_MISC_MEM} };
+parameter logic [31:0] INSN_FENCE   = { 17'h?,             3'b000, 5'h?, {OPCODE_MISC_MEM} };
+parameter logic [31:0] INSN_FENCEI  = { 17'h0,             3'b001, 5'h0, {OPCODE_MISC_MEM} };
 
 // Compressed Instructions
 // C0
-parameter logic [15:0] INSN_CADDI4SPN  = { 3'b000,       11'b?,                    {OPCODE_C0} };
-parameter logic [15:0] INSN_CLW        = { 3'b010,       11'b?,                    {OPCODE_C0} };
-parameter logic [15:0] INSN_CSW        = { 3'b110,       11'b?,                    {OPCODE_C0} };
+parameter logic [15:0] INSN_CADDI4SPN  = { 3'b000,       11'h?,                    {OPCODE_C0} };
+parameter logic [15:0] INSN_CLW        = { 3'b010,       11'h?,                    {OPCODE_C0} };
+parameter logic [15:0] INSN_CSW        = { 3'b110,       11'h?,                    {OPCODE_C0} };
 
 // C1
-parameter logic [15:0] INSN_CADDI      = { 3'b000,       11'b?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CJAL       = { 3'b001,       11'b?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CJ         = { 3'b101,       11'b?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CLI        = { 3'b010,       11'b?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CLUI       = { 3'b011,       11'b?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CBEQZ      = { 3'b110,       11'b?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CBNEZ      = { 3'b111,       11'b?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CSRLI      = { 3'b100, 1'b?, 2'b00, 8'b?,              {OPCODE_C1} };
-parameter logic [15:0] INSN_CSRAI      = { 3'b100, 1'b?, 2'b01, 8'b?,              {OPCODE_C1} };
-parameter logic [15:0] INSN_CANDI      = { 3'b100, 1'b?, 2'b10, 8'b?,              {OPCODE_C1} };
-parameter logic [15:0] INSN_CSUB       = { 3'b100, 1'b0, 2'b11, 3'b?, 2'b00, 3'b?, {OPCODE_C1} };
-parameter logic [15:0] INSN_CXOR       = { 3'b100, 1'b0, 2'b11, 3'b?, 2'b01, 3'b?, {OPCODE_C1} };
-parameter logic [15:0] INSN_COR        = { 3'b100, 1'b0, 2'b11, 3'b?, 2'b10, 3'b?, {OPCODE_C1} };
-parameter logic [15:0] INSN_CAND       = { 3'b100, 1'b0, 2'b11, 3'b?, 2'b11, 3'b?, {OPCODE_C1} };
+parameter logic [15:0] INSN_CADDI      = { 3'b000,       11'h?,                    {OPCODE_C1} };
+parameter logic [15:0] INSN_CJAL       = { 3'b001,       11'h?,                    {OPCODE_C1} };
+parameter logic [15:0] INSN_CJ         = { 3'b101,       11'h?,                    {OPCODE_C1} };
+parameter logic [15:0] INSN_CLI        = { 3'b010,       11'h?,                    {OPCODE_C1} };
+parameter logic [15:0] INSN_CLUI       = { 3'b011,       11'h?,                    {OPCODE_C1} };
+parameter logic [15:0] INSN_CBEQZ      = { 3'b110,       11'h?,                    {OPCODE_C1} };
+parameter logic [15:0] INSN_CBNEZ      = { 3'b111,       11'h?,                    {OPCODE_C1} };
+parameter logic [15:0] INSN_CSRLI      = { 3'b100, 1'h?, 2'b00, 8'h?,              {OPCODE_C1} };
+parameter logic [15:0] INSN_CSRAI      = { 3'b100, 1'h?, 2'b01, 8'h?,              {OPCODE_C1} };
+parameter logic [15:0] INSN_CANDI      = { 3'b100, 1'h?, 2'b10, 8'h?,              {OPCODE_C1} };
+parameter logic [15:0] INSN_CSUB       = { 3'b100, 1'b0, 2'b11, 3'h?, 2'b00, 3'h?, {OPCODE_C1} };
+parameter logic [15:0] INSN_CXOR       = { 3'b100, 1'b0, 2'b11, 3'h?, 2'b01, 3'h?, {OPCODE_C1} };
+parameter logic [15:0] INSN_COR        = { 3'b100, 1'b0, 2'b11, 3'h?, 2'b10, 3'h?, {OPCODE_C1} };
+parameter logic [15:0] INSN_CAND       = { 3'b100, 1'b0, 2'b11, 3'h?, 2'b11, 3'h?, {OPCODE_C1} };
 
 // C2
-parameter logic [15:0] INSN_CSLLI      = { 3'b000,       11'b?,                    {OPCODE_C2} };
-parameter logic [15:0] INSN_CLWSP      = { 3'b010,       11'b?,                    {OPCODE_C2} };
-parameter logic [15:0] INSN_SWSP       = { 3'b110,       11'b?,                    {OPCODE_C2} };
-parameter logic [15:0] INSN_CMV        = { 3'b100, 1'b0, 10'b?,                    {OPCODE_C2} };
-parameter logic [15:0] INSN_CADD       = { 3'b100, 1'b1, 10'b?,                    {OPCODE_C2} };
-parameter logic [15:0] INSN_CEBREAK    = { 3'b100, 1'b1,        5'b0,  5'b0,       {OPCODE_C2} };
-parameter logic [15:0] INSN_CJR        = { 3'b100, 1'b0,        5'b?,  5'b0,       {OPCODE_C2} };
-parameter logic [15:0] INSN_CJALR      = { 3'b100, 1'b1,        5'b?,  5'b0,       {OPCODE_C2} };
+parameter logic [15:0] INSN_CSLLI      = { 3'b000,       11'h?,                    {OPCODE_C2} };
+parameter logic [15:0] INSN_CLWSP      = { 3'b010,       11'h?,                    {OPCODE_C2} };
+parameter logic [15:0] INSN_SWSP       = { 3'b110,       11'h?,                    {OPCODE_C2} };
+parameter logic [15:0] INSN_CMV        = { 3'b100, 1'b0, 10'h?,                    {OPCODE_C2} };
+parameter logic [15:0] INSN_CADD       = { 3'b100, 1'b1, 10'h?,                    {OPCODE_C2} };
+parameter logic [15:0] INSN_CEBREAK    = { 3'b100, 1'b1,        5'h0,  5'h0,       {OPCODE_C2} };
+parameter logic [15:0] INSN_CJR        = { 3'b100, 1'b0,        5'h0,  5'h0,       {OPCODE_C2} };
+parameter logic [15:0] INSN_CJALR      = { 3'b100, 1'b1,        5'h?,  5'h0,       {OPCODE_C2} };
 
 endpackage

--- a/shared/rtl/bus.sv
+++ b/shared/rtl/bus.sv
@@ -15,10 +15,10 @@
  * - Host (master) arbitration is strictly priority based.
  */
 module bus #(
-  parameter NrDevices    = 1,
-  parameter NrHosts      = 1,
-  parameter DataWidth    = 32,
-  parameter AddressWidth = 32
+  parameter int NrDevices    = 1,
+  parameter int NrHosts      = 1,
+  parameter int DataWidth    = 32,
+  parameter int AddressWidth = 32
 ) (
   input                           clk_i,
   input                           rst_ni,

--- a/shared/rtl/sim/simulator_ctrl.sv
+++ b/shared/rtl/sim/simulator_ctrl.sv
@@ -38,8 +38,8 @@ module simulator_ctrl #(
   output logic [31:0] rdata_o
 );
 
-  localparam CHAR_OUT_ADDR = 0;
-  localparam SIM_CTRL_ADDR = 2;
+  localparam logic [7:0] CHAR_OUT_ADDR = 8'h0;
+  localparam logic [7:0] SIM_CTRL_ADDR = 8'h2;
 
   logic [7:0] ctrl_addr;
   logic [2:0] sim_finish = 3'b000;
@@ -81,6 +81,7 @@ module simulator_ctrl #(
               sim_finish <= 3'b001;
             end
           end
+          default: ;
         endcase
       end
     end
@@ -95,4 +96,3 @@ module simulator_ctrl #(
 
   assign rdata_o = '0;
 endmodule
-

--- a/shared/rtl/timer.sv
+++ b/shared/rtl/timer.sv
@@ -53,7 +53,7 @@ module timer #(
   assign timer_we = timer_req_i & timer_we_i;
 
   // mtime increments every cycle
-  assign mtime_inc = mtime_q + 64'b1;
+  assign mtime_inc = mtime_q + 64'd1;
 
   // Generate write data based on byte strobes
   for (genvar b = 0; b < DataWidth / 8; b++) begin : gen_byte_wdata


### PR DESCRIPTION
Fix all remaining issues reported by Verible lint.

It turns out that #965 undid some of the fixes in `ibex_alu.sv`
that were done in #980 around the `SHUFFLE_*`/`FLIP_*` signals.