### PR TITLE
Enforce Verible Lint in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ jobs:
       fusesoc --version
       verilator --version
       riscv32-unknown-elf-gcc --version
-      verilog_lint --version
+      verible-verilog-lint --version
     displayName: Display environment
 
   # Verible lint/format is experimental so only run on default config for now,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,19 +100,8 @@ jobs:
       verible-verilog-lint --version
     displayName: Display environment
 
-  # Verible lint/format is experimental so only run on default config for now,
+  # Verible format is experimental so only run on default config for now,
   # will eventually become part of the per-config CI
-  - bash: |
-      fusesoc --cores-root . run --no-export --target=lint --tool=veriblelint lowrisc:ibex:ibex_core_tracing
-      if [ $? != 0 ]; then
-        echo -n "##vso[task.logissue type=error]"
-        echo "Verilog lint with Verible failed. Run 'fusesoc --cores-root . run --target=lint --tool=veriblelint lowrisc:ibex:ibex_core_tracing' to check and fix all errors."
-        echo "This flow is currently experimental and failures can be ignored."
-        exit 1
-      fi
-    continueOnError: true
-    displayName: Lint Verilog source files with Verible (experimental)
-
   - bash: |
       fusesoc --cores-root . run --no-export --target=format --tool=veribleformat lowrisc:ibex:ibex_core_tracing
       if [ $? != 0 ]; then

--- a/ci/ibex-rtl-ci-steps.yml
+++ b/ci/ibex-rtl-ci-steps.yml
@@ -23,6 +23,15 @@ steps:
       displayName: Lint Verilog source files with Verilator for ${{ config }}
 
     - bash: |
+        fusesoc --cores-root . run --target=lint lowrisc:ibex:ibex_core_tracing $IBEX_CONFIG_OPTS
+        if [ $? != 0 ]; then
+          echo -n "##vso[task.logissue type=error]"
+          echo "Verilog lint failed. Run 'fusesoc --cores-root . run --target=lint --tool=veriblelint lowrisc:ibex:ibex_core_tracing $IBEX_CONFIG_OPTS' to check and fix all errors."
+          exit 1
+        fi
+      displayName: Lint Verilog source files with Verible Verilog Lint for ${{ config }}
+
+    - bash: |
         # Build simulation model of Ibex
         fusesoc --cores-root=. run --target=sim --setup --build lowrisc:ibex:ibex_riscv_compliance $IBEX_CONFIG_OPTS
         if [ $? != 0 ]; then

--- a/ci/ibex-rtl-ci-steps.yml
+++ b/ci/ibex-rtl-ci-steps.yml
@@ -17,7 +17,7 @@ steps:
         fusesoc --cores-root . run --target=lint lowrisc:ibex:ibex_core_tracing $IBEX_CONFIG_OPTS
         if [ $? != 0 ]; then
           echo -n "##vso[task.logissue type=error]"
-          echo "Verilog lint failed. Run 'fusesoc --cores-root . run --target=lint lowrisc:ibex:ibex_core_tracing' to check and fix all errors."
+          echo "Verilog lint failed. Run 'fusesoc --cores-root . run --target=lint --tool=verilator lowrisc:ibex:ibex_core_tracing $IBEX_CONFIG_OPTS' to check and fix all errors."
           exit 1
         fi
       displayName: Lint Verilog source files with Verilator for ${{ config }}

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -48,6 +48,10 @@ filesets:
     files:
       - lint/verilator_waiver.vlt: {file_type: vlt}
 
+  files_lint_verible:
+    files:
+      - lint/verible_waiver.vbw: {file_type: veribleLintWaiver}
+
   files_check_tool_requirements:
     depend:
      - lowrisc:tool:check_tool_requirements
@@ -132,22 +136,19 @@ parameters:
     description: "Number of PMP regions"
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - tool_verilator ? (files_lint_verilator)
+      - tool_veriblelint ? (files_lint_verible)
       - files_rtl
       - files_check_tool_requirements
+    toplevel: ibex_core
   lint:
-    filesets:
-      - tool_verilator ? (files_lint_verilator)
-      - files_rtl
-      - files_lint
-      - files_check_tool_requirements
+    <<: *default_target
     parameters:
       - SYNTHESIS=true
       - RVFI=true
     default_tool: verilator
-    toplevel: ibex_core
     tools:
       verilator:
         mode: lint-only

--- a/lint/verible_waiver.vbw
+++ b/lint/verible_waiver.vbw
@@ -1,0 +1,1 @@
+waive --rule=module-filename --regex=".*" --location="ibex_register_file_.+"


### PR DESCRIPTION
Add the last remaining things to enforce Verible lint in CI:
- Add a waiver file. The waiver files currently don't support comments, and require the "empty" regex; bugs have been filed to get that resolved upstream.
- Enable it per config
- Add lint for the simple system
- Some core file cleanups.

Fixes #579