### PR TITLE
Enable ibex_simple_system lint in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,3 +149,20 @@ jobs:
         - small
         - experimental-maxperf-pmp
         - experimental-maxperf-pmp-bmfull
+
+  # Run lint on simple system
+  - bash: |
+      fusesoc --cores-root . run --target=lint --tool=verilator lowrisc:ibex:ibex_simple_system
+      if [ $? != 0 ]; then
+        echo -n "##vso[task.logissue type=error]"
+        echo "Verilog lint with Verible failed. Run 'fusesoc --cores-root . run --target=lint --tool=verilator lowrisc:ibex:ibex_simple_system' to check and fix all errors."
+      fi
+    displayName: Run Verilator lint on simple system
+
+  - bash: |
+      fusesoc --cores-root . run --target=lint --tool=veriblelint lowrisc:ibex:ibex_simple_system
+      if [ $? != 0 ]; then
+        echo -n "##vso[task.logissue type=error]"
+        echo "Verilog lint with Verible failed. Run 'fusesoc --cores-root . run --target=lint --tool=verilator lowrisc:ibex:ibex_simple_system' to check and fix all errors."
+      fi
+    displayName: Run Verible lint on simple system

--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -22,7 +22,6 @@ filesets:
       - ibex_simple_system.cc: { file_type: cppSource }
       - lint/verilator_waiver.vlt: {file_type: vlt}
 
-
 parameters:
   RV32M:
     datatype: int
@@ -89,10 +88,6 @@ targets:
       - tool_verilator ? (files_verilator)
       - files_sim
     toplevel: ibex_simple_system
-
-  sim:
-    <<: *default_target
-    default_tool: verilator
     parameters:
       - RV32M
       - RV32E
@@ -104,6 +99,22 @@ targets:
       - PMPGranularity
       - PMPNumRegions
       - SRAMInitFile
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+          # RAM primitives wider than 64bit (required for ECC) fail to build in
+          # Verilator without increasing the unroll count (see Verilator#1266)
+          - "--unroll-count 72"
+
+  sim:
+    <<: *default_target
+    default_tool: verilator
     tools:
       vcs:
         vcs_options:
@@ -134,4 +145,3 @@ targets:
           # RAM primitives wider than 64bit (required for ECC) fail to build in
           # Verilator without increasing the unroll count (see Verilator#1266)
           - "--unroll-count 72"
-

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
+      - lowrisc:prim:clock_gating
       # TODO: Only lfsr is needed. Replace with a more specific dependency
       # once available.
       - lowrisc:prim:all

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:ibex:ibex_core:0.1"
-description: "CPU core with 2 stage pipeline implementing the RV32IMC_Zicsr_Zifencei ISA"
+description: "Ibex, a small RV32 CPU core"
 
 filesets:
   files_rtl:

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -41,10 +41,6 @@ filesets:
       - rtl/ibex_core.sv
     file_type: systemVerilogSource
 
-  files_lint:
-    depend:
-      - lowrisc:ibex:sim_shared
-
   files_lint_verilator:
     files:
       - lint/verilator_waiver.vlt: {file_type: vlt}

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -154,10 +154,6 @@ targets:
           # RAM primitives wider than 64bit (required for ECC) fail to build in
           # Verilator without increasing the unroll count (see Verilator#1266)
           - "--unroll-count 72"
-      veriblelint:
-        ruleset: default
-        rules:
-          - "-parameter-name-style"
   format:
     filesets:
       - files_rtl

--- a/ibex_core_tracing.core
+++ b/ibex_core_tracing.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:ibex:ibex_core_tracing:0.1"
-description: "Ibex CPU core with tracing enabled"
+description: "Ibex, a small RV32 CPU core with tracing enabled"
 filesets:
   files_rtl:
     depend:

--- a/ibex_core_tracing.core
+++ b/ibex_core_tracing.core
@@ -13,11 +13,6 @@ filesets:
       - rtl/ibex_core_tracing.sv
     file_type: systemVerilogSource
 
-
-  files_lint_verilator:
-    files:
-      - lint/verilator_waiver.vlt: {file_type: vlt}
-
 parameters:
   # The tracer uses the RISC-V Formal Interface (RVFI) to collect trace signals.
   RVFI:
@@ -100,19 +95,15 @@ parameters:
     description: "Number of PMP regions"
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_rtl
     parameters:
       - RVFI=true
+    toplevel: ibex_core_tracing
 
   lint:
-    filesets:
-      # Note on Verilator waivers:
-      # You *must* include the waiver file first, otherwise only global waivers
-      # are applied, but not file-specific waivers.
-      - tool_verilator ? (files_lint_verilator)
-      - files_rtl
+    <<: *default_target
     parameters:
       - RVFI=true
       - SYNTHESIS=true
@@ -127,7 +118,6 @@ targets:
       - PMPGranularity
       - PMPNumRegions
     default_tool: verilator
-    toplevel: ibex_core_tracing
     tools:
       verilator:
         mode: lint-only
@@ -136,10 +126,6 @@ targets:
           # RAM primitives wider than 64bit (required for ECC) fail to build in
           # Verilator without increasing the unroll count (see Verilator#1266)
           - "--unroll-count 72"
-      veriblelint:
-        ruleset: default
-        rules:
-          - "-parameter-name-style"
   format:
     filesets:
       - files_rtl

--- a/ibex_core_tracing.core
+++ b/ibex_core_tracing.core
@@ -13,9 +13,6 @@ filesets:
       - rtl/ibex_core_tracing.sv
     file_type: systemVerilogSource
 
-  files_lint:
-    depend:
-      - lowrisc:ibex:sim_shared
 
   files_lint_verilator:
     files:
@@ -116,7 +113,6 @@ targets:
       # are applied, but not file-specific waivers.
       - tool_verilator ? (files_lint_verilator)
       - files_rtl
-      - files_lint
     parameters:
       - RVFI=true
       - SYNTHESIS=true

--- a/ibex_icache.core
+++ b/ibex_icache.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:ibex:ibex_icache:0.1"
-description: "IBEX_ICACHE DV sim target"
+description: "Ibex instruction cache"
 filesets:
   files_rtl:
     depend:

--- a/ibex_icache.core
+++ b/ibex_icache.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:prim:secded
       - lowrisc:prim:ram_1p
+      - lowrisc:prim:assert
     files:
       - rtl/ibex_icache.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
This PR contains a rather odd collection of papercut commits, none of them are really spectacular.

The most significant change, besides the end result of enabling lint for simple system, is the addition of the prim_clock_gating dependency. I'll most likely put this one into a separate PR, but I want to see CI for the whole thing first.