### PR TITLE
Get the simple_system example working with VCS

### DIFF
--- a/examples/simple_system/README.md
+++ b/examples/simple_system/README.md
@@ -99,7 +99,7 @@ The simulator produces several output files
 Similar to the Verilator flow the Simple System simulator binary can be built using:
 
 ```
-fusesoc --cores-root=. run --target=sim --tool=vcs --setup --build lowrisc:ibex:ibex_simple_system --RV32M=1 --RV32E=0 --SRAM_INIT_FILE=`<sw_vmem_file>`
+fusesoc --cores-root=. run --target=sim --tool=vcs --setup --build lowrisc:ibex:ibex_simple_system --RV32M=1 --RV32E=0 --SRAMInitFile=`<sw_vmem_file>`
 ```
 
 `<sw_vmem_file>` should be a path to a vmem file built as described above, use
@@ -119,7 +119,7 @@ Pass `-gui` to use the DVE GUI.
 To build and run Simple System run:
 
 ```
-fusesoc --cores-root=. run --target=sim --tool=rivierapro lowrisc:ibex:ibex_simple_system --RV32M=1 --RV32E=0 --SRAM_INIT_FILE=<sw_vmem_file>
+fusesoc --cores-root=. run --target=sim --tool=rivierapro lowrisc:ibex:ibex_simple_system --RV32M=1 --RV32E=0 --SRAMInitFile=<sw_vmem_file>
 ```
 
 `<sw_vmem_file>` should be a path to a vmem file built as described above, use

--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -5,20 +5,21 @@ CAPI=2:
 name: "lowrisc:ibex:ibex_simple_system"
 description: "Generic simple system for running binaries on ibex using verilator"
 filesets:
-  files_sim_verilator:
+  files_sim:
+    depend:
+      - lowrisc:ibex:ibex_core_tracing
+      - lowrisc:ibex:sim_shared
+    files:
+      - rtl/ibex_simple_system.sv
+    file_type: systemVerilogSource
+
+  files_verilator:
     depend:
       - lowrisc:dv_verilator:memutil_verilator
       - lowrisc:dv_verilator:simutil_verilator
-      - lowrisc:ibex:ibex_core_tracing
-      - lowrisc:ibex:sim_shared
       - lowrisc:dv_verilator:ibex_pcounts
     files:
-      - rtl/ibex_simple_system.sv
       - ibex_simple_system.cc: { file_type: cppSource }
-    file_type: systemVerilogSource
-
-  files_verilator_waiver:
-    files:
       - lint/verilator_waiver.vlt: {file_type: vlt}
 
 
@@ -41,9 +42,9 @@ parameters:
     paramtype: vlogdefine
     description: "Bitmanip implementation parameter enum. See ibex_pkg.sv (EXPERIMENTAL)"
 
-  SRAM_INIT_FILE:
+  SRAMInitFile:
     datatype: str
-    paramtype: vlogdefine
+    paramtype: vlogparam
     description: "Path to a vmem file to initialize the RAM with"
 
   MultiplierImplementation:
@@ -85,8 +86,8 @@ parameters:
 targets:
   default: &default_target
     filesets:
-      - tool_verilator ? (files_verilator_waiver)
-      - files_sim_verilator
+      - tool_verilator ? (files_verilator)
+      - files_sim
     toplevel: ibex_simple_system
 
   sim:
@@ -102,7 +103,7 @@ targets:
       - PMPEnable
       - PMPGranularity
       - PMPNumRegions
-      - SRAM_INIT_FILE
+      - SRAMInitFile
     tools:
       vcs:
         vcs_options:

--- a/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/examples/simple_system/rtl/ibex_simple_system.sv
@@ -32,6 +32,7 @@ module ibex_simple_system (
   parameter bit               BranchTargetALU          = 1'b0;
   parameter bit               WritebackStage           = 1'b0;
   parameter                   MultiplierImplementation = "fast";
+  parameter                   SRAMInitFile             = "";
 
   logic clk_sys = 1'b0, rst_sys_n;
 
@@ -198,7 +199,8 @@ module ibex_simple_system (
 
   // SRAM block for instruction and data storage
   ram_2p #(
-      .Depth(1024*1024/4)
+      .Depth(1024*1024/4),
+      .MemInitFile(SRAMInitFile)
     ) u_ram (
       .clk_i       (clk_sys),
       .rst_ni      (rst_sys_n),

--- a/shared/rtl/ram_1p.sv
+++ b/shared/rtl/ram_1p.sv
@@ -9,7 +9,8 @@
 `include "prim_assert.sv"
 
 module ram_1p #(
-    parameter int Depth = 128
+    parameter int Depth       = 128,
+    parameter     MemInitFile = ""
 ) (
     input               clk_i,
     input               rst_ni,
@@ -53,7 +54,8 @@ module ram_1p #(
   prim_ram_1p #(
       .Width(32),
       .DataBitsPerMask(8),
-      .Depth(Depth)
+      .Depth(Depth),
+      .MemInitFile(MemInitFile)
     ) u_ram (
       .clk_i     (clk_i),
       .req_i     (req_i),

--- a/shared/rtl/ram_2p.sv
+++ b/shared/rtl/ram_2p.sv
@@ -9,7 +9,8 @@
 `include "prim_assert.sv"
 
 module ram_2p #(
-    parameter int Depth = 128
+    parameter int Depth       = 128,
+    parameter     MemInitFile = ""
 ) (
     input               clk_i,
     input               rst_ni,
@@ -66,7 +67,8 @@ module ram_2p #(
 
   prim_ram_2p #(
     .Width(32),
-    .Depth(Depth)
+    .Depth(Depth),
+    .MemInitFile(MemInitFile)
   ) u_ram (
     .clk_a_i   (clk_i),
     .clk_b_i   (clk_i),


### PR DESCRIPTION
This has two components:

1. Plumbing MemInitFile through properly
1. Rejigging the simple_system core file to allow non-verilator builds

I've checked, and the "hello world" example generates the same trace with VCS (modulo some Xs).
