### PR TITLE
Remove lowrisc:prim:clock_gating from shared core collections

### DIFF
--- a/shared/fpga_xilinx.core
+++ b/shared/fpga_xilinx.core
@@ -6,8 +6,6 @@ name: "lowrisc:ibex:fpga_xilinx_shared"
 description: "Collection of useful RTL for Xilinx based examples"
 filesets:
   files_sv:
-    depend:
-      - lowrisc:prim:clock_gating
     files:
       - rtl/fpga/xilinx/clkgen_xil7series.sv
       - rtl/ram_1p.sv

--- a/shared/sim_shared.core
+++ b/shared/sim_shared.core
@@ -10,7 +10,6 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:ram_1p
       - lowrisc:prim:ram_2p
-      - lowrisc:prim:clock_gating
     files:
       - ./rtl/ram_1p.sv
       - ./rtl/ram_2p.sv


### PR DESCRIPTION
The clock gating primitive is now a dependency of the
lowrisc:ibex:ibex_core file directly and only used in there, we can
remove it from the simulation or FPGA dependency collections.