### PR TITLE
Use the Xilinx primitives for the Arty board

### DIFF
--- a/examples/fpga/artya7/top_artya7.core
+++ b/examples/fpga/artya7/top_artya7.core
@@ -37,6 +37,12 @@ parameters:
     default: 1
     paramtype: vlogdefine
 
+  # For value definition, please see ip/prim/rtl/prim_pkg.sv
+  PRIM_DEFAULT_IMPL:
+    datatype: str
+    paramtype: vlogdefine
+    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
+
 targets:
   synth:
     default_tool: vivado
@@ -47,6 +53,7 @@ targets:
     parameters:
       - SRAMInitFile
       - FPGA_XILINX
+      - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
     tools:
       vivado:
         part: "xc7a100tcsg324-1"  # Default to Arty A7-100


### PR DESCRIPTION
Use Xilinx-specific implementations for primitives, such as RAM and the
clock gate (which will now be implemented using a BUFGCE macro, and no
longer with a latch).

Verified in Vivado synthesis to pick up the Xilinx primitive now.