### PR TITLE
Clean up Verilator sections in core files

### DIFF
--- a/dv/cs_registers/lint/verilator_waiver.vlt
+++ b/dv/cs_registers/lint/verilator_waiver.vlt
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Lint waivers for processing simple_system RTL with Verilator
+//
+// This should be used for rules applying to things like testbench
+// top-levels. For rules that apply to the actual design (files in the
+// 'rtl' directory), see verilator_waiver_rtl.vlt in the same
+// directory.
+//
+// See https://www.veripool.org/projects/verilator/wiki/Manual-verilator#CONFIGURATION-FILES
+// for documentation.
+//
+// Important: This file must included *before* any other Verilog file is read.
+// Otherwise, only global waivers are applied, but not file-specific waivers.
+
+`verilator_config
+
+// We use boolean top-level parameters.
+// When building with fusesoc, these get set with defines like
+// -GRV32M=1 (rather than -GRV32M=1'b1), leading to warnings like:
+//
+//   Operator VAR '<varname>' expects 1 bits on the Initial value, but
+//   Initial value's CONST '32'h1' generates 32 bits.
+//
+// This signoff rule ignores errors like this. Note that it only
+// matches when you set a 1-bit value to a literal 1, so it won't hide
+// silly mistakes like setting it to 2.
+//
+lint_off -rule WIDTH -file "*/tb/tb_cs_registers.sv"
+         -match "*expects 1 bits*Initial value's CONST '32'h1'*"

--- a/dv/cs_registers/tb/tb_cs_registers.sv
+++ b/dv/cs_registers/tb/tb_cs_registers.sv
@@ -3,15 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module tb_cs_registers #(
-    parameter bit          DbgTriggerEn     = 0,
-    parameter bit          ICache           = 0,
+    parameter bit          DbgTriggerEn     = 1'b0,
+    parameter bit          ICache           = 1'b0,
     parameter int unsigned MHPMCounterNum   = 8,
     parameter int unsigned MHPMCounterWidth = 40,
-    parameter bit          PMPEnable        = 0,
+    parameter bit          PMPEnable        = 1'b0,
     parameter int unsigned PMPGranularity   = 0,
     parameter int unsigned PMPNumRegions    = 4,
-    parameter bit          RV32E            = 0,
-    parameter bit          RV32M            = 0
+    parameter bit          RV32E            = 1'b0,
+    parameter bit          RV32M            = 1'b0
 ) (
     // Clock and Reset
     inout  wire                 clk_i,

--- a/dv/cs_registers/tb_cs_registers.core
+++ b/dv/cs_registers/tb_cs_registers.core
@@ -30,11 +30,12 @@ filesets:
       - model/register_model.h
     file_type: user
 
-  files_sim_verilator:
+  files_verilator:
     depend:
       - lowrisc:dv_verilator:simutil_verilator
     files:
       - tb/tb_cs_registers.cc: { file_type: cppSource }
+      - lint/verilator_waiver.vlt: {file_type: vlt}
 
   files_sim:
     depend:
@@ -90,7 +91,7 @@ targets:
     toplevel: tb_cs_registers
     filesets:
       - files_sim
-      - files_sim_verilator
+      - tool_verilator ? (files_verilator)
     hooks:
       pre_build:
         - build_so

--- a/dv/cs_registers/tb_cs_registers.core
+++ b/dv/cs_registers/tb_cs_registers.core
@@ -118,19 +118,9 @@ targets:
           # huge influence on runtime performance.
           - '--trace'
           - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
-          # Remove FST options for VCD trace (~100 x faster but larger files)
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
           - '-CFLAGS "-std=c++14 -Wall -DTOPLEVEL_NAME=tb_cs_registers -DVM_TRACE_FMT_FST -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
-          - "-Wno-PINCONNECTEMPTY"
-          # XXX: Cleanup all warnings and remove this option
-          # (or make it more fine-grained at least)
-          - "-Wno-fatal"
-        make_options:
-          # Optimization levels have a large impact on the runtime performance
-          # of the simulation model. -O2 and -O3 are pretty similar, -Os is
-          # slower than -O2/-O3
-          - OPT_FAST="-O2"

--- a/dv/riscv_compliance/ibex_riscv_compliance.core
+++ b/dv/riscv_compliance/ibex_riscv_compliance.core
@@ -103,19 +103,9 @@ targets:
           # huge influence on runtime performance.
           - '--trace'
           - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
-          # Remove FST options for VCD trace (~100 x faster but larger files)
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
           - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_riscv_compliance -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
-          - "-Wno-PINCONNECTEMPTY"
-          # XXX: Cleanup all warnings and remove this option
-          # (or make it more fine-grained at least)
-          - "-Wno-fatal"
-        make_options:
-          # Optimization levels have a large impact on the runtime performance
-          # of the simulation model. -O2 and -O3 are pretty similar, -Os is
-          # slower than -O2/-O3
-          - OPT_FAST="-O2"

--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -123,25 +123,16 @@ targets:
       verilator:
         mode: cc
         verilator_options:
-# Disabling tracing reduces compile times by multiple times, but doesn't have a
-# huge influence on runtime performance. (Based on early observations.)
+          # Disabling tracing reduces compile times but doesn't have a
+          # huge influence on runtime performance.
           - '--trace'
           - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-# compiler flags
-#
-# -O
-#   Optimization levels have a large impact on the runtime performance of the
-#   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g -O0"'
+          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
-          - "-Wno-PINCONNECTEMPTY"
-          # XXX: Cleanup all warnings and remove this option
-          # (or make it more fine-grained at least)
-          - "-Wno-fatal"
           # RAM primitives wider than 64bit (required for ECC) fail to build in
           # Verilator without increasing the unroll count (see Verilator#1266)
           - "--unroll-count 72"


### PR DESCRIPTION
- The "PINCONNECTEMPTY" waiver is part of our normal waiver file, no need
  to add it to the tool invocation.
- Recent versions of Verilator choose good defaults for MAKE_OPTS,
  passing it explicitly overrides the settings.
- All Verilator code is now lint clean, we can remove `-Wno-fatal`.
- FST traces are not much slower then VCD traces any more in recent
  Verilator versions, remove the respective comment.
- Align comment about the compile/sim time for tracing with other files
  and OpenTitan.