### PR TITLE
Format source code with Verible, part 1

### DIFF
--- a/ibex_core.core
+++ b/ibex_core.core
@@ -166,3 +166,4 @@ targets:
       veribleformat:
         verible_format_args:
           - "--inplace"
+          - "--format_module_port_declarations=false"

--- a/rtl/ibex_compressed_decoder.sv
+++ b/rtl/ibex_compressed_decoder.sv
@@ -35,7 +35,7 @@ module ibex_compressed_decoder (
 
   always_comb begin
     // By default, forward incoming instruction, mark it as legal.
-    instr_o         = instr_i;
+    instr_o = instr_i;
     illegal_instr_o = 1'b0;
 
     // Check if incoming instruction is compressed.
@@ -45,29 +45,24 @@ module ibex_compressed_decoder (
         unique case (instr_i[15:13])
           3'b000: begin
             // c.addi4spn -> addi rd', x2, imm
-            instr_o = {2'b0, instr_i[10:7], instr_i[12:11], instr_i[5],
-                       instr_i[6], 2'b00, 5'h02, 3'b000, 2'b01, instr_i[4:2], {OPCODE_OP_IMM}};
-            if (instr_i[12:5] == 8'b0)  illegal_instr_o = 1'b1;
+            instr_o = {2'b0, instr_i[10:7], instr_i[12:11], instr_i[5], instr_i[6], 2'b00, 5'h02,
+                       3'b000, 2'b01, instr_i[4:2], {OPCODE_OP_IMM}};
+            if (instr_i[12:5] == 8'b0) illegal_instr_o = 1'b1;
           end
 
           3'b010: begin
             // c.lw -> lw rd', imm(rs1')
-            instr_o = {5'b0, instr_i[5], instr_i[12:10], instr_i[6],
-                       2'b00, 2'b01, instr_i[9:7], 3'b010, 2'b01, instr_i[4:2], {OPCODE_LOAD}};
+            instr_o = {5'b0, instr_i[5], instr_i[12:10], instr_i[6], 2'b00, 2'b01, instr_i[9:7],
+                       3'b010, 2'b01, instr_i[4:2], {OPCODE_LOAD}};
           end
 
           3'b110: begin
             // c.sw -> sw rs2', imm(rs1')
-            instr_o = {5'b0, instr_i[5], instr_i[12], 2'b01, instr_i[4:2],
-                       2'b01, instr_i[9:7], 3'b010, instr_i[11:10], instr_i[6],
-                       2'b00, {OPCODE_STORE}};
+            instr_o = {5'b0, instr_i[5], instr_i[12], 2'b01, instr_i[4:2], 2'b01, instr_i[9:7],
+                       3'b010, instr_i[11:10], instr_i[6], 2'b00, {OPCODE_STORE}};
           end
 
-          3'b001,
-          3'b011,
-          3'b100,
-          3'b101,
-          3'b111: begin
+          3'b001, 3'b011, 3'b100, 3'b101, 3'b111: begin
             illegal_instr_o = 1'b1;
           end
 
@@ -87,34 +82,34 @@ module ibex_compressed_decoder (
           3'b000: begin
             // c.addi -> addi rd, rd, nzimm
             // c.nop
-            instr_o = {{6 {instr_i[12]}}, instr_i[12], instr_i[6:2],
-                       instr_i[11:7], 3'b0, instr_i[11:7], {OPCODE_OP_IMM}};
+            instr_o = {{6{instr_i[12]}}, instr_i[12], instr_i[6:2], instr_i[11:7], 3'b0,
+                       instr_i[11:7], {OPCODE_OP_IMM}};
           end
 
           3'b001, 3'b101: begin
             // 001: c.jal -> jal x1, imm
             // 101: c.j   -> jal x0, imm
-            instr_o = {instr_i[12], instr_i[8], instr_i[10:9], instr_i[6],
-                       instr_i[7], instr_i[2], instr_i[11], instr_i[5:3],
-                       {9 {instr_i[12]}}, 4'b0, ~instr_i[15], {OPCODE_JAL}};
+            instr_o = {instr_i[12], instr_i[8], instr_i[10:9], instr_i[6], instr_i[7],
+                       instr_i[2], instr_i[11], instr_i[5:3], {9{instr_i[12]}}, 4'b0, ~instr_i[15],
+                       {OPCODE_JAL}};
           end
 
           3'b010: begin
             // c.li -> addi rd, x0, nzimm
             // (c.li hints are translated into an addi hint)
-            instr_o = {{6 {instr_i[12]}}, instr_i[12], instr_i[6:2], 5'b0,
-                       3'b0, instr_i[11:7], {OPCODE_OP_IMM}};
+            instr_o = {{6{instr_i[12]}}, instr_i[12], instr_i[6:2], 5'b0, 3'b0, instr_i[11:7],
+                       {OPCODE_OP_IMM}};
           end
 
           3'b011: begin
             // c.lui -> lui rd, imm
             // (c.lui hints are translated into a lui hint)
-            instr_o = {{15 {instr_i[12]}}, instr_i[6:2], instr_i[11:7], {OPCODE_LUI}};
+            instr_o = {{15{instr_i[12]}}, instr_i[6:2], instr_i[11:7], {OPCODE_LUI}};
 
             if (instr_i[11:7] == 5'h02) begin
               // c.addi16sp -> addi x2, x2, nzimm
-              instr_o = {{3 {instr_i[12]}}, instr_i[4:3], instr_i[5], instr_i[2],
-                         instr_i[6], 4'b0, 5'h02, 3'b000, 5'h02, {OPCODE_OP_IMM}};
+              instr_o = {{3{instr_i[12]}}, instr_i[4:3], instr_i[5], instr_i[2], instr_i[6], 4'b0,
+                         5'h02, 3'b000, 5'h02, {OPCODE_OP_IMM}};
             end
 
             if ({instr_i[12], instr_i[6:2]} == 6'b0) illegal_instr_o = 1'b1;
@@ -122,52 +117,48 @@ module ibex_compressed_decoder (
 
           3'b100: begin
             unique case (instr_i[11:10])
-              2'b00,
-              2'b01: begin
+              2'b00, 2'b01: begin
                 // 00: c.srli -> srli rd, rd, shamt
                 // 01: c.srai -> srai rd, rd, shamt
                 // (c.srli/c.srai hints are translated into a srli/srai hint)
-                instr_o = {1'b0, instr_i[10], 5'b0, instr_i[6:2], 2'b01, instr_i[9:7],
-                           3'b101, 2'b01, instr_i[9:7], {OPCODE_OP_IMM}};
-                if (instr_i[12] == 1'b1)  illegal_instr_o = 1'b1;
+                instr_o = {1'b0, instr_i[10], 5'b0, instr_i[6:2], 2'b01, instr_i[9:7], 3'b101,
+                           2'b01, instr_i[9:7], {OPCODE_OP_IMM}};
+                if (instr_i[12] == 1'b1) illegal_instr_o = 1'b1;
               end
 
               2'b10: begin
                 // c.andi -> andi rd, rd, imm
-                instr_o = {{6 {instr_i[12]}}, instr_i[12], instr_i[6:2], 2'b01, instr_i[9:7],
-                           3'b111, 2'b01, instr_i[9:7], {OPCODE_OP_IMM}};
+                instr_o = {{6{instr_i[12]}}, instr_i[12], instr_i[6:2], 2'b01, instr_i[9:7], 3'b111,
+                           2'b01, instr_i[9:7], {OPCODE_OP_IMM}};
               end
 
               2'b11: begin
                 unique case ({instr_i[12], instr_i[6:5]})
                   3'b000: begin
                     // c.sub -> sub rd', rd', rs2'
-                    instr_o = {2'b01, 5'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7],
-                               3'b000, 2'b01, instr_i[9:7], {OPCODE_OP}};
+                    instr_o = {2'b01, 5'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b000, 2'b01,
+                               instr_i[9:7], {OPCODE_OP}};
                   end
 
                   3'b001: begin
                     // c.xor -> xor rd', rd', rs2'
-                    instr_o = {7'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b100,
-                               2'b01, instr_i[9:7], {OPCODE_OP}};
+                    instr_o = {7'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b100, 2'b01,
+                               instr_i[9:7], {OPCODE_OP}};
                   end
 
                   3'b010: begin
                     // c.or  -> or  rd', rd', rs2'
-                    instr_o = {7'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b110,
-                               2'b01, instr_i[9:7], {OPCODE_OP}};
+                    instr_o = {7'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b110, 2'b01,
+                               instr_i[9:7], {OPCODE_OP}};
                   end
 
                   3'b011: begin
                     // c.and -> and rd', rd', rs2'
-                    instr_o = {7'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b111,
-                               2'b01, instr_i[9:7], {OPCODE_OP}};
+                    instr_o = {7'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b111, 2'b01,
+                               instr_i[9:7], {OPCODE_OP}};
                   end
 
-                  3'b100,
-                  3'b101,
-                  3'b110,
-                  3'b111: begin
+                  3'b100, 3'b101, 3'b110, 3'b111: begin
                     // 100: c.subw
                     // 101: c.addw
                     illegal_instr_o = 1'b1;
@@ -188,9 +179,8 @@ module ibex_compressed_decoder (
           3'b110, 3'b111: begin
             // 0: c.beqz -> beq rs1', x0, imm
             // 1: c.bnez -> bne rs1', x0, imm
-            instr_o = {{4 {instr_i[12]}}, instr_i[6:5], instr_i[2], 5'b0, 2'b01,
-                       instr_i[9:7], 2'b00, instr_i[13], instr_i[11:10], instr_i[4:3],
-                       instr_i[12], {OPCODE_BRANCH}};
+            instr_o = {{4{instr_i[12]}}, instr_i[6:5], instr_i[2], 5'b0, 2'b01, instr_i[9:7], 2'b00,
+                       instr_i[13], instr_i[11:10], instr_i[4:3], instr_i[12], {OPCODE_BRANCH}};
           end
 
           default: begin
@@ -210,14 +200,14 @@ module ibex_compressed_decoder (
             // c.slli -> slli rd, rd, shamt
             // (c.ssli hints are translated into a slli hint)
             instr_o = {7'b0, instr_i[6:2], instr_i[11:7], 3'b001, instr_i[11:7], {OPCODE_OP_IMM}};
-            if (instr_i[12] == 1'b1)  illegal_instr_o = 1'b1; // reserved for custom extensions
+            if (instr_i[12] == 1'b1) illegal_instr_o = 1'b1;  // reserved for custom extensions
           end
 
           3'b010: begin
             // c.lwsp -> lw rd, imm(x2)
-            instr_o = {4'b0, instr_i[3:2], instr_i[12], instr_i[6:4], 2'b00, 5'h02,
-                       3'b010, instr_i[11:7], OPCODE_LOAD};
-            if (instr_i[11:7] == 5'b0)  illegal_instr_o = 1'b1;
+            instr_o = {4'b0, instr_i[3:2], instr_i[12], instr_i[6:4], 2'b00, 5'h02, 3'b010,
+                       instr_i[11:7], OPCODE_LOAD};
+            if (instr_i[11:7] == 5'b0) illegal_instr_o = 1'b1;
           end
 
           3'b100: begin
@@ -229,7 +219,7 @@ module ibex_compressed_decoder (
               end else begin
                 // c.jr -> jalr x0, rd/rs1, 0
                 instr_o = {12'b0, instr_i[11:7], 3'b0, 5'b0, {OPCODE_JALR}};
-                if (instr_i[11:7] == 5'b0)  illegal_instr_o = 1'b1;
+                if (instr_i[11:7] == 5'b0) illegal_instr_o = 1'b1;
               end
             end else begin
               if (instr_i[6:2] != 5'b0) begin
@@ -250,14 +240,11 @@ module ibex_compressed_decoder (
 
           3'b110: begin
             // c.swsp -> sw rs2, imm(x2)
-            instr_o = {4'b0, instr_i[8:7], instr_i[12], instr_i[6:2], 5'h02, 3'b010,
-                       instr_i[11:9], 2'b00, {OPCODE_STORE}};
+            instr_o = {4'b0, instr_i[8:7], instr_i[12], instr_i[6:2], 5'h02, 3'b010, instr_i[11:9],
+                       2'b00, {OPCODE_STORE}};
           end
 
-          3'b001,
-          3'b011,
-          3'b101,
-          3'b111: begin
+          3'b001, 3'b011, 3'b101, 3'b111: begin
             illegal_instr_o = 1'b1;
           end
 
@@ -283,18 +270,15 @@ module ibex_compressed_decoder (
   ////////////////
 
   // Selectors must be known/valid.
-  `ASSERT(IbexInstrLSBsKnown, valid_i |->
-      !$isunknown(instr_i[1:0]))
-  `ASSERT(IbexC0Known1, (valid_i && (instr_i[1:0] == 2'b00)) |->
-      !$isunknown(instr_i[15:13]))
-  `ASSERT(IbexC1Known1, (valid_i && (instr_i[1:0] == 2'b01)) |->
-      !$isunknown(instr_i[15:13]))
-  `ASSERT(IbexC1Known2, (valid_i && (instr_i[1:0] == 2'b01) && (instr_i[15:13] == 3'b100)) |->
-      !$isunknown(instr_i[11:10]))
-  `ASSERT(IbexC1Known3, (valid_i &&
-      (instr_i[1:0] == 2'b01) && (instr_i[15:13] == 3'b100) && (instr_i[11:10] == 2'b11)) |->
-      !$isunknown({instr_i[12], instr_i[6:5]}))
-  `ASSERT(IbexC2Known1, (valid_i && (instr_i[1:0] == 2'b10)) |->
-      !$isunknown(instr_i[15:13]))
+  `ASSERT(IbexInstrLSBsKnown, valid_i |-> !$isunknown(instr_i[1:0]))
+  `ASSERT(IbexC0Known1, (valid_i && (instr_i[1:0] == 2'b00)) |-> !$isunknown(instr_i[15:13]))
+  `ASSERT(IbexC1Known1, (valid_i && (instr_i[1:0] == 2'b01)) |-> !$isunknown(instr_i[15:13]))
+  `ASSERT(IbexC1Known2,
+          (valid_i && (instr_i[1:0] == 2'b01) && (instr_i[15:13] == 3'b100)) |->
+              !$isunknown(instr_i[11:10]))
+  `ASSERT(IbexC1Known3,
+          (valid_i && (instr_i[1:0] == 2'b01) && (instr_i[15:13] == 3'b100) && (
+           instr_i[11:10] == 2'b11)) |-> !$isunknown({instr_i[12], instr_i[6:5]}))
+  `ASSERT(IbexC2Known1, (valid_i && (instr_i[1:0] == 2'b10)) |-> !$isunknown(instr_i[15:13]))
 
 endmodule

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -106,8 +106,16 @@ module ibex_controller #(
 
   // FSM state encoding
   typedef enum logic [3:0] {
-    RESET, BOOT_SET, WAIT_SLEEP, SLEEP, FIRST_FETCH, DECODE, FLUSH,
-    IRQ_TAKEN, DBG_TAKEN_IF, DBG_TAKEN_ID
+    RESET,
+    BOOT_SET,
+    WAIT_SLEEP,
+    SLEEP,
+    FIRST_FETCH,
+    DECODE,
+    FLUSH,
+    IRQ_TAKEN,
+    DBG_TAKEN_IF,
+    DBG_TAKEN_ID
   } ctrl_fsm_e;
 
   ctrl_fsm_e ctrl_fsm_cs, ctrl_fsm_ns;
@@ -142,7 +150,7 @@ module ibex_controller #(
   logic handle_irq;
 
   logic [3:0] mfip_id;
-  logic       unused_irq_timer;
+  logic unused_irq_timer;
 
   logic ecall_insn;
   logic mret_insn;
@@ -170,16 +178,16 @@ module ibex_controller #(
   // Exceptions //
   ////////////////
 
-  assign load_err_d  = load_err_i;
+  assign load_err_d = load_err_i;
   assign store_err_d = store_err_i;
 
   // Decoder doesn't take instr_valid into account, factor it in here.
-  assign ecall_insn      = ecall_insn_i      & instr_valid_i;
-  assign mret_insn       = mret_insn_i       & instr_valid_i;
-  assign dret_insn       = dret_insn_i       & instr_valid_i;
-  assign wfi_insn        = wfi_insn_i        & instr_valid_i;
-  assign ebrk_insn       = ebrk_insn_i       & instr_valid_i;
-  assign csr_pipe_flush  = csr_pipe_flush_i  & instr_valid_i;
+  assign ecall_insn = ecall_insn_i & instr_valid_i;
+  assign mret_insn = mret_insn_i & instr_valid_i;
+  assign dret_insn = dret_insn_i & instr_valid_i;
+  assign wfi_insn = wfi_insn_i & instr_valid_i;
+  assign ebrk_insn = ebrk_insn_i & instr_valid_i;
+  assign csr_pipe_flush = csr_pipe_flush_i & instr_valid_i;
   assign instr_fetch_err = instr_fetch_err_i & instr_valid_i;
 
   // "Executing DRET outside of Debug Mode causes an illegal instruction exception."
@@ -203,8 +211,8 @@ module ibex_controller #(
   // the FLUSH state so the cycle following exc_req_q won't remain set for an
   // exception request that has just been handled.
   // All terms in this expression are qualified by instr_valid_i
-  assign exc_req_d = (ecall_insn | ebrk_insn | illegal_insn_d | instr_fetch_err) &
-                     (ctrl_fsm_cs != FLUSH);
+  assign exc_req_d =
+      (ecall_insn | ebrk_insn | illegal_insn_d | instr_fetch_err) & (ctrl_fsm_cs != FLUSH);
 
   // LSU exception requests
   assign exc_req_lsu = store_err_i | load_err_i;
@@ -222,28 +230,27 @@ module ibex_controller #(
   // generic special request signal, applies to all instructions
   // All terms in this expression are qualified by instr_valid_i except exc_req_lsu which can come
   // from the Writeback stage with no instr_valid_i from the ID stage
-  assign special_req_all = mret_insn | dret_insn | wfi_insn | csr_pipe_flush |
-      exc_req_d | exc_req_lsu;
+  assign
+      special_req_all = mret_insn | dret_insn | wfi_insn | csr_pipe_flush | exc_req_d | exc_req_lsu;
 
   // special request that can specifically occur during branch instructions
   // All terms in this expression are qualified by instr_valid_i
   assign special_req_branch = instr_fetch_err & (ctrl_fsm_cs != FLUSH);
 
-  `ASSERT(SpecialReqBranchGivesSpecialReqAll,
-    special_req_branch |-> special_req_all)
+  `ASSERT(SpecialReqBranchGivesSpecialReqAll, special_req_branch |-> special_req_all)
 
   `ASSERT(SpecialReqAllGivesSpecialReqBranchIfBranchInst,
-    special_req_all && (branch_set_i || jump_set_i) |-> special_req_branch)
+          special_req_all && (branch_set_i || jump_set_i) |-> special_req_branch)
 
   // Exception/fault prioritisation is taken from Table 3.7 of Priviledged Spec v1.11
   if (WritebackStage) begin : g_wb_exceptions
     always_comb begin
       instr_fetch_err_prio = 0;
-      illegal_insn_prio    = 0;
-      ecall_insn_prio      = 0;
-      ebrk_insn_prio       = 0;
-      store_err_prio       = 0;
-      load_err_prio        = 0;
+      illegal_insn_prio = 0;
+      ecall_insn_prio = 0;
+      ebrk_insn_prio = 0;
+      store_err_prio = 0;
+      load_err_prio = 0;
 
       // Note that with the writeback stage store/load errors occur on the instruction in writeback,
       // all other exception/faults occur on the instruction in ID/EX. The faults from writeback
@@ -251,7 +258,7 @@ module ibex_controller #(
       if (store_err_q) begin
         store_err_prio = 1'b1;
       end else if (load_err_q) begin
-        load_err_prio  = 1'b1;
+        load_err_prio = 1'b1;
       end else if (instr_fetch_err) begin
         instr_fetch_err_prio = 1'b1;
       end else if (illegal_insn_q) begin
@@ -268,11 +275,11 @@ module ibex_controller #(
   end else begin : g_no_wb_exceptions
     always_comb begin
       instr_fetch_err_prio = 0;
-      illegal_insn_prio    = 0;
-      ecall_insn_prio      = 0;
-      ebrk_insn_prio       = 0;
-      store_err_prio       = 0;
-      load_err_prio        = 0;
+      illegal_insn_prio = 0;
+      ecall_insn_prio = 0;
+      ebrk_insn_prio = 0;
+      store_err_prio = 0;
+      load_err_prio = 0;
 
       if (instr_fetch_err) begin
         instr_fetch_err_prio = 1'b1;
@@ -285,19 +292,15 @@ module ibex_controller #(
       end else if (store_err_q) begin
         store_err_prio = 1'b1;
       end else if (load_err_q) begin
-        load_err_prio  = 1'b1;
+        load_err_prio = 1'b1;
       end
     end
     assign wb_exception_o = 1'b0;
   end
 
   `ASSERT_IF(IbexExceptionPrioOnehot,
-             $onehot({instr_fetch_err_prio,
-                      illegal_insn_prio,
-                      ecall_insn_prio,
-                      ebrk_insn_prio,
-                      store_err_prio,
-                      load_err_prio}),
+             $onehot({instr_fetch_err_prio, illegal_insn_prio, ecall_insn_prio, ebrk_insn_prio,
+                      store_err_prio, load_err_prio}),
              (ctrl_fsm_cs == FLUSH) & exc_req_q);
 
   ////////////////
@@ -310,40 +313,39 @@ module ibex_controller #(
   // due to a recently flushed IF (or a delay in an instruction returning from
   // memory) before it has had anything to single step.
   // Also enter debug mode on a trigger match (hardware breakpoint)
-  assign enter_debug_mode = (debug_req_i | (debug_single_step_i & instr_valid_i) |
-                             trigger_match_i) & ~debug_mode_q;
+  assign enter_debug_mode =
+      (debug_req_i | (debug_single_step_i & instr_valid_i) | trigger_match_i) & ~debug_mode_q;
 
   // Set when an ebreak should enter debug mode rather than jump to exception
   // handler
   assign ebreak_into_debug = priv_mode_i == PRIV_LVL_M ? debug_ebreakm_i :
-                             priv_mode_i == PRIV_LVL_U ? debug_ebreaku_i :
-                                                         1'b0;
+      priv_mode_i == PRIV_LVL_U ? debug_ebreaku_i : 1'b0;
 
   // Interrupts including NMI are ignored,
   // - while in debug mode [Debug Spec v0.13.2, p.39],
   // - while in NMI mode (nested NMIs are not supported, NMI has highest priority and
   //   cannot be interrupted by regular interrupts).
-  assign handle_irq = ~debug_mode_q & ~nmi_mode_q &
-      (irq_nm_i | (irq_pending_i & csr_mstatus_mie_i));
+  assign
+      handle_irq = ~debug_mode_q & ~nmi_mode_q & (irq_nm_i | (irq_pending_i & csr_mstatus_mie_i));
 
   // generate ID of fast interrupts, highest priority to highest ID
   always_comb begin : gen_mfip_id
-    if      (irqs_i.irq_fast[14]) mfip_id = 4'd14;
+    if (irqs_i.irq_fast[14]) mfip_id = 4'd14;
     else if (irqs_i.irq_fast[13]) mfip_id = 4'd13;
     else if (irqs_i.irq_fast[12]) mfip_id = 4'd12;
     else if (irqs_i.irq_fast[11]) mfip_id = 4'd11;
     else if (irqs_i.irq_fast[10]) mfip_id = 4'd10;
-    else if (irqs_i.irq_fast[ 9]) mfip_id = 4'd9;
-    else if (irqs_i.irq_fast[ 8]) mfip_id = 4'd8;
-    else if (irqs_i.irq_fast[ 7]) mfip_id = 4'd7;
-    else if (irqs_i.irq_fast[ 6]) mfip_id = 4'd6;
-    else if (irqs_i.irq_fast[ 5]) mfip_id = 4'd5;
-    else if (irqs_i.irq_fast[ 5]) mfip_id = 4'd5;
-    else if (irqs_i.irq_fast[ 4]) mfip_id = 4'd4;
-    else if (irqs_i.irq_fast[ 3]) mfip_id = 4'd3;
-    else if (irqs_i.irq_fast[ 2]) mfip_id = 4'd2;
-    else if (irqs_i.irq_fast[ 1]) mfip_id = 4'd1;
-    else                          mfip_id = 4'd0;
+    else if (irqs_i.irq_fast[9]) mfip_id = 4'd9;
+    else if (irqs_i.irq_fast[8]) mfip_id = 4'd8;
+    else if (irqs_i.irq_fast[7]) mfip_id = 4'd7;
+    else if (irqs_i.irq_fast[6]) mfip_id = 4'd6;
+    else if (irqs_i.irq_fast[5]) mfip_id = 4'd5;
+    else if (irqs_i.irq_fast[5]) mfip_id = 4'd5;
+    else if (irqs_i.irq_fast[4]) mfip_id = 4'd4;
+    else if (irqs_i.irq_fast[3]) mfip_id = 4'd3;
+    else if (irqs_i.irq_fast[2]) mfip_id = 4'd2;
+    else if (irqs_i.irq_fast[1]) mfip_id = 4'd1;
+    else mfip_id = 4'd0;
   end
 
   assign unused_irq_timer = irqs_i.irq_timer;
@@ -354,78 +356,78 @@ module ibex_controller #(
 
   always_comb begin
     // Default values
-    instr_req_o           = 1'b1;
+    instr_req_o = 1'b1;
 
-    csr_save_if_o         = 1'b0;
-    csr_save_id_o         = 1'b0;
-    csr_save_wb_o         = 1'b0;
+    csr_save_if_o = 1'b0;
+    csr_save_id_o = 1'b0;
+    csr_save_wb_o = 1'b0;
     csr_restore_mret_id_o = 1'b0;
     csr_restore_dret_id_o = 1'b0;
-    csr_save_cause_o      = 1'b0;
-    csr_mtval_o           = '0;
+    csr_save_cause_o = 1'b0;
+    csr_mtval_o = '0;
 
     // The values of pc_mux and exc_pc_mux are only relevant if pc_set is set. Some of the states
     // below always set pc_mux and exc_pc_mux but only set pc_set if certain conditions are met.
     // This avoid having to factor those conditions into the pc_mux and exc_pc_mux select signals
     // helping timing.
-    pc_mux_o              = PC_BOOT;
-    pc_set_o              = 1'b0;
-    pc_set_spec_o         = 1'b0;
+    pc_mux_o = PC_BOOT;
+    pc_set_o = 1'b0;
+    pc_set_spec_o = 1'b0;
 
-    exc_pc_mux_o          = EXC_PC_IRQ;
-    exc_cause_o           = EXC_CAUSE_INSN_ADDR_MISA; // = 6'h00
+    exc_pc_mux_o = EXC_PC_IRQ;
+    exc_cause_o = EXC_CAUSE_INSN_ADDR_MISA;  // = 6'h00
 
-    ctrl_fsm_ns           = ctrl_fsm_cs;
+    ctrl_fsm_ns = ctrl_fsm_cs;
 
-    ctrl_busy_o           = 1'b1;
+    ctrl_busy_o = 1'b1;
 
-    halt_if               = 1'b0;
-    retain_id             = 1'b0;
-    flush_id              = 1'b0;
+    halt_if = 1'b0;
+    retain_id = 1'b0;
+    flush_id = 1'b0;
 
-    debug_csr_save_o      = 1'b0;
-    debug_cause_o         = DBG_CAUSE_EBREAK;
-    debug_mode_d          = debug_mode_q;
-    nmi_mode_d            = nmi_mode_q;
+    debug_csr_save_o = 1'b0;
+    debug_cause_o = DBG_CAUSE_EBREAK;
+    debug_mode_d = debug_mode_q;
+    nmi_mode_d = nmi_mode_q;
 
-    perf_tbranch_o        = 1'b0;
-    perf_jump_o           = 1'b0;
+    perf_tbranch_o = 1'b0;
+    perf_jump_o = 1'b0;
 
-    controller_run_o      = 1'b0;
+    controller_run_o = 1'b0;
 
     unique case (ctrl_fsm_cs)
       RESET: begin
-        instr_req_o   = 1'b0;
-        pc_mux_o      = PC_BOOT;
-        pc_set_o      = 1'b1;
+        instr_req_o = 1'b0;
+        pc_mux_o = PC_BOOT;
+        pc_set_o = 1'b1;
         pc_set_spec_o = 1'b1;
-        ctrl_fsm_ns   = BOOT_SET;
+        ctrl_fsm_ns = BOOT_SET;
       end
 
       BOOT_SET: begin
         // copy boot address to instr fetch address
-        instr_req_o   = 1'b1;
-        pc_mux_o      = PC_BOOT;
-        pc_set_o      = 1'b1;
+        instr_req_o = 1'b1;
+        pc_mux_o = PC_BOOT;
+        pc_set_o = 1'b1;
         pc_set_spec_o = 1'b1;
 
         ctrl_fsm_ns = FIRST_FETCH;
       end
 
       WAIT_SLEEP: begin
-        ctrl_busy_o   = 1'b0;
-        instr_req_o   = 1'b0;
-        halt_if       = 1'b1;
-        flush_id      = 1'b1;
-        ctrl_fsm_ns   = SLEEP;
+        ctrl_busy_o = 1'b0;
+        instr_req_o = 1'b0;
+        halt_if = 1'b1;
+        flush_id = 1'b1;
+        ctrl_fsm_ns = SLEEP;
       end
 
       SLEEP: begin
         // instruction in IF stage is already valid
         // we begin execution when an interrupt has arrived
-        instr_req_o   = 1'b0;
-        halt_if       = 1'b1;
-        flush_id      = 1'b1;
+        instr_req_o = 1'b0;
+        halt_if = 1'b1;
+        flush_id = 1'b1;
 
         // normal execution flow
         // in debug mode or single step mode we leave immediately (wfi=nop)
@@ -450,7 +452,7 @@ module ibex_controller #(
           // don't set flush_id: we must allow this instruction to complete
           // (since it might have outstanding loads or stores).
           ctrl_fsm_ns = IRQ_TAKEN;
-          halt_if     = 1'b1;
+          halt_if = 1'b1;
         end
 
         // enter debug mode
@@ -458,7 +460,7 @@ module ibex_controller #(
           ctrl_fsm_ns = DBG_TAKEN_IF;
           // Halt IF only for now, ID will be flushed in DBG_TAKEN_IF as the
           // ID state is needed for correct debug mode entry
-          halt_if     = 1'b1;
+          halt_if = 1'b1;
         end
       end
 
@@ -496,10 +498,10 @@ module ibex_controller #(
         end
 
         if ((branch_set_i || jump_set_i) && !special_req_branch) begin
-          pc_set_o       = 1'b1;
+          pc_set_o = 1'b1;
 
           perf_tbranch_o = branch_set_i;
-          perf_jump_o    = jump_set_i;
+          perf_jump_o = jump_set_i;
         end
 
         // pc_set signal excluding branch taken condition
@@ -520,7 +522,7 @@ module ibex_controller #(
             ctrl_fsm_ns = DBG_TAKEN_IF;
             // Halt IF only for now, ID will be flushed in DBG_TAKEN_IF as the
             // ID state is needed for correct debug mode entry
-            halt_if     = 1'b1;
+            halt_if = 1'b1;
           end else if (handle_irq) begin
             // handle interrupt (not in debug mode)
             ctrl_fsm_ns = IRQ_TAKEN;
@@ -529,27 +531,27 @@ module ibex_controller #(
             // to the handler, but don't set flush_id: we must allow this
             // instruction to complete (since it might have outstanding loads
             // or stores).
-            halt_if     = 1'b1;
+            halt_if = 1'b1;
           end
         end
 
-      end // DECODE
+      end  // DECODE
 
       IRQ_TAKEN: begin
-        pc_mux_o     = PC_EXC;
+        pc_mux_o = PC_EXC;
         exc_pc_mux_o = EXC_PC_IRQ;
 
         if (handle_irq) begin
-          pc_set_o         = 1'b1;
-          pc_set_spec_o    = 1'b1;
+          pc_set_o = 1'b1;
+          pc_set_spec_o = 1'b1;
 
-          csr_save_if_o    = 1'b1;
+          csr_save_if_o = 1'b1;
           csr_save_cause_o = 1'b1;
 
           // interrupt priorities according to Privileged Spec v1.11 p.31
           if (irq_nm_i && !nmi_mode_q) begin
             exc_cause_o = EXC_CAUSE_IRQ_NM;
-            nmi_mode_d  = 1'b1; // enter NMI mode
+            nmi_mode_d = 1'b1;  // enter NMI mode
           end else if (irqs_i.irq_fast != 15'b0) begin
             // generate exception cause ID from fast interrupt ID:
             // - first bit distinguishes interrupts from exceptions,
@@ -560,7 +562,7 @@ module ibex_controller #(
             exc_cause_o = EXC_CAUSE_IRQ_EXTERNAL_M;
           end else if (irqs_i.irq_software) begin
             exc_cause_o = EXC_CAUSE_IRQ_SOFTWARE_M;
-          end else begin // irqs_i.irq_timer
+          end else begin  // irqs_i.irq_timer
             exc_cause_o = EXC_CAUSE_IRQ_TIMER_M;
           end
         end
@@ -569,17 +571,17 @@ module ibex_controller #(
       end
 
       DBG_TAKEN_IF: begin
-        pc_mux_o     = PC_EXC;
+        pc_mux_o = PC_EXC;
         exc_pc_mux_o = EXC_PC_DBD;
 
         // enter debug mode and save PC in IF to dpc
         // jump to debug exception handler in debug memory
         if (debug_single_step_i || debug_req_i || trigger_match_i) begin
-          flush_id         = 1'b1;
-          pc_set_o         = 1'b1;
-          pc_set_spec_o    = 1'b1;
+          flush_id = 1'b1;
+          pc_set_o = 1'b1;
+          pc_set_spec_o = 1'b1;
 
-          csr_save_if_o    = 1'b1;
+          csr_save_if_o = 1'b1;
           debug_csr_save_o = 1'b1;
 
           csr_save_cause_o = 1'b1;
@@ -595,7 +597,7 @@ module ibex_controller #(
           debug_mode_d = 1'b1;
         end
 
-        ctrl_fsm_ns  = DECODE;
+        ctrl_fsm_ns = DECODE;
       end
 
       DBG_TAKEN_ID: begin
@@ -606,34 +608,34 @@ module ibex_controller #(
         //
         // for 1. do not update dcsr and dpc, for 2. do so [Debug Spec v0.13.2, p.39]
         // jump to debug exception handler in debug memory
-        flush_id      = 1'b1;
-        pc_mux_o      = PC_EXC;
-        pc_set_o      = 1'b1;
+        flush_id = 1'b1;
+        pc_mux_o = PC_EXC;
+        pc_set_o = 1'b1;
         pc_set_spec_o = 1'b1;
-        exc_pc_mux_o  = EXC_PC_DBD;
+        exc_pc_mux_o = EXC_PC_DBD;
 
         // update dcsr and dpc
-        if (ebreak_into_debug && !debug_mode_q) begin // ebreak with forced entry
+        if (ebreak_into_debug && !debug_mode_q) begin  // ebreak with forced entry
 
           // dpc (set to the address of the EBREAK, i.e. set to PC in ID stage)
           csr_save_cause_o = 1'b1;
-          csr_save_id_o    = 1'b1;
+          csr_save_id_o = 1'b1;
 
           // dcsr
           debug_csr_save_o = 1'b1;
-          debug_cause_o    = DBG_CAUSE_EBREAK;
+          debug_cause_o = DBG_CAUSE_EBREAK;
         end
 
         // enter debug mode
         debug_mode_d = 1'b1;
 
-        ctrl_fsm_ns  = DECODE;
+        ctrl_fsm_ns = DECODE;
       end
 
       FLUSH: begin
         // flush the pipeline
-        halt_if     = 1'b1;
-        flush_id    = 1'b1;
+        halt_if = 1'b1;
+        flush_id = 1'b1;
         ctrl_fsm_ns = DECODE;
 
         // As pc_mux and exc_pc_mux can take various values in this state they aren't set early
@@ -642,19 +644,19 @@ module ibex_controller #(
         // exceptions: set exception PC, save PC and exception cause
         // exc_req_lsu is high for one clock cycle only (in DECODE)
         if (exc_req_q || store_err_q || load_err_q) begin
-          pc_set_o         = 1'b1;
-          pc_set_spec_o    = 1'b1;
-          pc_mux_o         = PC_EXC;
-          exc_pc_mux_o     = debug_mode_q ? EXC_PC_DBG_EXC : EXC_PC_EXC;
+          pc_set_o = 1'b1;
+          pc_set_spec_o = 1'b1;
+          pc_mux_o = PC_EXC;
+          exc_pc_mux_o = debug_mode_q ? EXC_PC_DBG_EXC : EXC_PC_EXC;
 
           if (WritebackStage) begin : g_writeback_mepc_save
             // With the writeback stage present whether an instruction accessing memory will cause
             // an exception is only known when it is in writeback. So when taking such an exception
             // epc must come from writeback.
-            csr_save_id_o  = ~(store_err_q | load_err_q);
-            csr_save_wb_o  = store_err_q | load_err_q;
+            csr_save_id_o = ~(store_err_q | load_err_q);
+            csr_save_wb_o = store_err_q | load_err_q;
           end else begin : g_no_writeback_mepc_save
-            csr_save_id_o  = 1'b0;
+            csr_save_id_o = 1'b0;
           end
 
           csr_save_cause_o = 1'b1;
@@ -662,8 +664,8 @@ module ibex_controller #(
           // Exception/fault prioritisation logic will have set exactly 1 X_prio signal
           unique case (1'b1)
             instr_fetch_err_prio: begin
-                exc_cause_o = EXC_CAUSE_INSTR_ACCESS_FAULT;
-                csr_mtval_o = instr_fetch_err_plus2_i ? (pc_id_i + 32'd2) : pc_id_i;
+              exc_cause_o = EXC_CAUSE_INSTR_ACCESS_FAULT;
+              csr_mtval_o = instr_fetch_err_plus2_i ? (pc_id_i + 32'd2) : pc_id_i;
             end
             illegal_insn_prio: begin
               exc_cause_o = EXC_CAUSE_ILLEGAL_INSN;
@@ -671,7 +673,7 @@ module ibex_controller #(
             end
             ecall_insn_prio: begin
               exc_cause_o = (priv_mode_i == PRIV_LVL_M) ? EXC_CAUSE_ECALL_MMODE :
-                                                          EXC_CAUSE_ECALL_UMODE;
+                  EXC_CAUSE_ECALL_UMODE;
             end
             ebrk_insn_prio: begin
               if (debug_mode_q | ebreak_into_debug) begin
@@ -688,12 +690,12 @@ module ibex_controller #(
                  * "EBREAK instructions in M-mode enter Debug Mode."
                  * [Debug Spec v0.13.2, p.42]
                  */
-                pc_set_o         = 1'b0;
-                pc_set_spec_o    = 1'b0;
-                csr_save_id_o    = 1'b0;
+                pc_set_o = 1'b0;
+                pc_set_spec_o = 1'b0;
+                csr_save_id_o = 1'b0;
                 csr_save_cause_o = 1'b0;
-                ctrl_fsm_ns      = DBG_TAKEN_ID;
-                flush_id         = 1'b0;
+                ctrl_fsm_ns = DBG_TAKEN_ID;
+                flush_id = 1'b0;
               end else begin
                 /*
                  * "The EBREAK instruction is used by debuggers to cause control
@@ -704,7 +706,7 @@ module ibex_controller #(
                  * ECALL or EBREAK instruction itself, not the address of the
                  * following instruction." [Privileged Spec v1.11, p.40]
                  */
-                exc_cause_o      = EXC_CAUSE_BREAKPOINT;
+                exc_cause_o = EXC_CAUSE_BREAKPOINT;
               end
             end
             store_err_prio: begin
@@ -720,26 +722,26 @@ module ibex_controller #(
         end else begin
           // special instructions and pipeline flushes
           if (mret_insn) begin
-            pc_mux_o              = PC_ERET;
-            pc_set_o              = 1'b1;
-            pc_set_spec_o         = 1'b1;
+            pc_mux_o = PC_ERET;
+            pc_set_o = 1'b1;
+            pc_set_spec_o = 1'b1;
             csr_restore_mret_id_o = 1'b1;
             if (nmi_mode_q) begin
-              nmi_mode_d          = 1'b0; // exit NMI mode
+              nmi_mode_d = 1'b0;  // exit NMI mode
             end
           end else if (dret_insn) begin
-            pc_mux_o              = PC_DRET;
-            pc_set_o              = 1'b1;
-            pc_set_spec_o         = 1'b1;
-            debug_mode_d          = 1'b0;
+            pc_mux_o = PC_DRET;
+            pc_set_o = 1'b1;
+            pc_set_spec_o = 1'b1;
+            debug_mode_d = 1'b0;
             csr_restore_dret_id_o = 1'b1;
           end else if (wfi_insn) begin
-            ctrl_fsm_ns           = WAIT_SLEEP;
+            ctrl_fsm_ns = WAIT_SLEEP;
           end else if (csr_pipe_flush && handle_irq) begin
             // start handling IRQs when doing CSR-related pipeline flushes
-            ctrl_fsm_ns           = IRQ_TAKEN;
+            ctrl_fsm_ns = IRQ_TAKEN;
           end
-        end // exc_req_q
+        end  // exc_req_q
 
         // Entering debug mode due to either single step or debug_req. Ensure
         // registers are set for exception but then enter debug handler rather
@@ -750,7 +752,7 @@ module ibex_controller #(
         if (enter_debug_mode) begin
           ctrl_fsm_ns = DBG_TAKEN_IF;
         end
-      end // FLUSH
+      end  // FLUSH
 
       default: begin
         instr_req_o = 1'b0;
@@ -789,20 +791,20 @@ module ibex_controller #(
   // update registers
   always_ff @(posedge clk_i or negedge rst_ni) begin : update_regs
     if (!rst_ni) begin
-      ctrl_fsm_cs    <= RESET;
-      nmi_mode_q     <= 1'b0;
-      debug_mode_q   <= 1'b0;
-      load_err_q     <= 1'b0;
-      store_err_q    <= 1'b0;
-      exc_req_q      <= 1'b0;
+      ctrl_fsm_cs <= RESET;
+      nmi_mode_q <= 1'b0;
+      debug_mode_q <= 1'b0;
+      load_err_q <= 1'b0;
+      store_err_q <= 1'b0;
+      exc_req_q <= 1'b0;
       illegal_insn_q <= 1'b0;
     end else begin
-      ctrl_fsm_cs    <= ctrl_fsm_ns;
-      nmi_mode_q     <= nmi_mode_d;
-      debug_mode_q   <= debug_mode_d;
-      load_err_q     <= load_err_d;
-      store_err_q    <= store_err_d;
-      exc_req_q      <= exc_req_d;
+      ctrl_fsm_cs <= ctrl_fsm_ns;
+      nmi_mode_q <= nmi_mode_d;
+      debug_mode_q <= debug_mode_d;
+      load_err_q <= load_err_d;
+      store_err_q <= store_err_d;
+      exc_req_q <= exc_req_d;
       illegal_insn_q <= illegal_insn_d;
     end
   end
@@ -812,9 +814,9 @@ module ibex_controller #(
   ////////////////
 
   // Selectors must be known/valid.
-  `ASSERT(IbexCtrlStateValid, ctrl_fsm_cs inside {
-      RESET, BOOT_SET, WAIT_SLEEP, SLEEP, FIRST_FETCH, DECODE, FLUSH,
-      IRQ_TAKEN, DBG_TAKEN_IF, DBG_TAKEN_ID})
+  `ASSERT(IbexCtrlStateValid,
+          ctrl_fsm_cs inside {RESET, BOOT_SET, WAIT_SLEEP, SLEEP, FIRST_FETCH, DECODE, FLUSH,
+                              IRQ_TAKEN, DBG_TAKEN_IF, DBG_TAKEN_ID})
 
   // The speculative branch signal should be set whenever the actual branch signal is set
   `ASSERT(IbexSpecImpliesSetPC, pc_set_o |-> pc_set_spec_o)

--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 `ifndef RV32B
-  `define RV32B ibex_pkg::RV32BNone
+`define RV32B ibex_pkg::RV32BNone
 `endif
 
 /**
@@ -76,31 +76,31 @@ module ibex_core_tracing #(
   import ibex_pkg::*;
 
   // ibex_tracer relies on the signals from the RISC-V Formal Interface
-  `ifndef RVFI
-    $fatal("Fatal error: RVFI needs to be defined globally.");
-  `endif
+`ifndef RVFI
+  $fatal("Fatal error: RVFI needs to be defined globally.");
+`endif
 
-  logic        rvfi_valid;
+  logic rvfi_valid;
   logic [63:0] rvfi_order;
   logic [31:0] rvfi_insn;
-  logic        rvfi_trap;
-  logic        rvfi_halt;
-  logic        rvfi_intr;
-  logic [ 1:0] rvfi_mode;
-  logic [ 1:0] rvfi_ixl;
-  logic [ 4:0] rvfi_rs1_addr;
-  logic [ 4:0] rvfi_rs2_addr;
-  logic [ 4:0] rvfi_rs3_addr;
+  logic rvfi_trap;
+  logic rvfi_halt;
+  logic rvfi_intr;
+  logic [1:0] rvfi_mode;
+  logic [1:0] rvfi_ixl;
+  logic [4:0] rvfi_rs1_addr;
+  logic [4:0] rvfi_rs2_addr;
+  logic [4:0] rvfi_rs3_addr;
   logic [31:0] rvfi_rs1_rdata;
   logic [31:0] rvfi_rs2_rdata;
   logic [31:0] rvfi_rs3_rdata;
-  logic [ 4:0] rvfi_rd_addr;
+  logic [4:0] rvfi_rd_addr;
   logic [31:0] rvfi_rd_wdata;
   logic [31:0] rvfi_pc_rdata;
   logic [31:0] rvfi_pc_wdata;
   logic [31:0] rvfi_mem_addr;
-  logic [ 3:0] rvfi_mem_rmask;
-  logic [ 3:0] rvfi_mem_wmask;
+  logic [3:0] rvfi_mem_rmask;
+  logic [3:0] rvfi_mem_wmask;
   logic [31:0] rvfi_mem_rdata;
   logic [31:0] rvfi_mem_wdata;
 

--- a/rtl/ibex_counter.sv
+++ b/rtl/ibex_counter.sv
@@ -11,10 +11,10 @@ module ibex_counter #(
   output logic [63:0] counter_val_o
 );
 
-  logic [63:0]             counter;
+  logic [63:0] counter;
   logic [CounterWidth-1:0] counter_upd;
-  logic [63:0]             counter_load;
-  logic                    we;
+  logic [63:0] counter_load;
+  logic we;
   logic [CounterWidth-1:0] counter_d;
 
   // Update
@@ -23,28 +23,28 @@ module ibex_counter #(
     // Write
     we = counter_we_i | counterh_we_i;
     counter_load[63:32] = counter[63:32];
-    counter_load[31:0]  = counter_val_i;
+    counter_load[31:0] = counter_val_i;
     if (counterh_we_i) begin
       counter_load[63:32] = counter_val_i;
-      counter_load[31:0]  = counter[31:0];
+      counter_load[31:0] = counter[31:0];
     end
 
     // Increment
-    counter_upd = counter[CounterWidth-1:0] + {{CounterWidth-1{1'b0}},1'b1};
+    counter_upd = counter[CounterWidth - 1:0] + {{CounterWidth - 1{1'b0}}, 1'b1};
 
     // Next value logic
     if (we) begin
-      counter_d = counter_load[CounterWidth-1:0];
-    end else if (counter_inc_i)begin
-      counter_d = counter_upd[CounterWidth-1:0];
+      counter_d = counter_load[CounterWidth - 1:0];
+    end else if (counter_inc_i) begin
+      counter_d = counter_upd[CounterWidth - 1:0];
     end else begin
-      counter_d = counter[CounterWidth-1:0];
+      counter_d = counter[CounterWidth - 1:0];
     end
   end
 
 `ifdef FPGA_XILINX
   // Set DSP pragma for supported xilinx FPGAs
-  localparam int DspPragma = CounterWidth < 49  ? "yes" : "no";
+  localparam int DspPragma = CounterWidth < 49 ? "yes" : "no";
   (* use_dsp = DspPragma *) logic [CounterWidth-1:0] counter_q;
 
   // DSP output register requires synchronous reset.
@@ -67,9 +67,9 @@ module ibex_counter #(
   if (CounterWidth < 64) begin : g_counter_narrow
     logic [63:CounterWidth] unused_counter_load;
 
-    assign counter[CounterWidth-1:0] = counter_q;
-    assign counter[63:CounterWidth]  = '0;
-    assign unused_counter_load       = counter_load[63:CounterWidth];
+    assign counter[CounterWidth - 1:0] = counter_q;
+    assign counter[63:CounterWidth] = '0;
+    assign unused_counter_load = counter_load[63:CounterWidth];
   end else begin : g_counter_full
     assign counter = counter_q;
   end

--- a/rtl/ibex_dummy_instr.sv
+++ b/rtl/ibex_dummy_instr.sv
@@ -27,7 +27,7 @@ module ibex_dummy_instr (
 );
 
   localparam int unsigned TIMEOUT_CNT_W = 5;
-  localparam int unsigned OP_W          = 5;
+  localparam int unsigned OP_W = 5;
 
   typedef enum logic [1:0] {
     DUMMY_ADD = 2'b00,
@@ -37,24 +37,24 @@ module ibex_dummy_instr (
   } dummy_instr_e;
 
   typedef struct packed {
-    dummy_instr_e             instr_type;
-    logic [OP_W-1:0]          op_b;
-    logic [OP_W-1:0]          op_a;
+    dummy_instr_e instr_type;
+    logic [OP_W-1:0] op_b;
+    logic [OP_W-1:0] op_a;
     logic [TIMEOUT_CNT_W-1:0] cnt;
   } lfsr_data_t;
   localparam int unsigned LFSR_OUT_W = $bits(lfsr_data_t);
 
-  lfsr_data_t               lfsr_data;
+  lfsr_data_t lfsr_data;
   logic [TIMEOUT_CNT_W-1:0] dummy_cnt_incr, dummy_cnt_threshold;
   logic [TIMEOUT_CNT_W-1:0] dummy_cnt_d, dummy_cnt_q;
-  logic                     dummy_cnt_en;
-  logic                     lfsr_en;
-  logic [LFSR_OUT_W-1:0]    lfsr_state;
-  logic                     insert_dummy_instr;
-  logic [6:0]               dummy_set;
-  logic [2:0]               dummy_opcode;
-  logic [31:0]              dummy_instr;
-  logic [31:0]              dummy_instr_seed_q, dummy_instr_seed_d;
+  logic dummy_cnt_en;
+  logic lfsr_en;
+  logic [LFSR_OUT_W-1:0] lfsr_state;
+  logic insert_dummy_instr;
+  logic [6:0] dummy_set;
+  logic [2:0] dummy_opcode;
+  logic [31:0] dummy_instr;
+  logic [31:0] dummy_instr_seed_q, dummy_instr_seed_d;
 
   // Shift the LFSR every time we insert an instruction
   assign lfsr_en = insert_dummy_instr & id_in_ready_i;
@@ -87,14 +87,13 @@ module ibex_dummy_instr (
 
   // Set count threshold for inserting a new instruction. This is the pseudo-random value from the
   // LFSR with a mask applied (based on CSR config data) to shorten the period if required.
-  assign dummy_cnt_threshold = lfsr_data.cnt & {dummy_instr_mask_i,{TIMEOUT_CNT_W-3{1'b1}}};
-  assign dummy_cnt_incr      = dummy_cnt_q + {{TIMEOUT_CNT_W-1{1'b0}},1'b1};
+  assign dummy_cnt_threshold = lfsr_data.cnt & {dummy_instr_mask_i, {TIMEOUT_CNT_W - 3{1'b1}}};
+  assign dummy_cnt_incr = dummy_cnt_q + {{TIMEOUT_CNT_W - 1{1'b0}}, 1'b1};
   // Clear the counter everytime a new instruction is inserted
-  assign dummy_cnt_d         = insert_dummy_instr ? '0 : dummy_cnt_incr;
+  assign dummy_cnt_d = insert_dummy_instr ? '0 : dummy_cnt_incr;
   // Increment the counter for each executed instruction while dummy instuctions are
   // enabled.
-  assign dummy_cnt_en        = dummy_instr_en_i & id_in_ready_i &
-                               (fetch_valid_i | insert_dummy_instr);
+  assign dummy_cnt_en = dummy_instr_en_i & id_in_ready_i & (fetch_valid_i | insert_dummy_instr);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -110,34 +109,34 @@ module ibex_dummy_instr (
   // Encode instruction
   always_comb begin
     unique case (lfsr_data.instr_type)
-      DUMMY_ADD : begin
-        dummy_set    = 7'b0000000;
+      DUMMY_ADD: begin
+        dummy_set = 7'b0000000;
         dummy_opcode = 3'b000;
       end
-      DUMMY_MUL : begin
-        dummy_set    = 7'b0000001;
+      DUMMY_MUL: begin
+        dummy_set = 7'b0000001;
         dummy_opcode = 3'b000;
       end
-      DUMMY_DIV : begin
-        dummy_set    = 7'b0000001;
+      DUMMY_DIV: begin
+        dummy_set = 7'b0000001;
         dummy_opcode = 3'b100;
       end
-      DUMMY_AND : begin
-        dummy_set    = 7'b0000000;
+      DUMMY_AND: begin
+        dummy_set = 7'b0000000;
         dummy_opcode = 3'b111;
       end
-      default : begin
-        dummy_set    = 7'b0000000;
+      default: begin
+        dummy_set = 7'b0000000;
         dummy_opcode = 3'b000;
       end
     endcase
   end
 
-  //                    SET       RS2            RS1            OP           RD
-  assign dummy_instr = {dummy_set,lfsr_data.op_b,lfsr_data.op_a,dummy_opcode,5'h00,7'h33};
+  //                    SET        RS2             RS1             OP            RD
+  assign dummy_instr = {dummy_set, lfsr_data.op_b, lfsr_data.op_a, dummy_opcode, 5'h00, 7'h33};
 
   // Assign outputs
   assign insert_dummy_instr_o = insert_dummy_instr;
-  assign dummy_instr_data_o   = dummy_instr;
+  assign dummy_instr_data_o = dummy_instr;
 
 endmodule

--- a/rtl/ibex_ex_block.sv
+++ b/rtl/ibex_ex_block.sv
@@ -60,14 +60,14 @@ module ibex_ex_block #(
 
   logic [32:0] multdiv_alu_operand_b, multdiv_alu_operand_a;
   logic [33:0] alu_adder_result_ext;
-  logic        alu_cmp_result, alu_is_equal_result;
-  logic        multdiv_valid;
-  logic        multdiv_sel;
+  logic alu_cmp_result, alu_is_equal_result;
+  logic multdiv_valid;
+  logic multdiv_sel;
   logic [31:0] alu_imd_val_q[2];
   logic [31:0] alu_imd_val_d[2];
-  logic [ 1:0] alu_imd_val_we;
+  logic [1:0] alu_imd_val_we;
   logic [33:0] multdiv_imd_val_d[2];
-  logic [ 1:0] multdiv_imd_val_we;
+  logic [1:0] multdiv_imd_val_we;
 
   /*
     The multdiv_i output is never selected if RV32M=0
@@ -83,20 +83,20 @@ module ibex_ex_block #(
   // Intermediate Value Register Mux
   assign imd_val_d_o[0] = multdiv_sel ? multdiv_imd_val_d[0] : {2'b0, alu_imd_val_d[0]};
   assign imd_val_d_o[1] = multdiv_sel ? multdiv_imd_val_d[1] : {2'b0, alu_imd_val_d[1]};
-  assign imd_val_we_o   = multdiv_sel ? multdiv_imd_val_we : alu_imd_val_we;
+  assign imd_val_we_o = multdiv_sel ? multdiv_imd_val_we : alu_imd_val_we;
 
   assign alu_imd_val_q = '{imd_val_q_i[0][31:0], imd_val_q_i[1][31:0]};
 
-  assign result_ex_o  = multdiv_sel ? multdiv_result : alu_result;
+  assign result_ex_o = multdiv_sel ? multdiv_result : alu_result;
 
   // branch handling
-  assign branch_decision_o  = alu_cmp_result;
+  assign branch_decision_o = alu_cmp_result;
 
   if (BranchTargetALU) begin : g_branch_target_alu
     logic [32:0] bt_alu_result;
-    logic        unused_bt_carry;
+    logic unused_bt_carry;
 
-    assign bt_alu_result   = bt_a_operand_i + bt_b_operand_i;
+    assign bt_alu_result = bt_a_operand_i + bt_b_operand_i;
 
     assign unused_bt_carry = bt_alu_result[32];
     assign branch_target_o = bt_alu_result[31:0];
@@ -190,7 +190,7 @@ module ibex_ex_block #(
         .valid_o               ( multdiv_valid         ),
         .multdiv_result_o      ( multdiv_result        )
     );
-  end else if (MultiplierImplementation == "single-cycle") begin: gen_multdiv_single_cycle
+  end else if (MultiplierImplementation == "single-cycle") begin : gen_multdiv_single_cycle
     ibex_multdiv_fast #(
         .SingleCycleMultiply(1)
     ) multdiv_i (

--- a/rtl/ibex_fetch_fifo.sv
+++ b/rtl/ibex_fetch_fifo.sv
@@ -37,34 +37,34 @@ module ibex_fetch_fifo #(
     output logic                out_err_plus2_o
 );
 
-  localparam int unsigned DEPTH = NUM_REQS+1;
+  localparam int unsigned DEPTH = NUM_REQS + 1;
 
   // index 0 is used for output
-  logic [DEPTH-1:0] [31:0]  rdata_d,   rdata_q;
-  logic [DEPTH-1:0]         err_d,     err_q;
-  logic [DEPTH-1:0]         valid_d,   valid_q;
-  logic [DEPTH-1:0]         lowest_free_entry;
-  logic [DEPTH-1:0]         valid_pushed, valid_popped;
-  logic [DEPTH-1:0]         entry_en;
+  logic [DEPTH-1:0][31:0] rdata_d, rdata_q;
+  logic [DEPTH-1:0] err_d, err_q;
+  logic [DEPTH-1:0] valid_d, valid_q;
+  logic [DEPTH-1:0] lowest_free_entry;
+  logic [DEPTH-1:0] valid_pushed, valid_popped;
+  logic [DEPTH-1:0] entry_en;
 
-  logic                     pop_fifo;
-  logic             [31:0]  rdata, rdata_unaligned;
-  logic                     err,   err_unaligned, err_plus2;
-  logic                     valid, valid_unaligned;
+  logic pop_fifo;
+  logic [31:0] rdata, rdata_unaligned;
+  logic err, err_unaligned, err_plus2;
+  logic valid, valid_unaligned;
 
-  logic                     aligned_is_compressed, unaligned_is_compressed;
+  logic aligned_is_compressed, unaligned_is_compressed;
 
-  logic                     addr_incr_two;
-  logic [31:1]              instr_addr_d, instr_addr_q;
-  logic                     instr_addr_en;
-  logic                     unused_addr_in;
+  logic addr_incr_two;
+  logic [31:1] instr_addr_d, instr_addr_q;
+  logic instr_addr_en;
+  logic unused_addr_in;
 
   /////////////////
   // Output port //
   /////////////////
 
   assign rdata = valid_q[0] ? rdata_q[0] : in_rdata_i;
-  assign err   = valid_q[0] ? err_q[0]   : in_err_i;
+  assign err = valid_q[0] ? err_q[0] : in_err_i;
   assign valid = valid_q[0] | in_valid_i;
 
   // The FIFO contains word aligned memory fetches, but the instructions contained in each entry
@@ -79,30 +79,27 @@ module ibex_fetch_fifo #(
   //
 
   // Construct the output data for an unaligned instruction
-  assign rdata_unaligned = valid_q[1] ? {rdata_q[1][15:0], rdata[31:16]} :
-                                        {in_rdata_i[15:0], rdata[31:16]};
+  assign rdata_unaligned =
+      valid_q[1] ? {rdata_q[1][15:0], rdata[31:16]} : {in_rdata_i[15:0], rdata[31:16]};
 
   // If entry[1] is valid, an error can come from entry[0] or entry[1], unless the
   // instruction in entry[0] is compressed (entry[1] is a new instruction)
   // If entry[1] is not valid, and entry[0] is, an error can come from entry[0] or the incoming
   // data, unless the instruction in entry[0] is compressed
   // If entry[0] is not valid, the error must come from the incoming data
-  assign err_unaligned   = valid_q[1] ? ((err_q[1] & ~unaligned_is_compressed) | err_q[0]) :
-                                        ((valid_q[0] & err_q[0]) |
-                                         (in_err_i & (~valid_q[0] | ~unaligned_is_compressed)));
+  assign err_unaligned = valid_q[1] ? ((err_q[1] & ~unaligned_is_compressed) | err_q[0])
+      : ((valid_q[0] & err_q[0]) | (in_err_i & (~valid_q[0] | ~unaligned_is_compressed)));
 
   // Record when an error is caused by the second half of an unaligned 32bit instruction.
   // Only needs to be correct when unaligned and if err_unaligned is set
-  assign err_plus2       = valid_q[1] ? (err_q[1] & ~err_q[0]) :
-                                        (in_err_i & valid_q[0] & ~err_q[0]);
+  assign err_plus2 = valid_q[1] ? (err_q[1] & ~err_q[0]) : (in_err_i & valid_q[0] & ~err_q[0]);
 
   // An uncompressed unaligned instruction is only valid if both parts are available
-  assign valid_unaligned = valid_q[1] ? 1'b1 :
-                                        (valid_q[0] & in_valid_i);
+  assign valid_unaligned = valid_q[1] ? 1'b1 : (valid_q[0] & in_valid_i);
 
   // If there is an error, rdata is unknown
   assign unaligned_is_compressed = (rdata[17:16] != 2'b11) | err;
-  assign aligned_is_compressed   = (rdata[ 1: 0] != 2'b11) & ~err;
+  assign aligned_is_compressed = (rdata[1:0] != 2'b11) & ~err;
 
   ////////////////////////////////////////
   // Instruction aligner (if unaligned) //
@@ -111,8 +108,8 @@ module ibex_fetch_fifo #(
   always_comb begin
     if (out_addr_o[1]) begin
       // unaligned case
-      out_rdata_o     = rdata_unaligned;
-      out_err_o       = err_unaligned;
+      out_rdata_o = rdata_unaligned;
+      out_err_o = err_unaligned;
       out_err_plus2_o = err_plus2;
 
       if (unaligned_is_compressed) begin
@@ -122,10 +119,10 @@ module ibex_fetch_fifo #(
       end
     end else begin
       // aligned case
-      out_rdata_o     = rdata;
-      out_err_o       = err;
+      out_rdata_o = rdata;
+      out_err_o = err;
       out_err_plus2_o = 1'b0;
-      out_valid_o     = valid;
+      out_valid_o = valid;
     end
   end
 
@@ -137,8 +134,7 @@ module ibex_fetch_fifo #(
   assign instr_addr_en = clear_i | (out_ready_i & out_valid_o);
 
   // Increment the address by two every time a compressed instruction is popped
-  assign addr_incr_two = instr_addr_q[1] ? unaligned_is_compressed :
-                                           aligned_is_compressed;
+  assign addr_incr_two = instr_addr_q[1] ? unaligned_is_compressed : aligned_is_compressed;
 
   assign instr_addr_d = clear_i ? in_addr_i[31:1] :
                                   (instr_addr_q[31:1] +
@@ -152,7 +148,7 @@ module ibex_fetch_fifo #(
   end
 
   assign out_addr_o[31:1] = instr_addr_q[31:1];
-  assign out_addr_o[0]    = 1'b0;
+  assign out_addr_o[0] = 1'b0;
 
   // The LSB of the address is unused, since all addresses are halfword aligned
   assign unused_addr_in = in_addr_i[0];
@@ -164,7 +160,7 @@ module ibex_fetch_fifo #(
   // Indicate the fill level of fifo-entries. This is used to determine when a new request can be
   // made on the bus. The prefetch buffer only needs to know about the upper entries which overlap
   // with NUM_REQS.
-  assign busy_o = valid_q[DEPTH-1:DEPTH-NUM_REQS];
+  assign busy_o = valid_q[DEPTH - 1:DEPTH - NUM_REQS];
 
   /////////////////////
   // FIFO management //
@@ -178,34 +174,33 @@ module ibex_fetch_fifo #(
     if (i == 0) begin : g_ent0
       assign lowest_free_entry[i] = ~valid_q[i];
     end else begin : g_ent_others
-      assign lowest_free_entry[i] = ~valid_q[i] & valid_q[i-1];
+      assign lowest_free_entry[i] = ~valid_q[i] & valid_q[i - 1];
     end
 
     // An entry is set when an incoming request chooses the lowest available entry
-    assign valid_pushed[i] = (in_valid_i & lowest_free_entry[i]) |
-                             valid_q[i];
+    assign valid_pushed[i] = (in_valid_i & lowest_free_entry[i]) | valid_q[i];
     // Popping the FIFO shifts all entries down
-    assign valid_popped[i] = pop_fifo ? valid_pushed[i+1] : valid_pushed[i];
+    assign valid_popped[i] = pop_fifo ? valid_pushed[i + 1] : valid_pushed[i];
     // All entries are wiped out on a clear
     assign valid_d[i] = valid_popped[i] & ~clear_i;
 
     // data flops are enabled if there is new data to shift into it, or
-    assign entry_en[i] = (valid_pushed[i+1] & pop_fifo) |
-                         // a new request is incoming and this is the lowest free entry
-                         (in_valid_i & lowest_free_entry[i] & ~pop_fifo);
+    assign entry_en[i] = (valid_pushed[i + 1] & pop_fifo) |
+    // a new request is incoming and this is the lowest free entry
+    (in_valid_i & lowest_free_entry[i] & ~pop_fifo);
 
     // take the next entry or the incoming data
-    assign rdata_d[i]  = valid_q[i+1] ? rdata_q[i+1] : in_rdata_i;
-    assign err_d  [i]  = valid_q[i+1] ? err_q  [i+1] : in_err_i;
+    assign rdata_d[i] = valid_q[i + 1] ? rdata_q[i + 1] : in_rdata_i;
+    assign err_d[i] = valid_q[i + 1] ? err_q[i + 1] : in_err_i;
   end
   // The top entry is similar but with simpler muxing
-  assign lowest_free_entry[DEPTH-1] = ~valid_q[DEPTH-1] & valid_q[DEPTH-2];
-  assign valid_pushed     [DEPTH-1] = valid_q[DEPTH-1] | (in_valid_i & lowest_free_entry[DEPTH-1]);
-  assign valid_popped     [DEPTH-1] = pop_fifo ? 1'b0 : valid_pushed[DEPTH-1];
-  assign valid_d [DEPTH-1]          = valid_popped[DEPTH-1] & ~clear_i;
-  assign entry_en[DEPTH-1]          = in_valid_i & lowest_free_entry[DEPTH-1];
-  assign rdata_d [DEPTH-1]          = in_rdata_i;
-  assign err_d   [DEPTH-1]          = in_err_i;
+  assign lowest_free_entry[DEPTH - 1] = ~valid_q[DEPTH - 1] & valid_q[DEPTH - 2];
+  assign valid_pushed[DEPTH - 1] = valid_q[DEPTH - 1] | (in_valid_i & lowest_free_entry[DEPTH - 1]);
+  assign valid_popped[DEPTH - 1] = pop_fifo ? 1'b0 : valid_pushed[DEPTH - 1];
+  assign valid_d[DEPTH - 1] = valid_popped[DEPTH - 1] & ~clear_i;
+  assign entry_en[DEPTH - 1] = in_valid_i & lowest_free_entry[DEPTH - 1];
+  assign rdata_d[DEPTH - 1] = in_rdata_i;
+  assign err_d[DEPTH - 1] = in_err_i;
 
   ////////////////////
   // FIFO registers //
@@ -222,8 +217,8 @@ module ibex_fetch_fifo #(
   for (genvar i = 0; i < DEPTH; i++) begin : g_fifo_regs
     always_ff @(posedge clk_i) begin
       if (entry_en[i]) begin
-        rdata_q[i]   <= rdata_d[i];
-        err_q[i]     <= err_d[i];
+        rdata_q[i] <= rdata_d[i];
+        err_q[i] <= err_d[i];
       end
     end
   end
@@ -233,11 +228,9 @@ module ibex_fetch_fifo #(
   ////////////////
 
   // Must not push and pop simultaneously when FIFO full.
-  `ASSERT(IbexFetchFifoPushPopFull,
-      (in_valid_i && pop_fifo) |-> (!valid_q[DEPTH-1] || clear_i))
+  `ASSERT(IbexFetchFifoPushPopFull, (in_valid_i && pop_fifo) |-> (!valid_q[DEPTH - 1] || clear_i))
 
   // Must not push to FIFO when full.
-  `ASSERT(IbexFetchFifoPushFull,
-      (in_valid_i) |-> (!valid_q[DEPTH-1] || clear_i))
+  `ASSERT(IbexFetchFifoPushFull, (in_valid_i) |-> (!valid_q[DEPTH - 1] || clear_i))
 
 endmodule

--- a/rtl/ibex_icache.sv
+++ b/rtl/ibex_icache.sv
@@ -57,146 +57,146 @@ module ibex_icache #(
     output logic                busy_o
 );
   // Local constants
-  localparam int unsigned ADDR_W       = 32;
+  localparam int unsigned ADDR_W = 32;
   // Number of fill buffers (must be >= 2)
-  localparam int unsigned NUM_FB       = 4;
+  localparam int unsigned NUM_FB = 4;
   // Request throttling threshold
   localparam int unsigned FB_THRESHOLD = NUM_FB - 2;
   // Derived parameters
-  localparam int unsigned LINE_SIZE_ECC   = ICacheECC ? (LineSize + 8) : LineSize;
-  localparam int unsigned LINE_SIZE_BYTES = LineSize/8;
-  localparam int unsigned LINE_W          = $clog2(LINE_SIZE_BYTES);
-  localparam int unsigned BUS_BYTES       = BusWidth/8;
-  localparam int unsigned BUS_W           = $clog2(BUS_BYTES);
-  localparam int unsigned LINE_BEATS      = LINE_SIZE_BYTES / BUS_BYTES;
-  localparam int unsigned LINE_BEATS_W    = $clog2(LINE_BEATS);
-  localparam int unsigned NUM_LINES       = CacheSizeBytes / NumWays / LINE_SIZE_BYTES;
-  localparam int unsigned INDEX_W         = $clog2(NUM_LINES);
-  localparam int unsigned INDEX_HI        = INDEX_W + LINE_W - 1;
-  localparam int unsigned TAG_SIZE        = ADDR_W - INDEX_W - LINE_W + 1; // 1 valid bit
-  localparam int unsigned TAG_SIZE_ECC    = ICacheECC ? (TAG_SIZE + 6) : TAG_SIZE;
-  localparam int unsigned OUTPUT_BEATS    = (BUS_BYTES / 2); // number of halfwords
+  localparam int unsigned LINE_SIZE_ECC = ICacheECC ? (LineSize + 8) : LineSize;
+  localparam int unsigned LINE_SIZE_BYTES = LineSize / 8;
+  localparam int unsigned LINE_W = $clog2(LINE_SIZE_BYTES);
+  localparam int unsigned BUS_BYTES = BusWidth / 8;
+  localparam int unsigned BUS_W = $clog2(BUS_BYTES);
+  localparam int unsigned LINE_BEATS = LINE_SIZE_BYTES / BUS_BYTES;
+  localparam int unsigned LINE_BEATS_W = $clog2(LINE_BEATS);
+  localparam int unsigned NUM_LINES = CacheSizeBytes / NumWays / LINE_SIZE_BYTES;
+  localparam int unsigned INDEX_W = $clog2(NUM_LINES);
+  localparam int unsigned INDEX_HI = INDEX_W + LINE_W - 1;
+  localparam int unsigned TAG_SIZE = ADDR_W - INDEX_W - LINE_W + 1;  // 1 valid bit
+  localparam int unsigned TAG_SIZE_ECC = ICacheECC ? (TAG_SIZE + 6) : TAG_SIZE;
+  localparam int unsigned OUTPUT_BEATS = (BUS_BYTES / 2);  // number of halfwords
 
   // Prefetch signals
-  logic [ADDR_W-1:0]                   lookup_addr_aligned;
-  logic [ADDR_W-1:0]                   prefetch_addr_d, prefetch_addr_q;
-  logic                                prefetch_addr_en;
+  logic [ADDR_W-1:0] lookup_addr_aligned;
+  logic [ADDR_W-1:0] prefetch_addr_d, prefetch_addr_q;
+  logic prefetch_addr_en;
   // Cache pipelipe IC0 signals
-  logic                                branch_suppress;
-  logic                                lookup_throttle;
-  logic                                lookup_req_ic0;
-  logic [ADDR_W-1:0]                   lookup_addr_ic0;
-  logic [INDEX_W-1:0]                  lookup_index_ic0;
-  logic                                fill_req_ic0;
-  logic [INDEX_W-1:0]                  fill_index_ic0;
-  logic [TAG_SIZE-1:0]                 fill_tag_ic0;
-  logic [LineSize-1:0]                 fill_wdata_ic0;
-  logic                                lookup_grant_ic0;
-  logic                                lookup_actual_ic0;
-  logic                                fill_grant_ic0;
-  logic                                tag_req_ic0;
-  logic [INDEX_W-1:0]                  tag_index_ic0;
-  logic [NumWays-1:0]                  tag_banks_ic0;
-  logic                                tag_write_ic0;
-  logic [TAG_SIZE_ECC-1:0]             tag_wdata_ic0;
-  logic                                data_req_ic0;
-  logic [INDEX_W-1:0]                  data_index_ic0;
-  logic [NumWays-1:0]                  data_banks_ic0;
-  logic                                data_write_ic0;
-  logic [LINE_SIZE_ECC-1:0]            data_wdata_ic0;
+  logic branch_suppress;
+  logic lookup_throttle;
+  logic lookup_req_ic0;
+  logic [ADDR_W-1:0] lookup_addr_ic0;
+  logic [INDEX_W-1:0] lookup_index_ic0;
+  logic fill_req_ic0;
+  logic [INDEX_W-1:0] fill_index_ic0;
+  logic [TAG_SIZE-1:0] fill_tag_ic0;
+  logic [LineSize-1:0] fill_wdata_ic0;
+  logic lookup_grant_ic0;
+  logic lookup_actual_ic0;
+  logic fill_grant_ic0;
+  logic tag_req_ic0;
+  logic [INDEX_W-1:0] tag_index_ic0;
+  logic [NumWays-1:0] tag_banks_ic0;
+  logic tag_write_ic0;
+  logic [TAG_SIZE_ECC-1:0] tag_wdata_ic0;
+  logic data_req_ic0;
+  logic [INDEX_W-1:0] data_index_ic0;
+  logic [NumWays-1:0] data_banks_ic0;
+  logic data_write_ic0;
+  logic [LINE_SIZE_ECC-1:0] data_wdata_ic0;
   // Cache pipelipe IC1 signals
-  logic [TAG_SIZE_ECC-1:0]             tag_rdata_ic1  [NumWays];
-  logic [LINE_SIZE_ECC-1:0]            data_rdata_ic1 [NumWays];
-  logic [LINE_SIZE_ECC-1:0]            hit_data_ic1;
-  logic                                lookup_valid_ic1;
-  logic [ADDR_W-1:INDEX_HI+1]          lookup_addr_ic1;
-  logic [NumWays-1:0]                  tag_match_ic1;
-  logic                                tag_hit_ic1;
-  logic [NumWays-1:0]                  tag_invalid_ic1;
-  logic [NumWays-1:0]                  lowest_invalid_way_ic1;
-  logic [NumWays-1:0]                  round_robin_way_ic1, round_robin_way_q;
-  logic [NumWays-1:0]                  sel_way_ic1;
-  logic                                ecc_err_ic1;
-  logic                                ecc_write_req;
-  logic [NumWays-1:0]                  ecc_write_ways;
-  logic [INDEX_W-1:0]                  ecc_write_index;
+  logic [TAG_SIZE_ECC-1:0] tag_rdata_ic1[NumWays];
+  logic [LINE_SIZE_ECC-1:0] data_rdata_ic1[NumWays];
+  logic [LINE_SIZE_ECC-1:0] hit_data_ic1;
+  logic lookup_valid_ic1;
+  logic [ADDR_W-1:INDEX_HI+1] lookup_addr_ic1;
+  logic [NumWays-1:0] tag_match_ic1;
+  logic tag_hit_ic1;
+  logic [NumWays-1:0] tag_invalid_ic1;
+  logic [NumWays-1:0] lowest_invalid_way_ic1;
+  logic [NumWays-1:0] round_robin_way_ic1, round_robin_way_q;
+  logic [NumWays-1:0] sel_way_ic1;
+  logic ecc_err_ic1;
+  logic ecc_write_req;
+  logic [NumWays-1:0] ecc_write_ways;
+  logic [INDEX_W-1:0] ecc_write_index;
   // Fill buffer signals
-  logic                                gnt_or_pmp_err, gnt_not_pmp_err;
-  logic [$clog2(NUM_FB)-1:0]           fb_fill_level;
-  logic                                fill_cache_new;
-  logic                                fill_new_alloc;
-  logic                                fill_spec_req, fill_spec_done, fill_spec_hold;
-  logic [NUM_FB-1:0][NUM_FB-1:0]       fill_older_d, fill_older_q;
-  logic [NUM_FB-1:0]                   fill_alloc_sel, fill_alloc;
-  logic [NUM_FB-1:0]                   fill_busy_d, fill_busy_q;
-  logic [NUM_FB-1:0]                   fill_done;
-  logic [NUM_FB-1:0]                   fill_in_ic1;
-  logic [NUM_FB-1:0]                   fill_stale_d, fill_stale_q;
-  logic [NUM_FB-1:0]                   fill_cache_d, fill_cache_q;
-  logic [NUM_FB-1:0]                   fill_hit_ic1, fill_hit_d, fill_hit_q;
-  logic [NUM_FB-1:0][LINE_BEATS_W:0]   fill_ext_cnt_d, fill_ext_cnt_q;
-  logic [NUM_FB-1:0]                   fill_ext_hold_d, fill_ext_hold_q;
-  logic [NUM_FB-1:0]                   fill_ext_done;
-  logic [NUM_FB-1:0][LINE_BEATS_W:0]   fill_rvd_cnt_d, fill_rvd_cnt_q;
-  logic [NUM_FB-1:0]                   fill_rvd_done;
-  logic [NUM_FB-1:0]                   fill_ram_done_d, fill_ram_done_q;
-  logic [NUM_FB-1:0]                   fill_out_grant;
-  logic [NUM_FB-1:0][LINE_BEATS_W:0]   fill_out_cnt_d, fill_out_cnt_q;
-  logic [NUM_FB-1:0]                   fill_out_done;
-  logic [NUM_FB-1:0]                   fill_ext_req, fill_rvd_exp, fill_ram_req, fill_out_req;
-  logic [NUM_FB-1:0]                   fill_data_sel, fill_data_reg, fill_data_hit, fill_data_rvd;
+  logic gnt_or_pmp_err, gnt_not_pmp_err;
+  logic [$clog2(NUM_FB)-1:0] fb_fill_level;
+  logic fill_cache_new;
+  logic fill_new_alloc;
+  logic fill_spec_req, fill_spec_done, fill_spec_hold;
+  logic [NUM_FB-1:0][NUM_FB-1:0] fill_older_d, fill_older_q;
+  logic [NUM_FB-1:0] fill_alloc_sel, fill_alloc;
+  logic [NUM_FB-1:0] fill_busy_d, fill_busy_q;
+  logic [NUM_FB-1:0] fill_done;
+  logic [NUM_FB-1:0] fill_in_ic1;
+  logic [NUM_FB-1:0] fill_stale_d, fill_stale_q;
+  logic [NUM_FB-1:0] fill_cache_d, fill_cache_q;
+  logic [NUM_FB-1:0] fill_hit_ic1, fill_hit_d, fill_hit_q;
+  logic [NUM_FB-1:0][LINE_BEATS_W:0] fill_ext_cnt_d, fill_ext_cnt_q;
+  logic [NUM_FB-1:0] fill_ext_hold_d, fill_ext_hold_q;
+  logic [NUM_FB-1:0] fill_ext_done;
+  logic [NUM_FB-1:0][LINE_BEATS_W:0] fill_rvd_cnt_d, fill_rvd_cnt_q;
+  logic [NUM_FB-1:0] fill_rvd_done;
+  logic [NUM_FB-1:0] fill_ram_done_d, fill_ram_done_q;
+  logic [NUM_FB-1:0] fill_out_grant;
+  logic [NUM_FB-1:0][LINE_BEATS_W:0] fill_out_cnt_d, fill_out_cnt_q;
+  logic [NUM_FB-1:0] fill_out_done;
+  logic [NUM_FB-1:0] fill_ext_req, fill_rvd_exp, fill_ram_req, fill_out_req;
+  logic [NUM_FB-1:0] fill_data_sel, fill_data_reg, fill_data_hit, fill_data_rvd;
   logic [NUM_FB-1:0][LINE_BEATS_W-1:0] fill_ext_off, fill_rvd_off;
-  logic [NUM_FB-1:0][LINE_BEATS_W:0]   fill_rvd_beat;
-  logic [NUM_FB-1:0]                   fill_ext_arb, fill_ram_arb, fill_out_arb;
-  logic [NUM_FB-1:0]                   fill_rvd_arb;
-  logic [NUM_FB-1:0]                   fill_entry_en;
-  logic [NUM_FB-1:0]                   fill_addr_en;
-  logic [NUM_FB-1:0]                   fill_way_en;
-  logic [NUM_FB-1:0][LINE_BEATS-1:0]   fill_data_en;
-  logic [NUM_FB-1:0][LINE_BEATS-1:0]   fill_err_d, fill_err_q;
-  logic [ADDR_W-1:0]                   fill_addr_q [NUM_FB];
-  logic [NumWays-1:0]                  fill_way_q  [NUM_FB];
-  logic [LineSize-1:0]                 fill_data_d [NUM_FB];
-  logic [LineSize-1:0]                 fill_data_q [NUM_FB];
-  logic [ADDR_W-1:BUS_W]               fill_ext_req_addr;
-  logic [ADDR_W-1:0]                   fill_ram_req_addr;
-  logic [NumWays-1:0]                  fill_ram_req_way;
-  logic [LineSize-1:0]                 fill_ram_req_data;
-  logic [LineSize-1:0]                 fill_out_data;
-  logic [LINE_BEATS-1:0]               fill_out_err;
+  logic [NUM_FB-1:0][LINE_BEATS_W:0] fill_rvd_beat;
+  logic [NUM_FB-1:0] fill_ext_arb, fill_ram_arb, fill_out_arb;
+  logic [NUM_FB-1:0] fill_rvd_arb;
+  logic [NUM_FB-1:0] fill_entry_en;
+  logic [NUM_FB-1:0] fill_addr_en;
+  logic [NUM_FB-1:0] fill_way_en;
+  logic [NUM_FB-1:0][LINE_BEATS-1:0] fill_data_en;
+  logic [NUM_FB-1:0][LINE_BEATS-1:0] fill_err_d, fill_err_q;
+  logic [ADDR_W-1:0] fill_addr_q[NUM_FB];
+  logic [NumWays-1:0] fill_way_q[NUM_FB];
+  logic [LineSize-1:0] fill_data_d[NUM_FB];
+  logic [LineSize-1:0] fill_data_q[NUM_FB];
+  logic [ADDR_W-1:BUS_W] fill_ext_req_addr;
+  logic [ADDR_W-1:0] fill_ram_req_addr;
+  logic [NumWays-1:0] fill_ram_req_way;
+  logic [LineSize-1:0] fill_ram_req_data;
+  logic [LineSize-1:0] fill_out_data;
+  logic [LINE_BEATS-1:0] fill_out_err;
   // External req signals
-  logic                                instr_req;
-  logic [ADDR_W-1:BUS_W]               instr_addr;
+  logic instr_req;
+  logic [ADDR_W-1:BUS_W] instr_addr;
   // Data output signals
-  logic                                skid_complete_instr;
-  logic                                skid_ready;
-  logic                                output_compressed;
-  logic                                skid_valid_d, skid_valid_q, skid_en;
-  logic [15:0]                         skid_data_d, skid_data_q;
-  logic                                skid_err_q;
-  logic                                output_valid;
-  logic                                addr_incr_two;
-  logic                                output_addr_en;
-  logic [ADDR_W-1:1]                   output_addr_d, output_addr_q;
-  logic [15:0]                         output_data_lo, output_data_hi;
-  logic                                data_valid, output_ready;
-  logic [LineSize-1:0]                 line_data;
-  logic [LINE_BEATS-1:0]               line_err;
-  logic [31:0]                         line_data_muxed;
-  logic                                line_err_muxed;
-  logic [31:0]                         output_data;
-  logic                                output_err;
+  logic skid_complete_instr;
+  logic skid_ready;
+  logic output_compressed;
+  logic skid_valid_d, skid_valid_q, skid_en;
+  logic [15:0] skid_data_d, skid_data_q;
+  logic skid_err_q;
+  logic output_valid;
+  logic addr_incr_two;
+  logic output_addr_en;
+  logic [ADDR_W-1:1] output_addr_d, output_addr_q;
+  logic [15:0] output_data_lo, output_data_hi;
+  logic data_valid, output_ready;
+  logic [LineSize-1:0] line_data;
+  logic [LINE_BEATS-1:0] line_err;
+  logic [31:0] line_data_muxed;
+  logic line_err_muxed;
+  logic [31:0] output_data;
+  logic output_err;
   // Invalidations
-  logic                                start_inval, inval_done;
-  logic                                reset_inval_q;
-  logic                                inval_prog_d, inval_prog_q;
-  logic [INDEX_W-1:0]                  inval_index_d, inval_index_q;
+  logic start_inval, inval_done;
+  logic reset_inval_q;
+  logic inval_prog_d, inval_prog_q;
+  logic [INDEX_W-1:0] inval_index_d, inval_index_q;
 
   //////////////////////////
   // Instruction prefetch //
   //////////////////////////
 
-  assign lookup_addr_aligned = {lookup_addr_ic0[ADDR_W-1:LINE_W],{LINE_W{1'b0}}};
+  assign lookup_addr_aligned = {lookup_addr_ic0[ADDR_W - 1:LINE_W], {LINE_W{1'b0}}};
 
   // The prefetch address increments by one cache line for each granted request.
   // This address is also updated if there is a branch that is not granted, since the target
@@ -204,11 +204,10 @@ module ibex_icache #(
 
   // The captured branch target address is not forced to be aligned since the offset in the cache
   // line must also be recorded for later use by the fill buffers.
-  assign prefetch_addr_d     =
-      lookup_grant_ic0 ? (lookup_addr_aligned + {{ADDR_W-LINE_W-1{1'b0}},1'b1,{LINE_W{1'b0}}}) :
-                         addr_i;
+  assign prefetch_addr_d = lookup_grant_ic0
+      ? (lookup_addr_aligned + {{ADDR_W - LINE_W - 1{1'b0}}, 1'b1, {LINE_W{1'b0}}}) : addr_i;
 
-  assign prefetch_addr_en    = branch_i | lookup_grant_ic0;
+  assign prefetch_addr_en = branch_i | lookup_grant_ic0;
 
   always_ff @(posedge clk_i) begin
     if (prefetch_addr_en) begin
@@ -221,42 +220,38 @@ module ibex_icache #(
   ////////////////////////
 
   // Cache lookup
-  assign lookup_throttle  = (fb_fill_level > FB_THRESHOLD[$clog2(NUM_FB)-1:0]);
+  assign lookup_throttle = (fb_fill_level > FB_THRESHOLD[$clog2(NUM_FB) - 1:0]);
 
-  assign lookup_req_ic0   = req_i & ~&fill_busy_q & (branch_i | ~lookup_throttle) & ~ecc_write_req;
-  assign lookup_addr_ic0  = branch_spec_i ? addr_i :
-                                            prefetch_addr_q;
+  assign lookup_req_ic0 = req_i & ~&fill_busy_q & (branch_i | ~lookup_throttle) & ~ecc_write_req;
+  assign lookup_addr_ic0 = branch_spec_i ? addr_i : prefetch_addr_q;
   assign lookup_index_ic0 = lookup_addr_ic0[INDEX_HI:LINE_W];
 
   // Cache write
-  assign fill_req_ic0   = (|fill_ram_req);
+  assign fill_req_ic0 = (|fill_ram_req);
   assign fill_index_ic0 = fill_ram_req_addr[INDEX_HI:LINE_W];
   assign fill_tag_ic0   = {(~inval_prog_q & ~ecc_write_req),fill_ram_req_addr[ADDR_W-1:INDEX_HI+1]};
   assign fill_wdata_ic0 = fill_ram_req_data;
 
   // Suppress a new lookup on a not-taken branch (as the address will be incorrect)
-  assign branch_suppress   = branch_spec_i & ~branch_i;
+  assign branch_suppress = branch_spec_i & ~branch_i;
 
   // Arbitrated signals - lookups have highest priority
-  assign lookup_grant_ic0  = lookup_req_ic0 & ~branch_suppress;
-  assign fill_grant_ic0    = fill_req_ic0 & (~lookup_req_ic0 | branch_suppress) & ~inval_prog_q &
-                             ~ecc_write_req;
+  assign lookup_grant_ic0 = lookup_req_ic0 & ~branch_suppress;
+  assign fill_grant_ic0 =
+      fill_req_ic0 & (~lookup_req_ic0 | branch_suppress) & ~inval_prog_q & ~ecc_write_req;
   // Qualified lookup grant to mask ram signals in IC1 if access was not made
   assign lookup_actual_ic0 = lookup_grant_ic0 & icache_enable_i & ~inval_prog_q & ~start_inval;
 
   // Tagram
-  assign tag_req_ic0   = lookup_req_ic0 | fill_req_ic0 | inval_prog_q | ecc_write_req;
-  assign tag_index_ic0 = inval_prog_q   ? inval_index_q :
-                         ecc_write_req  ? ecc_write_index :
-                         fill_grant_ic0 ? fill_index_ic0 :
-                                          lookup_index_ic0;
-  assign tag_banks_ic0 = ecc_write_req  ? ecc_write_ways :
-                         fill_grant_ic0 ? fill_ram_req_way :
-                                          {NumWays{1'b1}};
+  assign tag_req_ic0 = lookup_req_ic0 | fill_req_ic0 | inval_prog_q | ecc_write_req;
+  assign tag_index_ic0 = inval_prog_q ? inval_index_q :
+      ecc_write_req ? ecc_write_index : fill_grant_ic0 ? fill_index_ic0 : lookup_index_ic0;
+  assign tag_banks_ic0 =
+      ecc_write_req ? ecc_write_ways : fill_grant_ic0 ? fill_ram_req_way : {NumWays{1'b1}};
   assign tag_write_ic0 = fill_grant_ic0 | inval_prog_q | ecc_write_req;
 
   // Dataram
-  assign data_req_ic0   = lookup_req_ic0 | fill_req_ic0;
+  assign data_req_ic0 = lookup_req_ic0 | fill_req_ic0;
   assign data_index_ic0 = tag_index_ic0;
   assign data_banks_ic0 = tag_banks_ic0;
   assign data_write_ic0 = tag_write_ic0;
@@ -266,19 +261,19 @@ module ibex_icache #(
 
     // Tagram ECC
     // Reuse the same ecc encoding module for larger cache sizes by padding with zeros
-    logic [21:0]          tag_ecc_input_padded;
-    logic [27:0]          tag_ecc_output_padded;
+    logic [21:0] tag_ecc_input_padded;
+    logic [27:0] tag_ecc_output_padded;
     logic [22-TAG_SIZE:0] tag_ecc_output_unused;
 
-    assign tag_ecc_input_padded  = {{22-TAG_SIZE{1'b0}},fill_tag_ic0};
-    assign tag_ecc_output_unused = tag_ecc_output_padded[21:TAG_SIZE-1];
+    assign tag_ecc_input_padded = {{22 - TAG_SIZE{1'b0}}, fill_tag_ic0};
+    assign tag_ecc_output_unused = tag_ecc_output_padded[21:TAG_SIZE - 1];
 
     prim_secded_28_22_enc tag_ecc_enc (
       .in  (tag_ecc_input_padded),
       .out (tag_ecc_output_padded)
     );
 
-    assign tag_wdata_ic0 = {tag_ecc_output_padded[27:22],tag_ecc_output_padded[TAG_SIZE-1:0]};
+    assign tag_wdata_ic0 = {tag_ecc_output_padded[27:22], tag_ecc_output_padded[TAG_SIZE - 1:0]};
 
     // Dataram ECC
     prim_secded_72_64_enc data_ecc_enc (
@@ -287,7 +282,7 @@ module ibex_icache #(
     );
 
   end else begin : gen_noecc_wdata
-    assign tag_wdata_ic0  = fill_tag_ic0;
+    assign tag_wdata_ic0 = fill_tag_ic0;
     assign data_wdata_ic0 = fill_wdata_ic0;
   end
 
@@ -336,8 +331,8 @@ module ibex_icache #(
 
   always_ff @(posedge clk_i) begin
     if (lookup_grant_ic0) begin
-      lookup_addr_ic1 <= lookup_addr_ic0[ADDR_W-1:INDEX_HI+1];
-      fill_in_ic1     <= fill_alloc_sel;
+      lookup_addr_ic1 <= lookup_addr_ic0[ADDR_W - 1:INDEX_HI + 1];
+      fill_in_ic1 <= fill_alloc_sel;
     end
   end
 
@@ -368,40 +363,38 @@ module ibex_icache #(
   // 1 first invalid way
   // 2 global round-robin (pseudorandom) way
   assign lowest_invalid_way_ic1[0] = tag_invalid_ic1[0];
-  assign round_robin_way_ic1[0]    = round_robin_way_q[NumWays-1];
+  assign round_robin_way_ic1[0] = round_robin_way_q[NumWays - 1];
   for (genvar way = 1; way < NumWays; way++) begin : gen_lowest_way
-    assign lowest_invalid_way_ic1[way] = tag_invalid_ic1[way] & ~|tag_invalid_ic1[way-1:0];
-    assign round_robin_way_ic1[way]    = round_robin_way_q[way-1];
+    assign lowest_invalid_way_ic1[way] = tag_invalid_ic1[way] & ~|tag_invalid_ic1[way - 1:0];
+    assign round_robin_way_ic1[way] = round_robin_way_q[way - 1];
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      round_robin_way_q <= {{NumWays-1{1'b0}},1'b1};
+      round_robin_way_q <= {{NumWays - 1{1'b0}}, 1'b1};
     end else if (lookup_valid_ic1) begin
       round_robin_way_q <= round_robin_way_ic1;
     end
   end
 
-  assign sel_way_ic1 = |tag_invalid_ic1 ? lowest_invalid_way_ic1 :
-                                          round_robin_way_q;
+  assign sel_way_ic1 = |tag_invalid_ic1 ? lowest_invalid_way_ic1 : round_robin_way_q;
 
   // ECC checking logic
   if (ICacheECC) begin : gen_data_ecc_checking
     logic [NumWays-1:0] tag_err_ic1;
-    logic [1:0]         data_err_ic1;
-    logic               ecc_correction_write_d, ecc_correction_write_q;
+    logic [1:0] data_err_ic1;
+    logic ecc_correction_write_d, ecc_correction_write_q;
     logic [NumWays-1:0] ecc_correction_ways_d, ecc_correction_ways_q;
     logic [INDEX_W-1:0] lookup_index_ic1, ecc_correction_index_q;
 
     // Tag ECC checking
     for (genvar way = 0; way < NumWays; way++) begin : gen_tag_ecc
-      logic [1:0]  tag_err_bank_ic1;
+      logic [1:0] tag_err_bank_ic1;
       logic [27:0] tag_rdata_padded_ic1;
 
       // Expand the tag rdata with extra padding if the tag size is less than the maximum
-      assign tag_rdata_padded_ic1 = {tag_rdata_ic1[way][TAG_SIZE_ECC-1-:6],
-                                     {22-TAG_SIZE{1'b0}},
-                                     tag_rdata_ic1[way][TAG_SIZE-1:0]};
+      assign tag_rdata_padded_ic1 = {tag_rdata_ic1[way][TAG_SIZE_ECC - 1 -: 6],
+                                     {22 - TAG_SIZE{1'b0}}, tag_rdata_ic1[way][TAG_SIZE - 1:0]};
 
       prim_secded_28_22_dec data_ecc_dec (
         .in         (tag_rdata_padded_ic1),
@@ -427,8 +420,8 @@ module ibex_icache #(
     // All ways will be invalidated on a tag error to prevent X-propagation from data_err_ic1 on
     // spurious hits. Also prevents the same line being allocated twice when there was a true
     // hit and a spurious hit.
-    assign ecc_correction_ways_d  = {NumWays{|tag_err_ic1}} |
-                                    (tag_match_ic1 & {NumWays{|data_err_ic1}});
+    assign ecc_correction_ways_d =
+        {NumWays{|tag_err_ic1}} | (tag_match_ic1 & {NumWays{|data_err_ic1}});
     assign ecc_correction_write_d = ecc_err_ic1;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -442,26 +435,26 @@ module ibex_icache #(
     // The index is required in IC1 only when ECC is configured so is registered here
     always_ff @(posedge clk_i) begin
       if (lookup_grant_ic0) begin
-        lookup_index_ic1 <= lookup_addr_ic0[INDEX_HI-:INDEX_W];
+        lookup_index_ic1 <= lookup_addr_ic0[INDEX_HI -: INDEX_W];
       end
     end
 
     // Store the ways with errors to be invalidated
     always_ff @(posedge clk_i) begin
       if (ecc_err_ic1) begin
-        ecc_correction_ways_q  <= ecc_correction_ways_d;
+        ecc_correction_ways_q <= ecc_correction_ways_d;
         ecc_correction_index_q <= lookup_index_ic1;
       end
     end
 
-    assign ecc_write_req   = ecc_correction_write_q;
-    assign ecc_write_ways  = ecc_correction_ways_q;
+    assign ecc_write_req = ecc_correction_write_q;
+    assign ecc_write_ways = ecc_correction_ways_q;
     assign ecc_write_index = ecc_correction_index_q;
 
   end else begin : gen_no_data_ecc
-    assign ecc_err_ic1     = 1'b0;
-    assign ecc_write_req   = 1'b0;
-    assign ecc_write_ways  = '0;
+    assign ecc_err_ic1 = 1'b0;
+    assign ecc_write_req = 1'b0;
+    assign ecc_write_ways = '0;
     assign ecc_write_index = '0;
   end
 
@@ -474,12 +467,12 @@ module ibex_icache #(
     // Cache branch target + a number of subsequent lines
     localparam int unsigned CACHE_AHEAD = 2;
     localparam int unsigned CACHE_CNT_W = (CACHE_AHEAD == 1) ? 1 : $clog2(CACHE_AHEAD) + 1;
-    logic                   cache_cnt_dec;
+    logic cache_cnt_dec;
     logic [CACHE_CNT_W-1:0] cache_cnt_d, cache_cnt_q;
 
     assign cache_cnt_dec = lookup_grant_ic0 & (|cache_cnt_q);
-    assign cache_cnt_d   = branch_i ? CACHE_AHEAD[CACHE_CNT_W-1:0] :
-                                      (cache_cnt_q - {{CACHE_CNT_W-1{1'b0}},cache_cnt_dec});
+    assign cache_cnt_d = branch_i ?
+        CACHE_AHEAD[CACHE_CNT_W - 1:0] : (cache_cnt_q - {{CACHE_CNT_W - 1{1'b0}}, cache_cnt_dec});
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
@@ -489,8 +482,8 @@ module ibex_icache #(
       end
     end
 
-    assign fill_cache_new = (branch_i | (|cache_cnt_q)) & icache_enable_i &
-                            ~icache_inval_i & ~inval_prog_q;
+    assign fill_cache_new =
+        (branch_i | (|cache_cnt_q)) & icache_enable_i & ~icache_inval_i & ~inval_prog_q;
 
   end else begin : gen_cache_all
 
@@ -506,18 +499,18 @@ module ibex_icache #(
     fb_fill_level = '0;
     for (int i = 0; i < NUM_FB; i++) begin
       if (fill_busy_q[i] & ~fill_stale_q[i]) begin
-        fb_fill_level += {{$clog2(NUM_FB)-1{1'b0}},1'b1};
+        fb_fill_level += {{$clog2(NUM_FB) - 1{1'b0}}, 1'b1};
       end
     end
   end
 
   // PMP errors might not / don't need to be granted (since the external request is masked)
-  assign gnt_or_pmp_err  = instr_gnt_i | instr_pmp_err_i;
+  assign gnt_or_pmp_err = instr_gnt_i | instr_pmp_err_i;
   assign gnt_not_pmp_err = instr_gnt_i & ~instr_pmp_err_i;
   // Allocate a new buffer for every granted lookup
   assign fill_new_alloc = lookup_grant_ic0;
   // Track whether a speculative external request was made from IC0, and whether it was granted
-  assign fill_spec_req  = (SpecRequest | branch_i) & ~|fill_ext_req;
+  assign fill_spec_req = (SpecRequest | branch_i) & ~|fill_ext_req;
   assign fill_spec_done = fill_spec_req & gnt_not_pmp_err;
   assign fill_spec_hold = fill_spec_req & ~gnt_or_pmp_err;
 
@@ -531,15 +524,15 @@ module ibex_icache #(
     if (fb == 0) begin : gen_fb_zero
       assign fill_alloc_sel[fb] = ~fill_busy_q[fb];
     end else begin : gen_fb_rest
-      assign fill_alloc_sel[fb] = ~fill_busy_q[fb] & (&fill_busy_q[fb-1:0]);
+      assign fill_alloc_sel[fb] = ~fill_busy_q[fb] & (&fill_busy_q[fb - 1:0]);
     end
 
-    assign fill_alloc[fb]      = fill_alloc_sel[fb] & fill_new_alloc;
-    assign fill_busy_d[fb]     = fill_alloc[fb] | (fill_busy_q[fb] & ~fill_done[fb]);
+    assign fill_alloc[fb] = fill_alloc_sel[fb] & fill_new_alloc;
+    assign fill_busy_d[fb] = fill_alloc[fb] | (fill_busy_q[fb] & ~fill_done[fb]);
 
     // Track which other fill buffers are older than this one (for age-based arbitration)
     // TODO sparsify
-    assign fill_older_d[fb]    = (fill_alloc[fb] ? fill_busy_q : fill_older_q[fb]) & ~fill_done;
+    assign fill_older_d[fb] = (fill_alloc[fb] ? fill_busy_q : fill_older_q[fb]) & ~fill_done;
 
     // A fill buffer can release once all its actions are completed
                                  // all data written to the cache (unless hit or error)
@@ -555,32 +548,29 @@ module ibex_icache #(
     /////////////////////////////////
 
     // Track staleness (requests become stale when a branch intervenes)
-    assign fill_stale_d[fb]    = fill_busy_q[fb] & (branch_i | fill_stale_q[fb]);
+    assign fill_stale_d[fb] = fill_busy_q[fb] & (branch_i | fill_stale_q[fb]);
     // Track whether or not this request should allocate to the cache
     // Any invalidation or disabling of the cache while the buffer is busy will stop allocation
-    assign fill_cache_d[fb]    = (fill_alloc[fb] & fill_cache_new) |
-                                 (fill_cache_q[fb] & fill_busy_q[fb] &
-                                  icache_enable_i & ~icache_inval_i);
+    assign fill_cache_d[fb] = (fill_alloc[fb] & fill_cache_new) | (
+        fill_cache_q[fb] & fill_busy_q[fb] & icache_enable_i & ~icache_inval_i);
     // Record whether the request hit in the cache
-    assign fill_hit_ic1[fb]    = lookup_valid_ic1 & fill_in_ic1[fb] & tag_hit_ic1 & ~ecc_err_ic1;
-    assign fill_hit_d[fb]      = fill_hit_ic1[fb] | (fill_hit_q[fb] & fill_busy_q[fb]);
+    assign fill_hit_ic1[fb] = lookup_valid_ic1 & fill_in_ic1[fb] & tag_hit_ic1 & ~ecc_err_ic1;
+    assign fill_hit_d[fb] = fill_hit_ic1[fb] | (fill_hit_q[fb] & fill_busy_q[fb]);
 
     ///////////////////////////////////////////
     // Fill buffer external request tracking //
     ///////////////////////////////////////////
 
     // Make an external request
-    assign fill_ext_req[fb]    = fill_busy_q[fb] & ~fill_ext_done[fb];
+    assign fill_ext_req[fb] = fill_busy_q[fb] & ~fill_ext_done[fb];
 
     // Count the number of completed external requests (each line requires LINE_BEATS requests)
     // Don't count fake PMP error grants here since they will never receive an rvalid response
-    assign fill_ext_cnt_d[fb]  = fill_alloc[fb] ?
-                                   {{LINE_BEATS_W{1'b0}},fill_spec_done} :
-                                   (fill_ext_cnt_q[fb] + {{LINE_BEATS_W{1'b0}},
-                                                          fill_ext_arb[fb] & gnt_not_pmp_err});
+    assign fill_ext_cnt_d[fb] = fill_alloc[fb] ? {{LINE_BEATS_W{1'b0}}, fill_spec_done} : (
+        fill_ext_cnt_q[fb] + {{LINE_BEATS_W{1'b0}}, fill_ext_arb[fb] & gnt_not_pmp_err});
     // External request must be held until granted
-    assign fill_ext_hold_d[fb] = (fill_alloc[fb] & fill_spec_hold) |
-                                 (fill_ext_arb[fb] & ~gnt_or_pmp_err);
+    assign fill_ext_hold_d[fb] =
+        (fill_alloc[fb] & fill_spec_hold) | (fill_ext_arb[fb] & ~gnt_or_pmp_err);
     // External requests are completed when the counter is filled or when the request is cancelled
     assign fill_ext_done[fb]   = (fill_ext_cnt_q[fb][LINE_BEATS_W] |
                                   // external requests are considered complete if the request hit
@@ -592,13 +582,12 @@ module ibex_icache #(
                                  // can't cancel while we are waiting for a grant on the bus
                                  ~fill_ext_hold_q[fb];
     // Track whether this fill buffer expects to receive beats of data
-    assign fill_rvd_exp[fb]    = fill_busy_q[fb] & ~fill_rvd_done[fb];
+    assign fill_rvd_exp[fb] = fill_busy_q[fb] & ~fill_rvd_done[fb];
     // Count the number of rvalid beats received
-    assign fill_rvd_cnt_d[fb]  = fill_alloc[fb] ? '0 :
-                                                  (fill_rvd_cnt_q[fb] +
-                                                   {{LINE_BEATS_W{1'b0}},fill_rvd_arb[fb]});
+    assign fill_rvd_cnt_d[fb] =
+        fill_alloc[fb] ? '0 : (fill_rvd_cnt_q[fb] + {{LINE_BEATS_W{1'b0}}, fill_rvd_arb[fb]});
     // External data is complete when all issued external requests have received their data
-    assign fill_rvd_done[fb]   = fill_ext_done[fb] & (fill_rvd_cnt_q[fb] == fill_ext_cnt_q[fb]);
+    assign fill_rvd_done[fb] = fill_ext_done[fb] & (fill_rvd_cnt_q[fb] == fill_ext_cnt_q[fb]);
 
     //////////////////////////////////////
     // Fill buffer data output tracking //
@@ -617,14 +606,14 @@ module ibex_icache #(
                                   (fill_rvd_beat[fb] > fill_out_cnt_q[fb]) | fill_rvd_arb[fb]);
 
     // Calculate when a beat of data is output. Any ECC error squashes the output that cycle.
-    assign fill_out_grant[fb]  = fill_out_arb[fb] & output_ready;
+    assign fill_out_grant[fb] = fill_out_arb[fb] & output_ready;
 
     // Count the beats of data output to the IF stage
     assign fill_out_cnt_d[fb]  = fill_alloc[fb] ? {1'b0,lookup_addr_ic0[LINE_W-1:BUS_W]} :
                                                   (fill_out_cnt_q[fb] +
                                                    {{LINE_BEATS_W{1'b0}},fill_out_grant[fb]});
     // Data output complete when the counter fills
-    assign fill_out_done[fb]   = fill_out_cnt_q[fb][LINE_BEATS_W];
+    assign fill_out_done[fb] = fill_out_cnt_q[fb][LINE_BEATS_W];
 
     //////////////////////////////////////
     // Fill buffer ram request tracking //
@@ -646,24 +635,23 @@ module ibex_icache #(
 
     // When we branch into the middle of a line, the output count will not start from zero. This
     // beat count is used to know which incoming rdata beats are relevant.
-    assign fill_rvd_beat[fb]   = {1'b0,fill_addr_q[fb][LINE_W-1:BUS_W]} +
-                                 fill_rvd_cnt_q[fb][LINE_BEATS_W:0];
-    assign fill_ext_off[fb]    = fill_addr_q[fb][LINE_W-1:BUS_W] +
-                                 fill_ext_cnt_q[fb][LINE_BEATS_W-1:0];
-    assign fill_rvd_off[fb]    = fill_rvd_beat[fb][LINE_BEATS_W-1:0];
+    assign fill_rvd_beat[fb] = {1'b0, fill_addr_q[fb][LINE_W - 1:BUS_W]} +
+        fill_rvd_cnt_q[fb][LINE_BEATS_W:0];
+    assign fill_ext_off[fb] =
+        fill_addr_q[fb][LINE_W - 1:BUS_W] + fill_ext_cnt_q[fb][LINE_BEATS_W - 1:0];
+    assign fill_rvd_off[fb] = fill_rvd_beat[fb][LINE_BEATS_W - 1:0];
 
     /////////////////////////////
     // Fill buffer arbitration //
     /////////////////////////////
 
     // Age based arbitration - all these signals are one-hot
-    assign fill_ext_arb[fb]    = fill_ext_req[fb] & ~|(fill_ext_req & fill_older_q[fb]);
+    assign fill_ext_arb[fb] = fill_ext_req[fb] & ~|(fill_ext_req & fill_older_q[fb]);
     assign fill_ram_arb[fb]    = fill_ram_req[fb] & fill_grant_ic0 & ~|(fill_ram_req & fill_older_q[fb]);
     // Calculate which fill buffer is the oldest one which still needs to output data to IF
-    assign fill_data_sel[fb]   = ~|(fill_busy_q & ~fill_out_done & ~fill_stale_q &
-                                    fill_older_q[fb]);
+    assign fill_data_sel[fb] = ~|(fill_busy_q & ~fill_out_done & ~fill_stale_q & fill_older_q[fb]);
     // Arbitrate the request which has data available to send, and is the oldest outstanding
-    assign fill_out_arb[fb]    = fill_out_req[fb] & fill_data_sel[fb];
+    assign fill_out_arb[fb] = fill_out_req[fb] & fill_data_sel[fb];
     // Assign incoming rvalid data to the oldest fill buffer expecting it
     assign fill_rvd_arb[fb]    = instr_rvalid_i & fill_rvd_exp[fb] & ~|(fill_rvd_exp & fill_older_q[fb]);
 
@@ -692,31 +680,31 @@ module ibex_icache #(
     ///////////////////////////
 
     // Fill buffer general enable
-    assign fill_entry_en[fb]   = fill_alloc[fb] | fill_busy_q[fb];
+    assign fill_entry_en[fb] = fill_alloc[fb] | fill_busy_q[fb];
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
-        fill_busy_q[fb]     <= 1'b0;
-        fill_older_q[fb]    <= '0;
-        fill_stale_q[fb]    <= 1'b0;
-        fill_cache_q[fb]    <= 1'b0;
-        fill_hit_q[fb]      <= 1'b0;
-        fill_ext_cnt_q[fb]  <= '0;
+        fill_busy_q[fb] <= 1'b0;
+        fill_older_q[fb] <= '0;
+        fill_stale_q[fb] <= 1'b0;
+        fill_cache_q[fb] <= 1'b0;
+        fill_hit_q[fb] <= 1'b0;
+        fill_ext_cnt_q[fb] <= '0;
         fill_ext_hold_q[fb] <= 1'b0;
-        fill_rvd_cnt_q[fb]  <= '0;
+        fill_rvd_cnt_q[fb] <= '0;
         fill_ram_done_q[fb] <= 1'b0;
-        fill_out_cnt_q[fb]  <= '0;
+        fill_out_cnt_q[fb] <= '0;
       end else if (fill_entry_en[fb]) begin
-        fill_busy_q[fb]     <= fill_busy_d[fb];
-        fill_older_q[fb]    <= fill_older_d[fb];
-        fill_stale_q[fb]    <= fill_stale_d[fb];
-        fill_cache_q[fb]    <= fill_cache_d[fb];
-        fill_hit_q[fb]      <= fill_hit_d[fb];
-        fill_ext_cnt_q[fb]  <= fill_ext_cnt_d[fb];
+        fill_busy_q[fb] <= fill_busy_d[fb];
+        fill_older_q[fb] <= fill_older_d[fb];
+        fill_stale_q[fb] <= fill_stale_d[fb];
+        fill_cache_q[fb] <= fill_cache_d[fb];
+        fill_hit_q[fb] <= fill_hit_d[fb];
+        fill_ext_cnt_q[fb] <= fill_ext_cnt_d[fb];
         fill_ext_hold_q[fb] <= fill_ext_hold_d[fb];
-        fill_rvd_cnt_q[fb]  <= fill_rvd_cnt_d[fb];
+        fill_rvd_cnt_q[fb] <= fill_rvd_cnt_d[fb];
         fill_ram_done_q[fb] <= fill_ram_done_d[fb];
-        fill_out_cnt_q[fb]  <= fill_out_cnt_d[fb];
+        fill_out_cnt_q[fb] <= fill_out_cnt_d[fb];
       end
     end
 
@@ -724,8 +712,8 @@ module ibex_icache #(
     // Fill buffer address / data storage //
     ////////////////////////////////////////
 
-    assign fill_addr_en[fb]    = fill_alloc[fb];
-    assign fill_way_en[fb]     = (lookup_valid_ic1 & fill_in_ic1[fb]);
+    assign fill_addr_en[fb] = fill_alloc[fb];
+    assign fill_way_en[fb] = (lookup_valid_ic1 & fill_in_ic1[fb]);
 
     always_ff @(posedge clk_i) begin
       if (fill_addr_en[fb]) begin
@@ -735,20 +723,20 @@ module ibex_icache #(
 
     always_ff @(posedge clk_i) begin
       if (fill_way_en[fb]) begin
-        fill_way_q[fb]  <= sel_way_ic1;
+        fill_way_q[fb] <= sel_way_ic1;
       end
     end
 
     // Data either comes from the cache or the bus. If there was an ECC error, we must take
     // the incoming bus data since the cache hit data is corrupted.
-    assign fill_data_d[fb] = fill_hit_ic1[fb] ? hit_data_ic1[LineSize-1:0] :
-                                                {LINE_BEATS{instr_rdata_i}};
+    assign fill_data_d[fb] =
+        fill_hit_ic1[fb] ? hit_data_ic1[LineSize - 1:0] : {LINE_BEATS{instr_rdata_i}};
 
     for (genvar b = 0; b < LINE_BEATS; b++) begin : gen_data_buf
       // Error tracking (per beat)
       //                           Either a PMP error on a speculative request,
-      assign fill_err_d[fb][b]   = (instr_pmp_err_i & fill_alloc[fb] & fill_spec_req &
-                                    (lookup_addr_ic0[LINE_W-1:BUS_W] == b[LINE_BEATS_W-1:0])) |
+      assign fill_err_d[fb][b] = (instr_pmp_err_i & fill_alloc[fb] & fill_spec_req & (
+                                  lookup_addr_ic0[LINE_W - 1:BUS_W] == b[LINE_BEATS_W - 1:0])) |
       //                           a PMP error on a fill buffer ext req
                                    (instr_pmp_err_i & fill_ext_arb[fb] &
                                     (fill_ext_off[fb] == b[LINE_BEATS_W-1:0])) |
@@ -768,13 +756,12 @@ module ibex_icache #(
 
       // Enable the relevant part of the data register (or all for cache hits)
       // Ignore incoming rvalid data when we already have cache hit data
-      assign fill_data_en[fb][b] = fill_hit_ic1[fb] |
-                                   (fill_rvd_arb[fb] & ~fill_hit_q[fb] &
-                                    (fill_rvd_off[fb] == b[LINE_BEATS_W-1:0]));
+      assign fill_data_en[fb][b] = fill_hit_ic1[fb] | (
+          fill_rvd_arb[fb] & ~fill_hit_q[fb] & (fill_rvd_off[fb] == b[LINE_BEATS_W - 1:0]));
 
       always_ff @(posedge clk_i) begin
         if (fill_data_en[fb][b]) begin
-          fill_data_q[fb][b*BusWidth+:BusWidth] <= fill_data_d[fb][b*BusWidth+:BusWidth];
+          fill_data_q[fb][b * BusWidth +: BusWidth] <= fill_data_d[fb][b * BusWidth +: BusWidth];
         end
       end
 
@@ -790,7 +777,7 @@ module ibex_icache #(
     fill_ext_req_addr = '0;
     for (int i = 0; i < NUM_FB; i++) begin
       if (fill_ext_arb[i]) begin
-        fill_ext_req_addr |= {fill_addr_q[i][ADDR_W-1:LINE_W], fill_ext_off[i]};
+        fill_ext_req_addr |= {fill_addr_q[i][ADDR_W - 1:LINE_W], fill_ext_off[i]};
       end
     end
   end
@@ -798,12 +785,12 @@ module ibex_icache #(
   // Cache req info
   always_comb begin
     fill_ram_req_addr = '0;
-    fill_ram_req_way  = '0;
+    fill_ram_req_way = '0;
     fill_ram_req_data = '0;
     for (int i = 0; i < NUM_FB; i++) begin
       if (fill_ram_arb[i]) begin
         fill_ram_req_addr |= fill_addr_q[i];
-        fill_ram_req_way  |= fill_way_q[i];
+        fill_ram_req_way |= fill_way_q[i];
         fill_ram_req_data |= fill_data_q[i];
       end
     end
@@ -812,12 +799,12 @@ module ibex_icache #(
   // IF stage output data
   always_comb begin
     fill_out_data = '0;
-    fill_out_err  = '0;
+    fill_out_err = '0;
     for (int i = 0; i < NUM_FB; i++) begin
       if (fill_data_reg[i]) begin
         fill_out_data |= fill_data_q[i];
         // Ignore any speculative errors accumulated on cache hits
-        fill_out_err  |= (fill_err_q[i] & ~{LINE_BEATS{fill_hit_q[i]}});
+        fill_out_err |= (fill_err_q[i] & ~{LINE_BEATS{fill_hit_q[i]}});
       end
     end
   end
@@ -826,40 +813,38 @@ module ibex_icache #(
   // External requests //
   ///////////////////////
 
-  assign instr_req  = ((SpecRequest | branch_i) & lookup_grant_ic0) |
-                      |fill_ext_req;
+  assign instr_req = ((SpecRequest | branch_i) & lookup_grant_ic0) | |fill_ext_req;
 
-  assign instr_addr = |fill_ext_req ? fill_ext_req_addr :
-                                      lookup_addr_ic0[ADDR_W-1:BUS_W];
+  assign instr_addr = |fill_ext_req ? fill_ext_req_addr : lookup_addr_ic0[ADDR_W - 1:BUS_W];
 
-  assign instr_req_o  = instr_req;
-  assign instr_addr_o = {instr_addr[ADDR_W-1:BUS_W],{BUS_W{1'b0}}};
+  assign instr_req_o = instr_req;
+  assign instr_addr_o = {instr_addr[ADDR_W - 1:BUS_W], {BUS_W{1'b0}}};
 
   ////////////////////////
   // Output data muxing //
   ////////////////////////
 
   // Mux between line-width data sources
-  assign line_data = |fill_data_hit ? hit_data_ic1[LineSize-1:0] : fill_out_data;
-  assign line_err  = |fill_data_hit ? {LINE_BEATS{1'b0}} : fill_out_err;
+  assign line_data = |fill_data_hit ? hit_data_ic1[LineSize - 1:0] : fill_out_data;
+  assign line_err = |fill_data_hit ? {LINE_BEATS{1'b0}} : fill_out_err;
 
   // Mux the relevant beat of line data, based on the output address
   always_comb begin
     line_data_muxed = '0;
-    line_err_muxed  = 1'b0;
+    line_err_muxed = 1'b0;
     for (int i = 0; i < LINE_BEATS; i++) begin
       // When data has been skidded, the output address is behind by one
-      if ((output_addr_q[LINE_W-1:BUS_W] + {{LINE_BEATS_W-1{1'b0}},skid_valid_q}) ==
-          i[LINE_BEATS_W-1:0]) begin
-        line_data_muxed |= line_data[i*32+:32];
-        line_err_muxed  |= line_err[i];
+      if ((output_addr_q[LINE_W - 1:BUS_W] + {{LINE_BEATS_W - 1{1'b0}}, skid_valid_q}) ==
+          i[LINE_BEATS_W - 1:0]) begin
+        line_data_muxed |= line_data[i * 32 +: 32];
+        line_err_muxed |= line_err[i];
       end
     end
   end
 
   // Mux between incoming rdata and the muxed line data
   assign output_data = |fill_data_rvd ? instr_rdata_i : line_data_muxed;
-  assign output_err  = |fill_data_rvd ? instr_err_i   : line_err_muxed;
+  assign output_err = |fill_data_rvd ? instr_err_i : line_err_muxed;
 
   // Output data is valid (from any of the three possible sources). Note that fill_out_arb
   // must be used here rather than fill_out_req because data can become valid out of order
@@ -869,12 +854,12 @@ module ibex_icache #(
   // Skid buffer data
   assign skid_data_d = output_data[31:16];
 
-  assign skid_en     = data_valid & (ready_i | skid_ready);
+  assign skid_en = data_valid & (ready_i | skid_ready);
 
   always_ff @(posedge clk_i) begin
     if (skid_en) begin
       skid_data_q <= skid_data_d;
-      skid_err_q  <= output_err;
+      skid_err_q <= output_err;
     end
   end
 
@@ -943,28 +928,28 @@ module ibex_icache #(
   always_comb begin
     output_data_lo = '0;
     for (int i = 0; i < OUTPUT_BEATS; i++) begin
-      if (output_addr_q[BUS_W-1:1] == i[BUS_W-2:0]) begin
-        output_data_lo |= output_data[i*16+:16];
+      if (output_addr_q[BUS_W - 1:1] == i[BUS_W - 2:0]) begin
+        output_data_lo |= output_data[i * 16 +: 16];
       end
     end
   end
 
   always_comb begin
     output_data_hi = '0;
-    for (int i = 0; i < OUTPUT_BEATS-1; i++) begin
-      if (output_addr_q[BUS_W-1:1] == i[BUS_W-2:0]) begin
-        output_data_hi |= output_data[(i+1)*16+:16];
+    for (int i = 0; i < OUTPUT_BEATS - 1; i++) begin
+      if (output_addr_q[BUS_W - 1:1] == i[BUS_W - 2:0]) begin
+        output_data_hi |= output_data[(i + 1) * 16 +: 16];
       end
     end
-    if (&output_addr_q[BUS_W-1:1]) begin
+    if (&output_addr_q[BUS_W - 1:1]) begin
       output_data_hi |= output_data[15:0];
     end
   end
 
-  assign valid_o     = output_valid;
-  assign rdata_o     = {output_data_hi, (skid_valid_q ? skid_data_q : output_data_lo)};
-  assign addr_o      = {output_addr_q, 1'b0};
-  assign err_o       = (skid_valid_q & skid_err_q) | (~skid_complete_instr & output_err);
+  assign valid_o = output_valid;
+  assign rdata_o = {output_data_hi, (skid_valid_q ? skid_data_q : output_data_lo)};
+  assign addr_o = {output_addr_q, 1'b0};
+  assign err_o = (skid_valid_q & skid_err_q) | (~skid_complete_instr & output_err);
   // Error caused by the second half of a misaligned uncompressed instruction
   // (only relevant when err_o is set)
   assign err_plus2_o = skid_valid_q & ~skid_err_q;
@@ -975,18 +960,17 @@ module ibex_icache #(
 
   // Invalidate on reset, or when instructed. If an invalidation request is received while a
   // previous invalidation is ongoing, it does not need to be restarted.
-  assign start_inval   = (~reset_inval_q | icache_inval_i) & ~inval_prog_q;
-  assign inval_prog_d  = start_inval | (inval_prog_q & ~inval_done);
-  assign inval_done    = &inval_index_q;
-  assign inval_index_d = start_inval ? '0 :
-                                       (inval_index_q + {{INDEX_W-1{1'b0}},1'b1});
+  assign start_inval = (~reset_inval_q | icache_inval_i) & ~inval_prog_q;
+  assign inval_prog_d = start_inval | (inval_prog_q & ~inval_done);
+  assign inval_done = &inval_index_q;
+  assign inval_index_d = start_inval ? '0 : (inval_index_q + {{INDEX_W - 1{1'b0}}, 1'b1});
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      inval_prog_q  <= 1'b0;
+      inval_prog_q <= 1'b0;
       reset_inval_q <= 1'b0;
     end else begin
-      inval_prog_q  <= inval_prog_d;
+      inval_prog_q <= inval_prog_d;
       reset_inval_q <= 1'b1;
     end
   end
@@ -1016,24 +1000,24 @@ module ibex_icache #(
   `ASSERT_INIT(ecc_data_param_legal, (LineSize <= 121))
 
   // Lookups in the tag ram should always give a known result
-  `ASSERT_KNOWN(TagHitKnown,     lookup_valid_ic1 & tag_hit_ic1)
+  `ASSERT_KNOWN(TagHitKnown, lookup_valid_ic1 & tag_hit_ic1)
   `ASSERT_KNOWN(TagInvalidKnown, lookup_valid_ic1 & tag_invalid_ic1)
 
   // This is only used for the Yosys-based formal flow. Once we have working bind support, we can
   // get rid of it.
 `ifdef FORMAL
- `ifdef YOSYS
+`ifdef YOSYS
   // Unfortunately, Yosys doesn't support passing unpacked arrays as ports. Explicitly pack up the
   // signals we need.
   logic [NUM_FB-1:0][ADDR_W-1:0] packed_fill_addr_q;
   always_comb begin
     for (int i = 0; i < NUM_FB; i++) begin
-      packed_fill_addr_q[i][ADDR_W-1:0] = fill_addr_q[i];
+      packed_fill_addr_q[i][ADDR_W - 1:0] = fill_addr_q[i];
     end
   end
 
   `include "formal_tb_frag.svh"
- `endif
+`endif
 `endif
 
 

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 `ifdef RISCV_FORMAL
-  `define RVFI
+`define RVFI
 `endif
 
 /**
@@ -17,13 +17,13 @@
 `include "prim_assert.sv"
 
 module ibex_id_stage #(
-    parameter bit               RV32E           = 0,
-    parameter bit               RV32M           = 1,
-    parameter ibex_pkg::rv32b_e RV32B           = ibex_pkg::RV32BNone,
-    parameter bit               DataIndTiming   = 1'b0,
-    parameter bit               BranchTargetALU = 0,
-    parameter bit               SpecBranch      = 0,
-    parameter bit               WritebackStage  = 0
+    parameter bit RV32E = 0,
+    parameter bit RV32M = 1,
+    parameter ibex_pkg::rv32b_e RV32B = ibex_pkg::RV32BNone,
+    parameter bit DataIndTiming = 1'b0,
+    parameter bit BranchTargetALU = 0,
+    parameter bit SpecBranch = 0,
+    parameter bit WritebackStage = 0
 ) (
     input  logic                      clk_i,
     input  logic                      rst_ni,
@@ -44,7 +44,7 @@ module ibex_id_stage #(
     output logic                      icache_inval_o,
 
     // Jumps and branches
-    input  logic                      branch_decision_i,
+    input logic branch_decision_i,
 
     // IF and ID stage signals
     output logic                      pc_set_o,
@@ -183,37 +183,37 @@ module ibex_id_stage #(
   import ibex_pkg::*;
 
   // Decoder/Controller, ID stage internal signals
-  logic        illegal_insn_dec;
-  logic        ebrk_insn;
-  logic        mret_insn_dec;
-  logic        dret_insn_dec;
-  logic        ecall_insn_dec;
-  logic        wfi_insn_dec;
+  logic illegal_insn_dec;
+  logic ebrk_insn;
+  logic mret_insn_dec;
+  logic dret_insn_dec;
+  logic ecall_insn_dec;
+  logic wfi_insn_dec;
 
-  logic        wb_exception;
+  logic wb_exception;
 
-  logic        branch_in_dec;
-  logic        branch_spec, branch_set_spec;
-  logic        branch_set, branch_set_d;
-  logic        branch_taken;
-  logic        jump_in_dec;
-  logic        jump_set_dec;
-  logic        jump_set;
+  logic branch_in_dec;
+  logic branch_spec, branch_set_spec;
+  logic branch_set, branch_set_d;
+  logic branch_taken;
+  logic jump_in_dec;
+  logic jump_set_dec;
+  logic jump_set;
 
-  logic        instr_first_cycle;
-  logic        instr_executing;
-  logic        instr_done;
-  logic        controller_run;
-  logic        stall_ld_hz;
-  logic        stall_mem;
-  logic        lsu_req_in_id;
-  logic        stall_multdiv;
-  logic        stall_branch;
-  logic        stall_jump;
-  logic        stall_id;
-  logic        stall_wb;
-  logic        flush_id;
-  logic        multicycle_done;
+  logic instr_first_cycle;
+  logic instr_executing;
+  logic instr_done;
+  logic controller_run;
+  logic stall_ld_hz;
+  logic stall_mem;
+  logic lsu_req_in_id;
+  logic stall_multdiv;
+  logic stall_branch;
+  logic stall_jump;
+  logic stall_id;
+  logic stall_wb;
+  logic flush_id;
+  logic multicycle_done;
 
   // Immediate decoding and sign extension
   logic [31:0] imm_i_type;
@@ -223,14 +223,14 @@ module ibex_id_stage #(
   logic [31:0] imm_j_type;
   logic [31:0] zimm_rs1_type;
 
-  logic [31:0] imm_a;       // contains the immediate for operand b
-  logic [31:0] imm_b;       // contains the immediate for operand b
+  logic [31:0] imm_a;  // contains the immediate for operand b
+  logic [31:0] imm_b;  // contains the immediate for operand b
 
   // Register file interface
 
-  rf_wd_sel_e  rf_wdata_sel;
-  logic        rf_we_dec, rf_we_raw;
-  logic        rf_ren_a, rf_ren_b;
+  rf_wd_sel_e rf_wdata_sel;
+  logic rf_we_dec, rf_we_raw;
+  logic rf_ren_a, rf_ren_b;
 
 `ifdef RVFI
   assign rf_ren_a_o = rf_ren_a;
@@ -241,36 +241,36 @@ module ibex_id_stage #(
   logic [31:0] rf_rdata_b_fwd;
 
   // ALU Control
-  alu_op_e     alu_operator;
-  op_a_sel_e   alu_op_a_mux_sel, alu_op_a_mux_sel_dec;
-  op_b_sel_e   alu_op_b_mux_sel, alu_op_b_mux_sel_dec;
-  logic        alu_multicycle_dec;
-  logic        stall_alu;
+  alu_op_e alu_operator;
+  op_a_sel_e alu_op_a_mux_sel, alu_op_a_mux_sel_dec;
+  op_b_sel_e alu_op_b_mux_sel, alu_op_b_mux_sel_dec;
+  logic alu_multicycle_dec;
+  logic stall_alu;
 
   logic [33:0] imd_val_q[2];
 
-  op_a_sel_e   bt_a_mux_sel;
-  imm_b_sel_e  bt_b_mux_sel;
+  op_a_sel_e bt_a_mux_sel;
+  imm_b_sel_e bt_b_mux_sel;
 
-  imm_a_sel_e  imm_a_mux_sel;
-  imm_b_sel_e  imm_b_mux_sel, imm_b_mux_sel_dec;
+  imm_a_sel_e imm_a_mux_sel;
+  imm_b_sel_e imm_b_mux_sel, imm_b_mux_sel_dec;
 
   // Multiplier Control
-  logic        mult_en_id, mult_en_dec; // use integer multiplier
-  logic        div_en_id, div_en_dec;   // use integer division or reminder
-  logic        multdiv_en_dec;
-  md_op_e      multdiv_operator;
-  logic [1:0]  multdiv_signed_mode;
+  logic mult_en_id, mult_en_dec;  // use integer multiplier
+  logic div_en_id, div_en_dec;  // use integer division or reminder
+  logic multdiv_en_dec;
+  md_op_e multdiv_operator;
+  logic [1:0] multdiv_signed_mode;
 
   // Data Memory Control
-  logic        lsu_we;
-  logic [1:0]  lsu_type;
-  logic        lsu_sign_ext;
-  logic        lsu_req, lsu_req_dec;
-  logic        data_req_allowed;
+  logic lsu_we;
+  logic [1:0] lsu_type;
+  logic lsu_sign_ext;
+  logic lsu_req, lsu_req_dec;
+  logic data_req_allowed;
 
   // CSR control
-  logic        csr_pipe_flush;
+  logic csr_pipe_flush;
 
   logic [31:0] alu_operand_a;
   logic [31:0] alu_operand_b;
@@ -280,9 +280,9 @@ module ibex_id_stage #(
   /////////////
 
   // Misaligned loads/stores result in two aligned loads/stores, compute second address
-  assign alu_op_a_mux_sel = lsu_addr_incr_req_i ? OP_A_FWD        : alu_op_a_mux_sel_dec;
-  assign alu_op_b_mux_sel = lsu_addr_incr_req_i ? OP_B_IMM        : alu_op_b_mux_sel_dec;
-  assign imm_b_mux_sel    = lsu_addr_incr_req_i ? IMM_B_INCR_ADDR : imm_b_mux_sel_dec;
+  assign alu_op_a_mux_sel = lsu_addr_incr_req_i ? OP_A_FWD : alu_op_a_mux_sel_dec;
+  assign alu_op_b_mux_sel = lsu_addr_incr_req_i ? OP_B_IMM : alu_op_b_mux_sel_dec;
+  assign imm_b_mux_sel = lsu_addr_incr_req_i ? IMM_B_INCR_ADDR : imm_b_mux_sel_dec;
 
   ///////////////////
   // Operand MUXES //
@@ -294,11 +294,11 @@ module ibex_id_stage #(
   // Main ALU MUX for Operand A
   always_comb begin : alu_operand_a_mux
     unique case (alu_op_a_mux_sel)
-      OP_A_REG_A:  alu_operand_a = rf_rdata_a_fwd;
-      OP_A_FWD:    alu_operand_a = lsu_addr_last_i;
+      OP_A_REG_A: alu_operand_a = rf_rdata_a_fwd;
+      OP_A_FWD: alu_operand_a = lsu_addr_last_i;
       OP_A_CURRPC: alu_operand_a = pc_id_i;
-      OP_A_IMM:    alu_operand_a = imm_a;
-      default:     alu_operand_a = pc_id_i;
+      OP_A_IMM: alu_operand_a = imm_a;
+      default: alu_operand_a = pc_id_i;
     endcase
   end
 
@@ -306,70 +306,62 @@ module ibex_id_stage #(
     // Branch target ALU operand A mux
     always_comb begin : bt_operand_a_mux
       unique case (bt_a_mux_sel)
-        OP_A_REG_A:  bt_a_operand_o = rf_rdata_a_fwd;
+        OP_A_REG_A: bt_a_operand_o = rf_rdata_a_fwd;
         OP_A_CURRPC: bt_a_operand_o = pc_id_i;
-        default:     bt_a_operand_o = pc_id_i;
+        default: bt_a_operand_o = pc_id_i;
       endcase
     end
 
     // Branch target ALU operand B mux
     always_comb begin : bt_immediate_b_mux
       unique case (bt_b_mux_sel)
-        IMM_B_I:         bt_b_operand_o = imm_i_type;
-        IMM_B_B:         bt_b_operand_o = imm_b_type;
-        IMM_B_J:         bt_b_operand_o = imm_j_type;
-        IMM_B_INCR_PC:   bt_b_operand_o = instr_is_compressed_i ? 32'h2 : 32'h4;
-        default:         bt_b_operand_o = instr_is_compressed_i ? 32'h2 : 32'h4;
+        IMM_B_I: bt_b_operand_o = imm_i_type;
+        IMM_B_B: bt_b_operand_o = imm_b_type;
+        IMM_B_J: bt_b_operand_o = imm_j_type;
+        IMM_B_INCR_PC: bt_b_operand_o = instr_is_compressed_i ? 32'h2 : 32'h4;
+        default: bt_b_operand_o = instr_is_compressed_i ? 32'h2 : 32'h4;
       endcase
     end
 
     // Reduced main ALU immediate MUX for Operand B
     always_comb begin : immediate_b_mux
       unique case (imm_b_mux_sel)
-        IMM_B_I:         imm_b = imm_i_type;
-        IMM_B_S:         imm_b = imm_s_type;
-        IMM_B_U:         imm_b = imm_u_type;
-        IMM_B_INCR_PC:   imm_b = instr_is_compressed_i ? 32'h2 : 32'h4;
+        IMM_B_I: imm_b = imm_i_type;
+        IMM_B_S: imm_b = imm_s_type;
+        IMM_B_U: imm_b = imm_u_type;
+        IMM_B_INCR_PC: imm_b = instr_is_compressed_i ? 32'h2 : 32'h4;
         IMM_B_INCR_ADDR: imm_b = 32'h4;
-        default:         imm_b = 32'h4;
+        default: imm_b = 32'h4;
       endcase
     end
-    `ASSERT(IbexImmBMuxSelValid, instr_valid_i |-> imm_b_mux_sel inside {
-        IMM_B_I,
-        IMM_B_S,
-        IMM_B_U,
-        IMM_B_INCR_PC,
-        IMM_B_INCR_ADDR})
+    `ASSERT(IbexImmBMuxSelValid,
+            instr_valid_i |->
+                imm_b_mux_sel inside {IMM_B_I, IMM_B_S, IMM_B_U, IMM_B_INCR_PC, IMM_B_INCR_ADDR})
   end else begin : g_nobtalu
-    op_a_sel_e  unused_a_mux_sel;
+    op_a_sel_e unused_a_mux_sel;
     imm_b_sel_e unused_b_mux_sel;
 
     assign unused_a_mux_sel = bt_a_mux_sel;
     assign unused_b_mux_sel = bt_b_mux_sel;
-    assign bt_a_operand_o   = '0;
-    assign bt_b_operand_o   = '0;
+    assign bt_a_operand_o = '0;
+    assign bt_b_operand_o = '0;
 
     // Full main ALU immediate MUX for Operand B
     always_comb begin : immediate_b_mux
       unique case (imm_b_mux_sel)
-        IMM_B_I:         imm_b = imm_i_type;
-        IMM_B_S:         imm_b = imm_s_type;
-        IMM_B_B:         imm_b = imm_b_type;
-        IMM_B_U:         imm_b = imm_u_type;
-        IMM_B_J:         imm_b = imm_j_type;
-        IMM_B_INCR_PC:   imm_b = instr_is_compressed_i ? 32'h2 : 32'h4;
+        IMM_B_I: imm_b = imm_i_type;
+        IMM_B_S: imm_b = imm_s_type;
+        IMM_B_B: imm_b = imm_b_type;
+        IMM_B_U: imm_b = imm_u_type;
+        IMM_B_J: imm_b = imm_j_type;
+        IMM_B_INCR_PC: imm_b = instr_is_compressed_i ? 32'h2 : 32'h4;
         IMM_B_INCR_ADDR: imm_b = 32'h4;
-        default:         imm_b = 32'h4;
+        default: imm_b = 32'h4;
       endcase
     end
-    `ASSERT(IbexImmBMuxSelValid, instr_valid_i |-> imm_b_mux_sel inside {
-        IMM_B_I,
-        IMM_B_S,
-        IMM_B_B,
-        IMM_B_U,
-        IMM_B_J,
-        IMM_B_INCR_PC,
-        IMM_B_INCR_ADDR})
+    `ASSERT(IbexImmBMuxSelValid,
+            instr_valid_i |-> imm_b_mux_sel inside {IMM_B_I, IMM_B_S, IMM_B_B, IMM_B_U, IMM_B_J,
+                                                    IMM_B_INCR_PC, IMM_B_INCR_ADDR})
   end
 
   // ALU MUX for Operand B
@@ -379,7 +371,7 @@ module ibex_id_stage #(
   // Multicycle Operation Stage Register //
   /////////////////////////////////////////
 
-  for (genvar i=0; i<2; i++) begin : gen_intermediate_val_reg
+  for (genvar i = 0; i < 2; i++) begin : gen_intermediate_val_reg
     always_ff @(posedge clk_i or negedge rst_ni) begin : intermediate_val_reg
       if (!rst_ni) begin
         imd_val_q[i] <= '0;
@@ -401,7 +393,7 @@ module ibex_id_stage #(
   // Register file write data mux
   always_comb begin : rf_wdata_id_mux
     unique case (rf_wdata_sel)
-      RF_WD_EX:  rf_wdata_id_o = result_ex_i;
+      RF_WD_EX: rf_wdata_id_o = result_ex_i;
       RF_WD_CSR: rf_wdata_id_o = csr_rdata_i;
       default:   rf_wdata_id_o = result_ex_i;
     endcase;
@@ -501,14 +493,13 @@ module ibex_id_stage #(
     //   see any pending IRQs and consequently does not start to handle interrupts.
     // - When modifying debug CSRs - TODO: Check if this is really needed
     if (csr_op_en_o == 1'b1 && (csr_op_o == CSR_OP_WRITE || csr_op_o == CSR_OP_SET)) begin
-      if (csr_num_e'(instr_rdata_i[31:20]) == CSR_MSTATUS   ||
+      if (csr_num_e'(instr_rdata_i[31:20]) == CSR_MSTATUS ||
           csr_num_e'(instr_rdata_i[31:20]) == CSR_MIE) begin
         csr_pipe_flush = 1'b1;
       end
     end else if (csr_op_en_o == 1'b1 && csr_op_o != CSR_OP_READ) begin
-      if (csr_num_e'(instr_rdata_i[31:20]) == CSR_DCSR      ||
-          csr_num_e'(instr_rdata_i[31:20]) == CSR_DPC       ||
-          csr_num_e'(instr_rdata_i[31:20]) == CSR_DSCRATCH0 ||
+      if (csr_num_e'(instr_rdata_i[31:20]) == CSR_DCSR || csr_num_e'(instr_rdata_i[31:20]) ==
+          CSR_DPC || csr_num_e'(instr_rdata_i[31:20]) == CSR_DSCRATCH0 ||
           csr_num_e'(instr_rdata_i[31:20]) == CSR_DSCRATCH1) begin
         csr_pipe_flush = 1'b1;
       end
@@ -611,34 +602,34 @@ module ibex_id_stage #(
       .perf_tbranch_o                 ( perf_tbranch_o          )
   );
 
-  assign multdiv_en_dec   = mult_en_dec | div_en_dec;
+  assign multdiv_en_dec = mult_en_dec | div_en_dec;
 
-  assign lsu_req         = instr_executing ? data_req_allowed & lsu_req_dec  : 1'b0;
-  assign mult_en_id      = instr_executing ? mult_en_dec                     : 1'b0;
-  assign div_en_id       = instr_executing ? div_en_dec                      : 1'b0;
+  assign lsu_req = instr_executing ? data_req_allowed & lsu_req_dec : 1'b0;
+  assign mult_en_id = instr_executing ? mult_en_dec : 1'b0;
+  assign div_en_id = instr_executing ? div_en_dec : 1'b0;
 
-  assign lsu_req_o               = lsu_req;
-  assign lsu_we_o                = lsu_we;
-  assign lsu_type_o              = lsu_type;
-  assign lsu_sign_ext_o          = lsu_sign_ext;
-  assign lsu_wdata_o             = rf_rdata_b_fwd;
+  assign lsu_req_o = lsu_req;
+  assign lsu_we_o = lsu_we;
+  assign lsu_type_o = lsu_type;
+  assign lsu_sign_ext_o = lsu_sign_ext;
+  assign lsu_wdata_o = rf_rdata_b_fwd;
   // csr_op_en_o is set when CSR access should actually happen.
   // csv_access_o is set when CSR access instruction is present and is used to compute whether a CSR
   // access is illegal. A combinational loop would be created if csr_op_en_o was used along (as
   // asserting it for an illegal csr access would result in a flush that would need to deassert it).
-  assign csr_op_en_o             = csr_access_o & instr_executing & instr_id_done_o;
+  assign csr_op_en_o = csr_access_o & instr_executing & instr_id_done_o;
 
-  assign alu_operator_ex_o           = alu_operator;
-  assign alu_operand_a_ex_o          = alu_operand_a;
-  assign alu_operand_b_ex_o          = alu_operand_b;
+  assign alu_operator_ex_o = alu_operator;
+  assign alu_operand_a_ex_o = alu_operand_a;
+  assign alu_operand_b_ex_o = alu_operand_b;
 
-  assign mult_en_ex_o                = mult_en_id;
-  assign div_en_ex_o                 = div_en_id;
+  assign mult_en_ex_o = mult_en_id;
+  assign div_en_ex_o = div_en_id;
 
-  assign multdiv_operator_ex_o       = multdiv_operator;
-  assign multdiv_signed_mode_ex_o    = multdiv_signed_mode;
-  assign multdiv_operand_a_ex_o      = rf_rdata_a_fwd;
-  assign multdiv_operand_b_ex_o      = rf_rdata_b_fwd;
+  assign multdiv_operator_ex_o = multdiv_operator;
+  assign multdiv_signed_mode_ex_o = multdiv_signed_mode;
+  assign multdiv_operand_a_ex_o = rf_rdata_a_fwd;
+  assign multdiv_operand_b_ex_o = rf_rdata_b_fwd;
 
   ////////////////////////
   // Branch set control //
@@ -647,7 +638,7 @@ module ibex_id_stage #(
   if (BranchTargetALU && !DataIndTiming) begin : g_branch_set_direct
     // Branch set fed straight to controller with branch target ALU
     // (condition pass/fail used same cycle as generated instruction request)
-    assign branch_set      = branch_set_d;
+    assign branch_set = branch_set_d;
     assign branch_set_spec = branch_spec;
   end else begin : g_branch_set_flop
     // Branch set flopped without branch target ALU, or in fixed time execution mode
@@ -665,7 +656,7 @@ module ibex_id_stage #(
     // Branches always take two cycles in fixed time execution mode, with or without the branch
     // target ALU (to avoid a path from the branch decision into the branch target ALU operand
     // muxing).
-    assign branch_set      = (BranchTargetALU && !data_ind_timing_i) ? branch_set_d : branch_set_q;
+    assign branch_set = (BranchTargetALU && !data_ind_timing_i) ? branch_set_d : branch_set_q;
     // Use the speculative branch signal when BTALU is enabled
     assign branch_set_spec = (BranchTargetALU && !data_ind_timing_i) ? branch_spec : branch_set_q;
   end
@@ -702,14 +693,17 @@ module ibex_id_stage #(
   // ID-EX FSM //
   ///////////////
 
-  typedef enum logic { FIRST_CYCLE, MULTI_CYCLE } id_fsm_e;
+  typedef enum logic {
+    FIRST_CYCLE,
+    MULTI_CYCLE
+  } id_fsm_e;
   id_fsm_e id_fsm_q, id_fsm_d;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : id_pipeline_reg
     if (!rst_ni) begin
-      id_fsm_q            <= FIRST_CYCLE;
+      id_fsm_q <= FIRST_CYCLE;
     end else begin
-      id_fsm_q            <= id_fsm_d;
+      id_fsm_q <= id_fsm_d;
     end
   end
 
@@ -719,16 +713,16 @@ module ibex_id_stage #(
   // (this is controlled by instr_executing).
 
   always_comb begin
-    id_fsm_d                = id_fsm_q;
-    rf_we_raw               = rf_we_dec;
-    stall_multdiv           = 1'b0;
-    stall_jump              = 1'b0;
-    stall_branch            = 1'b0;
-    stall_alu               = 1'b0;
-    branch_set_d            = 1'b0;
-    branch_spec             = 1'b0;
-    jump_set                = 1'b0;
-    perf_branch_o           = 1'b0;
+    id_fsm_d = id_fsm_q;
+    rf_we_raw = rf_we_dec;
+    stall_multdiv = 1'b0;
+    stall_jump = 1'b0;
+    stall_branch = 1'b0;
+    stall_alu = 1'b0;
+    branch_set_d = 1'b0;
+    branch_spec = 1'b0;
+    jump_set = 1'b0;
+    perf_branch_o = 1'b0;
 
     if (instr_executing) begin
       unique case (id_fsm_q)
@@ -737,10 +731,10 @@ module ibex_id_stage #(
             lsu_req_dec: begin
               if (!WritebackStage) begin
                 // LSU operation
-                id_fsm_d    = MULTI_CYCLE;
+                id_fsm_d = MULTI_CYCLE;
               end else begin
-                if(~lsu_req_done_i) begin
-                  id_fsm_d  = MULTI_CYCLE;
+                if (~lsu_req_done_i) begin
+                  id_fsm_d = MULTI_CYCLE;
                 end
               end
             end
@@ -749,8 +743,8 @@ module ibex_id_stage #(
               if (~ex_valid_i) begin
                 // When single-cycle multiply is configured mul can finish in the first cycle so
                 // only enter MULTI_CYCLE state if a result isn't immediately available
-                id_fsm_d      = MULTI_CYCLE;
-                rf_we_raw     = 1'b0;
+                id_fsm_d = MULTI_CYCLE;
+                rf_we_raw = 1'b0;
                 stall_multdiv = 1'b1;
               end
             end
@@ -758,48 +752,48 @@ module ibex_id_stage #(
               // cond branch operation
               // All branches take two cycles in fixed time execution mode, regardless of branch
               // condition.
-              id_fsm_d      = (data_ind_timing_i || (!BranchTargetALU && branch_decision_i)) ?
-                                  MULTI_CYCLE : FIRST_CYCLE;
-              stall_branch  = (~BranchTargetALU & branch_decision_i) | data_ind_timing_i;
-              branch_set_d  = branch_decision_i | data_ind_timing_i;
+              id_fsm_d = (data_ind_timing_i || (!BranchTargetALU && branch_decision_i)) ?
+                  MULTI_CYCLE : FIRST_CYCLE;
+              stall_branch = (~BranchTargetALU & branch_decision_i) | data_ind_timing_i;
+              branch_set_d = branch_decision_i | data_ind_timing_i;
               // Speculative branch (excludes branch_decision_i)
-              branch_spec   = SpecBranch ? 1'b1 : branch_decision_i;
+              branch_spec = SpecBranch ? 1'b1 : branch_decision_i;
               perf_branch_o = 1'b1;
             end
             jump_in_dec: begin
               // uncond branch operation
               // BTALU means jumps only need one cycle
-              id_fsm_d      = BranchTargetALU ? FIRST_CYCLE : MULTI_CYCLE;
-              stall_jump    = ~BranchTargetALU;
-              jump_set      = jump_set_dec;
+              id_fsm_d = BranchTargetALU ? FIRST_CYCLE : MULTI_CYCLE;
+              stall_jump = ~BranchTargetALU;
+              jump_set = jump_set_dec;
             end
             alu_multicycle_dec: begin
-              stall_alu     = 1'b1;
-              id_fsm_d      = MULTI_CYCLE;
-              rf_we_raw     = 1'b0;
+              stall_alu = 1'b1;
+              id_fsm_d = MULTI_CYCLE;
+              rf_we_raw = 1'b0;
             end
             default: begin
-              id_fsm_d      = FIRST_CYCLE;
+              id_fsm_d = FIRST_CYCLE;
             end
           endcase
         end
 
         MULTI_CYCLE: begin
-          if(multdiv_en_dec) begin
-            rf_we_raw       = rf_we_dec & ex_valid_i;
+          if (multdiv_en_dec) begin
+            rf_we_raw = rf_we_dec & ex_valid_i;
           end
 
           if (multicycle_done & ready_wb_i) begin
-            id_fsm_d        = FIRST_CYCLE;
+            id_fsm_d = FIRST_CYCLE;
           end else begin
-            stall_multdiv   = multdiv_en_dec;
-            stall_branch    = branch_in_dec;
-            stall_jump      = jump_in_dec;
+            stall_multdiv = multdiv_en_dec;
+            stall_branch = branch_in_dec;
+            stall_jump = jump_in_dec;
           end
         end
 
         default: begin
-          id_fsm_d          = FIRST_CYCLE;
+          id_fsm_d = FIRST_CYCLE;
         end
       endcase
     end
@@ -811,14 +805,13 @@ module ibex_id_stage #(
   `ASSERT(StallIDIfMulticycle, (id_fsm_q == FIRST_CYCLE) & (id_fsm_d == MULTI_CYCLE) |-> stall_id)
 
   // Stall ID/EX stage for reason that relates to instruction in ID/EX
-  assign stall_id = stall_ld_hz | stall_mem | stall_multdiv | stall_jump | stall_branch |
-                      stall_alu;
+  assign stall_id = stall_ld_hz | stall_mem | stall_multdiv | stall_jump | stall_branch | stall_alu;
 
   assign instr_done = ~stall_id & ~flush_id & instr_executing;
 
   // Signal instruction in ID is in it's first cycle. It can remain in its
   // first cycle if it is stalled.
-  assign instr_first_cycle      = instr_valid_i & (id_fsm_q == FIRST_CYCLE);
+  assign instr_first_cycle = instr_valid_i & (id_fsm_q == FIRST_CYCLE);
   // Used by RVFI to know when to capture register read data
   // Used by ALU to access RS3 if ternary instruction.
   assign instr_first_cycle_id_o = instr_first_cycle;
@@ -838,8 +831,8 @@ module ibex_id_stage #(
     assign multicycle_done = lsu_req_dec ? ~stall_mem : ex_valid_i;
 
     // Is a memory access ongoing that isn't finishing this cycle
-    assign outstanding_memory_access = (outstanding_load_wb_i | outstanding_store_wb_i) &
-                                       ~lsu_resp_valid_i;
+    assign outstanding_memory_access =
+        (outstanding_load_wb_i | outstanding_store_wb_i) & ~lsu_resp_valid_i;
 
     // Can start a new memory access if any previous one has finished or is finishing
     assign data_req_allowed = ~outstanding_memory_access;
@@ -852,9 +845,7 @@ module ibex_id_stage #(
     //   response to an IRQ or debug request or whilst the core is sleeping or resetting/fetching
     //   first instruction in which case any valid instruction in ID/EX should be ignored.
     // - There was an error on instruction fetch
-    assign instr_kill = instr_fetch_err_i |
-                        wb_exception      |
-                        ~controller_run;
+    assign instr_kill = instr_fetch_err_i | wb_exception | ~controller_run;
 
     // With writeback stage instructions must be prevented from executing if there is:
     // - A load hazard
@@ -870,7 +861,7 @@ module ibex_id_stage #(
                              ~outstanding_memory_access;
 
     `ASSERT(IbexStallIfValidInstrNotExecuting,
-      instr_valid_i & ~instr_kill & ~instr_executing |-> stall_id)
+            instr_valid_i & ~instr_kill & ~instr_executing |-> stall_id)
 
     // Stall for reasons related to memory:
     // * There is an outstanding memory access that won't resolve this cycle (need to wait to allow
@@ -881,8 +872,7 @@ module ibex_id_stage #(
 
     // If we stall a load in ID for any reason, it must not make an LSU request
     // (otherwide we might issue two requests for the same instruction)
-    `ASSERT(IbexStallMemNoRequest,
-      instr_valid_i & lsu_req_dec & ~instr_done |-> ~lsu_req_done_i)
+    `ASSERT(IbexStallMemNoRequest, instr_valid_i & lsu_req_dec & ~instr_done |-> ~lsu_req_done_i)
 
     // Indicate to the controller that an lsu req is in ID stage - we cannot handle interrupts or
     // debug requests until the load/store completes
@@ -927,14 +917,14 @@ module ibex_id_stage #(
     assign stall_mem = instr_valid_i & (lsu_req_dec & (~lsu_resp_valid_i | instr_first_cycle));
 
     // No load hazards without Writeback Stage
-    assign stall_ld_hz   = 1'b0;
+    assign stall_ld_hz = 1'b0;
     assign lsu_req_in_id = 1'b0;
 
     // Without writeback stage any valid instruction that hasn't seen an error will execute
     assign instr_executing = instr_valid_i & ~instr_fetch_err_i & controller_run;
 
     `ASSERT(IbexStallIfValidInstrNotExecuting,
-      instr_valid_i & ~instr_fetch_err_i & ~instr_executing & controller_run |-> stall_id)
+            instr_valid_i & ~instr_fetch_err_i & ~instr_executing & controller_run |-> stall_id)
 
     // No data forwarding without writeback stage so always take source register data direct from
     // register file
@@ -954,22 +944,22 @@ module ibex_id_stage #(
     logic unused_rf_ren_a, unused_rf_ren_b;
     logic [31:0] unused_rf_wdata_fwd_wb;
 
-    assign unused_data_req_done_ex     = lsu_req_done_i;
-    assign unused_rf_waddr_wb          = rf_waddr_wb_i;
-    assign unused_rf_write_wb          = rf_write_wb_i;
-    assign unused_outstanding_load_wb  = outstanding_load_wb_i;
+    assign unused_data_req_done_ex = lsu_req_done_i;
+    assign unused_rf_waddr_wb = rf_waddr_wb_i;
+    assign unused_rf_write_wb = rf_write_wb_i;
+    assign unused_outstanding_load_wb = outstanding_load_wb_i;
     assign unused_outstanding_store_wb = outstanding_store_wb_i;
-    assign unused_wb_exception         = wb_exception;
-    assign unused_rf_ren_a             = rf_ren_a;
-    assign unused_rf_ren_b             = rf_ren_b;
-    assign unused_rf_wdata_fwd_wb      = rf_wdata_fwd_wb_i;
+    assign unused_wb_exception = wb_exception;
+    assign unused_rf_ren_a = rf_ren_a;
+    assign unused_rf_ren_b = rf_ren_b;
+    assign unused_rf_wdata_fwd_wb = rf_wdata_fwd_wb_i;
 
     assign instr_type_wb_o = WB_INSTR_OTHER;
-    assign stall_wb        = 1'b0;
+    assign stall_wb = 1'b0;
 
     assign perf_dside_wait_o = instr_executing & lsu_req_dec & ~lsu_resp_valid_i;
 
-    assign en_wb_o         = 1'b0;
+    assign en_wb_o = 1'b0;
     assign instr_id_done_o = instr_done;
   end
 
@@ -984,49 +974,39 @@ module ibex_id_stage #(
 
   // Selectors must be known/valid.
   `ASSERT_KNOWN_IF(IbexAluOpMuxSelKnown, alu_op_a_mux_sel, instr_valid_i)
-  `ASSERT(IbexAluAOpMuxSelValid, instr_valid_i |-> alu_op_a_mux_sel inside {
-      OP_A_REG_A,
-      OP_A_FWD,
-      OP_A_CURRPC,
-      OP_A_IMM})
+  `ASSERT(IbexAluAOpMuxSelValid,
+          instr_valid_i |-> alu_op_a_mux_sel inside {OP_A_REG_A, OP_A_FWD, OP_A_CURRPC, OP_A_IMM})
   `ASSERT_KNOWN_IF(IbexBTAluAOpMuxSelKnown, bt_a_mux_sel, instr_valid_i)
-  `ASSERT(IbexBTAluAOpMuxSelValid, instr_valid_i |-> bt_a_mux_sel inside {
-      OP_A_REG_A,
-      OP_A_CURRPC})
+  `ASSERT(IbexBTAluAOpMuxSelValid, instr_valid_i |-> bt_a_mux_sel inside {OP_A_REG_A, OP_A_CURRPC})
   `ASSERT_KNOWN_IF(IbexBTAluBOpMuxSelKnown, bt_b_mux_sel, instr_valid_i)
-  `ASSERT(IbexBTAluBOpMuxSelValid, instr_valid_i |-> bt_b_mux_sel inside {
-      IMM_B_I,
-      IMM_B_B,
-      IMM_B_J,
-      IMM_B_INCR_PC})
-  `ASSERT(IbexRegfileWdataSelValid, instr_valid_i |-> rf_wdata_sel inside {
-      RF_WD_EX,
-      RF_WD_CSR})
+  `ASSERT(IbexBTAluBOpMuxSelValid,
+          instr_valid_i |-> bt_b_mux_sel inside {IMM_B_I, IMM_B_B, IMM_B_J, IMM_B_INCR_PC})
+  `ASSERT(IbexRegfileWdataSelValid, instr_valid_i |-> rf_wdata_sel inside {RF_WD_EX, RF_WD_CSR})
   `ASSERT_KNOWN(IbexWbStateKnown, id_fsm_q)
 
   // Branch decision must be valid when jumping.
   `ASSERT_KNOWN_IF(IbexBranchDecisionValid, branch_decision_i,
-      instr_valid_i && !(illegal_csr_insn_i || instr_fetch_err_i))
+                   instr_valid_i && !(illegal_csr_insn_i || instr_fetch_err_i))
 
   // Instruction delivered to ID stage can not contain X.
   `ASSERT_KNOWN_IF(IbexIdInstrKnown, instr_rdata_i,
-      instr_valid_i && !(illegal_c_insn_i || instr_fetch_err_i))
+                   instr_valid_i && !(illegal_c_insn_i || instr_fetch_err_i))
 
   // Instruction delivered to ID stage can not contain X.
   `ASSERT_KNOWN_IF(IbexIdInstrALUKnown, instr_rdata_alu_i,
-      instr_valid_i && !(illegal_c_insn_i || instr_fetch_err_i))
+                   instr_valid_i && !(illegal_c_insn_i || instr_fetch_err_i))
 
   // Multicycle enable signals must be unique.
   `ASSERT(IbexMulticycleEnableUnique,
-      $onehot0({lsu_req_dec, multdiv_en_dec, branch_in_dec, jump_in_dec}))
+          $onehot0({lsu_req_dec, multdiv_en_dec, branch_in_dec, jump_in_dec}))
 
   // Duplicated instruction flops must match
   // === as DV environment can produce instructions with Xs in, so must use precise match that
   // includes Xs
   `ASSERT(IbexDuplicateInstrMatch, instr_valid_i |-> instr_rdata_i === instr_rdata_alu_i)
 
-  `ifdef CHECK_MISALIGNED
+`ifdef CHECK_MISALIGNED
   `ASSERT(IbexMisalignedMemoryAccess, !lsu_addr_incr_req_i)
-  `endif
+`endif
 
 endmodule

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -88,66 +88,66 @@ module ibex_if_stage #(
 
   import ibex_pkg::*;
 
-  logic              instr_valid_id_d, instr_valid_id_q;
-  logic              instr_new_id_d, instr_new_id_q;
+  logic instr_valid_id_d, instr_valid_id_q;
+  logic instr_new_id_d, instr_new_id_q;
 
   // prefetch buffer related signals
-  logic              prefetch_busy;
-  logic              branch_req;
-  logic       [31:0] fetch_addr_n;
+  logic prefetch_busy;
+  logic branch_req;
+  logic [31:0] fetch_addr_n;
 
-  logic              fetch_valid;
-  logic              fetch_ready;
-  logic       [31:0] fetch_rdata;
-  logic       [31:0] fetch_addr;
-  logic              fetch_err;
-  logic              fetch_err_plus2;
+  logic fetch_valid;
+  logic fetch_ready;
+  logic [31:0] fetch_rdata;
+  logic [31:0] fetch_addr;
+  logic fetch_err;
+  logic fetch_err_plus2;
 
-  logic       [31:0] exc_pc;
+  logic [31:0] exc_pc;
 
-  logic        [5:0] irq_id;
-  logic              unused_irq_bit;
+  logic [5:0] irq_id;
+  logic unused_irq_bit;
 
-  logic              if_id_pipe_reg_we; // IF-ID pipeline reg write enable
+  logic if_id_pipe_reg_we;  // IF-ID pipeline reg write enable
 
   // Dummy instruction signals
-  logic              fetch_valid_out;
-  logic              stall_dummy_instr;
-  logic [31:0]       instr_out;
-  logic              instr_is_compressed_out;
-  logic              illegal_c_instr_out;
-  logic              instr_err_out;
+  logic fetch_valid_out;
+  logic stall_dummy_instr;
+  logic [31:0] instr_out;
+  logic instr_is_compressed_out;
+  logic illegal_c_instr_out;
+  logic instr_err_out;
 
-  logic        [7:0] unused_boot_addr;
-  logic        [7:0] unused_csr_mtvec;
+  logic [7:0] unused_boot_addr;
+  logic [7:0] unused_csr_mtvec;
 
   assign unused_boot_addr = boot_addr_i[7:0];
   assign unused_csr_mtvec = csr_mtvec_i[7:0];
 
   // extract interrupt ID from exception cause
-  assign irq_id         = {exc_cause};
-  assign unused_irq_bit = irq_id[5];   // MSB distinguishes interrupts from exceptions
+  assign irq_id = {exc_cause};
+  assign unused_irq_bit = irq_id[5];  // MSB distinguishes interrupts from exceptions
 
   // exception PC selection mux
   always_comb begin : exc_pc_mux
     unique case (exc_pc_mux_i)
-      EXC_PC_EXC:     exc_pc = { csr_mtvec_i[31:8], 8'h00                    };
-      EXC_PC_IRQ:     exc_pc = { csr_mtvec_i[31:8], 1'b0, irq_id[4:0], 2'b00 };
-      EXC_PC_DBD:     exc_pc = DmHaltAddr;
+      EXC_PC_EXC: exc_pc = {csr_mtvec_i[31:8], 8'h00};
+      EXC_PC_IRQ: exc_pc = {csr_mtvec_i[31:8], 1'b0, irq_id[4:0], 2'b00};
+      EXC_PC_DBD: exc_pc = DmHaltAddr;
       EXC_PC_DBG_EXC: exc_pc = DmExceptionAddr;
-      default:        exc_pc = { csr_mtvec_i[31:8], 8'h00                    };
+      default: exc_pc = {csr_mtvec_i[31:8], 8'h00};
     endcase
   end
 
   // fetch address selection mux
   always_comb begin : fetch_addr_mux
     unique case (pc_mux_i)
-      PC_BOOT: fetch_addr_n = { boot_addr_i[31:8], 8'h80 };
+      PC_BOOT: fetch_addr_n = {boot_addr_i[31:8], 8'h80};
       PC_JUMP: fetch_addr_n = branch_target_ex_i;
-      PC_EXC:  fetch_addr_n = exc_pc;                       // set PC to exception handler
-      PC_ERET: fetch_addr_n = csr_mepc_i;                   // restore PC when returning from EXC
+      PC_EXC: fetch_addr_n = exc_pc;  // set PC to exception handler
+      PC_ERET: fetch_addr_n = csr_mepc_i;  // restore PC when returning from EXC
       PC_DRET: fetch_addr_n = csr_depc_i;
-      default: fetch_addr_n = { boot_addr_i[31:8], 8'h80 };
+      default: fetch_addr_n = {boot_addr_i[31:8], 8'h80};
     endcase
   end
 
@@ -218,15 +218,15 @@ module ibex_if_stage #(
     );
     // ICache tieoffs
     logic unused_icen, unused_icinv;
-    assign unused_icen  = icache_enable_i;
+    assign unused_icen = icache_enable_i;
     assign unused_icinv = icache_inval_i;
   end
 
-  assign branch_req  = pc_set_i;
+  assign branch_req = pc_set_i;
   assign fetch_ready = id_in_ready_i & ~stall_dummy_instr;
 
-  assign pc_if_o     = fetch_addr;
-  assign if_busy_o   = prefetch_busy;
+  assign pc_if_o = fetch_addr;
+  assign if_busy_o = prefetch_busy;
 
   // compressed instruction decoding, or more precisely compressed instruction
   // expander
@@ -234,8 +234,8 @@ module ibex_if_stage #(
   // since it does not matter where we decompress instructions, we do it here
   // to ease timing closure
   logic [31:0] instr_decompressed;
-  logic        illegal_c_insn;
-  logic        instr_is_compressed;
+  logic illegal_c_insn;
+  logic instr_is_compressed;
 
   ibex_compressed_decoder compressed_decoder_i (
       .clk_i           ( clk_i                    ),
@@ -249,7 +249,7 @@ module ibex_if_stage #(
 
   // Dummy instruction insertion
   if (DummyInstructions) begin : gen_dummy_instr
-    logic        insert_dummy_instr;
+    logic insert_dummy_instr;
     logic [31:0] dummy_instr_data;
 
     ibex_dummy_instr dummy_instr_i (
@@ -266,11 +266,11 @@ module ibex_if_stage #(
     );
 
     // Mux between actual instructions and dummy instructions
-    assign fetch_valid_out         = insert_dummy_instr | fetch_valid;
-    assign instr_out               = insert_dummy_instr ? dummy_instr_data : instr_decompressed;
+    assign fetch_valid_out = insert_dummy_instr | fetch_valid;
+    assign instr_out = insert_dummy_instr ? dummy_instr_data : instr_decompressed;
     assign instr_is_compressed_out = insert_dummy_instr ? 1'b0 : instr_is_compressed;
-    assign illegal_c_instr_out     = insert_dummy_instr ? 1'b0 : illegal_c_insn;
-    assign instr_err_out           = insert_dummy_instr ? 1'b0 : fetch_err;
+    assign illegal_c_instr_out = insert_dummy_instr ? 1'b0 : illegal_c_insn;
+    assign instr_err_out = insert_dummy_instr ? 1'b0 : fetch_err;
 
     // Stall the IF stage if we insert a dummy instruction. The dummy will execute between whatever
     // is currently in the ID stage and whatever is valid from the prefetch buffer this cycle. The
@@ -287,59 +287,59 @@ module ibex_if_stage #(
     end
 
   end else begin : gen_no_dummy_instr
-    logic        unused_dummy_en;
-    logic [2:0]  unused_dummy_mask;
-    logic        unused_dummy_seed_en;
+    logic unused_dummy_en;
+    logic [2:0] unused_dummy_mask;
+    logic unused_dummy_seed_en;
     logic [31:0] unused_dummy_seed;
 
-    assign unused_dummy_en         = dummy_instr_en_i;
-    assign unused_dummy_mask       = dummy_instr_mask_i;
-    assign unused_dummy_seed_en    = dummy_instr_seed_en_i;
-    assign unused_dummy_seed       = dummy_instr_seed_i;
-    assign fetch_valid_out         = fetch_valid;
-    assign instr_out               = instr_decompressed;
+    assign unused_dummy_en = dummy_instr_en_i;
+    assign unused_dummy_mask = dummy_instr_mask_i;
+    assign unused_dummy_seed_en = dummy_instr_seed_en_i;
+    assign unused_dummy_seed = dummy_instr_seed_i;
+    assign fetch_valid_out = fetch_valid;
+    assign instr_out = instr_decompressed;
     assign instr_is_compressed_out = instr_is_compressed;
-    assign illegal_c_instr_out     = illegal_c_insn;
-    assign instr_err_out           = fetch_err;
-    assign stall_dummy_instr       = 1'b0;
-    assign dummy_instr_id_o        = 1'b0;
+    assign illegal_c_instr_out = illegal_c_insn;
+    assign instr_err_out = fetch_err;
+    assign stall_dummy_instr = 1'b0;
+    assign dummy_instr_id_o = 1'b0;
   end
 
   // The ID stage becomes valid as soon as any instruction is registered in the ID stage flops.
   // Note that the current instruction is squashed by the incoming pc_set_i signal.
   // Valid is held until it is explicitly cleared (due to an instruction completing or an exception)
-  assign instr_valid_id_d = (fetch_valid_out & id_in_ready_i & ~pc_set_i) |
-                            (instr_valid_id_q & ~instr_valid_clear_i);
-  assign instr_new_id_d   = fetch_valid_out & id_in_ready_i;
+  assign instr_valid_id_d =
+      (fetch_valid_out & id_in_ready_i & ~pc_set_i) | (instr_valid_id_q & ~instr_valid_clear_i);
+  assign instr_new_id_d = fetch_valid_out & id_in_ready_i;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       instr_valid_id_q <= 1'b0;
-      instr_new_id_q   <= 1'b0;
+      instr_new_id_q <= 1'b0;
     end else begin
       instr_valid_id_q <= instr_valid_id_d;
-      instr_new_id_q   <= instr_new_id_d;
+      instr_new_id_q <= instr_new_id_d;
     end
   end
 
   assign instr_valid_id_o = instr_valid_id_q;
   // Signal when a new instruction enters the ID stage (only used for RVFI signalling).
-  assign instr_new_id_o   = instr_new_id_q;
+  assign instr_new_id_o = instr_new_id_q;
 
   // IF-ID pipeline registers, frozen when the ID stage is stalled
   assign if_id_pipe_reg_we = instr_new_id_d;
 
   always_ff @(posedge clk_i) begin
     if (if_id_pipe_reg_we) begin
-      instr_rdata_id_o         <= instr_out;
+      instr_rdata_id_o <= instr_out;
       // To reduce fan-out and help timing from the instr_rdata_id flops they are replicated.
-      instr_rdata_alu_id_o     <= instr_out;
-      instr_fetch_err_o        <= instr_err_out;
-      instr_fetch_err_plus2_o  <= fetch_err_plus2;
-      instr_rdata_c_id_o       <= fetch_rdata[15:0];
+      instr_rdata_alu_id_o <= instr_out;
+      instr_fetch_err_o <= instr_err_out;
+      instr_fetch_err_plus2_o <= fetch_err_plus2;
+      instr_rdata_c_id_o <= fetch_rdata[15:0];
       instr_is_compressed_id_o <= instr_is_compressed_out;
-      illegal_c_insn_id_o      <= illegal_c_instr_out;
-      pc_id_o                  <= pc_if_o;
+      illegal_c_insn_id_o <= illegal_c_instr_out;
+      pc_id_o <= pc_if_o;
     end
   end
 
@@ -349,12 +349,7 @@ module ibex_if_stage #(
 
   // Selectors must be known/valid.
   `ASSERT_KNOWN(IbexExcPcMuxKnown, exc_pc_mux_i)
-  `ASSERT(IbexPcMuxValid, pc_mux_i inside {
-      PC_BOOT,
-      PC_JUMP,
-      PC_EXC,
-      PC_ERET,
-      PC_DRET})
+  `ASSERT(IbexPcMuxValid, pc_mux_i inside {PC_BOOT, PC_JUMP, PC_EXC, PC_ERET, PC_DRET})
 
   // Boot address must be aligned to 256 bytes.
   `ASSERT(IbexBootAddrUnaligned, boot_addr_i[7:0] == 8'h00)

--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -65,45 +65,48 @@ module ibex_load_store_unit
     output logic         perf_store_o
 );
 
-  logic [31:0]  data_addr;
-  logic [31:0]  data_addr_w_aligned;
-  logic [31:0]  addr_last_q;
+  logic [31:0] data_addr;
+  logic [31:0] data_addr_w_aligned;
+  logic [31:0] addr_last_q;
 
-  logic         addr_update;
-  logic         ctrl_update;
-  logic         rdata_update;
-  logic [31:8]  rdata_q;
-  logic [1:0]   rdata_offset_q;
-  logic [1:0]   data_type_q;
-  logic         data_sign_ext_q;
-  logic         data_we_q;
+  logic addr_update;
+  logic ctrl_update;
+  logic rdata_update;
+  logic [31:8] rdata_q;
+  logic [1:0] rdata_offset_q;
+  logic [1:0] data_type_q;
+  logic data_sign_ext_q;
+  logic data_we_q;
 
-  logic [1:0]   data_offset;   // mux control for data to be written to memory
+  logic [1:0] data_offset;  // mux control for data to be written to memory
 
-  logic [3:0]   data_be;
-  logic [31:0]  data_wdata;
+  logic [3:0] data_be;
+  logic [31:0] data_wdata;
 
-  logic [31:0]  data_rdata_ext;
+  logic [31:0] data_rdata_ext;
 
-  logic [31:0]  rdata_w_ext; // word realignment for misaligned loads
-  logic [31:0]  rdata_h_ext; // sign extension for half words
-  logic [31:0]  rdata_b_ext; // sign extension for bytes
+  logic [31:0] rdata_w_ext;  // word realignment for misaligned loads
+  logic [31:0] rdata_h_ext;  // sign extension for half words
+  logic [31:0] rdata_b_ext;  // sign extension for bytes
 
-  logic         split_misaligned_access;
-  logic         handle_misaligned_q, handle_misaligned_d; // high after receiving grant for first
-                                                          // part of a misaligned access
-  logic         pmp_err_q, pmp_err_d;
-  logic         lsu_err_q, lsu_err_d;
-  logic         data_or_pmp_err;
+  logic split_misaligned_access;
+  logic handle_misaligned_q, handle_misaligned_d;  // high after receiving grant for first
+                                                   // part of a misaligned access
+  logic pmp_err_q, pmp_err_d;
+  logic lsu_err_q, lsu_err_d;
+  logic data_or_pmp_err;
 
-  typedef enum logic [2:0]  {
-    IDLE, WAIT_GNT_MIS, WAIT_RVALID_MIS, WAIT_GNT,
+  typedef enum logic [2:0]{
+    IDLE,
+    WAIT_GNT_MIS,
+    WAIT_RVALID_MIS,
+    WAIT_GNT,
     WAIT_RVALID_MIS_GNTS_DONE
   } ls_fsm_e;
 
   ls_fsm_e ls_fsm_cs, ls_fsm_ns;
 
-  assign data_addr   = adder_result_ex_i;
+  assign data_addr = adder_result_ex_i;
   assign data_offset = data_addr[1:0];
 
   ///////////////////
@@ -111,54 +114,53 @@ module ibex_load_store_unit
   ///////////////////
 
   always_comb begin
-    unique case (lsu_type_i) // Data type 00 Word, 01 Half word, 11,10 byte
-      2'b00: begin // Writing a word
-        if (!handle_misaligned_q) begin // first part of potentially misaligned transaction
+    unique case (lsu_type_i)  // Data type 00 Word, 01 Half word, 11,10 byte
+      2'b00: begin  // Writing a word
+        if (!handle_misaligned_q) begin  // first part of potentially misaligned transaction
           unique case (data_offset)
-            2'b00:   data_be = 4'b1111;
-            2'b01:   data_be = 4'b1110;
-            2'b10:   data_be = 4'b1100;
-            2'b11:   data_be = 4'b1000;
+            2'b00: data_be = 4'b1111;
+            2'b01: data_be = 4'b1110;
+            2'b10: data_be = 4'b1100;
+            2'b11: data_be = 4'b1000;
             default: data_be = 4'b1111;
-          endcase // case (data_offset)
-        end else begin // second part of misaligned transaction
+          endcase  // case (data_offset)
+        end else begin  // second part of misaligned transaction
           unique case (data_offset)
-            2'b00:   data_be = 4'b0000; // this is not used, but included for completeness
-            2'b01:   data_be = 4'b0001;
-            2'b10:   data_be = 4'b0011;
-            2'b11:   data_be = 4'b0111;
+            2'b00: data_be = 4'b0000;  // this is not used, but included for completeness
+            2'b01: data_be = 4'b0001;
+            2'b10: data_be = 4'b0011;
+            2'b11: data_be = 4'b0111;
             default: data_be = 4'b1111;
-          endcase // case (data_offset)
+          endcase  // case (data_offset)
         end
       end
 
-      2'b01: begin // Writing a half word
-        if (!handle_misaligned_q) begin // first part of potentially misaligned transaction
+      2'b01: begin  // Writing a half word
+        if (!handle_misaligned_q) begin  // first part of potentially misaligned transaction
           unique case (data_offset)
-            2'b00:   data_be = 4'b0011;
-            2'b01:   data_be = 4'b0110;
-            2'b10:   data_be = 4'b1100;
-            2'b11:   data_be = 4'b1000;
+            2'b00: data_be = 4'b0011;
+            2'b01: data_be = 4'b0110;
+            2'b10: data_be = 4'b1100;
+            2'b11: data_be = 4'b1000;
             default: data_be = 4'b1111;
-          endcase // case (data_offset)
-        end else begin // second part of misaligned transaction
+          endcase  // case (data_offset)
+        end else begin  // second part of misaligned transaction
           data_be = 4'b0001;
         end
       end
 
-      2'b10,
-      2'b11: begin // Writing a byte
+      2'b10, 2'b11: begin  // Writing a byte
         unique case (data_offset)
-          2'b00:   data_be = 4'b0001;
-          2'b01:   data_be = 4'b0010;
-          2'b10:   data_be = 4'b0100;
-          2'b11:   data_be = 4'b1000;
+          2'b00: data_be = 4'b0001;
+          2'b01: data_be = 4'b0010;
+          2'b10: data_be = 4'b0100;
+          2'b11: data_be = 4'b1000;
           default: data_be = 4'b1111;
-        endcase // case (data_offset)
+        endcase  // case (data_offset)
       end
 
-      default:     data_be = 4'b1111;
-    endcase // case (lsu_type_i)
+      default: data_be = 4'b1111;
+    endcase  // case (lsu_type_i)
   end
 
   /////////////////////
@@ -169,12 +171,12 @@ module ibex_load_store_unit
   // we handle misaligned accesses, half word and byte accesses here
   always_comb begin
     unique case (data_offset)
-      2'b00:   data_wdata =  lsu_wdata_i[31:0];
-      2'b01:   data_wdata = {lsu_wdata_i[23:0], lsu_wdata_i[31:24]};
-      2'b10:   data_wdata = {lsu_wdata_i[15:0], lsu_wdata_i[31:16]};
-      2'b11:   data_wdata = {lsu_wdata_i[ 7:0], lsu_wdata_i[31: 8]};
-      default: data_wdata =  lsu_wdata_i[31:0];
-    endcase // case (data_offset)
+      2'b00: data_wdata = lsu_wdata_i[31:0];
+      2'b01: data_wdata = {lsu_wdata_i[23:0], lsu_wdata_i[31:24]};
+      2'b10: data_wdata = {lsu_wdata_i[15:0], lsu_wdata_i[31:16]};
+      2'b11: data_wdata = {lsu_wdata_i[7:0], lsu_wdata_i[31:8]};
+      default: data_wdata = lsu_wdata_i[31:0];
+    endcase  // case (data_offset)
   end
 
   /////////////////////
@@ -193,15 +195,15 @@ module ibex_load_store_unit
   // registers for transaction control
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      rdata_offset_q  <= 2'h0;
-      data_type_q     <= 2'h0;
+      rdata_offset_q <= 2'h0;
+      data_type_q <= 2'h0;
       data_sign_ext_q <= 1'b0;
-      data_we_q       <= 1'b0;
+      data_we_q <= 1'b0;
     end else if (ctrl_update) begin
-      rdata_offset_q  <= data_offset;
-      data_type_q     <= lsu_type_i;
+      rdata_offset_q <= data_offset;
+      data_type_q <= lsu_type_i;
       data_sign_ext_q <= lsu_sign_ext_i;
-      data_we_q       <= lsu_we_i;
+      data_we_q <= lsu_we_i;
     end
   end
 
@@ -218,11 +220,11 @@ module ibex_load_store_unit
   // take care of misaligned words
   always_comb begin
     unique case (rdata_offset_q)
-      2'b00:   rdata_w_ext =  data_rdata_i[31:0];
-      2'b01:   rdata_w_ext = {data_rdata_i[ 7:0], rdata_q[31:8]};
-      2'b10:   rdata_w_ext = {data_rdata_i[15:0], rdata_q[31:16]};
-      2'b11:   rdata_w_ext = {data_rdata_i[23:0], rdata_q[31:24]};
-      default: rdata_w_ext =  data_rdata_i[31:0];
+      2'b00: rdata_w_ext = data_rdata_i[31:0];
+      2'b01: rdata_w_ext = {data_rdata_i[7:0], rdata_q[31:8]};
+      2'b10: rdata_w_ext = {data_rdata_i[15:0], rdata_q[31:16]};
+      2'b11: rdata_w_ext = {data_rdata_i[23:0], rdata_q[31:24]};
+      default: rdata_w_ext = data_rdata_i[31:0];
     endcase
   end
 
@@ -266,7 +268,7 @@ module ibex_load_store_unit
       end
 
       default: rdata_h_ext = {16'h0000, data_rdata_i[15:0]};
-    endcase // case (rdata_offset_q)
+    endcase  // case (rdata_offset_q)
   end
 
   // sign extension for bytes
@@ -305,17 +307,17 @@ module ibex_load_store_unit
       end
 
       default: rdata_b_ext = {24'h00_0000, data_rdata_i[7:0]};
-    endcase // case (rdata_offset_q)
+    endcase  // case (rdata_offset_q)
   end
 
   // select word, half word or byte sign extended version
   always_comb begin
     unique case (data_type_q)
-      2'b00:       data_rdata_ext = rdata_w_ext;
-      2'b01:       data_rdata_ext = rdata_h_ext;
-      2'b10,2'b11: data_rdata_ext = rdata_b_ext;
-      default:     data_rdata_ext = rdata_w_ext;
-    endcase // case (data_type_q)
+      2'b00: data_rdata_ext = rdata_w_ext;
+      2'b01: data_rdata_ext = rdata_h_ext;
+      2'b10, 2'b11: data_rdata_ext = rdata_b_ext;
+      default: data_rdata_ext = rdata_w_ext;
+    endcase  // case (data_type_q)
   end
 
   /////////////
@@ -324,44 +326,44 @@ module ibex_load_store_unit
 
   // check for misaligned accesses that need to be split into two word-aligned accesses
   assign split_misaligned_access =
-      ((lsu_type_i == 2'b00) && (data_offset != 2'b00)) || // misaligned word access
-      ((lsu_type_i == 2'b01) && (data_offset == 2'b11));   // misaligned half-word access
+      ((lsu_type_i == 2'b00) && (data_offset != 2'b00)) ||  // misaligned word access
+      ((lsu_type_i == 2'b01) && (data_offset == 2'b11));  // misaligned half-word access
 
   // FSM
   always_comb begin
-    ls_fsm_ns       = ls_fsm_cs;
+    ls_fsm_ns = ls_fsm_cs;
 
-    data_req_o          = 1'b0;
-    addr_incr_req_o     = 1'b0;
+    data_req_o = 1'b0;
+    addr_incr_req_o = 1'b0;
     handle_misaligned_d = handle_misaligned_q;
-    pmp_err_d           = pmp_err_q;
-    lsu_err_d           = lsu_err_q;
+    pmp_err_d = pmp_err_q;
+    lsu_err_d = lsu_err_q;
 
-    addr_update         = 1'b0;
-    ctrl_update         = 1'b0;
-    rdata_update        = 1'b0;
+    addr_update = 1'b0;
+    ctrl_update = 1'b0;
+    rdata_update = 1'b0;
 
-    perf_load_o         = 1'b0;
-    perf_store_o        = 1'b0;
+    perf_load_o = 1'b0;
+    perf_store_o = 1'b0;
 
     unique case (ls_fsm_cs)
 
       IDLE: begin
         pmp_err_d = 1'b0;
         if (lsu_req_i) begin
-          data_req_o   = 1'b1;
-          pmp_err_d    = data_pmp_err_i;
-          lsu_err_d    = 1'b0;
-          perf_load_o  = ~lsu_we_i;
+          data_req_o = 1'b1;
+          pmp_err_d = data_pmp_err_i;
+          lsu_err_d = 1'b0;
+          perf_load_o = ~lsu_we_i;
           perf_store_o = lsu_we_i;
 
           if (data_gnt_i) begin
-            ctrl_update         = 1'b1;
-            addr_update         = 1'b1;
+            ctrl_update = 1'b1;
+            addr_update = 1'b1;
             handle_misaligned_d = split_misaligned_access;
-            ls_fsm_ns           = split_misaligned_access ? WAIT_RVALID_MIS : IDLE;
+            ls_fsm_ns = split_misaligned_access ? WAIT_RVALID_MIS : IDLE;
           end else begin
-            ls_fsm_ns           = split_misaligned_access ? WAIT_GNT_MIS    : WAIT_GNT;
+            ls_fsm_ns = split_misaligned_access ? WAIT_GNT_MIS : WAIT_GNT;
           end
         end
       end
@@ -373,10 +375,10 @@ module ibex_load_store_unit
         // pmp_err_q is only updated for new address phases and so can be used in WAIT_GNT* and
         // WAIT_RVALID* states
         if (data_gnt_i || pmp_err_q) begin
-          addr_update         = 1'b1;
-          ctrl_update         = 1'b1;
+          addr_update = 1'b1;
+          ctrl_update = 1'b1;
           handle_misaligned_d = 1'b1;
-          ls_fsm_ns           = WAIT_RVALID_MIS;
+          ls_fsm_ns = WAIT_RVALID_MIS;
         end
       end
 
@@ -413,12 +415,12 @@ module ibex_load_store_unit
       WAIT_GNT: begin
         // tell ID/EX stage to update the address
         addr_incr_req_o = handle_misaligned_q;
-        data_req_o      = 1'b1;
+        data_req_o = 1'b1;
         if (data_gnt_i || pmp_err_q) begin
-          ctrl_update         = 1'b1;
+          ctrl_update = 1'b1;
           // Update the address, unless there was an error
-          addr_update         = ~lsu_err_q;
-          ls_fsm_ns           = IDLE;
+          addr_update = ~lsu_err_q;
+          ls_fsm_ns = IDLE;
           handle_misaligned_d = 1'b0;
         end
       end
@@ -453,15 +455,15 @@ module ibex_load_store_unit
   // registers for FSM
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      ls_fsm_cs           <= IDLE;
+      ls_fsm_cs <= IDLE;
       handle_misaligned_q <= '0;
-      pmp_err_q           <= '0;
-      lsu_err_q           <= '0;
+      pmp_err_q <= '0;
+      lsu_err_q <= '0;
     end else begin
-      ls_fsm_cs           <= ls_fsm_ns;
+      ls_fsm_cs <= ls_fsm_ns;
       handle_misaligned_q <= handle_misaligned_d;
-      pmp_err_q           <= pmp_err_d;
-      lsu_err_q           <= lsu_err_d;
+      pmp_err_q <= pmp_err_d;
+      lsu_err_q <= lsu_err_d;
     end
   end
 
@@ -469,9 +471,9 @@ module ibex_load_store_unit
   // Outputs //
   /////////////
 
-  assign data_or_pmp_err    = lsu_err_q | data_err_i | pmp_err_q;
-  assign lsu_resp_valid_o   = (data_rvalid_i | pmp_err_q) & (ls_fsm_cs == IDLE);
-  assign lsu_rdata_valid_o  = (ls_fsm_cs == IDLE) & data_rvalid_i & ~data_or_pmp_err & ~data_we_q;
+  assign data_or_pmp_err = lsu_err_q | data_err_i | pmp_err_q;
+  assign lsu_resp_valid_o = (data_rvalid_i | pmp_err_q) & (ls_fsm_cs == IDLE);
+  assign lsu_rdata_valid_o = (ls_fsm_cs == IDLE) & data_rvalid_i & ~data_or_pmp_err & ~data_we_q;
 
   // output to register file
   assign lsu_rdata_o = data_rdata_ext;
@@ -480,17 +482,17 @@ module ibex_load_store_unit
   assign data_addr_w_aligned = {data_addr[31:2], 2'b00};
 
   // output to data interface
-  assign data_addr_o   = data_addr_w_aligned;
-  assign data_wdata_o  = data_wdata;
-  assign data_we_o     = lsu_we_i;
-  assign data_be_o     = data_be;
+  assign data_addr_o = data_addr_w_aligned;
+  assign data_wdata_o = data_wdata;
+  assign data_we_o = lsu_we_i;
+  assign data_be_o = data_be;
 
   // output to ID stage: mtval + AGU for misaligned transactions
-  assign addr_last_o   = addr_last_q;
+  assign addr_last_o = addr_last_q;
 
   // Signal a load or store error depending on the transaction type outstanding
-  assign load_err_o    = data_or_pmp_err & ~data_we_q & lsu_resp_valid_o;
-  assign store_err_o   = data_or_pmp_err &  data_we_q & lsu_resp_valid_o;
+  assign load_err_o = data_or_pmp_err & ~data_we_q & lsu_resp_valid_o;
+  assign store_err_o = data_or_pmp_err & data_we_q & lsu_resp_valid_o;
 
   assign busy_o = (ls_fsm_cs != IDLE);
 
@@ -503,9 +505,9 @@ module ibex_load_store_unit
   `ASSERT(IbexDataOffsetKnown, (lsu_req_i | busy_o) |-> !$isunknown(data_offset))
   `ASSERT_KNOWN(IbexRDataOffsetQKnown, rdata_offset_q)
   `ASSERT_KNOWN(IbexDataTypeQKnown, data_type_q)
-  `ASSERT(IbexLsuStateValid, ls_fsm_cs inside {
-      IDLE, WAIT_GNT_MIS, WAIT_RVALID_MIS, WAIT_GNT,
-      WAIT_RVALID_MIS_GNTS_DONE})
+  `ASSERT(IbexLsuStateValid,
+          ls_fsm_cs inside {IDLE, WAIT_GNT_MIS, WAIT_RVALID_MIS, WAIT_GNT,
+                            WAIT_RVALID_MIS_GNTS_DONE})
 
   // Address must not contain X when request is sent.
   `ASSERT(IbexDataAddrUnknown, data_req_o |-> !$isunknown(data_addr_o))

--- a/rtl/ibex_multdiv_fast.sv
+++ b/rtl/ibex_multdiv_fast.sv
@@ -49,11 +49,11 @@ module ibex_multdiv_fast #(
 
   // Both multiplier variants
   logic signed [34:0] mac_res_signed;
-  logic        [34:0] mac_res_ext;
-  logic        [33:0] accum;
-  logic        sign_a, sign_b;
-  logic        mult_valid;
-  logic        signed_mult;
+  logic [34:0] mac_res_ext;
+  logic [33:0] accum;
+  logic sign_a, sign_b;
+  logic mult_valid;
+  logic signed_mult;
 
   // Results that become intermediate value depending on whether mul or div is being calculated
   logic [33:0] mac_res_d, op_remainder_d;
@@ -61,9 +61,9 @@ module ibex_multdiv_fast #(
   logic [33:0] mac_res;
 
   // Divider signals
-  logic        div_sign_a, div_sign_b;
-  logic        is_greater_equal;
-  logic        div_change_sign, rem_change_sign;
+  logic div_sign_a, div_sign_b;
+  logic is_greater_equal;
+  logic div_change_sign, rem_change_sign;
   logic [31:0] one_shift;
   logic [31:0] op_denominator_q;
   logic [31:0] op_numerator_q;
@@ -74,18 +74,24 @@ module ibex_multdiv_fast #(
   logic [31:0] next_remainder;
   logic [32:0] next_quotient;
   logic [32:0] res_adder_h;
-  logic        div_valid;
-  logic [ 4:0] div_counter_q, div_counter_d;
-  logic        multdiv_en;
-  logic        mult_hold;
-  logic        div_hold;
-  logic        div_by_zero_d, div_by_zero_q;
+  logic div_valid;
+  logic [4:0] div_counter_q, div_counter_d;
+  logic multdiv_en;
+  logic mult_hold;
+  logic div_hold;
+  logic div_by_zero_d, div_by_zero_q;
 
-  logic        mult_en_internal;
-  logic        div_en_internal;
+  logic mult_en_internal;
+  logic div_en_internal;
 
-  typedef enum logic [2:0] {
-    MD_IDLE, MD_ABS_A, MD_ABS_B, MD_COMP, MD_LAST, MD_CHANGE_SIGN, MD_FINISH
+  typedef enum logic [2:0]{
+    MD_IDLE,
+    MD_ABS_A,
+    MD_ABS_B,
+    MD_COMP,
+    MD_LAST,
+    MD_CHANGE_SIGN,
+    MD_FINISH
   } md_fsm_e;
   md_fsm_e md_state_q, md_state_d;
 
@@ -93,21 +99,21 @@ module ibex_multdiv_fast #(
   assign unused_mult_sel_i = mult_sel_i;
 
   assign mult_en_internal = mult_en_i & ~mult_hold;
-  assign div_en_internal  = div_en_i & ~div_hold;
+  assign div_en_internal = div_en_i & ~div_hold;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      div_counter_q    <= '0;
-      md_state_q       <= MD_IDLE;
-      op_numerator_q   <= '0;
-      op_quotient_q    <= '0;
-      div_by_zero_q    <= '0;
+      div_counter_q <= '0;
+      md_state_q <= MD_IDLE;
+      op_numerator_q <= '0;
+      op_quotient_q <= '0;
+      div_by_zero_q <= '0;
     end else if (div_en_internal) begin
-      div_counter_q    <= div_counter_d;
-      op_numerator_q   <= op_numerator_d;
-      op_quotient_q    <= op_quotient_d;
-      md_state_q       <= md_state_d;
-      div_by_zero_q    <= div_by_zero_d;
+      div_counter_q <= div_counter_d;
+      op_numerator_q <= op_numerator_d;
+      op_quotient_q <= op_quotient_d;
+      md_state_q <= md_state_d;
+      div_by_zero_q <= div_by_zero_d;
     end
   end
 
@@ -127,7 +133,7 @@ module ibex_multdiv_fast #(
   logic [1:0] unused_imd_val;
   assign unused_imd_val = imd_val_q_i[1][33:32];
 
-  assign signed_mult      = (signed_mode_i != 2'b00);
+  assign signed_mult = (signed_mode_i != 2'b00);
   assign multdiv_result_o = div_sel_i ? imd_val_q_i[0][31:0] : mac_res_d[31:0];
 
   // The single cycle multiplier uses three 17 bit multipliers to compute MUL instructions in a
@@ -135,18 +141,19 @@ module ibex_multdiv_fast #(
   if (SingleCycleMultiply) begin : gen_multiv_single_cycle
 
     typedef enum logic {
-      MULL, MULH
+      MULL,
+      MULH
     } mult_fsm_e;
     mult_fsm_e mult_state_q, mult_state_d;
 
     logic signed [33:0] mult1_res, mult2_res, mult3_res;
-    logic [15:0]        mult1_op_a, mult1_op_b;
-    logic [15:0]        mult2_op_a, mult2_op_b;
-    logic [15:0]        mult3_op_a, mult3_op_b;
-    logic               mult1_sign_a, mult1_sign_b;
-    logic               mult2_sign_a, mult2_sign_b;
-    logic               mult3_sign_a, mult3_sign_b;
-    logic [33:0]        summand1, summand2, summand3;
+    logic [15:0] mult1_op_a, mult1_op_b;
+    logic [15:0] mult2_op_a, mult2_op_b;
+    logic [15:0] mult3_op_a, mult3_op_b;
+    logic mult1_sign_a, mult1_sign_b;
+    logic mult2_sign_a, mult2_sign_b;
+    logic mult3_sign_a, mult3_sign_b;
+    logic [33:0] summand1, summand2, summand3;
 
     assign mult1_res = $signed({mult1_sign_a, mult1_op_a}) * $signed({mult1_sign_b, mult1_op_b});
     assign mult2_res = $signed({mult2_sign_a, mult2_op_a}) * $signed({mult2_sign_b, mult2_op_b});
@@ -154,8 +161,8 @@ module ibex_multdiv_fast #(
 
     assign mac_res_signed = $signed(summand1) + $signed(summand2) + $signed(summand3);
 
-    assign mac_res_ext    = $unsigned(mac_res_signed);
-    assign mac_res        = mac_res_ext[33:0];
+    assign mac_res_ext = $unsigned(mac_res_signed);
+    assign mac_res = mac_res_ext[33:0];
 
     assign sign_a = signed_mode_i[0] & op_a_i[31];
     assign sign_b = signed_mode_i[1] & op_b_i[31];
@@ -231,7 +238,7 @@ module ibex_multdiv_fast #(
           mult_state_d = MULL;
         end
 
-      endcase // mult_state_q
+      endcase  // mult_state_q
     end
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -254,7 +261,10 @@ module ibex_multdiv_fast #(
     logic [15:0] mult_op_b;
 
     typedef enum logic [1:0] {
-      ALBL, ALBH, AHBL, AHBH
+      ALBL,
+      ALBH,
+      AHBL,
+      AHBH
     } mult_fsm_e;
     mult_fsm_e mult_state_q, mult_state_d;
 
@@ -264,19 +274,19 @@ module ibex_multdiv_fast #(
     // Thus, it is safe to ignore mac_res_ext[34].
     assign mac_res_signed =
         $signed({sign_a, mult_op_a}) * $signed({sign_b, mult_op_b}) + $signed(accum);
-    assign mac_res_ext    = $unsigned(mac_res_signed);
-    assign mac_res        = mac_res_ext[33:0];
+    assign mac_res_ext = $unsigned(mac_res_signed);
+    assign mac_res = mac_res_ext[33:0];
 
     always_comb begin
-      mult_op_a    = op_a_i[`OP_L];
-      mult_op_b    = op_b_i[`OP_L];
-      sign_a       = 1'b0;
-      sign_b       = 1'b0;
-      accum        = imd_val_q_i[0];
-      mac_res_d    = mac_res;
+      mult_op_a = op_a_i[`OP_L];
+      mult_op_b = op_b_i[`OP_L];
+      sign_a = 1'b0;
+      sign_b = 1'b0;
+      accum = imd_val_q_i[0];
+      mac_res_d = mac_res;
       mult_state_d = mult_state_q;
-      mult_valid   = 1'b0;
-      mult_hold    = 1'b0;
+      mult_valid = 1'b0;
+      mult_hold = 1'b0;
 
       unique case (mult_state_q)
 
@@ -284,9 +294,9 @@ module ibex_multdiv_fast #(
           // al*bl
           mult_op_a = op_a_i[`OP_L];
           mult_op_b = op_b_i[`OP_L];
-          sign_a    = 1'b0;
-          sign_b    = 1'b0;
-          accum     = '0;
+          sign_a = 1'b0;
+          sign_b = 1'b0;
+          accum = '0;
           mac_res_d = mac_res;
           mult_state_d = ALBH;
         end
@@ -295,10 +305,10 @@ module ibex_multdiv_fast #(
           // al*bh<<16
           mult_op_a = op_a_i[`OP_L];
           mult_op_b = op_b_i[`OP_H];
-          sign_a    = 1'b0;
-          sign_b    = signed_mode_i[1] & op_b_i[31];
+          sign_a = 1'b0;
+          sign_b = signed_mode_i[1] & op_b_i[31];
           // result of AL*BL (in imd_val_q_i[0]) always unsigned with no carry, so carries_q always 00
-          accum     = {18'b0, imd_val_q_i[0][31:16]};
+          accum = {18'b0, imd_val_q_i[0][31:16]};
           if (operator_i == MD_OP_MULL) begin
             mac_res_d = {2'b0, mac_res[`OP_L], imd_val_q_i[0][`OP_L]};
           end else begin
@@ -312,19 +322,19 @@ module ibex_multdiv_fast #(
           // ah*bl<<16
           mult_op_a = op_a_i[`OP_H];
           mult_op_b = op_b_i[`OP_L];
-          sign_a    = signed_mode_i[0] & op_a_i[31];
-          sign_b    = 1'b0;
+          sign_a = signed_mode_i[0] & op_a_i[31];
+          sign_b = 1'b0;
           if (operator_i == MD_OP_MULL) begin
-            accum        = {18'b0, imd_val_q_i[0][31:16]};
-            mac_res_d    = {2'b0, mac_res[15:0], imd_val_q_i[0][15:0]};
-            mult_valid   = 1'b1;
+            accum = {18'b0, imd_val_q_i[0][31:16]};
+            mac_res_d = {2'b0, mac_res[15:0], imd_val_q_i[0][15:0]};
+            mult_valid = 1'b1;
 
             // Note no state transition will occur if mult_hold is set
             mult_state_d = ALBL;
-            mult_hold    = ~multdiv_ready_id_i;
+            mult_hold = ~multdiv_ready_id_i;
           end else begin
-            accum        = imd_val_q_i[0];
-            mac_res_d    = mac_res;
+            accum = imd_val_q_i[0];
+            mac_res_d = mac_res;
             mult_state_d = AHBH;
           end
         end
@@ -334,22 +344,22 @@ module ibex_multdiv_fast #(
           // ah*bh
           mult_op_a = op_a_i[`OP_H];
           mult_op_b = op_b_i[`OP_H];
-          sign_a    = signed_mode_i[0] & op_a_i[31];
-          sign_b    = signed_mode_i[1] & op_b_i[31];
-          accum[17: 0]  = imd_val_q_i[0][33:16];
-          accum[33:18]  = {16{signed_mult & imd_val_q_i[0][33]}};
+          sign_a = signed_mode_i[0] & op_a_i[31];
+          sign_b = signed_mode_i[1] & op_b_i[31];
+          accum[17:0] = imd_val_q_i[0][33:16];
+          accum[33:18] = {16{signed_mult & imd_val_q_i[0][33]}};
           // result of AH*BL is not signed only if signed_mode_i == 2'b00
-          mac_res_d    = mac_res;
-          mult_valid   = 1'b1;
+          mac_res_d = mac_res;
+          mult_valid = 1'b1;
 
           // Note no state transition will occur if mult_hold is set
           mult_state_d = ALBL;
-          mult_hold    = ~multdiv_ready_id_i;
+          mult_hold = ~multdiv_ready_id_i;
         end
         default: begin
           mult_state_d = ALBL;
         end
-      endcase // mult_state_q
+      endcase  // mult_state_q
     end
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -365,16 +375,16 @@ module ibex_multdiv_fast #(
     // States must be knwon/valid.
     `ASSERT_KNOWN(IbexMultStateKnown, mult_state_q)
 
-  end // gen_multdiv_fast
+  end  // gen_multdiv_fast
 
   // Divider
-  assign res_adder_h    = alu_adder_ext_i[33:1];
+  assign res_adder_h = alu_adder_ext_i[33:1];
 
   assign next_remainder = is_greater_equal ? res_adder_h[31:0] : imd_val_q_i[0][31:0];
-  assign next_quotient  = is_greater_equal ? {1'b0, op_quotient_q} | {1'b0, one_shift} :
-                                             {1'b0, op_quotient_q};
+  assign next_quotient =
+      is_greater_equal ? {1'b0, op_quotient_q} | {1'b0, one_shift} : {1'b0, op_quotient_q};
 
-  assign one_shift      = {31'b0, 1'b1} << div_counter_q;
+  assign one_shift = {31'b0, 1'b1} << div_counter_q;
 
   // The adder in the ALU computes alu_operand_a_o + alu_operand_b_o which means
   // Remainder - Divisor. If Remainder - Divisor >= 0, is_greater_equal is equal to 1,
@@ -387,26 +397,26 @@ module ibex_multdiv_fast #(
     end
   end
 
-  assign div_sign_a      = op_a_i[31] & signed_mode_i[0];
-  assign div_sign_b      = op_b_i[31] & signed_mode_i[1];
+  assign div_sign_a = op_a_i[31] & signed_mode_i[0];
+  assign div_sign_b = op_b_i[31] & signed_mode_i[1];
   assign div_change_sign = (div_sign_a ^ div_sign_b) & ~div_by_zero_q;
   assign rem_change_sign = div_sign_a;
 
 
   always_comb begin
-    div_counter_d    = div_counter_q - 5'h1;
-    op_remainder_d   = imd_val_q_i[0];
-    op_quotient_d    = op_quotient_q;
-    md_state_d       = md_state_q;
-    op_numerator_d   = op_numerator_q;
+    div_counter_d = div_counter_q - 5'h1;
+    op_remainder_d = imd_val_q_i[0];
+    op_quotient_d = op_quotient_q;
+    md_state_d = md_state_q;
+    op_numerator_d = op_numerator_q;
     op_denominator_d = op_denominator_q;
-    alu_operand_a_o  = {32'h0  , 1'b1};
-    alu_operand_b_o  = {~op_b_i, 1'b1};
-    div_valid        = 1'b0;
-    div_hold         = 1'b0;
-    div_by_zero_d    = div_by_zero_q;
+    alu_operand_a_o = {32'h0, 1'b1};
+    alu_operand_b_o = {~op_b_i, 1'b1};
+    div_valid = 1'b0;
+    div_hold = 1'b0;
+    div_by_zero_d = div_by_zero_q;
 
-    unique case(md_state_q)
+    unique case (md_state_q)
       MD_IDLE: begin
         if (operator_i == MD_OP_DIV) begin
           // Check if the Denominator is 0
@@ -414,54 +424,54 @@ module ibex_multdiv_fast #(
           // Note with data-independent time option, the full divide operation will proceed as
           // normal and will naturally return -1
           op_remainder_d = '1;
-          md_state_d     = (!data_ind_timing_i && equal_to_zero_i) ? MD_FINISH : MD_ABS_A;
+          md_state_d = (!data_ind_timing_i && equal_to_zero_i) ? MD_FINISH : MD_ABS_A;
           // Record that this is a div by zero to stop the sign change at the end of the
           // division (in data_ind_timing mode).
-          div_by_zero_d  = equal_to_zero_i;
+          div_by_zero_d = equal_to_zero_i;
         end else begin
           // Check if the Denominator is 0
           // remainder for division by 0 is specified to be the numerator (operand a)
           // Note with data-independent time option, the full divide operation will proceed as
           // normal and will naturally return operand a
           op_remainder_d = {2'b0, op_a_i};
-          md_state_d     = (!data_ind_timing_i && equal_to_zero_i) ? MD_FINISH : MD_ABS_A;
+          md_state_d = (!data_ind_timing_i && equal_to_zero_i) ? MD_FINISH : MD_ABS_A;
         end
         // 0 - B = 0 iff B == 0
-        alu_operand_a_o  = {32'h0  , 1'b1};
-        alu_operand_b_o  = {~op_b_i, 1'b1};
-        div_counter_d    = 5'd31;
+        alu_operand_a_o = {32'h0, 1'b1};
+        alu_operand_b_o = {~op_b_i, 1'b1};
+        div_counter_d = 5'd31;
       end
 
       MD_ABS_A: begin
         // quotient
-        op_quotient_d   = '0;
+        op_quotient_d = '0;
         // A abs value
-        op_numerator_d  = div_sign_a ? alu_adder_i : op_a_i;
-        md_state_d      = MD_ABS_B;
-        div_counter_d   = 5'd31;
+        op_numerator_d = div_sign_a ? alu_adder_i : op_a_i;
+        md_state_d = MD_ABS_B;
+        div_counter_d = 5'd31;
         // ABS(A) = 0 - A
-        alu_operand_a_o = {32'h0  , 1'b1};
+        alu_operand_a_o = {32'h0, 1'b1};
         alu_operand_b_o = {~op_a_i, 1'b1};
       end
 
       MD_ABS_B: begin
         // remainder
-        op_remainder_d   = { 33'h0, op_numerator_q[31]};
+        op_remainder_d = {33'h0, op_numerator_q[31]};
         // B abs value
         op_denominator_d = div_sign_b ? alu_adder_i : op_b_i;
-        md_state_d       = MD_COMP;
-        div_counter_d    = 5'd31;
+        md_state_d = MD_COMP;
+        div_counter_d = 5'd31;
         // ABS(B) = 0 - B
-        alu_operand_a_o  = {32'h0  , 1'b1};
-        alu_operand_b_o  = {~op_b_i, 1'b1};
+        alu_operand_a_o = {32'h0, 1'b1};
+        alu_operand_b_o = {~op_b_i, 1'b1};
       end
 
       MD_COMP: begin
-        op_remainder_d  = {1'b0, next_remainder[31:0], op_numerator_q[div_counter_d]};
-        op_quotient_d   = next_quotient[31:0];
-        md_state_d      = (div_counter_q == 5'd1) ? MD_LAST : MD_COMP;
+        op_remainder_d = {1'b0, next_remainder[31:0], op_numerator_q[div_counter_d]};
+        op_quotient_d = next_quotient[31:0];
+        md_state_d = (div_counter_q == 5'd1) ? MD_LAST : MD_COMP;
         // Division
-        alu_operand_a_o = {imd_val_q_i[0][31:0], 1'b1}; // it contains the remainder
+        alu_operand_a_o = {imd_val_q_i[0][31:0], 1'b1};  // it contains the remainder
         alu_operand_b_o = {~op_denominator_q[31:0], 1'b1};  // -denominator two's compliment
       end
 
@@ -475,42 +485,43 @@ module ibex_multdiv_fast #(
           op_remainder_d = {2'b0, next_remainder[31:0]};
         end
         // Division
-        alu_operand_a_o  = {imd_val_q_i[0][31:0], 1'b1}; // it contains the remainder
-        alu_operand_b_o  = {~op_denominator_q[31:0], 1'b1};  // -denominator two's compliment
+        alu_operand_a_o = {imd_val_q_i[0][31:0], 1'b1};  // it contains the remainder
+        alu_operand_b_o = {~op_denominator_q[31:0], 1'b1};  // -denominator two's compliment
 
         md_state_d = MD_CHANGE_SIGN;
       end
 
       MD_CHANGE_SIGN: begin
-        md_state_d  = MD_FINISH;
+        md_state_d = MD_FINISH;
         if (operator_i == MD_OP_DIV) begin
           op_remainder_d = (div_change_sign) ? {2'h0, alu_adder_i} : imd_val_q_i[0];
         end else begin
           op_remainder_d = (rem_change_sign) ? {2'h0, alu_adder_i} : imd_val_q_i[0];
         end
         // ABS(Quotient) = 0 - Quotient (or Remainder)
-        alu_operand_a_o  = {32'h0  , 1'b1};
-        alu_operand_b_o  = {~imd_val_q_i[0][31:0], 1'b1};
+        alu_operand_a_o = {32'h0, 1'b1};
+        alu_operand_b_o = {~imd_val_q_i[0][31:0], 1'b1};
       end
 
       MD_FINISH: begin
         // Hold result until ID stage is ready to accept it
         // Note no state transition will occur if div_hold is set
         md_state_d = MD_IDLE;
-        div_hold   = ~multdiv_ready_id_i;
-        div_valid   = 1'b1;
+        div_hold = ~multdiv_ready_id_i;
+        div_valid = 1'b1;
       end
 
       default: begin
         md_state_d = MD_IDLE;
       end
-    endcase // md_state_q
+    endcase  // md_state_q
   end
 
   assign valid_o = mult_valid | div_valid;
 
   // States must be knwon/valid.
-  `ASSERT(IbexMultDivStateValid, md_state_q inside {
-      MD_IDLE, MD_ABS_A, MD_ABS_B, MD_COMP, MD_LAST, MD_CHANGE_SIGN, MD_FINISH})
+  `ASSERT(IbexMultDivStateValid,
+          md_state_q inside {MD_IDLE, MD_ABS_A, MD_ABS_B, MD_COMP, MD_LAST, MD_CHANGE_SIGN,
+                             MD_FINISH})
 
-endmodule // ibex_mult
+endmodule  // ibex_mult

--- a/rtl/ibex_multdiv_slow.sv
+++ b/rtl/ibex_multdiv_slow.sv
@@ -45,37 +45,43 @@ module ibex_multdiv_slow
   import ibex_pkg::*;
 
   typedef enum logic [2:0] {
-    MD_IDLE, MD_ABS_A, MD_ABS_B, MD_COMP, MD_LAST, MD_CHANGE_SIGN, MD_FINISH
+    MD_IDLE,
+    MD_ABS_A,
+    MD_ABS_B,
+    MD_COMP,
+    MD_LAST,
+    MD_CHANGE_SIGN,
+    MD_FINISH
   } md_fsm_e;
   md_fsm_e md_state_q, md_state_d;
 
   logic [32:0] accum_window_q, accum_window_d;
-  logic        unused_imd_val0;
-  logic [ 1:0] unused_imd_val1;
+  logic unused_imd_val0;
+  logic [1:0] unused_imd_val1;
 
   logic [32:0] res_adder_l;
   logic [32:0] res_adder_h;
 
-  logic [ 4:0] multdiv_count_q, multdiv_count_d;
+  logic [4:0] multdiv_count_q, multdiv_count_d;
   logic [32:0] op_b_shift_q, op_b_shift_d;
   logic [32:0] op_a_shift_q, op_a_shift_d;
   logic [32:0] op_a_ext, op_b_ext;
   logic [32:0] one_shift;
   logic [32:0] op_a_bw_pp, op_a_bw_last_pp;
   logic [31:0] b_0;
-  logic        sign_a, sign_b;
+  logic sign_a, sign_b;
   logic [32:0] next_quotient;
   logic [31:0] next_remainder;
   logic [31:0] op_numerator_q, op_numerator_d;
-  logic        is_greater_equal;
-  logic        div_change_sign, rem_change_sign;
-  logic        div_by_zero_d, div_by_zero_q;
-  logic        multdiv_hold;
-  logic        multdiv_en;
+  logic is_greater_equal;
+  logic div_change_sign, rem_change_sign;
+  logic div_by_zero_d, div_by_zero_q;
+  logic multdiv_hold;
+  logic multdiv_en;
 
-   // (accum_window_q + op_a_shift_q)
+  // (accum_window_q + op_a_shift_q)
   assign res_adder_l = alu_adder_ext_i[32:0];
-   // (accum_window_q + op_a_shift_q)>>1
+  // (accum_window_q + op_a_shift_q)>>1
   assign res_adder_h = alu_adder_ext_i[33:1];
 
   /////////////////////
@@ -83,20 +89,20 @@ module ibex_multdiv_slow
   /////////////////////
 
   // Intermediate value register shared with ALU
-  assign imd_val_d_o[0]  = {1'b0,accum_window_d};
+  assign imd_val_d_o[0] = {1'b0, accum_window_d};
   assign imd_val_we_o[0] = ~multdiv_hold;
-  assign accum_window_q  = imd_val_q_i[0][32:0];
+  assign accum_window_q = imd_val_q_i[0][32:0];
   assign unused_imd_val0 = imd_val_q_i[0][33];
 
-  assign imd_val_d_o[1]  = {2'b00, op_numerator_d};
+  assign imd_val_d_o[1] = {2'b00, op_numerator_d};
   assign imd_val_we_o[1] = multdiv_en;
-  assign op_numerator_q  = imd_val_q_i[1][31:0];
+  assign op_numerator_q = imd_val_q_i[1][31:0];
   assign unused_imd_val1 = imd_val_q_i[1][33:32];
 
   always_comb begin
     alu_operand_a_o = accum_window_q;
 
-    unique case(operator_i)
+    unique case (operator_i)
 
       MD_OP_MULL: begin
         alu_operand_b_o = op_a_bw_pp;
@@ -106,32 +112,31 @@ module ibex_multdiv_slow
         alu_operand_b_o = (md_state_q == MD_LAST) ? op_a_bw_last_pp : op_a_bw_pp;
       end
 
-      MD_OP_DIV,
-      MD_OP_REM: begin
-        unique case(md_state_q)
+      MD_OP_DIV, MD_OP_REM: begin
+        unique case (md_state_q)
           MD_IDLE: begin
             // 0 - B = 0 iff B == 0
-            alu_operand_a_o = {32'h0  , 1'b1};
+            alu_operand_a_o = {32'h0, 1'b1};
             alu_operand_b_o = {~op_b_i, 1'b1};
           end
           MD_ABS_A: begin
             // ABS(A) = 0 - A
-            alu_operand_a_o = {32'h0  , 1'b1};
+            alu_operand_a_o = {32'h0, 1'b1};
             alu_operand_b_o = {~op_a_i, 1'b1};
           end
           MD_ABS_B: begin
             // ABS(B) = 0 - B
-            alu_operand_a_o = {32'h0  , 1'b1};
+            alu_operand_a_o = {32'h0, 1'b1};
             alu_operand_b_o = {~op_b_i, 1'b1};
           end
           MD_CHANGE_SIGN: begin
             // ABS(Quotient) = 0 - Quotient (or Reminder)
-            alu_operand_a_o = {32'h0  , 1'b1};
+            alu_operand_a_o = {32'h0, 1'b1};
             alu_operand_b_o = {~accum_window_q[31:0], 1'b1};
           end
           default: begin
             // Division
-            alu_operand_a_o = {accum_window_q[31:0], 1'b1}; // it contains the remainder
+            alu_operand_a_o = {accum_window_q[31:0], 1'b1};  // it contains the remainder
             alu_operand_b_o = {~op_b_shift_q[31:0], 1'b1};  // -denominator two's compliment
           end
         endcase
@@ -144,13 +149,13 @@ module ibex_multdiv_slow
   end
 
   // Multiplier partial product calculation
-  assign b_0             = {32{op_b_shift_q[0]}};
-  assign op_a_bw_pp      = { ~(op_a_shift_q[32] & op_b_shift_q[0]),  (op_a_shift_q[31:0] & b_0) };
-  assign op_a_bw_last_pp = {  (op_a_shift_q[32] & op_b_shift_q[0]), ~(op_a_shift_q[31:0] & b_0) };
+  assign b_0 = {32{op_b_shift_q[0]}};
+  assign op_a_bw_pp = {~(op_a_shift_q[32] & op_b_shift_q[0]), (op_a_shift_q[31:0] & b_0)};
+  assign op_a_bw_last_pp = {(op_a_shift_q[32] & op_b_shift_q[0]), ~(op_a_shift_q[31:0] & b_0)};
 
   // Sign extend the input operands
-  assign sign_a   = op_a_i[31] & signed_mode_i[0];
-  assign sign_b   = op_b_i[31] & signed_mode_i[1];
+  assign sign_a = op_a_i[31] & signed_mode_i[0];
+  assign sign_b = op_b_i[31] & signed_mode_i[1];
 
   assign op_a_ext = {sign_a, op_a_i};
   assign op_b_ext = {sign_b, op_b_i};
@@ -160,44 +165,43 @@ module ibex_multdiv_slow
   // The adder in the ALU computes Remainder - Divisor. If Remainder - Divisor >= 0,
   // is_greater_equal is true, the next Remainder is the subtraction result and the Quotient
   // multdiv_count_q-th bit is set to 1.
-  assign is_greater_equal = (accum_window_q[31] == op_b_shift_q[31]) ?
-      ~res_adder_h[31] : accum_window_q[31];
+  assign is_greater_equal = (accum_window_q[31] == op_b_shift_q[31]) ? ~res_adder_h[31] :
+      accum_window_q[31];
 
-  assign one_shift      = {32'b0, 1'b1} << multdiv_count_q;
+  assign one_shift = {32'b0, 1'b1} << multdiv_count_q;
 
-  assign next_remainder = is_greater_equal ? res_adder_h[31:0]        : accum_window_q[31:0];
-  assign next_quotient  = is_greater_equal ? op_a_shift_q | one_shift : op_a_shift_q;
+  assign next_remainder = is_greater_equal ? res_adder_h[31:0] : accum_window_q[31:0];
+  assign next_quotient = is_greater_equal ? op_a_shift_q | one_shift : op_a_shift_q;
 
-  assign div_change_sign  = (sign_a ^ sign_b) & ~div_by_zero_q;
-  assign rem_change_sign  = sign_a;
+  assign div_change_sign = (sign_a ^ sign_b) & ~div_by_zero_q;
+  assign rem_change_sign = sign_a;
 
   always_comb begin
-    multdiv_count_d  = multdiv_count_q;
-    accum_window_d   = accum_window_q;
-    op_b_shift_d     = op_b_shift_q;
-    op_a_shift_d     = op_a_shift_q;
-    op_numerator_d   = op_numerator_q;
-    md_state_d       = md_state_q;
-    multdiv_hold     = 1'b0;
-    div_by_zero_d    = div_by_zero_q;
+    multdiv_count_d = multdiv_count_q;
+    accum_window_d = accum_window_q;
+    op_b_shift_d = op_b_shift_q;
+    op_a_shift_d = op_a_shift_q;
+    op_numerator_d = op_numerator_q;
+    md_state_d = md_state_q;
+    multdiv_hold = 1'b0;
+    div_by_zero_d = div_by_zero_q;
     if (mult_sel_i || div_sel_i) begin
-      unique case(md_state_q)
+      unique case (md_state_q)
         MD_IDLE: begin
-          unique case(operator_i)
+          unique case (operator_i)
             MD_OP_MULL: begin
-              op_a_shift_d   = op_a_ext << 1;
-              accum_window_d = {       ~(op_a_ext[32]   &     op_b_i[0]),
-                                         op_a_ext[31:0] & {32{op_b_i[0]}}  };
-              op_b_shift_d   = op_b_ext >> 1;
+              op_a_shift_d = op_a_ext << 1;
+              accum_window_d = {~(op_a_ext[32] & op_b_i[0]), op_a_ext[31:0] & {32{op_b_i[0]}}};
+              op_b_shift_d = op_b_ext >> 1;
               // Proceed with multiplication by 0/1 in data-independent time mode
-              md_state_d     = (!data_ind_timing_i && ((op_b_ext >> 1) == 0)) ? MD_LAST : MD_COMP;
+              md_state_d = (!data_ind_timing_i && ((op_b_ext >> 1) == 0)) ? MD_LAST : MD_COMP;
             end
             MD_OP_MULH: begin
-              op_a_shift_d   = op_a_ext;
-              accum_window_d = { 1'b1, ~(op_a_ext[32]   &     op_b_i[0]),
-                                         op_a_ext[31:1] & {31{op_b_i[0]}}  };
-              op_b_shift_d   = op_b_ext >> 1;
-              md_state_d     = MD_COMP;
+              op_a_shift_d = op_a_ext;
+              accum_window_d = {1'b1, ~(op_a_ext[32] & op_b_i[0]),
+                                op_a_ext[31:1] & {31{op_b_i[0]}}};
+              op_b_shift_d = op_b_ext >> 1;
+              md_state_d = MD_COMP;
             end
             MD_OP_DIV: begin
               // Check if the denominator is 0
@@ -205,10 +209,10 @@ module ibex_multdiv_slow
               // Note with data-independent time option, the full divide operation will proceed as
               // normal and will naturally return -1
               accum_window_d = {33{1'b1}};
-              md_state_d     = (!data_ind_timing_i && equal_to_zero_i) ? MD_FINISH : MD_ABS_A;
+              md_state_d = (!data_ind_timing_i && equal_to_zero_i) ? MD_FINISH : MD_ABS_A;
               // Record that this is a div by zero to stop the sign change at the end of the
               // division (in data_ind_timing mode).
-              div_by_zero_d  = equal_to_zero_i;
+              div_by_zero_d = equal_to_zero_i;
             end
             MD_OP_REM: begin
               // Check if the denominator is 0
@@ -216,36 +220,36 @@ module ibex_multdiv_slow
               // Note with data-independent time option, the full divide operation will proceed as
               // normal and will naturally return operand a
               accum_window_d = op_a_ext;
-              md_state_d     = (!data_ind_timing_i && equal_to_zero_i) ? MD_FINISH : MD_ABS_A;
+              md_state_d = (!data_ind_timing_i && equal_to_zero_i) ? MD_FINISH : MD_ABS_A;
             end
-            default:;
+            default: ;
           endcase
-          multdiv_count_d   = 5'd31;
+          multdiv_count_d = 5'd31;
         end
 
         MD_ABS_A: begin
           // quotient
-          op_a_shift_d   = '0;
+          op_a_shift_d = '0;
           // A abs value
           op_numerator_d = sign_a ? alu_adder_i : op_a_i;
-          md_state_d     = MD_ABS_B;
+          md_state_d = MD_ABS_B;
         end
 
         MD_ABS_B: begin
           // remainder
-          accum_window_d = {32'h0,op_numerator_q[31]};
+          accum_window_d = {32'h0, op_numerator_q[31]};
           // B abs value
-          op_b_shift_d   = sign_b ? {1'b0,alu_adder_i} : {1'b0,op_b_i};
-          md_state_d     = MD_COMP;
+          op_b_shift_d = sign_b ? {1'b0, alu_adder_i} : {1'b0, op_b_i};
+          md_state_d = MD_COMP;
         end
 
         MD_COMP: begin
           multdiv_count_d = multdiv_count_q - 5'h1;
-          unique case(operator_i)
+          unique case (operator_i)
             MD_OP_MULL: begin
               accum_window_d = res_adder_l;
-              op_a_shift_d   = op_a_shift_q << 1;
-              op_b_shift_d   = op_b_shift_q >> 1;
+              op_a_shift_d = op_a_shift_q << 1;
+              op_b_shift_d = op_b_shift_q >> 1;
               // Multiplication is complete once op_b is zero, unless in data_ind_timing mode where
               // the maximum possible shift-add operations will be completed regardless of op_b
               md_state_d     = ((!data_ind_timing_i && (op_b_shift_d == 0)) ||
@@ -253,47 +257,46 @@ module ibex_multdiv_slow
             end
             MD_OP_MULH: begin
               accum_window_d = res_adder_h;
-              op_a_shift_d   = op_a_shift_q;
-              op_b_shift_d   = op_b_shift_q >> 1;
-              md_state_d     = (multdiv_count_q == 5'd1) ? MD_LAST : MD_COMP;
+              op_a_shift_d = op_a_shift_q;
+              op_b_shift_d = op_b_shift_q >> 1;
+              md_state_d = (multdiv_count_q == 5'd1) ? MD_LAST : MD_COMP;
             end
-            MD_OP_DIV,
-            MD_OP_REM: begin
+            MD_OP_DIV, MD_OP_REM: begin
               accum_window_d = {next_remainder[31:0], op_numerator_q[multdiv_count_d]};
-              op_a_shift_d   = next_quotient;
-              md_state_d     = (multdiv_count_q == 5'd1) ? MD_LAST : MD_COMP;
+              op_a_shift_d = next_quotient;
+              md_state_d = (multdiv_count_q == 5'd1) ? MD_LAST : MD_COMP;
             end
             default: ;
           endcase
         end
 
         MD_LAST: begin
-          unique case(operator_i)
+          unique case (operator_i)
             MD_OP_MULL: begin
               accum_window_d = res_adder_l;
 
               // Note no state transition will occur if multdiv_hold is set
-              md_state_d   = MD_IDLE;
+              md_state_d = MD_IDLE;
               multdiv_hold = ~multdiv_ready_id_i;
             end
             MD_OP_MULH: begin
               accum_window_d = res_adder_l;
-              md_state_d     = MD_IDLE;
+              md_state_d = MD_IDLE;
 
               // Note no state transition will occur if multdiv_hold is set
-              md_state_d   = MD_IDLE;
+              md_state_d = MD_IDLE;
               multdiv_hold = ~multdiv_ready_id_i;
             end
             MD_OP_DIV: begin
               // this time we save the quotient in accum_window_q since we do not need anymore the
               // remainder
               accum_window_d = next_quotient;
-              md_state_d     = MD_CHANGE_SIGN;
+              md_state_d = MD_CHANGE_SIGN;
             end
             MD_OP_REM: begin
               // this time we do not save the quotient anymore since we need only the remainder
               accum_window_d = {1'b0, next_remainder[31:0]};
-              md_state_d     = MD_CHANGE_SIGN;
+              md_state_d = MD_CHANGE_SIGN;
             end
             default: ;
           endcase
@@ -301,26 +304,24 @@ module ibex_multdiv_slow
 
         MD_CHANGE_SIGN: begin
           md_state_d = MD_FINISH;
-          unique case(operator_i)
-            MD_OP_DIV:
-              accum_window_d = div_change_sign ? {1'b0,alu_adder_i} : accum_window_q;
-            MD_OP_REM:
-              accum_window_d = rem_change_sign ? {1'b0,alu_adder_i} : accum_window_q;
+          unique case (operator_i)
+            MD_OP_DIV: accum_window_d = div_change_sign ? {1'b0, alu_adder_i} : accum_window_q;
+            MD_OP_REM: accum_window_d = rem_change_sign ? {1'b0, alu_adder_i} : accum_window_q;
             default: ;
           endcase
         end
 
         MD_FINISH: begin
           // Note no state transition will occur if multdiv_hold is set
-          md_state_d   = MD_IDLE;
+          md_state_d = MD_IDLE;
           multdiv_hold = ~multdiv_ready_id_i;
         end
 
         default: begin
           md_state_d = MD_IDLE;
         end
-      endcase // md_state_q
-    end // (mult_sel_i || div_sel_i)
+      endcase  // md_state_q
+    end  // (mult_sel_i || div_sel_i)
   end
 
   //////////////////////////////////////////
@@ -331,17 +332,17 @@ module ibex_multdiv_slow
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      multdiv_count_q  <= 5'h0;
-      op_b_shift_q     <= 33'h0;
-      op_a_shift_q     <= 33'h0;
-      md_state_q       <= MD_IDLE;
-      div_by_zero_q    <= 1'b0;
+      multdiv_count_q <= 5'h0;
+      op_b_shift_q <= 33'h0;
+      op_a_shift_q <= 33'h0;
+      md_state_q <= MD_IDLE;
+      div_by_zero_q <= 1'b0;
     end else if (multdiv_en) begin
-      multdiv_count_q  <= multdiv_count_d;
-      op_b_shift_q     <= op_b_shift_d;
-      op_a_shift_q     <= op_a_shift_d;
-      md_state_q       <= md_state_d;
-      div_by_zero_q    <= div_by_zero_d;
+      multdiv_count_q <= multdiv_count_d;
+      op_b_shift_q <= op_b_shift_d;
+      op_a_shift_q <= op_a_shift_d;
+      md_state_q <= md_state_d;
+      div_by_zero_q <= div_by_zero_d;
     end
   end
 
@@ -361,8 +362,9 @@ module ibex_multdiv_slow
   ////////////////
 
   // State must be valid.
-  `ASSERT(IbexMultDivStateValid, md_state_q inside {
-      MD_IDLE, MD_ABS_A, MD_ABS_B, MD_COMP, MD_LAST, MD_CHANGE_SIGN, MD_FINISH
-      }, clk_i, !rst_ni)
+  `ASSERT(IbexMultDivStateValid,
+          md_state_q inside {MD_IDLE, MD_ABS_A, MD_ABS_B, MD_COMP, MD_LAST, MD_CHANGE_SIGN,
+                             MD_FINISH},
+          clk_i, !rst_ni)
 
 endmodule

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -8,487 +8,494 @@
  */
 package ibex_pkg;
 
-/////////////////////////
-// RV32B Paramter Enum //
-/////////////////////////
+  /////////////////////////
+  // RV32B Paramter Enum //
+  /////////////////////////
 
-typedef enum integer {
-  RV32BNone,
-  RV32BBalanced,
-  RV32BFull
-} rv32b_e;
+  typedef enum integer {
+    RV32BNone,
+    RV32BBalanced,
+    RV32BFull
+  } rv32b_e;
 
-/////////////
-// Opcodes //
-/////////////
+  /////////////
+  // Opcodes //
+  /////////////
 
-typedef enum logic [6:0] {
-  OPCODE_LOAD     = 7'h03,
-  OPCODE_MISC_MEM = 7'h0f,
-  OPCODE_OP_IMM   = 7'h13,
-  OPCODE_AUIPC    = 7'h17,
-  OPCODE_STORE    = 7'h23,
-  OPCODE_OP       = 7'h33,
-  OPCODE_LUI      = 7'h37,
-  OPCODE_BRANCH   = 7'h63,
-  OPCODE_JALR     = 7'h67,
-  OPCODE_JAL      = 7'h6f,
-  OPCODE_SYSTEM   = 7'h73
-} opcode_e;
-
-
-////////////////////
-// ALU operations //
-////////////////////
-
-typedef enum logic [5:0] {
-  // Arithmetics
-  ALU_ADD,
-  ALU_SUB,
-
-  // Logics
-  ALU_XOR,
-  ALU_OR,
-  ALU_AND,
-  // RV32B
-  ALU_XNOR,
-  ALU_ORN,
-  ALU_ANDN,
-
-  // Shifts
-  ALU_SRA,
-  ALU_SRL,
-  ALU_SLL,
-  // RV32B
-  ALU_SRO,
-  ALU_SLO,
-  ALU_ROR,
-  ALU_ROL,
-  ALU_GREV,
-  ALU_GORC,
-  ALU_SHFL,
-  ALU_UNSHFL,
-
-  // Comparisons
-  ALU_LT,
-  ALU_LTU,
-  ALU_GE,
-  ALU_GEU,
-  ALU_EQ,
-  ALU_NE,
-  // RV32B
-  ALU_MIN,
-  ALU_MINU,
-  ALU_MAX,
-  ALU_MAXU,
-
-  // Pack
-  // RV32B
-  ALU_PACK,
-  ALU_PACKU,
-  ALU_PACKH,
-
-  // Sign-Extend
-  // RV32B
-  ALU_SEXTB,
-  ALU_SEXTH,
-
-  // Bitcounting
-  // RV32B
-  ALU_CLZ,
-  ALU_CTZ,
-  ALU_PCNT,
-
-  // Set lower than
-  ALU_SLT,
-  ALU_SLTU,
-
-  // Ternary Bitmanip Operations
-  // RV32B
-  ALU_CMOV,
-  ALU_CMIX,
-  ALU_FSL,
-  ALU_FSR,
-
-  // Single-Bit Operations
-  // RV32B
-  ALU_SBSET,
-  ALU_SBCLR,
-  ALU_SBINV,
-  ALU_SBEXT,
-
-  // Bit Extract / Deposit
-  // RV32B
-  ALU_BEXT,
-  ALU_BDEP,
-
-  // Bit Field Place
-  // RV32B
-  ALU_BFP,
-
-  // Carry-less Multiply
-  // RV32B
-  ALU_CLMUL,
-  ALU_CLMULR,
-  ALU_CLMULH,
-
-  // Cyclic Redundancy Check
-  ALU_CRC32_B,
-  ALU_CRC32C_B,
-  ALU_CRC32_H,
-  ALU_CRC32C_H,
-  ALU_CRC32_W,
-  ALU_CRC32C_W
-} alu_op_e;
-
-typedef enum logic [1:0] {
-  // Multiplier/divider
-  MD_OP_MULL,
-  MD_OP_MULH,
-  MD_OP_DIV,
-  MD_OP_REM
-} md_op_e;
+  typedef enum logic [6:0] {
+    OPCODE_LOAD = 7'h03,
+    OPCODE_MISC_MEM = 7'h0f,
+    OPCODE_OP_IMM = 7'h13,
+    OPCODE_AUIPC = 7'h17,
+    OPCODE_STORE = 7'h23,
+    OPCODE_OP = 7'h33,
+    OPCODE_LUI = 7'h37,
+    OPCODE_BRANCH = 7'h63,
+    OPCODE_JALR = 7'h67,
+    OPCODE_JAL = 7'h6f,
+    OPCODE_SYSTEM = 7'h73
+  } opcode_e;
 
 
-//////////////////////////////////
-// Control and status registers //
-//////////////////////////////////
+  ////////////////////
+  // ALU operations //
+  ////////////////////
 
-// CSR operations
-typedef enum logic [1:0] {
-  CSR_OP_READ,
-  CSR_OP_WRITE,
-  CSR_OP_SET,
-  CSR_OP_CLEAR
-} csr_op_e;
+  typedef enum logic [5:0] {
+    // Arithmetics
+    ALU_ADD,
+    ALU_SUB,
 
-// Privileged mode
-typedef enum logic[1:0] {
-  PRIV_LVL_M = 2'b11,
-  PRIV_LVL_H = 2'b10,
-  PRIV_LVL_S = 2'b01,
-  PRIV_LVL_U = 2'b00
-} priv_lvl_e;
+    // Logics
+    ALU_XOR,
+    ALU_OR,
+    ALU_AND,
+    // RV32B
+    ALU_XNOR,
+    ALU_ORN,
+    ALU_ANDN,
 
-// Constants for the dcsr.xdebugver fields
-typedef enum logic[3:0] {
-   XDEBUGVER_NO     = 4'd0, // no external debug support
-   XDEBUGVER_STD    = 4'd4, // external debug according to RISC-V debug spec
-   XDEBUGVER_NONSTD = 4'd15 // debug not conforming to RISC-V debug spec
-} x_debug_ver_e;
+    // Shifts
+    ALU_SRA,
+    ALU_SRL,
+    ALU_SLL,
+    // RV32B
+    ALU_SRO,
+    ALU_SLO,
+    ALU_ROR,
+    ALU_ROL,
+    ALU_GREV,
+    ALU_GORC,
+    ALU_SHFL,
+    ALU_UNSHFL,
 
-//////////////
-// WB stage //
-//////////////
+    // Comparisons
+    ALU_LT,
+    ALU_LTU,
+    ALU_GE,
+    ALU_GEU,
+    ALU_EQ,
+    ALU_NE,
+    // RV32B
+    ALU_MIN,
+    ALU_MINU,
+    ALU_MAX,
+    ALU_MAXU,
 
-// Type of instruction present in writeback stage
-typedef enum logic[1:0] {
-  WB_INSTR_LOAD,  // Instruction is awaiting load data
-  WB_INSTR_STORE, // Instruction is awaiting store response
-  WB_INSTR_OTHER  // Instruction doesn't fit into above categories
-} wb_instr_type_e;
+    // Pack
+    // RV32B
+    ALU_PACK,
+    ALU_PACKU,
+    ALU_PACKH,
 
-//////////////
-// ID stage //
-//////////////
+    // Sign-Extend
+    // RV32B
+    ALU_SEXTB,
+    ALU_SEXTH,
 
-// Operand a selection
-typedef enum logic[1:0] {
-  OP_A_REG_A,
-  OP_A_FWD,
-  OP_A_CURRPC,
-  OP_A_IMM
-} op_a_sel_e;
+    // Bitcounting
+    // RV32B
+    ALU_CLZ,
+    ALU_CTZ,
+    ALU_PCNT,
 
-// Immediate a selection
-typedef enum logic {
-  IMM_A_Z,
-  IMM_A_ZERO
-} imm_a_sel_e;
+    // Set lower than
+    ALU_SLT,
+    ALU_SLTU,
 
-// Operand b selection
-typedef enum logic {
-  OP_B_REG_B,
-  OP_B_IMM
-} op_b_sel_e;
+    // Ternary Bitmanip Operations
+    // RV32B
+    ALU_CMOV,
+    ALU_CMIX,
+    ALU_FSL,
+    ALU_FSR,
 
-// Immediate b selection
-typedef enum logic [2:0] {
-  IMM_B_I,
-  IMM_B_S,
-  IMM_B_B,
-  IMM_B_U,
-  IMM_B_J,
-  IMM_B_INCR_PC,
-  IMM_B_INCR_ADDR
-} imm_b_sel_e;
+    // Single-Bit Operations
+    // RV32B
+    ALU_SBSET,
+    ALU_SBCLR,
+    ALU_SBINV,
+    ALU_SBEXT,
 
-// Regfile write data selection
-typedef enum logic {
-  RF_WD_EX,
-  RF_WD_CSR
-} rf_wd_sel_e;
+    // Bit Extract / Deposit
+    // RV32B
+    ALU_BEXT,
+    ALU_BDEP,
 
-//////////////
-// IF stage //
-//////////////
+    // Bit Field Place
+    // RV32B
+    ALU_BFP,
 
-// PC mux selection
-typedef enum logic [2:0] {
-  PC_BOOT,
-  PC_JUMP,
-  PC_EXC,
-  PC_ERET,
-  PC_DRET
-} pc_sel_e;
+    // Carry-less Multiply
+    // RV32B
+    ALU_CLMUL,
+    ALU_CLMULR,
+    ALU_CLMULH,
 
-// Exception PC mux selection
-typedef enum logic [1:0] {
-  EXC_PC_EXC,
-  EXC_PC_IRQ,
-  EXC_PC_DBD,
-  EXC_PC_DBG_EXC // Exception while in debug mode
-} exc_pc_sel_e;
+    // Cyclic Redundancy Check
+    ALU_CRC32_B,
+    ALU_CRC32C_B,
+    ALU_CRC32_H,
+    ALU_CRC32C_H,
+    ALU_CRC32_W,
+    ALU_CRC32C_W
+  } alu_op_e;
 
-// Interrupt requests
-typedef struct packed {
-  logic        irq_software;
-  logic        irq_timer;
-  logic        irq_external;
-  logic [14:0] irq_fast; // 15 fast interrupts,
-                         // one interrupt is reserved for NMI (not visible through mip/mie)
-} irqs_t;
+  typedef enum logic [1:0] {
+    // Multiplier/divider
+    MD_OP_MULL,
+    MD_OP_MULH,
+    MD_OP_DIV,
+    MD_OP_REM
+  } md_op_e;
 
-// Exception cause
-typedef enum logic [5:0] {
-  EXC_CAUSE_IRQ_SOFTWARE_M     = {1'b1, 5'd03},
-  EXC_CAUSE_IRQ_TIMER_M        = {1'b1, 5'd07},
-  EXC_CAUSE_IRQ_EXTERNAL_M     = {1'b1, 5'd11},
-  // EXC_CAUSE_IRQ_FAST_0      = {1'b1, 5'd16},
-  // EXC_CAUSE_IRQ_FAST_14     = {1'b1, 5'd30},
-  EXC_CAUSE_IRQ_NM             = {1'b1, 5'd31}, // == EXC_CAUSE_IRQ_FAST_15
-  EXC_CAUSE_INSN_ADDR_MISA     = {1'b0, 5'd00},
-  EXC_CAUSE_INSTR_ACCESS_FAULT = {1'b0, 5'd01},
-  EXC_CAUSE_ILLEGAL_INSN       = {1'b0, 5'd02},
-  EXC_CAUSE_BREAKPOINT         = {1'b0, 5'd03},
-  EXC_CAUSE_LOAD_ACCESS_FAULT  = {1'b0, 5'd05},
-  EXC_CAUSE_STORE_ACCESS_FAULT = {1'b0, 5'd07},
-  EXC_CAUSE_ECALL_UMODE        = {1'b0, 5'd08},
-  EXC_CAUSE_ECALL_MMODE        = {1'b0, 5'd11}
-} exc_cause_e;
 
-// Debug cause
-typedef enum logic [2:0] {
-  DBG_CAUSE_NONE    = 3'h0,
-  DBG_CAUSE_EBREAK  = 3'h1,
-  DBG_CAUSE_TRIGGER = 3'h2,
-  DBG_CAUSE_HALTREQ = 3'h3,
-  DBG_CAUSE_STEP    = 3'h4
-} dbg_cause_e;
+  //////////////////////////////////
+  // Control and status registers //
+  //////////////////////////////////
 
-// PMP constants
-parameter int unsigned PMP_MAX_REGIONS      = 16;
-parameter int unsigned PMP_CFG_W            = 8;
+  // CSR operations
+  typedef enum logic [1:0] {
+    CSR_OP_READ,
+    CSR_OP_WRITE,
+    CSR_OP_SET,
+    CSR_OP_CLEAR
+  } csr_op_e;
 
-// PMP acces type
-parameter int unsigned PMP_I = 0;
-parameter int unsigned PMP_D = 1;
+  // Privileged mode
+  typedef enum logic [1:0] {
+    PRIV_LVL_M = 2'b11,
+    PRIV_LVL_H = 2'b10,
+    PRIV_LVL_S = 2'b01,
+    PRIV_LVL_U = 2'b00
+  } priv_lvl_e;
 
-typedef enum logic [1:0] {
-  PMP_ACC_EXEC    = 2'b00,
-  PMP_ACC_WRITE   = 2'b01,
-  PMP_ACC_READ    = 2'b10
-} pmp_req_e;
+  // Constants for the dcsr.xdebugver fields
+  typedef enum logic [3:0] {
+    XDEBUGVER_NO = 4'd0
+    ,  // no external debug support
+    XDEBUGVER_STD = 4'd4
+    ,  // external debug according to RISC-V debug spec
+    XDEBUGVER_NONSTD = 4'd15  // debug not conforming to RISC-V debug spec
+  } x_debug_ver_e;
 
-// PMP cfg structures
-typedef enum logic [1:0] {
-  PMP_MODE_OFF   = 2'b00,
-  PMP_MODE_TOR   = 2'b01,
-  PMP_MODE_NA4   = 2'b10,
-  PMP_MODE_NAPOT = 2'b11
-} pmp_cfg_mode_e;
+  //////////////
+  // WB stage //
+  //////////////
 
-typedef struct packed {
-  logic          lock;
-  pmp_cfg_mode_e mode;
-  logic          exec;
-  logic          write;
-  logic          read;
-} pmp_cfg_t;
+  // Type of instruction present in writeback stage
+  typedef enum logic [1:0] {
+    WB_INSTR_LOAD
+    ,  // Instruction is awaiting load data
+    WB_INSTR_STORE
+    ,  // Instruction is awaiting store response
+    WB_INSTR_OTHER  // Instruction doesn't fit into above categories
+  } wb_instr_type_e;
 
-// CSRs
-typedef enum logic[11:0] {
-  // Machine information
-  CSR_MHARTID   = 12'hF14,
+  //////////////
+  // ID stage //
+  //////////////
 
-  // Machine trap setup
-  CSR_MSTATUS   = 12'h300,
-  CSR_MISA      = 12'h301,
-  CSR_MIE       = 12'h304,
-  CSR_MTVEC     = 12'h305,
+  // Operand a selection
+  typedef enum logic [1:0] {
+    OP_A_REG_A,
+    OP_A_FWD,
+    OP_A_CURRPC,
+    OP_A_IMM
+  } op_a_sel_e;
 
-  // Machine trap handling
-  CSR_MSCRATCH  = 12'h340,
-  CSR_MEPC      = 12'h341,
-  CSR_MCAUSE    = 12'h342,
-  CSR_MTVAL     = 12'h343,
-  CSR_MIP       = 12'h344,
+  // Immediate a selection
+  typedef enum logic {
+    IMM_A_Z,
+    IMM_A_ZERO
+  } imm_a_sel_e;
 
-  // Physical memory protection
-  CSR_PMPCFG0   = 12'h3A0,
-  CSR_PMPCFG1   = 12'h3A1,
-  CSR_PMPCFG2   = 12'h3A2,
-  CSR_PMPCFG3   = 12'h3A3,
-  CSR_PMPADDR0  = 12'h3B0,
-  CSR_PMPADDR1  = 12'h3B1,
-  CSR_PMPADDR2  = 12'h3B2,
-  CSR_PMPADDR3  = 12'h3B3,
-  CSR_PMPADDR4  = 12'h3B4,
-  CSR_PMPADDR5  = 12'h3B5,
-  CSR_PMPADDR6  = 12'h3B6,
-  CSR_PMPADDR7  = 12'h3B7,
-  CSR_PMPADDR8  = 12'h3B8,
-  CSR_PMPADDR9  = 12'h3B9,
-  CSR_PMPADDR10 = 12'h3BA,
-  CSR_PMPADDR11 = 12'h3BB,
-  CSR_PMPADDR12 = 12'h3BC,
-  CSR_PMPADDR13 = 12'h3BD,
-  CSR_PMPADDR14 = 12'h3BE,
-  CSR_PMPADDR15 = 12'h3BF,
+  // Operand b selection
+  typedef enum logic {
+    OP_B_REG_B,
+    OP_B_IMM
+  } op_b_sel_e;
 
-  // Debug trigger
-  CSR_TSELECT   = 12'h7A0,
-  CSR_TDATA1    = 12'h7A1,
-  CSR_TDATA2    = 12'h7A2,
-  CSR_TDATA3    = 12'h7A3,
-  CSR_MCONTEXT  = 12'h7A8,
-  CSR_SCONTEXT  = 12'h7AA,
+  // Immediate b selection
+  typedef enum logic [2:0] {
+    IMM_B_I,
+    IMM_B_S,
+    IMM_B_B,
+    IMM_B_U,
+    IMM_B_J,
+    IMM_B_INCR_PC,
+    IMM_B_INCR_ADDR
+  } imm_b_sel_e;
 
-  // Debug/trace
-  CSR_DCSR      = 12'h7b0,
-  CSR_DPC       = 12'h7b1,
+  // Regfile write data selection
+  typedef enum logic {
+    RF_WD_EX,
+    RF_WD_CSR
+  } rf_wd_sel_e;
 
-  // Debug
-  CSR_DSCRATCH0 = 12'h7b2, // optional
-  CSR_DSCRATCH1 = 12'h7b3, // optional
+  //////////////
+  // IF stage //
+  //////////////
 
-  // Machine Counter/Timers
-  CSR_MCOUNTINHIBIT  = 12'h320,
-  CSR_MHPMEVENT3     = 12'h323,
-  CSR_MHPMEVENT4     = 12'h324,
-  CSR_MHPMEVENT5     = 12'h325,
-  CSR_MHPMEVENT6     = 12'h326,
-  CSR_MHPMEVENT7     = 12'h327,
-  CSR_MHPMEVENT8     = 12'h328,
-  CSR_MHPMEVENT9     = 12'h329,
-  CSR_MHPMEVENT10    = 12'h32A,
-  CSR_MHPMEVENT11    = 12'h32B,
-  CSR_MHPMEVENT12    = 12'h32C,
-  CSR_MHPMEVENT13    = 12'h32D,
-  CSR_MHPMEVENT14    = 12'h32E,
-  CSR_MHPMEVENT15    = 12'h32F,
-  CSR_MHPMEVENT16    = 12'h330,
-  CSR_MHPMEVENT17    = 12'h331,
-  CSR_MHPMEVENT18    = 12'h332,
-  CSR_MHPMEVENT19    = 12'h333,
-  CSR_MHPMEVENT20    = 12'h334,
-  CSR_MHPMEVENT21    = 12'h335,
-  CSR_MHPMEVENT22    = 12'h336,
-  CSR_MHPMEVENT23    = 12'h337,
-  CSR_MHPMEVENT24    = 12'h338,
-  CSR_MHPMEVENT25    = 12'h339,
-  CSR_MHPMEVENT26    = 12'h33A,
-  CSR_MHPMEVENT27    = 12'h33B,
-  CSR_MHPMEVENT28    = 12'h33C,
-  CSR_MHPMEVENT29    = 12'h33D,
-  CSR_MHPMEVENT30    = 12'h33E,
-  CSR_MHPMEVENT31    = 12'h33F,
-  CSR_MCYCLE         = 12'hB00,
-  CSR_MINSTRET       = 12'hB02,
-  CSR_MHPMCOUNTER3   = 12'hB03,
-  CSR_MHPMCOUNTER4   = 12'hB04,
-  CSR_MHPMCOUNTER5   = 12'hB05,
-  CSR_MHPMCOUNTER6   = 12'hB06,
-  CSR_MHPMCOUNTER7   = 12'hB07,
-  CSR_MHPMCOUNTER8   = 12'hB08,
-  CSR_MHPMCOUNTER9   = 12'hB09,
-  CSR_MHPMCOUNTER10  = 12'hB0A,
-  CSR_MHPMCOUNTER11  = 12'hB0B,
-  CSR_MHPMCOUNTER12  = 12'hB0C,
-  CSR_MHPMCOUNTER13  = 12'hB0D,
-  CSR_MHPMCOUNTER14  = 12'hB0E,
-  CSR_MHPMCOUNTER15  = 12'hB0F,
-  CSR_MHPMCOUNTER16  = 12'hB10,
-  CSR_MHPMCOUNTER17  = 12'hB11,
-  CSR_MHPMCOUNTER18  = 12'hB12,
-  CSR_MHPMCOUNTER19  = 12'hB13,
-  CSR_MHPMCOUNTER20  = 12'hB14,
-  CSR_MHPMCOUNTER21  = 12'hB15,
-  CSR_MHPMCOUNTER22  = 12'hB16,
-  CSR_MHPMCOUNTER23  = 12'hB17,
-  CSR_MHPMCOUNTER24  = 12'hB18,
-  CSR_MHPMCOUNTER25  = 12'hB19,
-  CSR_MHPMCOUNTER26  = 12'hB1A,
-  CSR_MHPMCOUNTER27  = 12'hB1B,
-  CSR_MHPMCOUNTER28  = 12'hB1C,
-  CSR_MHPMCOUNTER29  = 12'hB1D,
-  CSR_MHPMCOUNTER30  = 12'hB1E,
-  CSR_MHPMCOUNTER31  = 12'hB1F,
-  CSR_MCYCLEH        = 12'hB80,
-  CSR_MINSTRETH      = 12'hB82,
-  CSR_MHPMCOUNTER3H  = 12'hB83,
-  CSR_MHPMCOUNTER4H  = 12'hB84,
-  CSR_MHPMCOUNTER5H  = 12'hB85,
-  CSR_MHPMCOUNTER6H  = 12'hB86,
-  CSR_MHPMCOUNTER7H  = 12'hB87,
-  CSR_MHPMCOUNTER8H  = 12'hB88,
-  CSR_MHPMCOUNTER9H  = 12'hB89,
-  CSR_MHPMCOUNTER10H = 12'hB8A,
-  CSR_MHPMCOUNTER11H = 12'hB8B,
-  CSR_MHPMCOUNTER12H = 12'hB8C,
-  CSR_MHPMCOUNTER13H = 12'hB8D,
-  CSR_MHPMCOUNTER14H = 12'hB8E,
-  CSR_MHPMCOUNTER15H = 12'hB8F,
-  CSR_MHPMCOUNTER16H = 12'hB90,
-  CSR_MHPMCOUNTER17H = 12'hB91,
-  CSR_MHPMCOUNTER18H = 12'hB92,
-  CSR_MHPMCOUNTER19H = 12'hB93,
-  CSR_MHPMCOUNTER20H = 12'hB94,
-  CSR_MHPMCOUNTER21H = 12'hB95,
-  CSR_MHPMCOUNTER22H = 12'hB96,
-  CSR_MHPMCOUNTER23H = 12'hB97,
-  CSR_MHPMCOUNTER24H = 12'hB98,
-  CSR_MHPMCOUNTER25H = 12'hB99,
-  CSR_MHPMCOUNTER26H = 12'hB9A,
-  CSR_MHPMCOUNTER27H = 12'hB9B,
-  CSR_MHPMCOUNTER28H = 12'hB9C,
-  CSR_MHPMCOUNTER29H = 12'hB9D,
-  CSR_MHPMCOUNTER30H = 12'hB9E,
-  CSR_MHPMCOUNTER31H = 12'hB9F,
-  CSR_CPUCTRL        = 12'h7C0,
-  CSR_SECURESEED     = 12'h7C1
-} csr_num_e;
+  // PC mux selection
+  typedef enum logic [2:0] {
+    PC_BOOT,
+    PC_JUMP,
+    PC_EXC,
+    PC_ERET,
+    PC_DRET
+  } pc_sel_e;
 
-// CSR pmp-related offsets
-parameter logic [11:0] CSR_OFF_PMP_CFG  = 12'h3A0; // pmp_cfg  @ 12'h3a0 - 12'h3a3
-parameter logic [11:0] CSR_OFF_PMP_ADDR = 12'h3B0; // pmp_addr @ 12'h3b0 - 12'h3bf
+  // Exception PC mux selection
+  typedef enum logic [1:0] {
+    EXC_PC_EXC,
+    EXC_PC_IRQ,
+    EXC_PC_DBD,
+    EXC_PC_DBG_EXC  // Exception while in debug mode
+  } exc_pc_sel_e;
 
-// CSR status bits
-parameter int unsigned CSR_MSTATUS_MIE_BIT      = 3;
-parameter int unsigned CSR_MSTATUS_MPIE_BIT     = 7;
-parameter int unsigned CSR_MSTATUS_MPP_BIT_LOW  = 11;
-parameter int unsigned CSR_MSTATUS_MPP_BIT_HIGH = 12;
-parameter int unsigned CSR_MSTATUS_MPRV_BIT     = 17;
-parameter int unsigned CSR_MSTATUS_TW_BIT       = 21;
+  // Interrupt requests
+  typedef struct packed {
+    logic irq_software;
+    logic irq_timer;
+    logic irq_external;
+    logic [14:0] irq_fast;  // 15 fast interrupts,
+  // one interrupt is reserved for NMI (not visible through mip/mie)
+  } irqs_t;
 
-// CSR machine ISA
-parameter logic [1:0] CSR_MISA_MXL = 2'd1; // M-XLEN: XLEN in M-Mode for RV32
+  // Exception cause
+  typedef enum logic [5:0] {
+    EXC_CAUSE_IRQ_SOFTWARE_M = {1'b1, 5'd03},
+    EXC_CAUSE_IRQ_TIMER_M = {1'b1, 5'd07},
+    EXC_CAUSE_IRQ_EXTERNAL_M = {1'b1, 5'd11},
+    // EXC_CAUSE_IRQ_FAST_0      = {1'b1, 5'd16},
+    // EXC_CAUSE_IRQ_FAST_14     = {1'b1, 5'd30},
+    EXC_CAUSE_IRQ_NM = {1'b1, 5'd31}
+    ,  // == EXC_CAUSE_IRQ_FAST_15
+    EXC_CAUSE_INSN_ADDR_MISA = {1'b0, 5'd00},
+    EXC_CAUSE_INSTR_ACCESS_FAULT = {1'b0, 5'd01},
+    EXC_CAUSE_ILLEGAL_INSN = {1'b0, 5'd02},
+    EXC_CAUSE_BREAKPOINT = {1'b0, 5'd03},
+    EXC_CAUSE_LOAD_ACCESS_FAULT = {1'b0, 5'd05},
+    EXC_CAUSE_STORE_ACCESS_FAULT = {1'b0, 5'd07},
+    EXC_CAUSE_ECALL_UMODE = {1'b0, 5'd08},
+    EXC_CAUSE_ECALL_MMODE = {1'b0, 5'd11}
+  } exc_cause_e;
 
-// CSR interrupt pending/enable bits
-parameter int unsigned CSR_MSIX_BIT      = 3;
-parameter int unsigned CSR_MTIX_BIT      = 7;
-parameter int unsigned CSR_MEIX_BIT      = 11;
-parameter int unsigned CSR_MFIX_BIT_LOW  = 16;
-parameter int unsigned CSR_MFIX_BIT_HIGH = 30;
+  // Debug cause
+  typedef enum logic [2:0] {
+    DBG_CAUSE_NONE = 3'h0,
+    DBG_CAUSE_EBREAK = 3'h1,
+    DBG_CAUSE_TRIGGER = 3'h2,
+    DBG_CAUSE_HALTREQ = 3'h3,
+    DBG_CAUSE_STEP = 3'h4
+  } dbg_cause_e;
+
+  // PMP constants
+  parameter int unsigned PMP_MAX_REGIONS = 16;
+  parameter int unsigned PMP_CFG_W = 8;
+
+  // PMP acces type
+  parameter int unsigned PMP_I = 0;
+  parameter int unsigned PMP_D = 1;
+
+  typedef enum logic [1:0] {
+    PMP_ACC_EXEC = 2'b00,
+    PMP_ACC_WRITE = 2'b01,
+    PMP_ACC_READ = 2'b10
+  } pmp_req_e;
+
+  // PMP cfg structures
+  typedef enum logic [1:0] {
+    PMP_MODE_OFF = 2'b00,
+    PMP_MODE_TOR = 2'b01,
+    PMP_MODE_NA4 = 2'b10,
+    PMP_MODE_NAPOT = 2'b11
+  } pmp_cfg_mode_e;
+
+  typedef struct packed {
+    logic lock;
+    pmp_cfg_mode_e mode;
+    logic exec;
+    logic write;
+    logic read;
+  } pmp_cfg_t;
+
+  // CSRs
+  typedef enum logic [11:0] {
+    // Machine information
+    CSR_MHARTID = 12'hF14,
+
+    // Machine trap setup
+    CSR_MSTATUS = 12'h300,
+    CSR_MISA = 12'h301,
+    CSR_MIE = 12'h304,
+    CSR_MTVEC = 12'h305,
+
+    // Machine trap handling
+    CSR_MSCRATCH = 12'h340,
+    CSR_MEPC = 12'h341,
+    CSR_MCAUSE = 12'h342,
+    CSR_MTVAL = 12'h343,
+    CSR_MIP = 12'h344,
+
+    // Physical memory protection
+    CSR_PMPCFG0 = 12'h3A0,
+    CSR_PMPCFG1 = 12'h3A1,
+    CSR_PMPCFG2 = 12'h3A2,
+    CSR_PMPCFG3 = 12'h3A3,
+    CSR_PMPADDR0 = 12'h3B0,
+    CSR_PMPADDR1 = 12'h3B1,
+    CSR_PMPADDR2 = 12'h3B2,
+    CSR_PMPADDR3 = 12'h3B3,
+    CSR_PMPADDR4 = 12'h3B4,
+    CSR_PMPADDR5 = 12'h3B5,
+    CSR_PMPADDR6 = 12'h3B6,
+    CSR_PMPADDR7 = 12'h3B7,
+    CSR_PMPADDR8 = 12'h3B8,
+    CSR_PMPADDR9 = 12'h3B9,
+    CSR_PMPADDR10 = 12'h3BA,
+    CSR_PMPADDR11 = 12'h3BB,
+    CSR_PMPADDR12 = 12'h3BC,
+    CSR_PMPADDR13 = 12'h3BD,
+    CSR_PMPADDR14 = 12'h3BE,
+    CSR_PMPADDR15 = 12'h3BF,
+
+    // Debug trigger
+    CSR_TSELECT = 12'h7A0,
+    CSR_TDATA1 = 12'h7A1,
+    CSR_TDATA2 = 12'h7A2,
+    CSR_TDATA3 = 12'h7A3,
+    CSR_MCONTEXT = 12'h7A8,
+    CSR_SCONTEXT = 12'h7AA,
+
+    // Debug/trace
+    CSR_DCSR = 12'h7b0,
+    CSR_DPC = 12'h7b1,
+
+    // Debug
+    CSR_DSCRATCH0 = 12'h7b2
+    ,  // optional
+    CSR_DSCRATCH1 = 12'h7b3
+    ,  // optional
+
+    // Machine Counter/Timers
+    CSR_MCOUNTINHIBIT = 12'h320,
+    CSR_MHPMEVENT3 = 12'h323,
+    CSR_MHPMEVENT4 = 12'h324,
+    CSR_MHPMEVENT5 = 12'h325,
+    CSR_MHPMEVENT6 = 12'h326,
+    CSR_MHPMEVENT7 = 12'h327,
+    CSR_MHPMEVENT8 = 12'h328,
+    CSR_MHPMEVENT9 = 12'h329,
+    CSR_MHPMEVENT10 = 12'h32A,
+    CSR_MHPMEVENT11 = 12'h32B,
+    CSR_MHPMEVENT12 = 12'h32C,
+    CSR_MHPMEVENT13 = 12'h32D,
+    CSR_MHPMEVENT14 = 12'h32E,
+    CSR_MHPMEVENT15 = 12'h32F,
+    CSR_MHPMEVENT16 = 12'h330,
+    CSR_MHPMEVENT17 = 12'h331,
+    CSR_MHPMEVENT18 = 12'h332,
+    CSR_MHPMEVENT19 = 12'h333,
+    CSR_MHPMEVENT20 = 12'h334,
+    CSR_MHPMEVENT21 = 12'h335,
+    CSR_MHPMEVENT22 = 12'h336,
+    CSR_MHPMEVENT23 = 12'h337,
+    CSR_MHPMEVENT24 = 12'h338,
+    CSR_MHPMEVENT25 = 12'h339,
+    CSR_MHPMEVENT26 = 12'h33A,
+    CSR_MHPMEVENT27 = 12'h33B,
+    CSR_MHPMEVENT28 = 12'h33C,
+    CSR_MHPMEVENT29 = 12'h33D,
+    CSR_MHPMEVENT30 = 12'h33E,
+    CSR_MHPMEVENT31 = 12'h33F,
+    CSR_MCYCLE = 12'hB00,
+    CSR_MINSTRET = 12'hB02,
+    CSR_MHPMCOUNTER3 = 12'hB03,
+    CSR_MHPMCOUNTER4 = 12'hB04,
+    CSR_MHPMCOUNTER5 = 12'hB05,
+    CSR_MHPMCOUNTER6 = 12'hB06,
+    CSR_MHPMCOUNTER7 = 12'hB07,
+    CSR_MHPMCOUNTER8 = 12'hB08,
+    CSR_MHPMCOUNTER9 = 12'hB09,
+    CSR_MHPMCOUNTER10 = 12'hB0A,
+    CSR_MHPMCOUNTER11 = 12'hB0B,
+    CSR_MHPMCOUNTER12 = 12'hB0C,
+    CSR_MHPMCOUNTER13 = 12'hB0D,
+    CSR_MHPMCOUNTER14 = 12'hB0E,
+    CSR_MHPMCOUNTER15 = 12'hB0F,
+    CSR_MHPMCOUNTER16 = 12'hB10,
+    CSR_MHPMCOUNTER17 = 12'hB11,
+    CSR_MHPMCOUNTER18 = 12'hB12,
+    CSR_MHPMCOUNTER19 = 12'hB13,
+    CSR_MHPMCOUNTER20 = 12'hB14,
+    CSR_MHPMCOUNTER21 = 12'hB15,
+    CSR_MHPMCOUNTER22 = 12'hB16,
+    CSR_MHPMCOUNTER23 = 12'hB17,
+    CSR_MHPMCOUNTER24 = 12'hB18,
+    CSR_MHPMCOUNTER25 = 12'hB19,
+    CSR_MHPMCOUNTER26 = 12'hB1A,
+    CSR_MHPMCOUNTER27 = 12'hB1B,
+    CSR_MHPMCOUNTER28 = 12'hB1C,
+    CSR_MHPMCOUNTER29 = 12'hB1D,
+    CSR_MHPMCOUNTER30 = 12'hB1E,
+    CSR_MHPMCOUNTER31 = 12'hB1F,
+    CSR_MCYCLEH = 12'hB80,
+    CSR_MINSTRETH = 12'hB82,
+    CSR_MHPMCOUNTER3H = 12'hB83,
+    CSR_MHPMCOUNTER4H = 12'hB84,
+    CSR_MHPMCOUNTER5H = 12'hB85,
+    CSR_MHPMCOUNTER6H = 12'hB86,
+    CSR_MHPMCOUNTER7H = 12'hB87,
+    CSR_MHPMCOUNTER8H = 12'hB88,
+    CSR_MHPMCOUNTER9H = 12'hB89,
+    CSR_MHPMCOUNTER10H = 12'hB8A,
+    CSR_MHPMCOUNTER11H = 12'hB8B,
+    CSR_MHPMCOUNTER12H = 12'hB8C,
+    CSR_MHPMCOUNTER13H = 12'hB8D,
+    CSR_MHPMCOUNTER14H = 12'hB8E,
+    CSR_MHPMCOUNTER15H = 12'hB8F,
+    CSR_MHPMCOUNTER16H = 12'hB90,
+    CSR_MHPMCOUNTER17H = 12'hB91,
+    CSR_MHPMCOUNTER18H = 12'hB92,
+    CSR_MHPMCOUNTER19H = 12'hB93,
+    CSR_MHPMCOUNTER20H = 12'hB94,
+    CSR_MHPMCOUNTER21H = 12'hB95,
+    CSR_MHPMCOUNTER22H = 12'hB96,
+    CSR_MHPMCOUNTER23H = 12'hB97,
+    CSR_MHPMCOUNTER24H = 12'hB98,
+    CSR_MHPMCOUNTER25H = 12'hB99,
+    CSR_MHPMCOUNTER26H = 12'hB9A,
+    CSR_MHPMCOUNTER27H = 12'hB9B,
+    CSR_MHPMCOUNTER28H = 12'hB9C,
+    CSR_MHPMCOUNTER29H = 12'hB9D,
+    CSR_MHPMCOUNTER30H = 12'hB9E,
+    CSR_MHPMCOUNTER31H = 12'hB9F,
+    CSR_CPUCTRL = 12'h7C0,
+    CSR_SECURESEED = 12'h7C1
+  } csr_num_e;
+
+  // CSR pmp-related offsets
+  parameter logic [11:0] CSR_OFF_PMP_CFG = 12'h3A0;  // pmp_cfg  @ 12'h3a0 - 12'h3a3
+  parameter logic [11:0] CSR_OFF_PMP_ADDR = 12'h3B0;  // pmp_addr @ 12'h3b0 - 12'h3bf
+
+  // CSR status bits
+  parameter int unsigned CSR_MSTATUS_MIE_BIT = 3;
+  parameter int unsigned CSR_MSTATUS_MPIE_BIT = 7;
+  parameter int unsigned CSR_MSTATUS_MPP_BIT_LOW = 11;
+  parameter int unsigned CSR_MSTATUS_MPP_BIT_HIGH = 12;
+  parameter int unsigned CSR_MSTATUS_MPRV_BIT = 17;
+  parameter int unsigned CSR_MSTATUS_TW_BIT = 21;
+
+  // CSR machine ISA
+  parameter logic [1:0] CSR_MISA_MXL = 2'd1;  // M-XLEN: XLEN in M-Mode for RV32
+
+  // CSR interrupt pending/enable bits
+  parameter int unsigned CSR_MSIX_BIT = 3;
+  parameter int unsigned CSR_MTIX_BIT = 7;
+  parameter int unsigned CSR_MEIX_BIT = 11;
+  parameter int unsigned CSR_MFIX_BIT_LOW = 16;
+  parameter int unsigned CSR_MFIX_BIT_HIGH = 30;
 
 endpackage

--- a/rtl/ibex_pmp.sv
+++ b/rtl/ibex_pmp.sv
@@ -30,14 +30,14 @@ module ibex_pmp #(
   import ibex_pkg::*;
 
   // Access Checking Signals
-  logic [33:0]                                region_start_addr [PMPNumRegions];
-  logic [33:PMPGranularity+2]                 region_addr_mask  [PMPNumRegions];
-  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_gt;
-  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_lt;
-  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_eq;
-  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_match_all;
-  logic [PMPNumChan-1:0][PMPNumRegions-1:0]   region_perm_check;
-  logic [PMPNumChan-1:0]                      access_fault;
+  logic [33:0] region_start_addr[PMPNumRegions];
+  logic [33:PMPGranularity+2] region_addr_mask[PMPNumRegions];
+  logic [PMPNumChan-1:0][PMPNumRegions-1:0] region_match_gt;
+  logic [PMPNumChan-1:0][PMPNumRegions-1:0] region_match_lt;
+  logic [PMPNumChan-1:0][PMPNumRegions-1:0] region_match_eq;
+  logic [PMPNumChan-1:0][PMPNumRegions-1:0] region_match_all;
+  logic [PMPNumChan-1:0][PMPNumRegions-1:0] region_perm_check;
+  logic [PMPNumChan-1:0] access_fault;
 
 
   // ---------------
@@ -48,14 +48,14 @@ module ibex_pmp #(
     // Start address for TOR matching
     if (r == 0) begin : g_entry0
       assign region_start_addr[r] = (csr_pmp_cfg_i[r].mode == PMP_MODE_TOR) ? 34'h000000000 :
-                                                                              csr_pmp_addr_i[r];
+          csr_pmp_addr_i[r];
     end else begin : g_oth
-      assign region_start_addr[r] = (csr_pmp_cfg_i[r].mode == PMP_MODE_TOR) ? csr_pmp_addr_i[r-1] :
-                                                                              csr_pmp_addr_i[r];
+      assign region_start_addr[r] = (csr_pmp_cfg_i[r].mode == PMP_MODE_TOR) ?
+          csr_pmp_addr_i[r - 1] : csr_pmp_addr_i[r];
     end
     // Address mask for NA matching
-    for (genvar b = PMPGranularity+2; b < 34; b++) begin : g_bitmask
-      if (b == PMPGranularity+2) begin : g_bit0
+    for (genvar b = PMPGranularity + 2; b < 34; b++) begin : g_bitmask
+      if (b == PMPGranularity + 2) begin : g_bit0
         // Always mask bit (G+2) for NAPOT
         assign region_addr_mask[r][b] = (csr_pmp_cfg_i[r].mode != PMP_MODE_NAPOT);
       end else begin : g_others
@@ -85,14 +85,14 @@ module ibex_pmp #(
       always_comb begin
         region_match_all[c][r] = 1'b0;
         unique case (csr_pmp_cfg_i[r].mode)
-          PMP_MODE_OFF   : region_match_all[c][r] = 1'b0;
-          PMP_MODE_NA4   : region_match_all[c][r] = region_match_eq[c][r];
-          PMP_MODE_NAPOT : region_match_all[c][r] = region_match_eq[c][r];
-          PMP_MODE_TOR   : begin
+          PMP_MODE_OFF: region_match_all[c][r] = 1'b0;
+          PMP_MODE_NA4: region_match_all[c][r] = region_match_eq[c][r];
+          PMP_MODE_NAPOT: region_match_all[c][r] = region_match_eq[c][r];
+          PMP_MODE_TOR: begin
             region_match_all[c][r] = (region_match_eq[c][r] | region_match_gt[c][r]) &
-                                     region_match_lt[c][r];
+                region_match_lt[c][r];
           end
-          default        : region_match_all[c][r] = 1'b0;
+          default: region_match_all[c][r] = 1'b0;
         endcase
       end
 
@@ -110,7 +110,7 @@ module ibex_pmp #(
 
       // PMP entries are statically prioritized, from 0 to N-1
       // The lowest-numbered PMP entry which matches an address determines accessability
-      for (int r = PMPNumRegions-1; r >= 0; r--) begin
+      for (int r = PMPNumRegions - 1; r >= 0; r--) begin
         if (region_match_all[c][r]) begin
           access_fault[c] = (priv_mode_i[c] == PRIV_LVL_M) ?
               // For M-mode, any region which matches with the L-bit clear, or with sufficient

--- a/rtl/ibex_prefetch_buffer.sv
+++ b/rtl/ibex_prefetch_buffer.sv
@@ -41,28 +41,28 @@ module ibex_prefetch_buffer (
     output logic        busy_o
 );
 
-  localparam int unsigned NUM_REQS  = 2;
+  localparam int unsigned NUM_REQS = 2;
 
-  logic                branch_suppress;
-  logic                valid_new_req, valid_req;
-  logic                valid_req_d, valid_req_q;
-  logic                discard_req_d, discard_req_q;
-  logic                gnt_or_pmp_err, rvalid_or_pmp_err;
+  logic branch_suppress;
+  logic valid_new_req, valid_req;
+  logic valid_req_d, valid_req_q;
+  logic discard_req_d, discard_req_q;
+  logic gnt_or_pmp_err, rvalid_or_pmp_err;
   logic [NUM_REQS-1:0] rdata_outstanding_n, rdata_outstanding_s, rdata_outstanding_q;
   logic [NUM_REQS-1:0] branch_discard_n, branch_discard_s, branch_discard_q;
   logic [NUM_REQS-1:0] rdata_pmp_err_n, rdata_pmp_err_s, rdata_pmp_err_q;
   logic [NUM_REQS-1:0] rdata_outstanding_rev;
 
-  logic [31:0]         stored_addr_d, stored_addr_q;
-  logic                stored_addr_en;
-  logic [31:0]         fetch_addr_d, fetch_addr_q;
-  logic                fetch_addr_en;
-  logic [31:0]         instr_addr, instr_addr_w_aligned;
-  logic                instr_or_pmp_err;
+  logic [31:0] stored_addr_d, stored_addr_q;
+  logic stored_addr_en;
+  logic [31:0] fetch_addr_d, fetch_addr_q;
+  logic fetch_addr_en;
+  logic [31:0] instr_addr, instr_addr_w_aligned;
+  logic instr_or_pmp_err;
 
-  logic                fifo_valid;
-  logic                fifo_ready;
-  logic                fifo_clear;
+  logic fifo_valid;
+  logic fifo_ready;
+  logic fifo_clear;
   logic [NUM_REQS-1:0] fifo_busy;
 
   ////////////////////////////
@@ -86,7 +86,7 @@ module ibex_prefetch_buffer (
 
   // Reversed version of rdata_outstanding_q which can be overlaid with fifo fill state
   for (genvar i = 0; i < NUM_REQS; i++) begin : gen_rd_rev
-    assign rdata_outstanding_rev[i] = rdata_outstanding_q[NUM_REQS-1-i];
+    assign rdata_outstanding_rev[i] = rdata_outstanding_q[NUM_REQS - 1 - i];
   end
 
   // The fifo is ready to accept a new request if it is not full - including space reserved for
@@ -124,8 +124,8 @@ module ibex_prefetch_buffer (
   assign branch_suppress = branch_spec_i & ~branch_i;
 
   // Make a new request any time there is space in the FIFO, and space in the request queue
-  assign valid_new_req = ~branch_suppress & req_i & (fifo_ready | branch_i) &
-                         ~rdata_outstanding_q[NUM_REQS-1];
+  assign valid_new_req =
+      ~branch_suppress & req_i & (fifo_ready | branch_i) & ~rdata_outstanding_q[NUM_REQS - 1];
 
   assign valid_req = valid_req_q | valid_new_req;
 
@@ -189,9 +189,7 @@ module ibex_prefetch_buffer (
   end
 
   // Address mux
-  assign instr_addr = valid_req_q   ? stored_addr_q :
-                      branch_spec_i ? addr_i :
-                                      fetch_addr_q;
+  assign instr_addr = valid_req_q ? stored_addr_q : branch_spec_i ? addr_i : fetch_addr_q;
 
   assign instr_addr_w_aligned = {instr_addr[31:2], 2'b00};
 
@@ -204,39 +202,36 @@ module ibex_prefetch_buffer (
     if (i == 0) begin : g_req0
       // A request becomes outstanding once granted, and is cleared once the rvalid is received.
       // Outstanding requests shift down the queue towards entry 0.
-      assign rdata_outstanding_n[i] = (valid_req & gnt_or_pmp_err) |
-                                      rdata_outstanding_q[i];
+      assign rdata_outstanding_n[i] = (valid_req & gnt_or_pmp_err) | rdata_outstanding_q[i];
       // If a branch is received at any point while a request is outstanding, it must be tracked
       // to ensure we discard the data once received
-      assign branch_discard_n[i]    = (valid_req & gnt_or_pmp_err & discard_req_d) |
-                                      (branch_i & rdata_outstanding_q[i]) | branch_discard_q[i];
+      assign branch_discard_n[i] = (valid_req & gnt_or_pmp_err & discard_req_d) | (
+          branch_i & rdata_outstanding_q[i]) | branch_discard_q[i];
       // Record whether this request received a PMP error
-      assign rdata_pmp_err_n[i]     = (valid_req & ~rdata_outstanding_q[i] & instr_pmp_err_i) |
-                                      rdata_pmp_err_q[i];
+      assign rdata_pmp_err_n[i] = (valid_req & ~rdata_outstanding_q[i] & instr_pmp_err_i) |
+          rdata_pmp_err_q[i];
 
     end else begin : g_reqtop
-    // Entries > 0 consider the FIFO fill state to calculate their next state (by checking
-    // whether the previous entry is valid)
+      // Entries > 0 consider the FIFO fill state to calculate their next state (by checking
+      // whether the previous entry is valid)
 
-      assign rdata_outstanding_n[i] = (valid_req & gnt_or_pmp_err &
-                                       rdata_outstanding_q[i-1]) |
-                                      rdata_outstanding_q[i];
-      assign branch_discard_n[i]    = (valid_req & gnt_or_pmp_err & discard_req_d &
-                                       rdata_outstanding_q[i-1]) |
-                                      (branch_i & rdata_outstanding_q[i]) | branch_discard_q[i];
-      assign rdata_pmp_err_n[i]     = (valid_req & ~rdata_outstanding_q[i] & instr_pmp_err_i &
-                                       rdata_outstanding_q[i-1]) |
-                                      rdata_pmp_err_q[i];
+      assign rdata_outstanding_n[i] = (valid_req & gnt_or_pmp_err & rdata_outstanding_q[i - 1]) |
+          rdata_outstanding_q[i];
+      assign branch_discard_n[i] =
+          (valid_req & gnt_or_pmp_err & discard_req_d & rdata_outstanding_q[i - 1]) | (
+          branch_i & rdata_outstanding_q[i]) | branch_discard_q[i];
+      assign rdata_pmp_err_n[i] = (valid_req & ~rdata_outstanding_q[i] & instr_pmp_err_i &
+                                   rdata_outstanding_q[i - 1]) | rdata_pmp_err_q[i];
     end
   end
 
   // Shift the entries down on each instr_rvalid_i
-  assign rdata_outstanding_s = rvalid_or_pmp_err ? {1'b0,rdata_outstanding_n[NUM_REQS-1:1]} :
-                                                   rdata_outstanding_n;
-  assign branch_discard_s    = rvalid_or_pmp_err ? {1'b0,branch_discard_n[NUM_REQS-1:1]} :
-                                                   branch_discard_n;
-  assign rdata_pmp_err_s     = rvalid_or_pmp_err ? {1'b0,rdata_pmp_err_n[NUM_REQS-1:1]} :
-                                                   rdata_pmp_err_n;
+  assign rdata_outstanding_s =
+      rvalid_or_pmp_err ? {1'b0, rdata_outstanding_n[NUM_REQS - 1:1]} : rdata_outstanding_n;
+  assign branch_discard_s =
+      rvalid_or_pmp_err ? {1'b0, branch_discard_n[NUM_REQS - 1:1]} : branch_discard_n;
+  assign rdata_pmp_err_s =
+      rvalid_or_pmp_err ? {1'b0, rdata_pmp_err_n[NUM_REQS - 1:1]} : rdata_pmp_err_n;
 
   // Push a new entry to the FIFO once complete (and not cancelled by a branch)
   assign fifo_valid = rvalid_or_pmp_err & ~branch_discard_q[0];
@@ -247,17 +242,17 @@ module ibex_prefetch_buffer (
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      valid_req_q          <= 1'b0;
-      discard_req_q        <= 1'b0;
-      rdata_outstanding_q  <= 'b0;
-      branch_discard_q     <= 'b0;
-      rdata_pmp_err_q      <= 'b0;
+      valid_req_q <= 1'b0;
+      discard_req_q <= 1'b0;
+      rdata_outstanding_q <= 'b0;
+      branch_discard_q <= 'b0;
+      rdata_pmp_err_q <= 'b0;
     end else begin
-      valid_req_q          <= valid_req_d;
-      discard_req_q        <= discard_req_d;
-      rdata_outstanding_q  <= rdata_outstanding_s;
-      branch_discard_q     <= branch_discard_s;
-      rdata_pmp_err_q      <= rdata_pmp_err_s;
+      valid_req_q <= valid_req_d;
+      discard_req_q <= discard_req_d;
+      rdata_outstanding_q <= rdata_outstanding_s;
+      branch_discard_q <= branch_discard_s;
+      rdata_pmp_err_q <= rdata_pmp_err_s;
     end
   end
 
@@ -265,7 +260,7 @@ module ibex_prefetch_buffer (
   // Outputs //
   /////////////
 
-  assign instr_req_o  = valid_req;
+  assign instr_req_o = valid_req;
   assign instr_addr_o = instr_addr_w_aligned;
 
 endmodule

--- a/rtl/ibex_register_file_ff.sv
+++ b/rtl/ibex_register_file_ff.sv
@@ -56,7 +56,7 @@ module ibex_register_file #(
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
         rf_reg_q[i] <= '0;
-      end else if(we_a_dec[i]) begin
+      end else if (we_a_dec[i]) begin
         rf_reg_q[i] <= wdata_a_i;
       end
     end
@@ -65,7 +65,7 @@ module ibex_register_file #(
   // With dummy instructions enabled, R0 behaves as a real register but will always return 0 for
   // real instructions.
   if (DummyInstructions) begin : g_dummy_r0
-    logic        we_r0_dummy;
+    logic we_r0_dummy;
     logic [31:0] rf_r0_q;
 
     // Write enable for dummy R0 register (waddr_a_i will always be 0 for dummy instructions)
@@ -90,7 +90,7 @@ module ibex_register_file #(
     assign rf_reg[0] = '0;
   end
 
-  assign rf_reg[NUM_WORDS-1:1] = rf_reg_q[NUM_WORDS-1:1];
+  assign rf_reg[NUM_WORDS - 1:1] = rf_reg_q[NUM_WORDS - 1:1];
 
   assign rdata_a_o = rf_reg[raddr_a_i];
   assign rdata_b_o = rf_reg[raddr_b_i];

--- a/rtl/ibex_tracer_pkg.sv
+++ b/rtl/ibex_tracer_pkg.sv
@@ -4,299 +4,299 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package ibex_tracer_pkg;
-import ibex_pkg::*;
+  import ibex_pkg::*;
 
-parameter logic [1:0] OPCODE_C0 = 2'b00;
-parameter logic [1:0] OPCODE_C1 = 2'b01;
-parameter logic [1:0] OPCODE_C2 = 2'b10;
+  parameter logic [1:0] OPCODE_C0 = 2'b00;
+  parameter logic [1:0] OPCODE_C1 = 2'b01;
+  parameter logic [1:0] OPCODE_C2 = 2'b10;
 
-// instruction masks (for tracer)
-parameter logic [31:0] INSN_LUI     = { 25'h?,                           {OPCODE_LUI  } };
-parameter logic [31:0] INSN_AUIPC   = { 25'h?,                           {OPCODE_AUIPC} };
-parameter logic [31:0] INSN_JAL     = { 25'h?,                           {OPCODE_JAL  } };
-parameter logic [31:0] INSN_JALR    = { 17'h?,             3'b000, 5'h?, {OPCODE_JALR } };
+  // instruction masks (for tracer)
+  parameter logic [31:0] INSN_LUI     = { 25'h?,                           {OPCODE_LUI  } };
+  parameter logic [31:0] INSN_AUIPC   = { 25'h?,                           {OPCODE_AUIPC} };
+  parameter logic [31:0] INSN_JAL     = { 25'h?,                           {OPCODE_JAL  } };
+  parameter logic [31:0] INSN_JALR    = { 17'h?,             3'b000, 5'h?, {OPCODE_JALR } };
 
-// BRANCH
-parameter logic [31:0] INSN_BEQ     = { 17'h?,             3'b000, 5'h?, {OPCODE_BRANCH} };
-parameter logic [31:0] INSN_BNE     = { 17'h?,             3'b001, 5'h?, {OPCODE_BRANCH} };
-parameter logic [31:0] INSN_BLT     = { 17'h?,             3'b100, 5'h?, {OPCODE_BRANCH} };
-parameter logic [31:0] INSN_BGE     = { 17'h?,             3'b101, 5'h?, {OPCODE_BRANCH} };
-parameter logic [31:0] INSN_BLTU    = { 17'h?,             3'b110, 5'h?, {OPCODE_BRANCH} };
-parameter logic [31:0] INSN_BGEU    = { 17'h?,             3'b111, 5'h?, {OPCODE_BRANCH} };
-parameter logic [31:0] INSN_BALL    = { 17'h?,             3'b010, 5'h?, {OPCODE_BRANCH} };
+  // BRANCH
+  parameter logic [31:0] INSN_BEQ     = { 17'h?,             3'b000, 5'h?, {OPCODE_BRANCH} };
+  parameter logic [31:0] INSN_BNE     = { 17'h?,             3'b001, 5'h?, {OPCODE_BRANCH} };
+  parameter logic [31:0] INSN_BLT     = { 17'h?,             3'b100, 5'h?, {OPCODE_BRANCH} };
+  parameter logic [31:0] INSN_BGE     = { 17'h?,             3'b101, 5'h?, {OPCODE_BRANCH} };
+  parameter logic [31:0] INSN_BLTU    = { 17'h?,             3'b110, 5'h?, {OPCODE_BRANCH} };
+  parameter logic [31:0] INSN_BGEU    = { 17'h?,             3'b111, 5'h?, {OPCODE_BRANCH} };
+  parameter logic [31:0] INSN_BALL    = { 17'h?,             3'b010, 5'h?, {OPCODE_BRANCH} };
 
-// OPIMM
-parameter logic [31:0] INSN_ADDI    = { 17'h?,             3'b000, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SLTI    = { 17'h?,             3'b010, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SLTIU   = { 17'h?,             3'b011, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_XORI    = { 17'h?,             3'b100, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORI     = { 17'h?,             3'b110, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ANDI    = { 17'h?,             3'b111, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SLLI    = { 7'b0000000, 10'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SRLI    = { 7'b0000000, 10'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SRAI    = { 7'b0100000, 10'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  // OPIMM
+  parameter logic [31:0] INSN_ADDI    = { 17'h?,             3'b000, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_SLTI    = { 17'h?,             3'b010, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_SLTIU   = { 17'h?,             3'b011, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_XORI    = { 17'h?,             3'b100, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORI     = { 17'h?,             3'b110, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ANDI    = { 17'h?,             3'b111, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_SLLI    = { 7'b0000000, 10'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_SRLI    = { 7'b0000000, 10'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_SRAI    = { 7'b0100000, 10'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 
-// OP
-parameter logic [31:0] INSN_ADD     = { 7'b0000000, 10'h?, 3'b000, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SUB     = { 7'b0100000, 10'h?, 3'b000, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SLL     = { 7'b0000000, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SLT     = { 7'b0000000, 10'h?, 3'b010, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SLTU    = { 7'b0000000, 10'h?, 3'b011, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_XOR     = { 7'b0000000, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SRL     = { 7'b0000000, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SRA     = { 7'b0100000, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_OR      = { 7'b0000000, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_AND     = { 7'b0000000, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
+  // OP
+  parameter logic [31:0] INSN_ADD     = { 7'b0000000, 10'h?, 3'b000, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SUB     = { 7'b0100000, 10'h?, 3'b000, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SLL     = { 7'b0000000, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SLT     = { 7'b0000000, 10'h?, 3'b010, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SLTU    = { 7'b0000000, 10'h?, 3'b011, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_XOR     = { 7'b0000000, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SRL     = { 7'b0000000, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SRA     = { 7'b0100000, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_OR      = { 7'b0000000, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_AND     = { 7'b0000000, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
 
-// SYSTEM
-parameter logic [31:0] INSN_CSRRW   = { 17'h?,             3'b001, 5'h?, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_CSRRS   = { 17'h?,             3'b010, 5'h?, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_CSRRC   = { 17'h?,             3'b011, 5'h?, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_CSRRWI  = { 17'h?,             3'b101, 5'h?, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_CSRRSI  = { 17'h?,             3'b110, 5'h?, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_CSRRCI  = { 17'h?,             3'b111, 5'h?, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_ECALL   = { 12'b000000000000,         13'b0, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_EBREAK  = { 12'b000000000001,         13'b0, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_MRET    = { 12'b001100000010,         13'b0, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_DRET    = { 12'b011110110010,         13'b0, {OPCODE_SYSTEM} };
-parameter logic [31:0] INSN_WFI     = { 12'b000100000101,         13'b0, {OPCODE_SYSTEM} };
+  // SYSTEM
+  parameter logic [31:0] INSN_CSRRW   = { 17'h?,             3'b001, 5'h?, {OPCODE_SYSTEM} };
+  parameter logic [31:0] INSN_CSRRS   = { 17'h?,             3'b010, 5'h?, {OPCODE_SYSTEM} };
+  parameter logic [31:0] INSN_CSRRC   = { 17'h?,             3'b011, 5'h?, {OPCODE_SYSTEM} };
+  parameter logic [31:0] INSN_CSRRWI  = { 17'h?,             3'b101, 5'h?, {OPCODE_SYSTEM} };
+  parameter logic [31:0] INSN_CSRRSI  = { 17'h?,             3'b110, 5'h?, {OPCODE_SYSTEM} };
+  parameter logic [31:0] INSN_CSRRCI  = { 17'h?,             3'b111, 5'h?, {OPCODE_SYSTEM} };
+  parameter logic [31:0] INSN_ECALL   = { 12'b000000000000,         13'b0, {OPCODE_SYSTEM} };
+  parameter logic [31:0] INSN_EBREAK  = { 12'b000000000001,         13'b0, {OPCODE_SYSTEM} };
+  parameter logic [31:0] INSN_MRET    = { 12'b001100000010,         13'b0, {OPCODE_SYSTEM} };
+  parameter logic [31:0] INSN_DRET    = { 12'b011110110010,         13'b0, {OPCODE_SYSTEM} };
+  parameter logic [31:0] INSN_WFI     = { 12'b000100000101,         13'b0, {OPCODE_SYSTEM} };
 
-// RV32M
-parameter logic [31:0] INSN_DIV     = { 7'b0000001, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_DIVU    = { 7'b0000001, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_REM     = { 7'b0000001, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_REMU    = { 7'b0000001, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PMUL    = { 7'b0000001, 10'h?, 3'b000, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PMUH    = { 7'b0000001, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PMULHSU = { 7'b0000001, 10'h?, 3'b010, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PMULHU  = { 7'b0000001, 10'h?, 3'b011, 5'h?, {OPCODE_OP} };
+  // RV32M
+  parameter logic [31:0] INSN_DIV     = { 7'b0000001, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_DIVU    = { 7'b0000001, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_REM     = { 7'b0000001, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_REMU    = { 7'b0000001, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_PMUL    = { 7'b0000001, 10'h?, 3'b000, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_PMUH    = { 7'b0000001, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_PMULHSU = { 7'b0000001, 10'h?, 3'b010, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_PMULHU  = { 7'b0000001, 10'h?, 3'b011, 5'h?, {OPCODE_OP} };
 
-// RV32B
-// ZBB
-parameter logic [31:0] INSN_SLOI = { 5'b00100        , 12'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SROI = { 5'b00100        , 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_RORI = { 5'b01100        , 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CLZ  = { 12'b011000000000, 5'h?,  3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CTZ  = { 12'b011000000001, 5'h?,  3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_PCNT = { 12'b011000000010, 5'h?,  3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SEXTB = { 12'b011000000100, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SEXTH = { 12'b011000000101, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-// sext -- pseudoinstruction: andi rd, rs 255
-parameter logic [31:0] INSN_ZEXTB = { 4'b0000, 8'b11111111, 5'h?, 3'b111, 5'h?, {OPCODE_OP_IMM} };
-// sext -- pseudoinstruction: pack rd, rs zero
-parameter logic [31:0] INSN_ZEXTH = { 7'b0000100, 5'b00000, 5'h?, 3'b100, 5'h?, {OPCODE_OP} };
+  // RV32B
+  // ZBB
+  parameter logic [31:0] INSN_SLOI = { 5'b00100        , 12'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_SROI = { 5'b00100        , 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_RORI = { 5'b01100        , 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_CLZ  = { 12'b011000000000, 5'h?,  3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_CTZ  = { 12'b011000000001, 5'h?,  3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_PCNT = { 12'b011000000010, 5'h?,  3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_SEXTB = { 12'b011000000100, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_SEXTH = { 12'b011000000101, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  // sext -- pseudoinstruction: andi rd, rs 255
+  parameter logic [31:0] INSN_ZEXTB = { 4'b0000, 8'b11111111, 5'h?, 3'b111, 5'h?, {OPCODE_OP_IMM} };
+  // sext -- pseudoinstruction: pack rd, rs zero
+  parameter logic [31:0] INSN_ZEXTH = { 7'b0000100, 5'b00000, 5'h?, 3'b100, 5'h?, {OPCODE_OP} };
 
-parameter logic [31:0] INSN_SLO   = { 7'b0010000, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SRO   = { 7'b0010000, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_ROL   = { 7'b0110000, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_ROR   = { 7'b0110000, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_MIN   = { 7'b0000101, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_MAX   = { 7'b0000101, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_MINU  = { 7'b0000101, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_MAXU  = { 7'b0000101, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_XNOR  = { 7'b0100000, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_ORN   = { 7'b0100000, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_ANDN  = { 7'b0100000, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PACK  = { 7'b0000100, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PACKU = { 7'b0100100, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_PACKH = { 7'b0000100, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SLO   = { 7'b0010000, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SRO   = { 7'b0010000, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_ROL   = { 7'b0110000, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_ROR   = { 7'b0110000, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_MIN   = { 7'b0000101, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_MAX   = { 7'b0000101, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_MINU  = { 7'b0000101, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_MAXU  = { 7'b0000101, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_XNOR  = { 7'b0100000, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_ORN   = { 7'b0100000, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_ANDN  = { 7'b0100000, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_PACK  = { 7'b0000100, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_PACKU = { 7'b0100100, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_PACKH = { 7'b0000100, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
 
-// ZBS
-parameter logic [31:0] INSN_SBCLRI = { 5'b01001, 12'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SBSETI = { 5'b00101, 12'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SBINVI = { 5'b01101, 12'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_SBEXTI = { 5'b01001, 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  // ZBS
+  parameter logic [31:0] INSN_SBCLRI = { 5'b01001, 12'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_SBSETI = { 5'b00101, 12'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_SBINVI = { 5'b01101, 12'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_SBEXTI = { 5'b01001, 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 
-parameter logic [31:0] INSN_SBCLR = { 7'b0100100, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SBSET = { 7'b0010100, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SBINV = { 7'b0110100, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SBEXT = { 7'b0100100, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SBCLR = { 7'b0100100, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SBSET = { 7'b0010100, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SBINV = { 7'b0110100, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SBEXT = { 7'b0100100, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
 
-// ZBP
-// grevi
-parameter logic [31:0] INSN_GREVI = { 5'b01101, 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-// grevi -- pseudo-instructions
-parameter logic [31:0] INSN_REV_P =
-    { 5'b01101, 2'h?, 5'b00001, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV2_N =
-    { 5'b01101, 2'h?, 5'b00010, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV_N =
-    { 5'b01101, 2'h?, 5'b00011, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV4_B =
-    { 5'b01101, 2'h?, 5'b00100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV2_B =
-    { 5'b01101, 2'h?, 5'b00110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV_B =
-    { 5'b01101, 2'h?, 5'b00111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV8_H =
-    { 5'b01101, 2'h?, 5'b01000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV4_H =
-    { 5'b01101, 2'h?, 5'b01100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV2_H =
-    { 5'b01101, 2'h?, 5'b01110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV_H =
-    { 5'b01101, 2'h?, 5'b01111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV16 =
-    { 5'b01101, 2'h?, 5'b01000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV8 =
-    { 5'b01101, 2'h?, 5'b11000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV4 =
-    { 5'b01101, 2'h?, 5'b11100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV2 =
-    { 5'b01101, 2'h?, 5'b11110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_REV =
-    { 5'b01101, 2'h?, 5'b11111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-// gorci
-parameter logic [31:0] INSN_GORCI = { 5'b00101, 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-// gorci -- pseudo-instructions
-parameter logic [31:0] INSN_ORC_P =
-    { 5'b00101, 2'h?, 5'b00001, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC2_N =
-    { 5'b00101, 2'h?, 5'b00010, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC_N =
-    { 5'b00101, 2'h?, 5'b00011, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC4_B =
-    { 5'b00101, 2'h?, 5'b00100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC2_B =
-    { 5'b00101, 2'h?, 5'b00110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC_B =
-    { 5'b00101, 2'h?, 5'b00111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC8_H =
-    { 5'b00101, 2'h?, 5'b01000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC4_H =
-    { 5'b00101, 2'h?, 5'b01100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC2_H =
-    { 5'b00101, 2'h?, 5'b01110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC_H =
-    { 5'b00101, 2'h?, 5'b01111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC16 =
-    { 5'b00101, 2'h?, 5'b01000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC8 =
-    { 5'b00101, 2'h?, 5'b11000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC4 =
-    { 5'b00101, 2'h?, 5'b11100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC2 =
-    { 5'b00101, 2'h?, 5'b11110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ORC =
-    { 5'b00101, 2'h?, 5'b11111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-// shfli
-parameter logic [31:0] INSN_SHFLI = { 6'b000010, 11'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-// shfli -- pseudo-instructions
-parameter logic [31:0] INSN_ZIP_N =
-    { 5'b00010, 3'h?, 4'b0001, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ZIP2_B =
-    { 5'b00010, 3'h?, 4'b0010, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ZIP_B =
-    { 5'b00010, 3'h?, 4'b0011, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ZIP4_H =
-    { 5'b00010, 3'h?, 4'b0100, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ZIP2_H =
-    { 5'b00010, 3'h?, 4'b0110, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ZIP_H =
-    { 5'b00010, 3'h?, 4'b0111, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ZIP8 =
-    { 5'b00010, 3'h?, 4'b1000, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ZIP4 =
-    { 5'b00010, 3'h?, 4'b1100, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ZIP2 =
-    { 5'b00010, 3'h?, 4'b1110, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_ZIP =
-    { 5'b00010, 3'h?, 4'b1111, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
-// unshfli
-parameter logic [31:0] INSN_UNSHFLI = { 6'b000010, 11'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-// unshfli -- pseudo-instructions
-parameter logic [31:0] INSN_UNZIP_N =
-    { 5'b00010, 3'h?, 4'b0001, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_UNZIP2_B =
-    { 5'b00010, 3'h?, 4'b0010, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_UNZIP_B =
-    { 5'b00010, 3'h?, 4'b0011, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_UNZIP4_H =
-    { 5'b00010, 3'h?, 4'b0100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_UNZIP2_H =
-    { 5'b00010, 3'h?, 4'b0110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_UNZIP_H =
-    { 5'b00010, 3'h?, 4'b0111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_UNZIP8 =
-    { 5'b00010, 3'h?, 4'b1000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_UNZIP4 =
-    { 5'b00010, 3'h?, 4'b1100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_UNZIP2 =
-    { 5'b00010, 3'h?, 4'b1110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_UNZIP =
-    { 5'b00010, 3'h?, 4'b1111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  // ZBP
+  // grevi
+  parameter logic [31:0] INSN_GREVI = { 5'b01101, 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  // grevi -- pseudo-instructions
+  parameter logic [31:0] INSN_REV_P =
+      { 5'b01101, 2'h?, 5'b00001, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV2_N =
+      { 5'b01101, 2'h?, 5'b00010, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV_N =
+      { 5'b01101, 2'h?, 5'b00011, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV4_B =
+      { 5'b01101, 2'h?, 5'b00100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV2_B =
+      { 5'b01101, 2'h?, 5'b00110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV_B =
+      { 5'b01101, 2'h?, 5'b00111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV8_H =
+      { 5'b01101, 2'h?, 5'b01000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV4_H =
+      { 5'b01101, 2'h?, 5'b01100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV2_H =
+      { 5'b01101, 2'h?, 5'b01110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV_H =
+      { 5'b01101, 2'h?, 5'b01111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV16 =
+      { 5'b01101, 2'h?, 5'b01000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV8 =
+      { 5'b01101, 2'h?, 5'b11000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV4 =
+      { 5'b01101, 2'h?, 5'b11100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV2 =
+      { 5'b01101, 2'h?, 5'b11110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_REV =
+      { 5'b01101, 2'h?, 5'b11111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  // gorci
+  parameter logic [31:0] INSN_GORCI = { 5'b00101, 12'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  // gorci -- pseudo-instructions
+  parameter logic [31:0] INSN_ORC_P =
+      { 5'b00101, 2'h?, 5'b00001, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC2_N =
+      { 5'b00101, 2'h?, 5'b00010, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC_N =
+      { 5'b00101, 2'h?, 5'b00011, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC4_B =
+      { 5'b00101, 2'h?, 5'b00100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC2_B =
+      { 5'b00101, 2'h?, 5'b00110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC_B =
+      { 5'b00101, 2'h?, 5'b00111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC8_H =
+      { 5'b00101, 2'h?, 5'b01000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC4_H =
+      { 5'b00101, 2'h?, 5'b01100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC2_H =
+      { 5'b00101, 2'h?, 5'b01110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC_H =
+      { 5'b00101, 2'h?, 5'b01111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC16 =
+      { 5'b00101, 2'h?, 5'b01000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC8 =
+      { 5'b00101, 2'h?, 5'b11000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC4 =
+      { 5'b00101, 2'h?, 5'b11100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC2 =
+      { 5'b00101, 2'h?, 5'b11110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ORC =
+      { 5'b00101, 2'h?, 5'b11111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  // shfli
+  parameter logic [31:0] INSN_SHFLI = { 6'b000010, 11'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  // shfli -- pseudo-instructions
+  parameter logic [31:0] INSN_ZIP_N =
+      { 5'b00010, 3'h?, 4'b0001, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ZIP2_B =
+      { 5'b00010, 3'h?, 4'b0010, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ZIP_B =
+      { 5'b00010, 3'h?, 4'b0011, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ZIP4_H =
+      { 5'b00010, 3'h?, 4'b0100, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ZIP2_H =
+      { 5'b00010, 3'h?, 4'b0110, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ZIP_H =
+      { 5'b00010, 3'h?, 4'b0111, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ZIP8 =
+      { 5'b00010, 3'h?, 4'b1000, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ZIP4 =
+      { 5'b00010, 3'h?, 4'b1100, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ZIP2 =
+      { 5'b00010, 3'h?, 4'b1110, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_ZIP =
+      { 5'b00010, 3'h?, 4'b1111, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+  // unshfli
+  parameter logic [31:0] INSN_UNSHFLI = { 6'b000010, 11'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  // unshfli -- pseudo-instructions
+  parameter logic [31:0] INSN_UNZIP_N =
+      { 5'b00010, 3'h?, 4'b0001, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_UNZIP2_B =
+      { 5'b00010, 3'h?, 4'b0010, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_UNZIP_B =
+      { 5'b00010, 3'h?, 4'b0011, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_UNZIP4_H =
+      { 5'b00010, 3'h?, 4'b0100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_UNZIP2_H =
+      { 5'b00010, 3'h?, 4'b0110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_UNZIP_H =
+      { 5'b00010, 3'h?, 4'b0111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_UNZIP8 =
+      { 5'b00010, 3'h?, 4'b1000, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_UNZIP4 =
+      { 5'b00010, 3'h?, 4'b1100, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_UNZIP2 =
+      { 5'b00010, 3'h?, 4'b1110, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_UNZIP =
+      { 5'b00010, 3'h?, 4'b1111, 5'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 
-parameter logic [31:0] INSN_GREV   = { 7'b0110100, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_GORC   = { 7'b0010100, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_SHFL   = { 7'b0000100, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_UNSHFL = { 7'b0000100, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_GREV   = { 7'b0110100, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_GORC   = { 7'b0010100, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SHFL   = { 7'b0000100, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_UNSHFL = { 7'b0000100, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
 
-// ZBE
-parameter logic [31:0] INSN_BDEP = {7'b0100100, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_BEXT = {7'b0000100, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
+  // ZBE
+  parameter logic [31:0] INSN_BDEP = {7'b0100100, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_BEXT = {7'b0000100, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
 
-// ZBT
-parameter logic [31:0] INSN_FSRI = { 5'h?, 1'b1, 11'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
+  // ZBT
+  parameter logic [31:0] INSN_FSRI = { 5'h?, 1'b1, 11'h?, 3'b101, 5'h?, {OPCODE_OP_IMM} };
 
-parameter logic [31:0] INSN_CMIX = {5'h?, 2'b11, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_CMOV = {5'h?, 2'b11, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_FSL  = {5'h?, 2'b10, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_FSR  = {5'h?, 2'b10, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_CMIX = {5'h?, 2'b11, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_CMOV = {5'h?, 2'b11, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_FSL  = {5'h?, 2'b10, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_FSR  = {5'h?, 2'b10, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
 
-// ZBF
-parameter logic [31:0] INSN_BFP  = {7'b0100100, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
+  // ZBF
+  parameter logic [31:0] INSN_BFP  = {7'b0100100, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
 
-// ZBC
-parameter logic [31:0] INSN_CLMUL  = {7'b0000101, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_CLMULR = {7'b0000101, 10'h?, 3'b010, 5'h?, {OPCODE_OP} };
-parameter logic [31:0] INSN_CLMULH = {7'b0000101, 10'h?, 3'b011, 5'h?, {OPCODE_OP} };
+  // ZBC
+  parameter logic [31:0] INSN_CLMUL  = {7'b0000101, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_CLMULR = {7'b0000101, 10'h?, 3'b010, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_CLMULH = {7'b0000101, 10'h?, 3'b011, 5'h?, {OPCODE_OP} };
 
-// ZBR
-parameter logic [31:0] INSN_CRC32_B  = {7'b0110000, 5'b10000, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32_H  = {7'b0110000, 5'b10001, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32_W  = {7'b0110000, 5'b10010, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32C_B = {7'b0110000, 5'b11000, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32C_H = {7'b0110000, 5'b11001, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
-parameter logic [31:0] INSN_CRC32C_W = {7'b0110000, 5'b11010, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
+  // ZBR
+  parameter logic [31:0] INSN_CRC32_B  = {7'b0110000, 5'b10000, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_CRC32_H  = {7'b0110000, 5'b10001, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_CRC32_W  = {7'b0110000, 5'b10010, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_CRC32C_B = {7'b0110000, 5'b11000, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_CRC32C_H = {7'b0110000, 5'b11001, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
+  parameter logic [31:0] INSN_CRC32C_W = {7'b0110000, 5'b11010, 5'h?, 3'b001, 5'h?,  {OPCODE_OP_IMM} };
 
-// LOAD & STORE
-parameter logic [31:0] INSN_LOAD    = {25'h?,                            {OPCODE_LOAD } };
-parameter logic [31:0] INSN_STORE   = {25'h?,                            {OPCODE_STORE} };
+  // LOAD & STORE
+  parameter logic [31:0] INSN_LOAD    = {25'h?,                            {OPCODE_LOAD } };
+  parameter logic [31:0] INSN_STORE   = {25'h?,                            {OPCODE_STORE} };
 
-// MISC-MEM
-parameter logic [31:0] INSN_FENCE   = { 17'h?,             3'b000, 5'h?, {OPCODE_MISC_MEM} };
-parameter logic [31:0] INSN_FENCEI  = { 17'h0,             3'b001, 5'h0, {OPCODE_MISC_MEM} };
+  // MISC-MEM
+  parameter logic [31:0] INSN_FENCE   = { 17'h?,             3'b000, 5'h?, {OPCODE_MISC_MEM} };
+  parameter logic [31:0] INSN_FENCEI  = { 17'h0,             3'b001, 5'h0, {OPCODE_MISC_MEM} };
 
-// Compressed Instructions
-// C0
-parameter logic [15:0] INSN_CADDI4SPN  = { 3'b000,       11'h?,                    {OPCODE_C0} };
-parameter logic [15:0] INSN_CLW        = { 3'b010,       11'h?,                    {OPCODE_C0} };
-parameter logic [15:0] INSN_CSW        = { 3'b110,       11'h?,                    {OPCODE_C0} };
+  // Compressed Instructions
+  // C0
+  parameter logic [15:0] INSN_CADDI4SPN  = { 3'b000,       11'h?,                    {OPCODE_C0} };
+  parameter logic [15:0] INSN_CLW        = { 3'b010,       11'h?,                    {OPCODE_C0} };
+  parameter logic [15:0] INSN_CSW        = { 3'b110,       11'h?,                    {OPCODE_C0} };
 
-// C1
-parameter logic [15:0] INSN_CADDI      = { 3'b000,       11'h?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CJAL       = { 3'b001,       11'h?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CJ         = { 3'b101,       11'h?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CLI        = { 3'b010,       11'h?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CLUI       = { 3'b011,       11'h?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CBEQZ      = { 3'b110,       11'h?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CBNEZ      = { 3'b111,       11'h?,                    {OPCODE_C1} };
-parameter logic [15:0] INSN_CSRLI      = { 3'b100, 1'h?, 2'b00, 8'h?,              {OPCODE_C1} };
-parameter logic [15:0] INSN_CSRAI      = { 3'b100, 1'h?, 2'b01, 8'h?,              {OPCODE_C1} };
-parameter logic [15:0] INSN_CANDI      = { 3'b100, 1'h?, 2'b10, 8'h?,              {OPCODE_C1} };
-parameter logic [15:0] INSN_CSUB       = { 3'b100, 1'b0, 2'b11, 3'h?, 2'b00, 3'h?, {OPCODE_C1} };
-parameter logic [15:0] INSN_CXOR       = { 3'b100, 1'b0, 2'b11, 3'h?, 2'b01, 3'h?, {OPCODE_C1} };
-parameter logic [15:0] INSN_COR        = { 3'b100, 1'b0, 2'b11, 3'h?, 2'b10, 3'h?, {OPCODE_C1} };
-parameter logic [15:0] INSN_CAND       = { 3'b100, 1'b0, 2'b11, 3'h?, 2'b11, 3'h?, {OPCODE_C1} };
+  // C1
+  parameter logic [15:0] INSN_CADDI      = { 3'b000,       11'h?,                    {OPCODE_C1} };
+  parameter logic [15:0] INSN_CJAL       = { 3'b001,       11'h?,                    {OPCODE_C1} };
+  parameter logic [15:0] INSN_CJ         = { 3'b101,       11'h?,                    {OPCODE_C1} };
+  parameter logic [15:0] INSN_CLI        = { 3'b010,       11'h?,                    {OPCODE_C1} };
+  parameter logic [15:0] INSN_CLUI       = { 3'b011,       11'h?,                    {OPCODE_C1} };
+  parameter logic [15:0] INSN_CBEQZ      = { 3'b110,       11'h?,                    {OPCODE_C1} };
+  parameter logic [15:0] INSN_CBNEZ      = { 3'b111,       11'h?,                    {OPCODE_C1} };
+  parameter logic [15:0] INSN_CSRLI      = { 3'b100, 1'h?, 2'b00, 8'h?,              {OPCODE_C1} };
+  parameter logic [15:0] INSN_CSRAI      = { 3'b100, 1'h?, 2'b01, 8'h?,              {OPCODE_C1} };
+  parameter logic [15:0] INSN_CANDI      = { 3'b100, 1'h?, 2'b10, 8'h?,              {OPCODE_C1} };
+  parameter logic [15:0] INSN_CSUB       = { 3'b100, 1'b0, 2'b11, 3'h?, 2'b00, 3'h?, {OPCODE_C1} };
+  parameter logic [15:0] INSN_CXOR       = { 3'b100, 1'b0, 2'b11, 3'h?, 2'b01, 3'h?, {OPCODE_C1} };
+  parameter logic [15:0] INSN_COR        = { 3'b100, 1'b0, 2'b11, 3'h?, 2'b10, 3'h?, {OPCODE_C1} };
+  parameter logic [15:0] INSN_CAND       = { 3'b100, 1'b0, 2'b11, 3'h?, 2'b11, 3'h?, {OPCODE_C1} };
 
-// C2
-parameter logic [15:0] INSN_CSLLI      = { 3'b000,       11'h?,                    {OPCODE_C2} };
-parameter logic [15:0] INSN_CLWSP      = { 3'b010,       11'h?,                    {OPCODE_C2} };
-parameter logic [15:0] INSN_SWSP       = { 3'b110,       11'h?,                    {OPCODE_C2} };
-parameter logic [15:0] INSN_CMV        = { 3'b100, 1'b0, 10'h?,                    {OPCODE_C2} };
-parameter logic [15:0] INSN_CADD       = { 3'b100, 1'b1, 10'h?,                    {OPCODE_C2} };
-parameter logic [15:0] INSN_CEBREAK    = { 3'b100, 1'b1,        5'h0,  5'h0,       {OPCODE_C2} };
-parameter logic [15:0] INSN_CJR        = { 3'b100, 1'b0,        5'h0,  5'h0,       {OPCODE_C2} };
-parameter logic [15:0] INSN_CJALR      = { 3'b100, 1'b1,        5'h?,  5'h0,       {OPCODE_C2} };
+  // C2
+  parameter logic [15:0] INSN_CSLLI      = { 3'b000,       11'h?,                    {OPCODE_C2} };
+  parameter logic [15:0] INSN_CLWSP      = { 3'b010,       11'h?,                    {OPCODE_C2} };
+  parameter logic [15:0] INSN_SWSP       = { 3'b110,       11'h?,                    {OPCODE_C2} };
+  parameter logic [15:0] INSN_CMV        = { 3'b100, 1'b0, 10'h?,                    {OPCODE_C2} };
+  parameter logic [15:0] INSN_CADD       = { 3'b100, 1'b1, 10'h?,                    {OPCODE_C2} };
+  parameter logic [15:0] INSN_CEBREAK    = { 3'b100, 1'b1,        5'h0,  5'h0,       {OPCODE_C2} };
+  parameter logic [15:0] INSN_CJR        = { 3'b100, 1'b0,        5'h0,  5'h0,       {OPCODE_C2} };
+  parameter logic [15:0] INSN_CJALR      = { 3'b100, 1'b1,        5'h?,  5'h0,       {OPCODE_C2} };
 
 endpackage

--- a/rtl/ibex_wb_stage.sv
+++ b/rtl/ibex_wb_stage.sv
@@ -51,21 +51,21 @@ module ibex_wb_stage #(
 
   // 0 == RF write from ID
   // 1 == RF write from LSU
-  logic [31:0] rf_wdata_wb_mux    [2];
-  logic [1:0]  rf_wdata_wb_mux_we;
+  logic [31:0] rf_wdata_wb_mux[2];
+  logic [1:0] rf_wdata_wb_mux_we;
 
-  if(WritebackStage) begin : g_writeback_stage
-    logic [31:0]    rf_wdata_wb_q;
-    logic           rf_we_wb_q;
-    logic [4:0]     rf_waddr_wb_q;
+  if (WritebackStage) begin : g_writeback_stage
+    logic [31:0] rf_wdata_wb_q;
+    logic rf_we_wb_q;
+    logic [4:0] rf_waddr_wb_q;
 
-    logic           wb_done;
+    logic wb_done;
 
-    logic           wb_valid_q;
-    logic [31:0]    wb_pc_q;
+    logic wb_valid_q;
+    logic [31:0] wb_pc_q;
     wb_instr_type_e wb_instr_type_q;
 
-    logic           wb_valid_d;
+    logic wb_valid_d;
 
     // Stage becomes valid if an instruction enters for ID/EX and valid is cleared when instruction
     // is done
@@ -77,7 +77,7 @@ module ibex_wb_stage #(
     assign wb_done = (wb_instr_type_q == WB_INSTR_OTHER) | lsu_resp_valid_i;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
-      if(~rst_ni) begin
+      if (~rst_ni) begin
         wb_valid_q <= 1'b0;
       end else begin
         wb_valid_q <= wb_valid_d;
@@ -85,17 +85,17 @@ module ibex_wb_stage #(
     end
 
     always_ff @(posedge clk_i) begin
-      if(en_wb_i) begin
-        rf_we_wb_q      <= rf_we_id_i;
-        rf_waddr_wb_q   <= rf_waddr_id_i;
-        rf_wdata_wb_q   <= rf_wdata_id_i;
+      if (en_wb_i) begin
+        rf_we_wb_q <= rf_we_id_i;
+        rf_waddr_wb_q <= rf_waddr_id_i;
+        rf_wdata_wb_q <= rf_wdata_id_i;
         wb_instr_type_q <= instr_type_wb_i;
-        wb_pc_q         <= pc_id_i;
+        wb_pc_q <= pc_id_i;
       end
     end
 
-    assign rf_waddr_wb_o         = rf_waddr_wb_q;
-    assign rf_wdata_wb_mux[0]    = rf_wdata_wb_q;
+    assign rf_waddr_wb_o = rf_waddr_wb_q;
+    assign rf_wdata_wb_mux[0] = rf_wdata_wb_q;
     assign rf_wdata_wb_mux_we[0] = rf_we_wb_q & wb_valid_q;
 
     assign ready_wb_o = ~wb_valid_q | wb_done;
@@ -104,7 +104,7 @@ module ibex_wb_stage #(
     // is awaiting load data. This is used for determining RF read hazards in ID/EX
     assign rf_write_wb_o = wb_valid_q & (rf_we_wb_q | (wb_instr_type_q == WB_INSTR_LOAD));
 
-    assign outstanding_load_wb_o  = wb_valid_q & (wb_instr_type_q == WB_INSTR_LOAD);
+    assign outstanding_load_wb_o = wb_valid_q & (wb_instr_type_q == WB_INSTR_LOAD);
     assign outstanding_store_wb_o = wb_valid_q & (wb_instr_type_q == WB_INSTR_STORE);
 
     assign pc_wb_o = wb_pc_q;
@@ -117,45 +117,45 @@ module ibex_wb_stage #(
     assign rf_wdata_fwd_wb_o = rf_wdata_wb_q;
   end else begin : g_bypass_wb
     // without writeback stage just pass through register write signals
-    assign rf_waddr_wb_o         = rf_waddr_id_i;
-    assign rf_wdata_wb_mux[0]    = rf_wdata_id_i;
+    assign rf_waddr_wb_o = rf_waddr_id_i;
+    assign rf_wdata_wb_mux[0] = rf_wdata_id_i;
     assign rf_wdata_wb_mux_we[0] = rf_we_id_i;
 
     // ready needs to be constant 1 without writeback stage (otherwise ID/EX stage will stall)
-    assign ready_wb_o    = 1'b1;
+    assign ready_wb_o = 1'b1;
 
     // Unused Writeback stage only IO & wiring
     // Assign inputs and internal wiring to unused signals to satisfy lint checks
     // Tie-off outputs to constant values
-    logic           unused_clk;
-    logic           unused_rst;
-    logic           unused_en_wb;
+    logic unused_clk;
+    logic unused_rst;
+    logic unused_en_wb;
     wb_instr_type_e unused_instr_type_wb;
-    logic [31:0]    unused_pc_id;
-    logic           unused_lsu_resp_valid;
+    logic [31:0] unused_pc_id;
+    logic unused_lsu_resp_valid;
 
-    assign unused_clk            = clk_i;
-    assign unused_rst            = rst_ni;
-    assign unused_en_wb          = en_wb_i;
-    assign unused_instr_type_wb  = instr_type_wb_i;
-    assign unused_pc_id          = pc_id_i;
+    assign unused_clk = clk_i;
+    assign unused_rst = rst_ni;
+    assign unused_en_wb = en_wb_i;
+    assign unused_instr_type_wb = instr_type_wb_i;
+    assign unused_pc_id = pc_id_i;
     assign unused_lsu_resp_valid = lsu_resp_valid_i;
 
-    assign outstanding_load_wb_o  = 1'b0;
+    assign outstanding_load_wb_o = 1'b0;
     assign outstanding_store_wb_o = 1'b0;
-    assign pc_wb_o                = '0;
-    assign rf_write_wb_o          = 1'b0;
-    assign rf_wdata_fwd_wb_o      = 32'b0;
-    assign instr_done_wb_o        = 1'b0;
+    assign pc_wb_o = '0;
+    assign rf_write_wb_o = 1'b0;
+    assign rf_wdata_fwd_wb_o = 32'b0;
+    assign instr_done_wb_o = 1'b0;
   end
 
-  assign rf_wdata_wb_mux[1]    = rf_wdata_lsu_i;
+  assign rf_wdata_wb_mux[1] = rf_wdata_lsu_i;
   assign rf_wdata_wb_mux_we[1] = rf_we_lsu_i;
 
   // RF write data can come from ID results (all RF writes that aren't because of loads will come
   // from here) or the LSU (RF writes for load data)
   assign rf_wdata_wb_o = rf_wdata_wb_mux_we[0] ? rf_wdata_wb_mux[0] : rf_wdata_wb_mux[1];
-  assign rf_we_wb_o    = |rf_wdata_wb_mux_we;
+  assign rf_we_wb_o = |rf_wdata_wb_mux_we;
 
   `ASSERT(RFWriteFromOneSourceOnly, $onehot0(rf_wdata_wb_mux_we))
 endmodule


### PR DESCRIPTION
This commit is the first, incomplete run of Verible format on the source
code in the `rtl` directory. The goal is to get the "easy cases" out of
the way, the ones we agree on that the produced formatting is good
enough. This should leave us with the cases where we either don't agree
with the formatting produced by Verible format (either because it
violates the lowRISC style guide, or because it hurts readability), or
the cases where Verible format breaks down. Ultimately, we should be
able to reduce the diff between what verible-verilog-format produces,
and our code bases, iteratively to zero.

The commit doesn't contain all changes made by Verible format:
- All changes to module headers (parameters and port lists) have been
  excluded due to known formatting issues there.
- Many changes to case statements have been excluded, as there are a
  couple formatting issues and inconsistencies.
- Some assign statement changes have been excluded for too badly hurting
  readbility.
- Some other obvious misformattings have been corrected or excluded.

Most limitations of Verible format are tracked in
https://github.com/lowRISC/ibex/issues/687. Not all problems I've seen
have been filed upstream yet,

The diff contains a rather exhaustive list of changes which I
pre-filtered to remove the most obvious "ugly ones" (see above). That
still leaves a couple ones which are worth discussing:

- Verible doesn't use tabular style for blocks of signal definitions.
  Doing that would most likely be possible in an algorithmic way if we
  agree that readability is hurt too much by not doing it.
- Verible doesn't use tabular style for other assignment code. Doing
  that in a consistent, automated fashion is probably harder. Also, the
  readability trade-offs are different.

I invite you all to look at the diff and classify the changes:
- Changes you're OK with.
- Changes which might not be your preferred style, but are not too bad
  either.
- Changes which you think severely hurt readability, or are against the
  style guide.

I'll go through those comments and remove all contentious items from
the diff; we can then discuss them individually, also involving the
style guide team and the verible developers.

In general, the trade off is as follows: Verible format takes away the
arguing and manual formatting completely out of the code writing and
review process. We win a significant amount of time there. There will
always be cases where a manual formatting might be marginally better,
but expressing that into an automated formatting rule is (close to)
impossible. In those cases, we win by "swallowing the pill" of not fully
optimal styling, for the benefit of never having to think about styling
again (TM).