### PR TITLE
Only include necessary LFSR primitive

### DIFF
--- a/ibex_core.core
+++ b/ibex_core.core
@@ -10,9 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:assert
       - lowrisc:prim:clock_gating
-      # TODO: Only lfsr is needed. Replace with a more specific dependency
-      # once available.
-      - lowrisc:prim:all
+      - lowrisc:prim:lfsr
       - lowrisc:ibex:ibex_pkg
       - lowrisc:ibex:ibex_icache
     files:

--- a/vendor/lowrisc_ip.lock.hjson
+++ b/vendor/lowrisc_ip.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/opentitan
-    rev: 9ac4f9c8b924b79eb7d3581b29346a612f705751
+    rev: ebf4663b42a9d81d026db5821b5c8249d54f23a7
   }
 }

--- a/vendor/lowrisc_ip/prim/fpv/prim_lfsr_fpv.core
+++ b/vendor/lowrisc_ip/prim/fpv/prim_lfsr_fpv.core
@@ -3,11 +3,11 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:fpv:prim_lfsr_fpv:0.1"
-description: "ALERT_HANDLER FPV target"
+description: "LFSR primitive FPV target"
 filesets:
   files_formal:
     depend:
-      - lowrisc:prim:all
+      - lowrisc:prim:lfsr
     files:
       - tb/prim_lfsr_fpv.sv
     file_type: systemVerilogSource

--- a/vendor/lowrisc_ip/prim/prim.core
+++ b/vendor/lowrisc_ip/prim/prim.core
@@ -32,7 +32,6 @@ filesets:
       - rtl/prim_flop_2sync.sv
       - rtl/prim_sync_reqack.sv
       - rtl/prim_keccak.sv
-      - rtl/prim_lfsr.sv
       - rtl/prim_packer.sv
       - rtl/prim_cipher_pkg.sv
       - rtl/prim_present.sv

--- a/vendor/lowrisc_ip/prim/prim_lfsr.core
+++ b/vendor/lowrisc_ip/prim/prim_lfsr.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:lfsr:0.1"
+description: "A Linear-Feedback Shift Register (LFSR) primitive"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+    files:
+      - rtl/prim_lfsr.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl


### PR DESCRIPTION
We previously had a dependency on all primitives in Ibex, even though we 
only depend on the LFSR primitive. Now that there's a more fine-grained 
dependency available, we can use that.

This has the great benefit of restricting all lint tools to only the code
we're interested in, and not linting all primitives in OpenTitan together
with Ibex. This also helps tools like yosys, which aren't able to parse all
of OpenTitan's code yet.