### PR TITLE
Clarifications to the README of the simple system

### DIFF
--- a/examples/simple_system/README.md
+++ b/examples/simple_system/README.md
@@ -14,9 +14,13 @@ run stand-alone binaries. It contains:
 * [Verilator](https://www.veripool.org/wiki/verilator)
   Note Linux package managers may have Verilator but often a very old version
   that is not suitable. It is recommended Verilator is built from source.
-* [FuseSoC](https://github.com/olofk/fusesoc)
+* The Python dependencies of this repository.
+  Install them with `pip3 install -U python3-requirements.txt` from the
+  repository root.
 * RISC-V Compiler Toolchain - lowRISC provides a pre-built GCC based toolchain
   <https://github.com/lowRISC/lowrisc-toolchains/releases>
+* libelf and its development libraries.
+  On Debian/Ubuntu, install it by running `apt-get install libelf-dev`.
 
 ## Building Simulation
 
@@ -37,9 +41,9 @@ To build the hello world example, from the Ibex reposistory root run:
 make -C examples/sw/simple_system/hello_test
 ```
 
-This should create the file
-`examples/sw/simple_system/hello_test/hello_test.vmem` which is the memory
-initialisation file used to run the `hello_test` program.
+The compiled program is available at
+`examples/sw/simple_system/hello_test/hello_test.elf`. The same directory also
+contains a Verilog memory file (vmem file) to be used with some simulators.
 
 To build new software make a copy of the `hello_test` directory named as desired.
 Look inside the Makefile for further instructions.
@@ -53,11 +57,11 @@ correct compiler binaries.
 Having built the simulator and software, from the Ibex repository root run:
 
 ```
-./build/lowrisc_ibex_ibex_simple_system_0/sim-verilator/Vibex_simple_system [-t] --meminit=ram,<sw_vmem_file>
+./build/lowrisc_ibex_ibex_simple_system_0/sim-verilator/Vibex_simple_system [-t] --meminit=ram,<sw_elf_file>
 ```
 
-`<sw_vmem_file>` should be a path to a Verilog memory (vmem) file, or an ELF
-file built as described above. Use
+`<sw_elf_file>` should be a path to an ELF file  (or alternatively a vmem file)
+built as described above. Use
 `./examples/sw/simple_system/hello_test/hello_test.elf` to run the `hello_test`
 binary.
 
@@ -91,7 +95,7 @@ Compressed Instructions:    182
 The simulator produces several output files
 
 * `ibex_simple_system.log` - The ASCII output written via the output peripheral
-* `ibex_simple_system_pcount.csv` - A csv of the performance counters
+* `ibex_simple_system_pcount.csv` - A CSV of the performance counters
 * `trace_core_00000000.log` - An instruction trace of execution
 
 ## Simulating with Synopsys VCS
@@ -137,4 +141,3 @@ binary.
 | 0x30008             | RISC-V timer `mtimecmp` register                                                                       |
 | 0x3000C             | RISC-V timer `mtimecmph` register                                                                      |
 | 0x100000 – 0x1FFFFF | 1 MB memory for instruction and data. Execution starts at 0x100080, exception handler base is 0x100000 |
-


### PR DESCRIPTION
* Mention the need to install `libelf-dev`. Thanks to Bert Pieters for
  reporting this.
* Guide users to install our Python dependencies, including fusesoc and
  edalize, from `python-requirements.txt`, to ensure they have the
  right version.
* Prefer ELF files for Verilator simulations. This makes it easier to
  use existing ELF files from another software build system.

Fixes #1019