### PR TITLE
correct wrong assignment to enum

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -483,7 +483,7 @@ class core_ibex_directed_test extends core_ibex_debug_intr_basic_test;
     bit [12:0]                                    system_imm;
     instr_t                                       instr_fields;
 
-    opcode      = instr[6:0];
+    opcode      = ibex_pkg::opcode_e'(instr[6:0]);
     funct3      = instr[14:12];
     funct7      = instr[31:25];
     system_imm  = instr[31:20];


### PR DESCRIPTION
Hey!
Enum should be assignment only by enum type. LRM1800-2017 6.19.4: `A cast shall be required for an expression that is assigned to an enum variable where the type of the expression is not equivalent to the enumeration type of the variable.`