### PR TITLE
Fix some AscentLint warnings

### DIFF
--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -123,8 +123,8 @@ module ibex_core #(
   logic        instr_valid_id;
   logic        instr_new_id;
   logic [31:0] instr_rdata_id;                 // Instruction sampled inside IF stage
-  logic [31:0] instr_rdata_alu_id;             // Instruction sampled inside IF stage (replicated to ease
-                                               // fan-out)
+  logic [31:0] instr_rdata_alu_id;             // Instruction sampled inside IF stage (replicated to
+                                               // ease fan-out)
   logic [15:0] instr_rdata_c_id;               // Compressed instruction sampled inside IF stage
   logic        instr_is_compressed_id;
   logic        instr_fetch_err;                // Bus error on instr fetch
@@ -779,8 +779,10 @@ module ibex_core #(
   logic outstanding_load_id;
   logic outstanding_store_id;
 
-  assign outstanding_load_id  = id_stage_i.instr_executing & id_stage_i.lsu_req_dec & ~id_stage_i.lsu_we;
-  assign outstanding_store_id = id_stage_i.instr_executing & id_stage_i.lsu_req_dec &  id_stage_i.lsu_we;
+  assign outstanding_load_id  = id_stage_i.instr_executing & id_stage_i.lsu_req_dec &
+                                ~id_stage_i.lsu_we;
+  assign outstanding_store_id = id_stage_i.instr_executing & id_stage_i.lsu_req_dec &
+                                id_stage_i.lsu_we;
 
   if (WritebackStage) begin : gen_wb_stage
     // When the writeback stage is present a load/store could be in ID or WB. A Load/store in ID can

--- a/rtl/ibex_counter.sv
+++ b/rtl/ibex_counter.sv
@@ -56,7 +56,7 @@ module ibex_counter #(
 `endif
 
   // Counter flop
-  always @(`COUNTER_FLOP_RST) begin
+  always_ff @(`COUNTER_FLOP_RST) begin
     if (!rst_ni) begin
       counter_q <= '0;
     end else begin

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -862,7 +862,8 @@ module ibex_cs_registers #(
   // update enable signals
   always_comb begin : mcountinhibit_update
     if (mcountinhibit_we == 1'b1) begin
-      mcountinhibit_d = {csr_wdata_int[MHPMCounterNum+2:2], 1'b0, csr_wdata_int[0]}; // bit 1 must always be 0
+      // bit 1 must always be 0
+      mcountinhibit_d = {csr_wdata_int[MHPMCounterNum+2:2], 1'b0, csr_wdata_int[0]};
     end else begin
       mcountinhibit_d = mcountinhibit_q;
     end

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -877,7 +877,8 @@ module ibex_id_stage #(
     //   precise exceptions)
     // * There is a load/store request not being granted or which is unaligned and waiting to issue
     //   a second request (needs to stay in ID for the address calculation)
-    assign stall_mem = instr_valid_i & (outstanding_memory_access | (lsu_req_dec & ~lsu_req_done_i));
+    assign stall_mem = instr_valid_i &
+                       (outstanding_memory_access | (lsu_req_dec & ~lsu_req_done_i));
 
     // If we stall a load in ID for any reason, it must not make an LSU request
     // (otherwide we might issue two requests for the same instruction)
@@ -915,7 +916,8 @@ module ibex_id_stage #(
     // Stall ID/EX as instruction in ID/EX cannot proceed to writeback yet
     assign stall_wb = en_wb_o & ~ready_wb_i;
 
-    assign perf_dside_wait_o = instr_valid_i & ~instr_kill & (outstanding_memory_access | stall_ld_hz);
+    assign perf_dside_wait_o = instr_valid_i & ~instr_kill &
+                               (outstanding_memory_access | stall_ld_hz);
   end else begin : gen_no_stall_mem
 
     assign multicycle_done = lsu_req_dec ? lsu_resp_valid_i : ex_valid_i;


### PR DESCRIPTION
Fix some of the warnings seen in the nighly lint report at https://reports.opentitan.org/hw/ip/rv_core_ibex/lint/ascentlint/latest/results.html. 

I didn't even attempt to do this systematically, just a couple drive-by ones.