### PR TITLE
[dv/ibex] Switch to request/response terminology

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf.sv
@@ -20,7 +20,7 @@ interface ibex_mem_intf#(
   logic [DATA_WIDTH-1:0]   rdata;
   logic                    error;
 
-  clocking host_driver_cb @(posedge clk);
+  clocking request_driver_cb @(posedge clk);
     input   reset;
     output  request;
     input   grant;
@@ -33,7 +33,7 @@ interface ibex_mem_intf#(
     input   error;
   endclocking
 
-  clocking device_driver_cb @(posedge clk);
+  clocking response_driver_cb @(posedge clk);
     input   reset;
     input   request;
     output  grant;

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent.core
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent.core
@@ -11,14 +11,14 @@ filesets:
     files:
       - ibex_mem_intf.sv
       - ibex_mem_intf_agent_pkg.sv
-      - ibex_mem_intf_master_agent.sv: {is_include_file: true}
-      - ibex_mem_intf_master_driver.sv: {is_include_file: true}
+      - ibex_mem_intf_request_agent.sv: {is_include_file: true}
+      - ibex_mem_intf_request_driver.sv: {is_include_file: true}
       - ibex_mem_intf_monitor.sv: {is_include_file: true}
       - ibex_mem_intf_seq_item.sv: {is_include_file: true}
-      - ibex_mem_intf_slave_agent.sv: {is_include_file: true}
-      - ibex_mem_intf_slave_driver.sv: {is_include_file: true}
-      - ibex_mem_intf_slave_seq_lib.sv: {is_include_file: true}
-      - ibex_mem_intf_slave_sequencer.sv: {is_include_file: true}
+      - ibex_mem_intf_response_agent.sv: {is_include_file: true}
+      - ibex_mem_intf_response_driver.sv: {is_include_file: true}
+      - ibex_mem_intf_response_seq_lib.sv: {is_include_file: true}
+      - ibex_mem_intf_response_sequencer.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
@@ -15,14 +15,14 @@ package ibex_mem_intf_agent_pkg;
   `include "uvm_macros.svh"
   `include "ibex_mem_intf_seq_item.sv"
 
-  typedef uvm_sequencer#(ibex_mem_intf_seq_item) ibex_mem_intf_master_sequencer;
+  typedef uvm_sequencer#(ibex_mem_intf_seq_item) ibex_mem_intf_request_sequencer;
 
   `include "ibex_mem_intf_monitor.sv"
-  `include "ibex_mem_intf_slave_driver.sv"
-  `include "ibex_mem_intf_slave_sequencer.sv"
-  `include "ibex_mem_intf_slave_seq_lib.sv"
-  `include "ibex_mem_intf_slave_agent.sv"
-  `include "ibex_mem_intf_master_driver.sv"
-  `include "ibex_mem_intf_master_agent.sv"
+  `include "ibex_mem_intf_response_driver.sv"
+  `include "ibex_mem_intf_response_sequencer.sv"
+  `include "ibex_mem_intf_response_seq_lib.sv"
+  `include "ibex_mem_intf_response_agent.sv"
+  `include "ibex_mem_intf_request_driver.sv"
+  `include "ibex_mem_intf_request_agent.sv"
 
 endpackage

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_request_agent.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_request_agent.sv
@@ -3,24 +3,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //------------------------------------------------------------------------------
-// CLASS: ibex_mem_intf_slave_agent
+// CLASS: ibex_mem_intf_request_agent
 //------------------------------------------------------------------------------
 
-class ibex_mem_intf_slave_agent extends uvm_agent;
+class ibex_mem_intf_request_agent extends uvm_agent;
 
-  ibex_mem_intf_slave_driver     driver;
-  ibex_mem_intf_slave_sequencer  sequencer;
-  ibex_mem_intf_monitor          monitor;
+  ibex_mem_intf_request_driver driver;
+  ibex_mem_intf_request_sequencer sequencer;
+  ibex_mem_intf_monitor monitor;
 
-  `uvm_component_utils(ibex_mem_intf_slave_agent)
+  `uvm_component_utils(ibex_mem_intf_request_agent)
   `uvm_component_new
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     monitor = ibex_mem_intf_monitor::type_id::create("monitor", this);
     if(get_is_active() == UVM_ACTIVE) begin
-      driver = ibex_mem_intf_slave_driver::type_id::create("driver", this);
-      sequencer = ibex_mem_intf_slave_sequencer::type_id::create("sequencer", this);
+      driver = ibex_mem_intf_request_driver::type_id::create("driver", this);
+      sequencer = ibex_mem_intf_request_sequencer::type_id::create("sequencer", this);
     end
   endfunction : build_phase
 
@@ -28,12 +28,7 @@ class ibex_mem_intf_slave_agent extends uvm_agent;
     super.connect_phase(phase);
     if(get_is_active() == UVM_ACTIVE) begin
       driver.seq_item_port.connect(sequencer.seq_item_export);
-      monitor.addr_ph_port.connect(sequencer.addr_ph_port.analysis_export);
     end
   endfunction : connect_phase
 
-  function void reset();
-    sequencer.reset();
-  endfunction
-
-endclass : ibex_mem_intf_slave_agent
+endclass : ibex_mem_intf_request_agent

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_request_driver.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_request_driver.sv
@@ -3,14 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //------------------------------------------------------------------------------
-// CLASS: ibex_mem_intf_master_driver
+// CLASS: ibex_mem_intf_request_driver
 //------------------------------------------------------------------------------
 
-class ibex_mem_intf_master_driver extends uvm_driver #(ibex_mem_intf_seq_item);
+class ibex_mem_intf_request_driver extends uvm_driver #(ibex_mem_intf_seq_item);
 
   protected virtual ibex_mem_intf vif;
 
-  `uvm_component_utils(ibex_mem_intf_master_driver)
+  `uvm_component_utils(ibex_mem_intf_request_driver)
   `uvm_component_new
 
   mailbox #(ibex_mem_intf_seq_item) rdata_queue;
@@ -31,7 +31,7 @@ class ibex_mem_intf_master_driver extends uvm_driver #(ibex_mem_intf_seq_item);
   endtask : run_phase
 
   virtual protected task get_and_drive();
-    @(negedge vif.host_driver_cb.reset);
+    @(negedge vif.request_driver_cb.reset);
     forever begin
       vif.wait_clks(1);
       seq_item_port.get_next_item(req);
@@ -45,12 +45,12 @@ class ibex_mem_intf_master_driver extends uvm_driver #(ibex_mem_intf_seq_item);
 
   virtual protected task reset_signals();
     forever begin
-      @(posedge vif.host_driver_cb.reset);
-      vif.host_driver_cb.request        <= 'h0;
-      vif.host_driver_cb.addr           <= 'hz;
-      vif.host_driver_cb.wdata          <= 'hz;
-      vif.host_driver_cb.be             <= 'bz;
-      vif.host_driver_cb.we             <= 'bz;
+      @(posedge vif.request_driver_cb.reset);
+      vif.request_driver_cb.request        <= 'h0;
+      vif.request_driver_cb.addr           <= 'hz;
+      vif.request_driver_cb.wdata          <= 'hz;
+      vif.request_driver_cb.be             <= 'bz;
+      vif.request_driver_cb.we             <= 'bz;
     end
   endtask : reset_signals
 
@@ -58,18 +58,18 @@ class ibex_mem_intf_master_driver extends uvm_driver #(ibex_mem_intf_seq_item);
     if (trans.req_delay > 0) begin
       vif.wait_clks(trans.req_delay);
     end
-    vif.host_driver_cb.request <= 1'b1;
-    vif.host_driver_cb.addr    <= trans.addr;
-    vif.host_driver_cb.be      <= trans.be;
-    vif.host_driver_cb.we      <= trans.read_write;
-    vif.host_driver_cb.wdata   <= trans.data;
-    wait (vif.host_driver_cb.grant === 1'b1);
+    vif.request_driver_cb.request <= 1'b1;
+    vif.request_driver_cb.addr    <= trans.addr;
+    vif.request_driver_cb.be      <= trans.be;
+    vif.request_driver_cb.we      <= trans.read_write;
+    vif.request_driver_cb.wdata   <= trans.data;
+    wait (vif.request_driver_cb.grant === 1'b1);
     vif.wait_clks(1);
-    vif.host_driver_cb.request <= 'h0;
-    vif.host_driver_cb.addr    <= 'hz;
-    vif.host_driver_cb.wdata   <= 'hz;
-    vif.host_driver_cb.be      <= 'bz;
-    vif.host_driver_cb.we      <= 'bz;
+    vif.request_driver_cb.request <= 'h0;
+    vif.request_driver_cb.addr    <= 'hz;
+    vif.request_driver_cb.wdata   <= 'hz;
+    vif.request_driver_cb.be      <= 'bz;
+    vif.request_driver_cb.we      <= 'bz;
     rdata_queue.put(trans);
   endtask : drive_transfer
 
@@ -80,9 +80,9 @@ class ibex_mem_intf_master_driver extends uvm_driver #(ibex_mem_intf_seq_item);
       vif.wait_clks(1);
       while(vif.rvalid !== 1'b1) vif.wait_clks(1);
       if(tr.read_write == READ)
-        tr.data = vif.host_driver_cb.rdata;
+        tr.data = vif.request_driver_cb.rdata;
       seq_item_port.put_response(tr);
     end
   endtask : collect_response
 
-endclass : ibex_mem_intf_master_driver
+endclass : ibex_mem_intf_request_driver

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent.sv
@@ -3,24 +3,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //------------------------------------------------------------------------------
-// CLASS: ibex_mem_intf_master_agent
+// CLASS: ibex_mem_intf_response_agent
 //------------------------------------------------------------------------------
 
-class ibex_mem_intf_master_agent extends uvm_agent;
+class ibex_mem_intf_response_agent extends uvm_agent;
 
-  ibex_mem_intf_master_driver driver;
-  ibex_mem_intf_master_sequencer sequencer;
-  ibex_mem_intf_monitor monitor;
+  ibex_mem_intf_response_driver     driver;
+  ibex_mem_intf_response_sequencer  sequencer;
+  ibex_mem_intf_monitor          monitor;
 
-  `uvm_component_utils(ibex_mem_intf_master_agent)
+  `uvm_component_utils(ibex_mem_intf_response_agent)
   `uvm_component_new
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     monitor = ibex_mem_intf_monitor::type_id::create("monitor", this);
     if(get_is_active() == UVM_ACTIVE) begin
-      driver = ibex_mem_intf_master_driver::type_id::create("driver", this);
-      sequencer = ibex_mem_intf_master_sequencer::type_id::create("sequencer", this);
+      driver = ibex_mem_intf_response_driver::type_id::create("driver", this);
+      sequencer = ibex_mem_intf_response_sequencer::type_id::create("sequencer", this);
     end
   endfunction : build_phase
 
@@ -28,7 +28,12 @@ class ibex_mem_intf_master_agent extends uvm_agent;
     super.connect_phase(phase);
     if(get_is_active() == UVM_ACTIVE) begin
       driver.seq_item_port.connect(sequencer.seq_item_export);
+      monitor.addr_ph_port.connect(sequencer.addr_ph_port.analysis_export);
     end
   endfunction : connect_phase
 
-endclass : ibex_mem_intf_master_agent
+  function void reset();
+    sequencer.reset();
+  endfunction
+
+endclass : ibex_mem_intf_response_agent

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_seq_lib.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_seq_lib.sv
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //------------------------------------------------------------------------------
-// SEQUENCE: ibex_mem_intf_slave_seq
+// SEQUENCE: ibex_mem_intf_response_seq
 //------------------------------------------------------------------------------
 
-class ibex_mem_intf_slave_seq extends uvm_sequence #(ibex_mem_intf_seq_item);
+class ibex_mem_intf_response_seq extends uvm_sequence #(ibex_mem_intf_seq_item);
 
   int                     max_rvalid_delay = 20;
   int                     min_rvalid_delay = 0;
@@ -18,8 +18,8 @@ class ibex_mem_intf_slave_seq extends uvm_sequence #(ibex_mem_intf_seq_item);
   bit                     error_synch = 1'b1;
   bit                     is_dmem_seq = 1'b0;
 
-  `uvm_object_utils(ibex_mem_intf_slave_seq)
-  `uvm_declare_p_sequencer(ibex_mem_intf_slave_sequencer)
+  `uvm_object_utils(ibex_mem_intf_response_seq)
+  `uvm_declare_p_sequencer(ibex_mem_intf_response_sequencer)
   `uvm_object_new
 
   virtual task body();
@@ -47,7 +47,7 @@ class ibex_mem_intf_slave_seq extends uvm_sequence #(ibex_mem_intf_seq_item);
         };
         error == enable_error;
       }) begin
-        `uvm_fatal(`gfn, "Cannot randomize slave request")
+        `uvm_fatal(`gfn, "Cannot randomize response request")
       end
       enable_error = 1'b0;
       error_synch = 1'b1;
@@ -92,4 +92,4 @@ class ibex_mem_intf_slave_seq extends uvm_sequence #(ibex_mem_intf_seq_item);
     return this.error_synch;
   endfunction
 
-endclass : ibex_mem_intf_slave_seq
+endclass : ibex_mem_intf_response_seq

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_sequencer.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_sequencer.sv
@@ -3,15 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //------------------------------------------------------------------------------
-// CLASS: ibex_mem_intf_slave_sequencer
+// CLASS: ibex_mem_intf_response_sequencer
 //------------------------------------------------------------------------------
 
-class ibex_mem_intf_slave_sequencer extends uvm_sequencer #(ibex_mem_intf_seq_item);
+class ibex_mem_intf_response_sequencer extends uvm_sequencer #(ibex_mem_intf_seq_item);
 
-  // TLM port to peek the address phase from the slave monitor
+  // TLM port to peek the address phase from the response monitor
   uvm_tlm_analysis_fifo #(ibex_mem_intf_seq_item) addr_ph_port;
 
-  `uvm_component_utils(ibex_mem_intf_slave_sequencer)
+  `uvm_component_utils(ibex_mem_intf_response_sequencer)
 
   function new (string name, uvm_component parent);
     super.new(name, parent);
@@ -23,4 +23,4 @@ class ibex_mem_intf_slave_sequencer extends uvm_sequencer #(ibex_mem_intf_seq_it
     addr_ph_port.flush();
   endfunction
 
-endclass : ibex_mem_intf_slave_sequencer
+endclass : ibex_mem_intf_response_sequencer

--- a/dv/uvm/core_ibex/common/irq_agent/irq_agent_pkg.sv
+++ b/dv/uvm/core_ibex/common/irq_agent/irq_agent_pkg.sv
@@ -12,10 +12,10 @@ package irq_agent_pkg;
   `include "uvm_macros.svh"
   `include "irq_seq_item.sv"
 
-  typedef uvm_sequencer#(irq_seq_item) irq_master_sequencer;
+  typedef uvm_sequencer#(irq_seq_item) irq_request_sequencer;
 
   `include "irq_monitor.sv"
-  `include "irq_master_driver.sv"
-  `include "irq_master_agent.sv"
+  `include "irq_request_driver.sv"
+  `include "irq_request_agent.sv"
 
 endpackage

--- a/dv/uvm/core_ibex/common/irq_agent/irq_request_agent.sv
+++ b/dv/uvm/core_ibex/common/irq_agent/irq_request_agent.sv
@@ -2,21 +2,21 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class irq_master_agent extends uvm_agent;
+class irq_request_agent extends uvm_agent;
 
-  irq_master_driver     driver;
-  irq_master_sequencer  sequencer;
-  irq_monitor           monitor;
+  irq_request_driver     driver;
+  irq_request_sequencer  sequencer;
+  irq_monitor         monitor;
 
-  `uvm_component_utils(irq_master_agent)
+  `uvm_component_utils(irq_request_agent)
   `uvm_component_new
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     monitor = irq_monitor::type_id::create("monitor", this);
     if (get_is_active() == UVM_ACTIVE) begin
-      driver = irq_master_driver::type_id::create("driver", this);
-      sequencer = irq_master_sequencer::type_id::create("sequencer", this);
+      driver = irq_request_driver::type_id::create("driver", this);
+      sequencer = irq_request_sequencer::type_id::create("sequencer", this);
     end
   endfunction : build_phase
 
@@ -26,4 +26,4 @@ class irq_master_agent extends uvm_agent;
     end
   endfunction : connect_phase
 
-endclass : irq_master_agent
+endclass : irq_request_agent

--- a/dv/uvm/core_ibex/common/irq_agent/irq_request_driver.sv
+++ b/dv/uvm/core_ibex/common/irq_agent/irq_request_driver.sv
@@ -2,12 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class irq_master_driver extends uvm_driver #(irq_seq_item);
+class irq_request_driver extends uvm_driver #(irq_seq_item);
 
   // The virtual interface used to drive and view HDL signals.
   protected virtual irq_if vif;
-
-  `uvm_component_utils(irq_master_driver)
+`uvm_component_utils(irq_request_driver)
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
@@ -78,5 +77,5 @@ class irq_master_driver extends uvm_driver #(irq_seq_item);
     vif.driver_cb.irq_nm       <= '0;
   endtask : drive_reset_value
 
-endclass : irq_master_driver
+endclass : irq_request_driver
 

--- a/dv/uvm/core_ibex/env/core_ibex_env.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_env.sv
@@ -7,9 +7,9 @@
 // ---------------------------------------------
 class core_ibex_env extends uvm_env;
 
-  ibex_mem_intf_slave_agent   data_if_slave_agent;
-  ibex_mem_intf_slave_agent   instr_if_slave_agent;
-  irq_master_agent            irq_agent;
+  ibex_mem_intf_response_agent   data_if_response_agent;
+  ibex_mem_intf_response_agent   instr_if_response_agent;
+  irq_request_agent            irq_agent;
   core_ibex_vseqr             vseqr;
   core_ibex_env_cfg           cfg;
 
@@ -21,25 +21,25 @@ class core_ibex_env extends uvm_env;
     if (!uvm_config_db#(core_ibex_env_cfg)::get(this, "", "cfg", cfg)) begin
       `uvm_fatal(get_full_name(), "Cannot get cfg")
     end
-    data_if_slave_agent = ibex_mem_intf_slave_agent::type_id::
-                          create("data_if_slave_agent", this);
-    instr_if_slave_agent = ibex_mem_intf_slave_agent::type_id::
-                           create("instr_if_slave_agent", this);
-    irq_agent = irq_master_agent::type_id::create("irq_agent", this);
+    data_if_response_agent = ibex_mem_intf_response_agent::type_id::
+                          create("data_if_response_agent", this);
+    instr_if_response_agent = ibex_mem_intf_response_agent::type_id::
+                           create("instr_if_response_agent", this);
+    irq_agent = irq_request_agent::type_id::create("irq_agent", this);
     // Create virtual sequencer
     vseqr = core_ibex_vseqr::type_id::create("vseqr", this);
   endfunction : build_phase
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
-    vseqr.data_if_seqr = data_if_slave_agent.sequencer;
-    vseqr.instr_if_seqr = instr_if_slave_agent.sequencer;
+    vseqr.data_if_seqr = data_if_response_agent.sequencer;
+    vseqr.instr_if_seqr = instr_if_response_agent.sequencer;
     vseqr.irq_seqr = irq_agent.sequencer;
   endfunction : connect_phase
 
   function void reset();
-    data_if_slave_agent.reset();
-    instr_if_slave_agent.reset();
+    data_if_response_agent.reset();
+    instr_if_response_agent.reset();
   endfunction
 
 endclass

--- a/dv/uvm/core_ibex/env/core_ibex_vseqr.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_vseqr.sv
@@ -7,9 +7,9 @@
 // ---------------------------------------------
 class core_ibex_vseqr extends uvm_sequencer;
 
-  ibex_mem_intf_slave_sequencer                   data_if_seqr;
-  ibex_mem_intf_slave_sequencer                   instr_if_seqr;
-  irq_master_sequencer                            irq_seqr;
+  ibex_mem_intf_response_sequencer                   data_if_seqr;
+  ibex_mem_intf_response_sequencer                   instr_if_seqr;
+  irq_request_sequencer                            irq_seqr;
 
   `uvm_component_utils(core_ibex_vseqr)
   `uvm_component_new

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -155,8 +155,8 @@ module core_ibex_tb_top;
                                                             instr_monitor_if);
     uvm_config_db#(virtual core_ibex_csr_if)::set(null, "*", "csr_if", csr_if);
     uvm_config_db#(virtual core_ibex_rvfi_if)::set(null, "*", "rvfi_if", rvfi_if);
-    uvm_config_db#(virtual ibex_mem_intf)::set(null, "*data_if_slave*", "vif", data_mem_vif);
-    uvm_config_db#(virtual ibex_mem_intf)::set(null, "*instr_if_slave*", "vif", instr_mem_vif);
+    uvm_config_db#(virtual ibex_mem_intf)::set(null, "*data_if_response*", "vif", data_mem_vif);
+    uvm_config_db#(virtual ibex_mem_intf)::set(null, "*instr_if_response*", "vif", instr_mem_vif);
     uvm_config_db#(virtual irq_if)::set(null, "*", "vif", irq_vif);
     run_test();
   end

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -65,7 +65,7 @@ class core_ibex_base_test extends uvm_test;
 
   virtual function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
-    env.data_if_slave_agent.monitor.item_collected_port.connect(
+    env.data_if_response_agent.monitor.item_collected_port.connect(
       this.item_collected_port.analysis_export);
     env.irq_agent.monitor.irq_port.connect(this.irq_collected_port.analysis_export);
   endfunction

--- a/dv/uvm/core_ibex/tests/core_ibex_vseq.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_vseq.sv
@@ -8,8 +8,8 @@
 
 class core_ibex_vseq extends uvm_sequence;
 
-  ibex_mem_intf_slave_seq                       instr_intf_seq;
-  ibex_mem_intf_slave_seq                       data_intf_seq;
+  ibex_mem_intf_response_seq                       instr_intf_seq;
+  ibex_mem_intf_response_seq                       data_intf_seq;
   mem_model_pkg::mem_model                      mem;
   irq_raise_seq                                 irq_raise_seq_h;
   irq_raise_single_seq                          irq_raise_single_seq_h;
@@ -24,8 +24,8 @@ class core_ibex_vseq extends uvm_sequence;
   `uvm_object_new
 
   virtual task body();
-    instr_intf_seq = ibex_mem_intf_slave_seq::type_id::create("instr_intf_seq");
-    data_intf_seq  = ibex_mem_intf_slave_seq::type_id::create("data_intf_seq");
+    instr_intf_seq = ibex_mem_intf_response_seq::type_id::create("instr_intf_seq");
+    data_intf_seq  = ibex_mem_intf_response_seq::type_id::create("data_intf_seq");
     data_intf_seq.is_dmem_seq = 1'b1;
     if (cfg.enable_irq_single_seq) begin
       irq_raise_single_seq_h = irq_raise_single_seq::type_id::create("irq_single_seq_h");


### PR DESCRIPTION
This PR modifies the Ibex DV environment to match OpenTitan terminology
standards of using host/device. These changes are purely aesthetic.