### PR TITLE
[rtl] remove lsu_req_in_id signal

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -90,7 +90,6 @@ module ibex_controller #(
     input  logic                  csr_mstatus_tw_i,
 
     // stall & flush signals
-    input  logic                  lsu_req_in_id_i,
     input  logic                  stall_id_i,
     input  logic                  stall_wb_i,
     output logic                  flush_id_o,
@@ -510,11 +509,11 @@ module ibex_controller #(
         // If entering debug mode or handling an IRQ the core needs to wait
         // until the current instruction has finished executing. Stall IF
         // during that time.
-        if ((enter_debug_mode || handle_irq) && (stall || lsu_req_in_id_i)) begin
+        if ((enter_debug_mode || handle_irq) && stall) begin
           halt_if = 1'b1;
         end
 
-        if (!stall && !lsu_req_in_id_i && !special_req_all) begin
+        if (!stall && !special_req_all) begin
           if (enter_debug_mode) begin
             // enter debug mode
             ctrl_fsm_ns = DBG_TAKEN_IF;

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -206,7 +206,6 @@ module ibex_id_stage #(
   logic        controller_run;
   logic        stall_ld_hz;
   logic        stall_mem;
-  logic        lsu_req_in_id;
   logic        stall_multdiv;
   logic        stall_branch;
   logic        stall_jump;
@@ -597,8 +596,6 @@ module ibex_id_stage #(
       .debug_ebreaku_i                ( debug_ebreaku_i         ),
       .trigger_match_i                ( trigger_match_i         ),
 
-      // stall signals
-      .lsu_req_in_id_i                ( lsu_req_in_id           ),
       .stall_id_i                     ( stall_id                ),
       .stall_wb_i                     ( stall_wb                ),
       .flush_id_o                     ( flush_id                ),
@@ -883,10 +880,6 @@ module ibex_id_stage #(
     `ASSERT(IbexStallMemNoRequest,
       instr_valid_i & lsu_req_dec & ~instr_done |-> ~lsu_req_done_i)
 
-    // Indicate to the controller that an lsu req is in ID stage - we cannot handle interrupts or
-    // debug requests until the load/store completes
-    assign lsu_req_in_id = instr_valid_i & lsu_req_dec;
-
     assign rf_rd_a_wb_match = (rf_waddr_wb_i == rf_raddr_a_o) & |rf_raddr_a_o;
     assign rf_rd_b_wb_match = (rf_waddr_wb_i == rf_raddr_b_o) & |rf_raddr_b_o;
 
@@ -931,7 +924,6 @@ module ibex_id_stage #(
 
     // No load hazards without Writeback Stage
     assign stall_ld_hz   = 1'b0;
-    assign lsu_req_in_id = 1'b0;
 
     // Without writeback stage any valid instruction that hasn't seen an error will execute
     assign instr_executing = instr_valid_i & ~instr_fetch_err_i & controller_run;


### PR DESCRIPTION
This signal aimed to ensure loads/stores completed succesfully when an
interrupt or debug request appeared at the same time they were being
executed when the writeback stage is present. However other stall logic
suffices for this purpose (debug/interrupt will wait for instruction to
unstall in ID/EX which only happens once request has been sent out, then
first instruction of debug/interrupt handler will stall until load/store
response has been seen based on the generic stall logic for lsu requests
in the writeback stage).

With this signal in place debug single stepping was broken around loads
and stores.

Fixes #1029

This half undoes the fix from this PR: https://github.com/lowRISC/ibex/pull/928 which was in response to this OT issue: https://github.com/lowRISC/opentitan/issues/2405

I'm happy to accept this is not the correct fix but I did have a play with interrupts appearing the same cycle as a load in simple system with various delays on gnt/rvalid and it all seems to work fine. The DV interrupt tests all looked fine. The test in OT that found the original bug was broken on main yesterday (chip_uart_tx_rx) but looking at the latest nightly it seems to be fixed, so I'll have another play with that. Also realised there's some other timing scenarios I can check out with simple system.
