### PR TITLE
[dv/ibex] Enhance riscv_debug_single_step test

### DIFF
--- a/dv/uvm/core_ibex/env/core_ibex_instr_monitor_if.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_instr_monitor_if.sv
@@ -6,7 +6,11 @@
 //
 // TODO: does not support dummy instruction insertion right now,
 //       might have to revisit and update.
-interface core_ibex_instr_monitor_if #(parameter DATA_WIDTH = 32);
+interface core_ibex_instr_monitor_if #(
+  parameter DATA_WIDTH = 32
+) (
+  input clk
+);
 
   // ID stage
   logic                   valid_id;
@@ -14,5 +18,19 @@ interface core_ibex_instr_monitor_if #(parameter DATA_WIDTH = 32);
   logic                   is_compressed_id;
   logic [15:0]            instr_compressed_id;
   logic [DATA_WIDTH-1:0]  instr_id;
+  logic [DATA_WIDTH-1:0]  pc_id;
+  logic                   branch_taken_id;
+  logic [DATA_WIDTH-1:0]  branch_target_id;
+
+  clocking instr_cb @(posedge clk);
+    input valid_id;
+    input err_id;
+    input is_compressed_id;
+    input instr_compressed_id;
+    input instr_id;
+    input pc_id;
+    input branch_taken_id;
+    input branch_target_id;
+  endclocking
 
 endinterface

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -535,11 +535,11 @@
     +require_signature_addr=1
     +gen_debug_section=1
     +no_ebreak=1
-    +no_branch_jump=1
+    +no_branch_jump=0
     +instr_cnt=10000
     +no_csr_instr=1
     +no_fence=1
-    +num_of_sub_program=0
+    +num_of_sub_program=2
     +randomize_csr=1
     +enable_debug_single_step=1
   rtl_test: core_ibex_debug_single_step_test

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -21,7 +21,7 @@ module core_ibex_tb_top;
   core_ibex_dut_probe_if dut_if(.clk(clk));
 
   // Instruction monitor interface
-  core_ibex_instr_monitor_if instr_monitor_if();
+  core_ibex_instr_monitor_if instr_monitor_if(.clk(clk));
 
   // RVFI interface
   core_ibex_rvfi_if rvfi_if(.clk(clk));
@@ -139,6 +139,9 @@ module core_ibex_tb_top;
   assign instr_monitor_if.is_compressed_id    = dut.u_ibex_core.id_stage_i.instr_is_compressed_i;
   assign instr_monitor_if.instr_compressed_id = dut.u_ibex_core.id_stage_i.instr_rdata_c_i;
   assign instr_monitor_if.instr_id            = dut.u_ibex_core.id_stage_i.instr_rdata_i;
+  assign instr_monitor_if.pc_id               = dut.u_ibex_core.pc_id;
+  assign instr_monitor_if.branch_taken_id     = dut.u_ibex_core.id_stage_i.controller_i.branch_set_i;
+  assign instr_monitor_if.branch_target_id    = dut.u_ibex_core.branch_target_ex;
   // CSR interface connections
   assign csr_if.csr_access                    = dut.u_ibex_core.csr_access;
   assign csr_if.csr_addr                      = dut.u_ibex_core.csr_addr;


### PR DESCRIPTION
As pointed out by @tomroberts-lowrisc in #983, the current
implementation of riscv_debug_single_step_test cannot handle
single-stepping over instructions that change the PC.
This PR aims to introduce this functionality, utilizing the
new instr_monitor_if.

Now, if the core single-steps onto a branch/jump instruction, the
testbench will log the new target PC and compare it against the actual
target address stored in `dpc`.
"Normal" instructions are checked as usual by incrementing the
instruction's PC by either 2 or 4 (depending whether it is compressed)
and comparing that against `dpc`.

This test passes successfully when combined with the RTL patch in #1034.