### PR TITLE
Fix bug in ICache testbench with chained sequences

### DIFF
--- a/dv/uvm/icache/doc/ibex_icache_dv_plan.md
+++ b/dv/uvm/icache/doc/ibex_icache_dv_plan.md
@@ -143,12 +143,16 @@ To do so, we would just need to monitor fetches in the memory agent as well as s
 ## Building and running tests
 
 Tests are built and run with the [`dvsim`](https://github.com/lowRISC/ibex/tree/master/vendor/lowrisc_ip/dvsim) tool (vendored in from the OpenTitan project).
-To run a basic sanity test:
+To ensure output files end up in the right place without ugly command lines, this is wrapped up in a Makefile.
+To run the test suite, run:
 
 ```console
-$ cd dv/uvm/icache/dv
-$ dvsim.py icache_sim_cfg.hjson -i ibex_icache_sanity
+$ make -C dv/uvm/icache/dv
 ```
+
+For more complicated use cases (enabling wave dumps, coverage, specific seeds), there are some options in the Makefile.
+For very specific use cases, you'll need to run dvsim.py directly.
+The easiest way to get an initial command to edit is to run `make -n`.
 
 ## Testplan
 

--- a/dv/uvm/icache/dv/Makefile
+++ b/dv/uvm/icache/dv/Makefile
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Simple wrappers around dvsim.py to avoid needing long command lines. This
-# doesn't do any dependency tracking (as you might expect in a Makefile) because
-# the dvsim infrastructure doesn't support it.
+# doesn't do any dependency tracking (as you might expect in a Makefile).
 
 # Set WAVES to 1 to get wave dumps
 WAVES=0
@@ -16,34 +15,35 @@ COVERAGE=0
 # --verbosity parameter, overriding whatever was set in the hjson file.
 VERBOSITY=
 
-# Specify the seed for the test to run. If this is empty, dvsim.py will pick
-# random seeds. By default, we make runs reproducible, so force the seed.
-SEED=1
+# The number of seeds to run for each selected test. Defaults to 1.
+RESEED=1
 
-#SIMULATOR
-SIMULATOR=vcs
+# Specify the seed for the test to run. If this is empty, dvsim.py
+# will pick random seeds. By default, we make runs reproducible, so
+# force the seed if RESEED is 1.
+default-seed := 123
+SEED=$(if $(filter 1,$(RESEED)),$(default-seed),)
+
+# Specify which tests to run. Defaults to the empty string, which
+# means dvsim will run its default (the "sanity" suite).
+TESTS=
 
 ibex-top       := ../../../..
 scratch-root   := $(ibex-top)/build
 dvsim-py       := $(ibex-top)/vendor/lowrisc_ip/dvsim/dvsim.py
-dvsim-std-args := --scratch-root $(scratch-root) --tool $(SIMULATOR)
+dvsim-std-args := --scratch-root $(scratch-root)
 
 waves-arg      := $(if $(filter-out 0,$(WAVES)),--waves,)
 coverage-arg   := $(if $(filter-out 0,$(COVERAGE)),-c,)
 verbosity-arg  := $(if $(VERBOSITY),--verbosity $(VERBOSITY),)
+reseed-arg     := --reseed $(RESEED)
 seed-arg       := $(if $(SEED),--fixed-seed $(SEED),)
+tests-arg      := $(if $(TESTS),--items $(TESTS))
 
-dvsim-mk-args    := $(waves-arg) $(coverage-arg) $(verbosity-arg) $(seed-arg)
-run-icache-dvsim := $(dvsim-py) ibex_icache_sim_cfg.hjson $(dvsim-std-args) $(dvsim-mk-args)
-
-
-.PHONY: all
-all: run
-
-.PHONY: just-build
-just-build:
-	$(run-icache-dvsim) --build-only
+dvsim-mk-args := \
+  $(waves-arg) $(coverage-arg) $(verbosity-arg) \
+  $(reseed-arg) $(seed-arg) $(tests-arg)
 
 .PHONY: run
 run:
-	$(run-icache-dvsim)
+	$(dvsim-py) ibex_icache_sim_cfg.hjson $(dvsim-std-args) $(dvsim-mk-args)


### PR DESCRIPTION
There's a long description in the second commit message, but it boils down to the fact that memory requests slightly "smear" across sequence boundaries, and the scoreboard needs to be a bit cleverer about tracking `mem_err_shift` (a parameter that controls the proportion of the address space that generates errors).