### PR TITLE
[dvsim] Print a more helpful path to coverage dashboard

### DIFF
--- a/dv/uvm/data/vcs/vcs.hjson
+++ b/dv/uvm/data/vcs/vcs.hjson
@@ -77,7 +77,7 @@
                         "-elfile {vcs_cov_excl_files}",
                         "-report {cov_report_dir}"]
   cov_report_txt:       "{cov_report_dir}/dashboard.txt"
-  cov_report_page:      "cov_report/dashboard.html"
+  cov_report_page:      "{cov_report_dir}/dashboard.html"
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.

--- a/dv/uvm/data/xcelium/xcelium.hjson
+++ b/dv/uvm/data/xcelium/xcelium.hjson
@@ -73,7 +73,7 @@
                      "-licqueue",
                      "-exec {tool_srcs_dir}/cov_report.tcl"]
   cov_report_txt:   "{cov_report_dir}/cov_report.txt"
-  cov_report_page:  "cov_report/index.html"
+  cov_report_page:  "{cov_report_dir}/index.html"
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.


### PR DESCRIPTION
cov_report_page is used by dvsim's SimCfg.py to print a message to the
console with the path to the dashboard HTML page. Most of these
messages have the full path (useful for copy-pasting), but this one
didn't.

This is essentially a duplicate of OpenTitan PR 2934[1] (because we're
not able to vendor these files properly yet).

[1] https://github.com/lowRISC/opentitan/pull/2934