### PR TITLE
Update google_riscv-dv to google/riscv-dv@dc2f215

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: 3cf691dcb96f2cd72250690216b60f2b0c0ac804
+    rev: dc2f21586638fc7dfa47c5bf314108cbb84e99ee
   }
 }

--- a/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_pkg.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_pkg.py
@@ -1191,7 +1191,7 @@ class riscv_instr_pkg:
         formatted_str = length * " "
         if (int(length) < len(string)):
             return string
-        formatted_str = string + formatted_str[0: (int(length) - len(string) - 1)]
+        formatted_str = string + formatted_str[0: (int(length) - len(string))]
         return formatted_str
 
     def format_data(self, data, byte_per_group = 4):

--- a/vendor/google_riscv-dv/src/isa/riscv_vector_instr.sv
+++ b/vendor/google_riscv-dv/src/isa/riscv_vector_instr.sv
@@ -261,12 +261,12 @@ class riscv_vector_instr extends riscv_floating_point_instr;
     }
     // 7.8.3 For vector indexed segment loads, the destination vector register groups
     // cannot overlap the source vectorregister group (specied by vs2), nor can they
-    // overlap the mask register if maske
-    if (format == VLX_FORMAT) {
+    // overlap the mask register if masked
+    // AMO instruction uses indexed address mode
+    if (format inside {VLX_FORMAT, VAMO_FORMAT}) {
       vd != vs2;
     }
   }
-
 
   `uvm_object_utils(riscv_vector_instr)
   `uvm_object_new
@@ -419,6 +419,15 @@ class riscv_vector_instr extends riscv_floating_point_instr;
         end else begin
           asm_str = $sformatf("%0s %0s,(%0s),%0s", get_instr_name(),
                                                    vs3.name(), rs1.name(), vs2.name());
+        end
+      end
+      VAMO_FORMAT: begin
+        if (wd) begin
+          asm_str = $sformatf("%0s %0s,(%0s),%0s,%0s", get_instr_name(), vd.name(),
+                                                   rs1.name(), vs2.name(), vd.name());
+        end else begin
+          asm_str = $sformatf("%0s x0,(%0s),%0s,%0s", get_instr_name(),
+                                                  rs1.name(), vs2.name(), vs3.name());
         end
       end
       default: begin

--- a/vendor/google_riscv-dv/src/isa/rv32v_instr.sv
+++ b/vendor/google_riscv-dv/src/isa/rv32v_instr.sv
@@ -298,3 +298,27 @@
 `DEFINE_VA_INSTR(VSUXSEGH_V, VSX_FORMAT, STORE, RVV, {}, "zvlsseg")
 `DEFINE_VA_INSTR(VSUXSEGW_V, VSX_FORMAT, STORE, RVV, {}, "zvlsseg")
 `DEFINE_VA_INSTR(VSUXSEGE_V, VSX_FORMAT, STORE, RVV, {}, "zvlsseg")
+
+// -------------------------------------------------------------------------
+//  Section 8. Vector AMO Operations (Zvamo)
+// -------------------------------------------------------------------------
+// 32-bit vector AMOs
+`DEFINE_VA_INSTR(VAMOSWAPW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOADDW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOXORW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOANDW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOORW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMINW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMAXW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMINUW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMAXUW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+// SEW-bit vector AMOs
+`DEFINE_VA_INSTR(VAMOSWAPE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOADDE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOXORE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOANDE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOORE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMINE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMAXE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMINUE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMAXUE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")

--- a/vendor/google_riscv-dv/src/riscv_amo_instr_lib.sv
+++ b/vendor/google_riscv-dv/src/riscv_amo_instr_lib.sv
@@ -188,3 +188,32 @@ class riscv_amo_instr_stream extends riscv_amo_base_instr_stream;
   endfunction
 
 endclass : riscv_amo_instr_stream
+
+
+class riscv_vector_amo_instr_stream extends riscv_vector_load_store_instr_stream;
+
+  constraint amo_address_mode_c {
+    // AMO operation only supports word alignment or element alignemt
+    alignment inside {W_ALIGNMENT, E_ALIGNMENT};
+    // AMO operation uses indexed address mode
+    address_mode == INDEXED;
+    // For the 32-bit vector AMO operations, SEW must be at least 32 bit
+    (cfg.vector_cfg.vtype.vsew < 32) -> (alignment != W_ALIGNMENT);
+  }
+
+  `uvm_object_utils(riscv_vector_amo_instr_stream)
+  `uvm_object_new
+
+  virtual function void add_element_vec_load_stores();
+    allowed_instr = {VAMOSWAPE_V, VAMOADDE_V, VAMOXORE_V,
+                     VAMOANDE_V, VAMOORE_V, VAMOMINE_V,
+                     VAMOMAXE_V, VAMOMINUE_V, VAMOMAXUE_V, allowed_instr};
+  endfunction
+
+  virtual function void add_w_vec_load_stores();
+    allowed_instr = {VAMOSWAPW_V, VAMOADDW_V, VAMOXORW_V,
+                     VAMOANDW_V, VAMOORW_V, VAMOMINW_V,
+                     VAMOMAXW_V, VAMOMINUW_V, VAMOMAXUW_V, allowed_instr};
+  endfunction
+
+endclass : riscv_vector_amo_instr_stream

--- a/vendor/google_riscv-dv/src/riscv_illegal_instr.sv
+++ b/vendor/google_riscv-dv/src/riscv_illegal_instr.sv
@@ -166,11 +166,13 @@ class riscv_illegal_instr extends uvm_object;
     c_op != 2'b11;
   }
 
-  // Avoid generating illegal func3/func7 errors for opcode used by B-extension
+  // Avoid generating illegal func3/func7 errors for opcode used by B-extension for now
+  //
+  // TODO(udi): add support for generating illegal B-extension instructions
   constraint b_extension_c {
     if (RV32B inside {supported_isa}) {
       if (exception inside {kIllegalFunc3, kIllegalFunc7}) {
-        !(opcode inside {7'b0011011, 7'b0010011, 7'b0111011});
+        !(opcode inside {7'b0110011, 7'b0010011, 7'b0111011});
       }
     }
   }
@@ -356,8 +358,8 @@ class riscv_illegal_instr extends uvm_object;
     if (riscv_instr_pkg::RV32A inside {riscv_instr_pkg::supported_isa}) begin
       legal_opcode = {legal_opcode, 7'b0101111};
     end
-    if ((riscv_instr_pkg::RV64I inside {riscv_instr_pkg::supported_isa}) ||
-         riscv_instr_pkg::RV64M inside {riscv_instr_pkg::supported_isa}) begin
+    if (riscv_instr_pkg::RV64I inside {riscv_instr_pkg::supported_isa} ||
+        riscv_instr_pkg::RV64M inside {riscv_instr_pkg::supported_isa}) begin
       legal_opcode = {legal_opcode, 7'b0111011};
     end
     if (riscv_instr_pkg::RV64I inside {riscv_instr_pkg::supported_isa}) begin

--- a/vendor/google_riscv-dv/src/riscv_instr_pkg.sv
+++ b/vendor/google_riscv-dv/src/riscv_instr_pkg.sv
@@ -641,6 +641,7 @@ package riscv_instr_pkg;
     VLHUFF_V,
     VLWUFF_V,
     VLEFF_V,
+    // Segmented load/store instruction
     VLSEGE_V,
     VSSEGE_V,
     VLSEGB_V,
@@ -685,6 +686,27 @@ package riscv_instr_pkg;
     VSUXSEGH_V,
     VSUXSEGW_V,
     VSUXSEGE_V,
+    // Vector AMO instruction
+    // 32-bit vector AMOs
+    VAMOSWAPW_V,
+    VAMOADDW_V,
+    VAMOXORW_V,
+    VAMOANDW_V,
+    VAMOORW_V,
+    VAMOMINW_V,
+    VAMOMAXW_V,
+    VAMOMINUW_V,
+    VAMOMAXUW_V,
+    // SEW-bit vector AMOs
+    VAMOSWAPE_V,
+    VAMOADDE_V,
+    VAMOXORE_V,
+    VAMOANDE_V,
+    VAMOORE_V,
+    VAMOMINE_V,
+    VAMOMAXE_V,
+    VAMOMINUE_V,
+    VAMOMAXUE_V,
     // Supervisor instruction
     DRET,
     MRET,
@@ -747,7 +769,8 @@ package riscv_instr_pkg;
     VLX_FORMAT,
     VSX_FORMAT,
     VLS_FORMAT,
-    VSS_FORMAT
+    VSS_FORMAT,
+    VAMO_FORMAT
   } riscv_instr_format_t;
 
 

--- a/vendor/google_riscv-dv/src/riscv_load_store_instr_lib.sv
+++ b/vendor/google_riscv-dv/src/riscv_load_store_instr_lib.sv
@@ -519,7 +519,7 @@ class riscv_load_store_rand_addr_instr_stream extends riscv_load_store_base_inst
 
 endclass
 
-class riscv_vector_stride_load_store_instr_stream extends riscv_mem_access_stream;
+class riscv_vector_load_store_instr_stream extends riscv_mem_access_stream;
 
   typedef enum {B_ALIGNMENT, H_ALIGNMENT, W_ALIGNMENT, E_ALIGNMENT} alignment_e;
   typedef enum {UNIT_STRIDED, STRIDED, INDEXED} address_mode_e;
@@ -573,7 +573,7 @@ class riscv_vector_stride_load_store_instr_stream extends riscv_mem_access_strea
   int max_load_store_addr;
   riscv_vector_instr load_store_instr;
 
-  `uvm_object_utils(riscv_vector_stride_load_store_instr_stream)
+  `uvm_object_utils(riscv_vector_load_store_instr_stream)
   `uvm_object_new
 
   virtual function int get_addr_alignment_mask(int alignment_bytes);
@@ -590,6 +590,7 @@ class riscv_vector_stride_load_store_instr_stream extends riscv_mem_access_strea
     if (address_mode == STRIDED) begin
       instr_list.push_front(get_init_gpr_instr(rs2_reg, stride_byte_offset));
     end else if (address_mode == INDEXED) begin
+      // TODO: Support different index address for each element
       add_init_vector_gpr_instr(vs2_reg, index_addr);
     end
     super.post_randomize();

--- a/vendor/google_riscv-dv/target/rv64gcv/testlist.yaml
+++ b/vendor/google_riscv-dv/target/rv64gcv/testlist.yaml
@@ -74,8 +74,23 @@
     +num_of_sub_program=0
     +enable_floating_point=1
     +enable_vector_extension=1
-    +directed_instr_0=riscv_vector_stride_load_store_instr_stream,4
-    +enable_fault_only_first_load=1
+    +directed_instr_0=riscv_vector_load_store_instr_stream,10
+    +no_branch_jump=1
+    +boot_mode=m
+    +no_csr_instr=1
+  iterations: 5
+  gen_test: riscv_instr_base_test
+  rtl_test: core_base_test
+
+- test: riscv_vector_amo_test
+  description: >
+    Vector AMO random test
+  gen_opts: >
+    +instr_cnt=10000
+    +num_of_sub_program=0
+    +enable_floating_point=1
+    +enable_vector_extension=1
+    +directed_instr_0=riscv_vector_amo_instr_stream,10
     +no_branch_jump=1
     +boot_mode=m
     +no_csr_instr=1


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision dc2f21586638fc7dfa47c5bf314108cbb84e99ee

* Fix opcode in b_extension_c constraint (google/riscv-dv#659)
  (udinator)
* Add vector AMO instruction support (google/riscv-dv#658) (taoliug)
* Fix Indentation (aneels3)
* fix imm constraint issue (aneels3)
* fix typo in extend_imm() (aneels3)

Fixes #1038

Signed-off-by: Udi <udij@google.com>