### PR TITLE
Pulpissimo interrupt fix

### DIFF
--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -726,7 +726,7 @@ module ibex_cs_registers #(
       mstack_epc_q   <= '0;
       mstack_cause_q <= '0;
 
-      miex_q         <= '0;
+      miex_q         <= {32{1'b1}};
       mtvecx_q       <= 32'b01;
 
     end else begin


### PR DESCRIPTION
This is a modification of the additional "CLINTx" Interrupt Interface for the Pulpissimo µC.
The Interface is intended to work with the platform-level Interrupt Controller. This controller is managed via an APB-Interface and brings its own Interrupt Enable Mask. Therefore the miex register is redundant. Because the mask register is also never written by the PULP SDK the core does not react to an interrupt.

This modification goes hand in hand with some other modifications in the [pulp-rt](https://github.com/pulp-platform/pulp-rt/pull/36) and [pulp-configs](https://github.com/pulp-platform/pulp-configs/pull/12) Repositories. 