### PR TITLE
Set `FPGA_XILINX` define whenever Vivado is used

### DIFF
--- a/examples/fpga/artya7/top_artya7.core
+++ b/examples/fpga/artya7/top_artya7.core
@@ -31,12 +31,6 @@ parameters:
     default: "../../../../../examples/sw/led/led.vmem"
     paramtype: vlogparam
 
-  FPGA_XILINX:
-    datatype: str
-    description: Identifies Xilinx FPGA targets to set DSP pragmas for performance counters.
-    default: 1
-    paramtype: vlogdefine
-
   # For value definition, please see ip/prim/rtl/prim_pkg.sv
   PRIM_DEFAULT_IMPL:
     datatype: str
@@ -52,7 +46,6 @@ targets:
     toplevel: top_artya7
     parameters:
       - SRAMInitFile
-      - FPGA_XILINX
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
     tools:
       vivado:

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -60,6 +60,12 @@ parameters:
     datatype: bool
     paramtype: vlogdefine
 
+  FPGA_XILINX:
+    datatype: bool
+    description: Identifies Xilinx FPGA targets to set DSP pragmas for performance counters.
+    default: false
+    paramtype: vlogdefine
+
   RV32E:
     datatype: int
     default: 0
@@ -138,6 +144,8 @@ targets:
       - files_rtl
       - files_check_tool_requirements
     toplevel: ibex_core
+    parameters:
+      - tool_vivado ? (FPGA_XILINX=true)
   lint:
     <<: *default_target
     parameters:


### PR DESCRIPTION
This PR makes sure that whenever Vivado is used, the Verilog define `FPGA_XILINX` is set. This define can be used to enable Xilinx specific pragmas in the RTL code. It is currently used to implement the performance counters with DSP slices (incl. integrated output registers for counter widths <= 32) which helps to save logic resources and FFs (e.g. -7% and -15% when using 10 32-bit counters).

Previously, we had to set this parameter in every single top-level .core file using Ibex.