### PR TITLE
Update google_riscv-dv to google/riscv-dv@61755c0

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: 3cf691dcb96f2cd72250690216b60f2b0c0ac804
+    rev: 61755c001bec0433fb69458f74d95476d2101cf3
   }
 }

--- a/vendor/google_riscv-dv/pygen/pygen_src/isa/riscv_instr_cov.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/isa/riscv_instr_cov.py
@@ -1,0 +1,46 @@
+import sys
+import vsc
+import logging
+from enum import Enum, auto
+from pygen_src.riscv_instr_pkg import riscv_reg_t
+
+class operand_sign_e(Enum):
+    POSITIVE = 0
+    NEGATIVE = auto()
+
+class div_result_e(Enum):
+    DIV_NORMAL = 0
+    DIV_BY_ZERO = auto()
+    DIV_OVERFLOW = auto()
+
+class compare_result_e(Enum):
+    EQUAL = 0
+    LARGER = auto()
+    SMALLER = auto()
+
+class logical_similarity_e(Enum):
+    IDENTICAL = 0
+    OPPOSITE = auto()
+    SIMILAR = auto()
+    DIFFERENT = auto()
+
+class special_val_e(Enum):
+    NORMAL_VAL = 0
+    MIN_VAL = auto()
+    MAX_VAL = auto()
+    ZERO_VAL = auto()
+
+
+def get_gpr(reg_name):
+    reg_name = reg_name.upper()
+    if not reg_name in riscv_reg_t:
+        logging.fatal("Cannot convert {} to GPR".format(reg_name))
+    return riscv_reg_t[reg_name]
+
+def get_gpr_state(reg_name):
+    if reg_name in ["zero", "x0"]:
+        return 0
+    elif reg_name in gpr_state:
+        return gpr_state[reg_name]
+    else:
+        logging.warning("Cannot find GPR state: {}".format(reg_name))

--- a/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_gen_config.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_gen_config.py
@@ -63,7 +63,14 @@ class riscv_instr_gen_config:
 
         self.fcsr_rm = list(map(lambda csr_rm: csr_rm.name, f_rounding_mode_t))
         self.enable_sfence = 0
-        self.gpr = vsc.rand_list_t(vsc.enum_t(riscv_reg_t), sz =4)
+        self.gpr = []
+
+        # Helper fields for gpr
+        self.gpr0 = vsc.rand_enum_t(riscv_reg_t)
+        self.gpr1 = vsc.rand_enum_t(riscv_reg_t)
+        self.gpr2 = vsc.rand_enum_t(riscv_reg_t)
+        self.gpr3 = vsc.rand_enum_t(riscv_reg_t)
+
         self.scratch_reg = vsc.rand_enum_t(riscv_reg_t)
         self.pmp_reg = vsc.rand_enum_t(riscv_reg_t)
         self.sp = vsc.rand_enum_t(riscv_reg_t)
@@ -154,7 +161,15 @@ class riscv_instr_gen_config:
 
     @vsc.constraint
     def gpr_c(self):
-        pass  # TODO
+        self.gpr0.not_inside(vsc.rangelist(self.sp, self.tp, self.scratch_reg, self.pmp_reg,
+                                           riscv_reg_t.ZERO, riscv_reg_t.RA, riscv_reg_t.GP))
+        self.gpr1.not_inside(vsc.rangelist(self.sp, self.tp, self.scratch_reg, self.pmp_reg,
+                                           riscv_reg_t.ZERO, riscv_reg_t.RA, riscv_reg_t.GP))
+        self.gpr2.not_inside(vsc.rangelist(self.sp, self.tp, self.scratch_reg, self.pmp_reg,
+                                           riscv_reg_t.ZERO, riscv_reg_t.RA, riscv_reg_t.GP))
+        self.gpr3.not_inside(vsc.rangelist(self.sp, self.tp, self.scratch_reg, self.pmp_reg,
+                                           riscv_reg_t.ZERO, riscv_reg_t.RA, riscv_reg_t.GP))
+        vsc.unique(self.gpr0, self.gpr1, self.gpr2, self.gpr3)
 
     def check_setting(self):
         support_64b = 0
@@ -221,6 +236,9 @@ class riscv_instr_gen_config:
             self.s_mode_interrupt_delegation[j] = 0
 
     def pre_randomize(self):
+        # Clearing the contents of self.gpr after each randomization.
+        # As it is being extended in post_randomize function.
+        self.gpr.clear()
         for x in rcs.supported_privileged_mode:
             if(x == "SUPERVISOR_MODE"):
                 self.support_supervisor_mode = 1
@@ -229,6 +247,9 @@ class riscv_instr_gen_config:
         pass
 
     def post_randomize(self):
+        # Temporary fix for gpr_c constraint.
+        self.gpr.extend((self.gpr0, self.gpr1, self.gpr2, self.gpr3))
+
         self.reserved_regs.append(self.tp)
         self.reserved_regs.append(self.sp)
         self.reserved_regs.append(self.scratch_reg)
@@ -252,7 +273,7 @@ class riscv_instr_gen_config:
         for mode in self.init_privileged_mode:
             if mode == "MACHINE_MODE":
                 continue
-            elif mode == 'SUPERVISOR_MODE':
+            if mode == 'SUPERVISOR_MODE':
                 invalid_lvl.append('M')
                 logging.info("supr_mode---")
                 logging.debug(invalid_lvl)
@@ -295,8 +316,10 @@ def parse_args():
     parse.add_argument('--no_ebreak', help = 'no_ebreak', choices = [0, 1], type = int, default = 1)
     parse.add_argument('--no_dret', help = 'no_dret', choices = [0, 1], type = int, default = 1)
     parse.add_argument('--no_wfi', help = 'no_wfi', choices = [0, 1], type = int, default = 1)
+
+    # TODO : Enabling no_branch_jump default to 1 for now.
     parse.add_argument('--no_branch_jump', help = 'no_branch_jump',
-                       choices = [0, 1], type = int, default = 0)
+                       choices = [0, 1], type = int, default = 1)
     parse.add_argument('--no_load_store', help = 'no_load_store',
                        choices = [0, 1], type = int, default = 0)
     parse.add_argument('--no_csr_instr', help = 'no_csr_instr',

--- a/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_pkg.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_pkg.py
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 """
 
+import logging
 from enum import Enum, auto
 from bitstring import BitArray
 from pygen_src.target.rv32i import riscv_core_setting as rcs
@@ -1160,6 +1161,23 @@ class all_categories(Enum):
     INTERRUPT = auto()
     AMO = auto()
 
+def get_val(in_string, hexa=0):
+    if len(in_string) > 2:
+        if "0x" in in_string:
+            out_val = hex(int(in_string, base=16))
+            return out_val
+        if hexa:
+            out_val = hex(int(in_string, base=16))
+        else:
+            out_val = int(in_string)
+            logging.info("riscv_instr_pkg: imm: {} -> {}".format(in_string, out_val))
+        return out_val
+
+class hazard_e(Enum):
+    NO_HAZARD = 0
+    RAW_HAZARD = auto()
+    WAR_HAZARD = auto()
+    WAW_HAZARD = auto()
 
 class riscv_instr_pkg:
     def __init__(self):
@@ -1191,7 +1209,7 @@ class riscv_instr_pkg:
         formatted_str = length * " "
         if (int(length) < len(string)):
             return string
-        formatted_str = string + formatted_str[0: (int(length) - len(string) - 1)]
+        formatted_str = string + formatted_str[0: (int(length) - len(string))]
         return formatted_str
 
     def format_data(self, data, byte_per_group = 4):
@@ -1201,6 +1219,12 @@ class riscv_instr_pkg:
                 string = string + ", 0x"
             string = string + f"{hex(data[i])}"
         return string
+
+    def push_gpr_to_kernel_stack(self, status, scratch, mprv, sp, tp, instr):
+        pass
+
+    def pop_gpr_from_kernel_stack(self, status, scratch, mprv, sp, tp, instr):
+        pass
 
 
 pkg_ins = riscv_instr_pkg()

--- a/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_stream.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_stream.py
@@ -63,6 +63,7 @@ class riscv_instr_stream:
                     return
         elif idx > current_instr_cnt or idx < 0:
             logging.error("Cannot insert instr:%0s at idx %0d", instr.convert2asm(), idx)
+            sys.exit(1)
         self.instr_list.insert(idx, instr)
 
     def insert_instr_stream(self, new_instr, idx = -1, replace = 0):
@@ -128,7 +129,7 @@ class riscv_instr_stream:
         if len(insert_instr_position) > 0:
             insert_instr_position.sort()
         for i in range(new_instr_cnt):
-            insert_instr_position[i] = random.rangeint(0, current_instr_cnt)
+            insert_instr_position[i] = random.randint(0, current_instr_cnt)
         if len(insert_instr_position) > 0:
             insert_instr_position.sort()
         if contained:
@@ -201,7 +202,7 @@ class riscv_rand_instr_stream(riscv_instr_stream):
             if len(self.instr_list) == 0:
                 break
 
-    def randomize_instr(self, instr, is_in_debug = 0, disable_dist = 0):
+    def randomize_instr(self, instr, is_in_debug = 0):
         exclude_instr = []
         is_SP_in_reserved_rd = riscv_reg_t.SP in self.reserved_rd
         is_SP_in_reserved_regs = riscv_reg_t.SP in cfg.reserved_regs

--- a/vendor/google_riscv-dv/pygen/pygen_src/target/rv32i/riscv_core_setting.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/target/rv32i/riscv_core_setting.py
@@ -16,7 +16,7 @@ XLEN = 32
 implemented_csr = ['MVENDORID', 'MARCHID', 'MIMPID', 'MHARTID', 'MSTATUS', 'MISA', 'MIE',
                    'MTVEC', 'MCOUNTEREN', 'MSCRATCH', 'MEPC', 'MCAUSE', 'MTVAL', 'MIP']
 
-SATP_MODE = ['BARE']
+SATP_MODE = 'BARE'
 
 supported_isa = ['RV32I']
 

--- a/vendor/google_riscv-dv/pygen/pygen_src/test/riscv_instr_cov_test.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/test/riscv_instr_cov_test.py
@@ -1,0 +1,407 @@
+# Lint as: python3
+"""Tests for riscv_instr_cov."""
+import sys
+import os
+import logging
+import argparse
+import vsc  # PyVSC library
+import csv  # Python library to read/write from/to CSV files
+from bitstring import BitArray
+from pygen.pygen_src.isa.riscv_instr_cov import *
+from pygen.pygen_src.riscv_instr_pkg import *
+from pygen.pygen_src.target.rv32i import riscv_core_setting as rcs
+
+
+
+logging.basicConfig(filename='logging.log',level=logging.DEBUG)
+
+class riscv_instr():
+    """ Class for a riscv instruction; data parsed from the CSV file will fill
+    different fields of an instruction """
+    # class attr. to keep track of reg_name:reg_value throughout the program
+    gpr_state = {}
+    def __init__(self, instr_name):
+        self.pc = 0 # Program counter (PC) of the instruction
+        self.instr = instr_name
+        self.gpr = None # destination operand of the instruction
+        self.csr = None
+        self.binary = 0 # Instruction binary
+        self.mode = None # Instruction mode
+        self.trace = "None" # String representation of the instruction
+        self.operands = "None"  # Instruction operands (srcss/dests)
+        self.pad = None # Not used
+
+        self.rs1_value = None
+        self.rs2_value = None
+        self.rs3_value = None
+        self.rd_value = None
+        self.fs1_value = None
+        self.fs2_value = None
+        self.fs3_value = None
+        self.fd_value = None
+
+        self.mem_addr = None
+        self.unaligned_pc = 0
+        self.unaligned_mem_access = 0
+        self.compressed = 0
+        self.branch_hit = 0
+        self.div_result = None
+        self.rs1_sign = None
+        self.rs2_sign = None
+        self.rs3_sign = None
+        self.fs1_sign = None
+        self.fs2_sign = None
+        self.fs3_sign = None
+        self.imm_sign = None
+        self.rd_sign = None
+        self.gpr_hazard = None
+        self.lsu_hazard = None
+        self.rs1_special_value = None
+        self.rs2_special_value = None
+        self.rs3_special_value = None
+        self.rd_special_value = None
+        self.imm_special_value = None
+        self.compare_result = None
+        self.logical_similarity = None
+
+        # TODO: add & map...
+        #self.imm
+        #self.format
+        #self.category
+
+    def pre_sample(self):
+        unaligned_pc = self.pc[-2:] != "00"
+        self.rs1_sign = self.get_operand_sign(self.rs1_value)
+        self.rs2_sign = self.get_operand_sign(self.rs2_value)
+        self.rs3_sign = self.get_operand_sign(self.rs3_value)
+        self.rd_sign = self.get_operand_sign(self.rd_value) 
+        self.fs1_sign = self.get_operand_sign(self.fs1_value)
+        self.fs2_sign = self.get_operand_sign(self.fs2_value)
+        self.fs3_sign = self.get_operand_sign(self.fs3_value)
+        self.fd_sign = self.get_operand_sign(self.fd_value)
+        self.imm_sign = self.get_imm_sign(self.imm)
+        self.rs1_special_value = self.get_operand_special_value(self.rs1_value)
+        self.rd_special_value = self.get_operand_special_value(self.rd_value)
+        self.rs2_special_value = self.get_operand_special_value(self.rs2_value)
+        self.rs3_special_value = self.get_operand_special_value(self.rs3_value)
+        if (self.format != riscv_instr_format_t.R_FORMAT and
+            self.format != riscv_instr_format_t.CR_FORMAT):
+            self.imm_special_value = self.get_imm_special_val(self.imm)
+        if self.category in [riscv_instr_category_t.COMPARE,
+                            riscv_instr_category_t.BRANCH]:
+            self.compare_result = self.get_compare_result()
+        if self.category in [riscv_instr_category_t.LOAD,
+                             riscv_instr_category_t.STORE]:
+            self.mem_addr = self.rs1_value + self.imm
+            self.unaligned_mem_access = self.is_unaligned_mem_access()
+            if self.unaligned_mem_access:
+                logging.info("Unaligned: {}, mem_addr: {}".format(
+                self.instr, self.mem_addr))
+        if self.category == riscv_instr_category_t.LOGICAL:
+            self.logical_similarity = self.get_logical_similarity()
+        if self.category == riscv_instr_category_t.BRANCH:
+            self.branch_hit = self.is_branch_hit()
+        #TODO: string > enumeration
+        if self.instr in ["DIV", "DIVU", "REM", "REMU", "DIVW", "DIVUW", 
+                          "REMW", "REMUW"]:
+            self.div_result = self.get_div_result()
+
+    def get_operand_sign(self, operand):
+        #TODO: change operand to vsc.bit_t
+        out = BitArray(int=operand.val, length=rcs.XLEN)
+        if out[0]:
+            return operand_sign_e["NEGATIVE"]
+        else:
+            return operand_sign_e["POSITIVE"]
+
+    def is_unaligned_mem_access(self):
+        #TODO: string > enumeration
+        if (self.instr in ["LWU", "LD", "SD", "C_LD", "C_SD"] and
+            self.mem_addr % 8 != 0):
+            return True
+        elif (self.instr in ["LW", "SW", "C_LW", "C_SW"] and
+              self.mem_addr % 4 != 0):
+            return True
+        elif (self.instr in ["LH", "LHU", "SH"] and
+              self.mem_addr % 2 != 0):
+            return True
+        return False
+
+    def get_imm_sign(self, imm):
+        #TODO: change imm to vsc.int_t(32)
+        out = BitArray(int=imm.val, length=rcs.XLEN)
+        if out[0]:
+            return operand_sign_e["NEGATIVE"]
+        else:
+            return operand_sign_e["POSITIVE"]
+
+    def get_div_result(self):
+        #TODO: change rs2_value to vsc.int_t(32)
+        if self.rs2_value.val == 0:
+            return div_result_e["DIV_BY_ZERO"]
+        elif self.rs2_value.val == 1 and self.rs1_value.val == (1 << (rcs.XLEN-1)):
+            return div_result_e["DIV_OVERFLOW"]
+        else:
+            return div_result_e["DIV_NORMAL"]
+
+    def get_operand_special_value(self, operand):
+        if operand.val == 0:
+            return special_val_e["ZERO_VAL"]
+        elif operand.val == 1 << (rcs.XLEN-1):
+            return special_val_e["MIN_VAL"]
+        elif operand.val == 1 >> 1:
+            return special_val_e["MAX_VAL"]
+        else:
+            return special_val_e["NORMAL_VAL"]
+
+    def get_imm_special_val(self, imm):
+        if imm.val == 0:
+            return special_val_e["ZERO_VAL"]
+        elif self.format == riscv_instr_format_t.U_FORMAT:
+            # unsigned immediate value
+            # TODO: self.imm_len
+            max = vsc.int_t(32, (1 << self.imm_len)-1)
+            if imm.val == 0:
+                return special_val_e["MIN_VAL"]
+            if imm.val == max.val:
+                return special_val_e["MAX_VAL"]
+        else:
+            # signed immediate value
+            max = vsc.int_t(32, (2 ** (self.imm_len - 1)) - 1)
+            min = vsc.int_t(32, -2 ** (self.imm_len - 1))
+            if min.val == imm.val:
+                return special_val_e["MIN_VAL"]
+            if max.val == imm.val:
+                return special_val_e["MAX_VAL"]
+        return special_val_e["NORMAL_VAL"]
+
+    def get_compare_result(self):
+        val1 = vsc.int_t(rcs.XLEN)
+        val2 = vsc.int_t(rcs.XLEN)
+        val1.val = self.rs1_value.val
+        val2.val = self.imm.val if (
+                self.format == riscv_instr_format_t.I_FORMAT) \
+            else self.rs2_value.val
+        if val1.val == val2.val:
+            return compare_result_e["EQUAL"]
+        elif val1.val < val2.val:
+            return compare_result_e["SMALLER"]
+        else:
+            return compare_result_e["LARGER"]
+
+    def is_branch_hit(self):
+        # TODO: string/enumeration
+        if self.instr == "BEQ":
+            return self.rs1_value.val == self.rs2_value.val
+        elif self.instr == "C_BEQZ":
+            return self.rs1_value.val == 0
+        elif self.instr == "BNE":
+            return self.rs1_value.val != self.rs2_value.val
+        elif self.instr == "C_BNEZ":
+            return self.rs1_value.val != 0
+        elif self.instr == "BLT" or self.instr == "BLTU":
+            return self.rs1_value.val < self.rs2_value.val
+        elif self.instr == "BGE" or self.instr == "BGEU":
+            return self.rs1_value.val >= self.rs2_value.val
+        else:
+            logging.error("Unexpected instruction {}".format(self.instr))
+
+    def get_logical_similarity(self):
+        val1 = vsc.int_t(rcs.XLEN, self.rs1_value.val)
+        val2 = vsc.int_t(rcs.XLEN)
+        val2.val = (self.imm.val if self.format == riscv_instr_format_t.I_FORMAT
+                    else self.rs2_value.val)
+        temp = bin(val1.val ^ val2.val)
+        bit_difference = len([[ones for ones in temp[2:] if ones=='1']])
+        if val1.val == val2.val:
+            return logical_similarity_e["IDENTICAL"]
+        elif bit_difference == 32:
+            return logical_similarity_e["OPPOSITE"]
+        elif bit_difference < 5:
+            return logical_similarity_e["SIMILAR"]
+        else:
+            return logical_similarity_e["DIFFERENT"]
+
+    def check_hazard_condition(self, pre_instr):
+        # TODO: has_rd(), has_rs1, has_rs2, rd, category, convert2asm (from IG)
+        if pre_instr.has_rd():
+            if ((self.has_rs1 and self.rs1 == pre_instr.rd) or
+                    (self.has_rs2 and self.rs1 == pre_instr.rd)):
+                self.gpr_hazard = hazard_e["RAW_HAZARD"]
+            elif self.has_rd and self.rd == pre_instr.rd:
+                self.gpr_hazard = hazard_e["WAW_HAZARD"]
+            elif (self.has_rd and
+                  ((pre_instr.has_rs1 and (pre_instr.rs1 == self.rd)) or
+                   (pre_instr.has_rs2 and (pre_instr.rs2 == self.rd)))):
+                self.gpr_hazard = hazard_e["WAR_HAZARD"]
+            else:
+                self.gpr_hazard = hazard_e["NO_HAZARD"]
+        if self.category == riscv_instr_category_t.LOAD:
+            # TODO: change mem_addr to vsc type
+            if (pre_instr.category == riscv_instr_category_t.STORE and
+                    pre_instr.mem_addr == self.mem_addr):
+                self.lsu_hazard = hazard_e["RAW_HAZARD"]
+            else:
+                self.lsu_hazard = hazard_e["NO_HAZARD"]
+        if self.category == riscv_instr_category_t.STORE:
+            if (pre_instr.category == riscv_instr_category_t.STORE and
+                    pre_instr.mem_addr == self.mem_addr):
+                self.lsu_hazard = hazard_e["WAW_HAZARD"]
+            elif (pre_instr.category == riscv_instr_category_t.LOAD and
+                    pre_instr.mem_addr == self.mem_addr):
+                self.lsu_hazard = hazard_e["WAR_HAZARD"]
+            else:
+                self.lsu_hazard = hazard_e["NO_HAZARD"]
+        logging.info("Pre: {}, Cur: {}, Hazard: {}/{}".format(
+            pre_instr.convert2asm(), self.convert2asm(),
+            self.gpr_hazard.name, self.lsu_hazard.name))
+
+    def update_src_regs(self, operands):
+        pass
+
+    def update_dst_regs(self, reg_name, val_str):
+        pass
+
+class riscv_instr_cov_test():
+    """ Main class for applying the functional coverage test """
+    def __init__(self, argv):
+        self.trace = {}
+        self.csv_trace = argv
+        self.entry_cnt, self.total_entry_cnt, self.skipped_cnt, \
+        self.unexpected_illegal_instr_cnt = 0, 0, 0, 0
+
+    def run_phase(self):
+        if not self.csv_trace:
+            sys.exit("No CSV file found!")
+        logging.info("{} CSV trace files to be "
+                     "processed...\n".format(len(self.csv_trace)))
+        expect_illegal_instr = False
+        # Assuming we get list of csv files pathname from cov.py in argv
+        for csv_file in self.csv_trace:
+            with open("{}".format(csv_file)) as trace_file:
+                self.entry_cnt = 0
+                header = []
+                entry = []
+                csv_reader = csv.reader(trace_file, delimiter=',')
+                line_count = 0
+                # Get the header line
+                for row in csv_reader:
+                    if line_count == 0:
+                        header = row
+                        logging.info("Header: {}".format(header))
+                    else:
+                        entry = row
+                        if len(entry) != len(header):
+                            logging.info("Skipping malformed entry[{}]: "
+                                         "[{}]".format(self.entry_cnt, entry))
+                            self.skipped_cnt += 1
+                        else:
+                            self.trace["csv_entry"] = row
+                            for idx in range(len(header)):
+                                if "illegal" in entry[idx]:
+                                    expect_illegal_instr = True
+                                self.trace[header[idx]] = entry[idx]
+                                if header[idx] != "pad":
+                                    logging.info("{} = {}".format(header[idx],
+                                                                  entry[idx])) 
+                            self.post_process_trace()
+                            if self.trace["instr"] in ["li", "ret", "la"]:
+                                pass
+                            if "amo" in self.trace["instr"] or \
+                               "lr" in self.trace["instr"] or \
+                               "sc" in self.trace["instr"]:
+                                # TODO: Enable functional coverage for AMO test
+                                pass
+                            if not self.sample():
+                                if not expect_illegal_instr:
+                                    logging.error("Found unexpected illegal "
+                                                  "instr: {} "
+                                                  "[{}]".format(self.trace[
+                                                      "instr"],entry))
+                                    self.unexpected_illegal_instr_cnt += 1
+                        self.entry_cnt += 1
+                    line_count += 1
+                logging.info("[{}]: {} instr processed".format(csv_file,
+                                                               self.entry_cnt))
+                self.total_entry_cnt += self.entry_cnt
+        logging.info("Finished processing {} trace CSV, {} "
+                     "instructions".format(len(self.csv_trace),
+                                          self.total_entry_cnt))
+        if self.skipped_cnt > 0 or self.unexpected_illegal_instr_cnt > 0:
+            logging.error("{} instruction skipped, {} illegal "
+                          "instructions".format(self.skipped_cnt),
+                          self.unexpected_illegal_instr_cnt)
+
+    def post_process_trace(self):
+        pass
+
+    def sample(self):
+        instr_name, binary = "", ""
+        binary = get_val(self.trace["binary"], hexa=1)
+        if binary[-2:] != "11": #TODO: and RV32C in supported_isa 
+            #TODO: sample compressed instruction
+            pass
+        if binary[-2:] == "11":
+            #TODO: sampling
+            pass
+        #TODO: buch of if statements to check if the instruction name is valid
+        # and is a member of registered ones
+        instr_name = self.process_instr_name(self.trace["instr"])
+        instruction = riscv_instr(instr_name)
+        #TODO: check the instruction group...
+        self.assign_trace_info_to_instr(instruction)
+        #TODO: instruction.pre_sample() and sample(instruction)
+        return True
+
+    def assign_trace_info_to_instr(self, instruction):
+        operands, gpr_update, pair = [], [], []
+        instruction.pc = get_val(self.trace["pc"], hexa=1)
+        instruction.binary = get_val(self.trace["binary"], hexa=1)
+        instruction.gpr = self.trace["gpr"]
+        instruction.csr = self.trace["csr"]
+        instruction.mode = self.trace["mode"]
+        instruction.trace = self.trace["instr_str"]
+        instruction.operands = self.trace["operand"]
+        operands = self.trace["operand"].split(",")
+        instruction.update_src_regs(operands)
+        gpr_update = self.trace["gpr"].split(";")
+        if len(gpr_update) == 1 and gpr_update[0] == "": 
+            gpr_update = []
+        for dest in gpr_update:
+            pair = dest.split(":")
+            if len(pair) != 2:
+                logging.error("Illegal gpr update format: {}".format(dest))
+            instruction.update_dst_regs(pair[0], pair[1])
+        instruction.pad = self.trace["pad"]
+
+    def process_instr_name(self, instruction):
+        instruction = instruction.upper()
+        instruction.replace(".", "_")
+        instruction = self.update_instr_name(instruction)
+        return instruction
+
+    def update_instr_name(self, instruction):
+        switcher = {
+            # Rename to new name as ovpsim still uses old name
+            "FMV_S_X": "FMV_W_X",
+            "FMV_X_S": "FMV_X_W",
+            # Convert pseudoinstructions
+            "FMV_S":  "FSGNJ_S",
+            "FABS_S": "FSGNJX_S",
+            "FNEG_S": "FSGNJN_S",
+            "FMV_D":  "FSGNJ_D",
+            "FABS_D": "FSGNJX_D",
+            "FNEG_D": "FSGNJN_D",
+        }
+        # if instruction is not present in the dictionary,second argument well
+        # be assigned as default value of passed argument
+        instruction = switcher.get(instruction, instruction)
+        return instruction
+
+
+def main(argv): 
+    cov_test = riscv_instr_cov_test(argv)
+    cov_test.run_phase()
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/vendor/google_riscv-dv/src/isa/rv32v_instr.sv
+++ b/vendor/google_riscv-dv/src/isa/rv32v_instr.sv
@@ -298,3 +298,27 @@
 `DEFINE_VA_INSTR(VSUXSEGH_V, VSX_FORMAT, STORE, RVV, {}, "zvlsseg")
 `DEFINE_VA_INSTR(VSUXSEGW_V, VSX_FORMAT, STORE, RVV, {}, "zvlsseg")
 `DEFINE_VA_INSTR(VSUXSEGE_V, VSX_FORMAT, STORE, RVV, {}, "zvlsseg")
+
+// -------------------------------------------------------------------------
+//  Section 8. Vector AMO Operations (Zvamo)
+// -------------------------------------------------------------------------
+// 32-bit vector AMOs
+`DEFINE_VA_INSTR(VAMOSWAPW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOADDW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOXORW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOANDW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOORW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMINW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMAXW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMINUW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMAXUW_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+// SEW-bit vector AMOs
+`DEFINE_VA_INSTR(VAMOSWAPE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOADDE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOXORE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOANDE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOORE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMINE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMAXE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMINUE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")
+`DEFINE_VA_INSTR(VAMOMAXUE_V, VAMO_FORMAT, AMO, RVV, {}, "zvamo")

--- a/vendor/google_riscv-dv/src/riscv_amo_instr_lib.sv
+++ b/vendor/google_riscv-dv/src/riscv_amo_instr_lib.sv
@@ -188,3 +188,32 @@ class riscv_amo_instr_stream extends riscv_amo_base_instr_stream;
   endfunction
 
 endclass : riscv_amo_instr_stream
+
+
+class riscv_vector_amo_instr_stream extends riscv_vector_load_store_instr_stream;
+
+  constraint amo_address_mode_c {
+    // AMO operation only supports word alignment or element alignemt
+    alignment inside {W_ALIGNMENT, E_ALIGNMENT};
+    // AMO operation uses indexed address mode
+    address_mode == INDEXED;
+    // For the 32-bit vector AMO operations, SEW must be at least 32 bit
+    (cfg.vector_cfg.vtype.vsew < 32) -> (alignment != W_ALIGNMENT);
+  }
+
+  `uvm_object_utils(riscv_vector_amo_instr_stream)
+  `uvm_object_new
+
+  virtual function void add_element_vec_load_stores();
+    allowed_instr = {VAMOSWAPE_V, VAMOADDE_V, VAMOXORE_V,
+                     VAMOANDE_V, VAMOORE_V, VAMOMINE_V,
+                     VAMOMAXE_V, VAMOMINUE_V, VAMOMAXUE_V, allowed_instr};
+  endfunction
+
+  virtual function void add_w_vec_load_stores();
+    allowed_instr = {VAMOSWAPW_V, VAMOADDW_V, VAMOXORW_V,
+                     VAMOANDW_V, VAMOORW_V, VAMOMINW_V,
+                     VAMOMAXW_V, VAMOMINUW_V, VAMOMAXUW_V, allowed_instr};
+  endfunction
+
+endclass : riscv_vector_amo_instr_stream

--- a/vendor/google_riscv-dv/src/riscv_illegal_instr.sv
+++ b/vendor/google_riscv-dv/src/riscv_illegal_instr.sv
@@ -166,11 +166,13 @@ class riscv_illegal_instr extends uvm_object;
     c_op != 2'b11;
   }
 
-  // Avoid generating illegal func3/func7 errors for opcode used by B-extension
+  // Avoid generating illegal func3/func7 errors for opcode used by B-extension for now
+  //
+  // TODO(udi): add support for generating illegal B-extension instructions
   constraint b_extension_c {
     if (RV32B inside {supported_isa}) {
       if (exception inside {kIllegalFunc3, kIllegalFunc7}) {
-        !(opcode inside {7'b0011011, 7'b0010011, 7'b0111011});
+        !(opcode inside {7'b0110011, 7'b0010011, 7'b0111011});
       }
     }
   }
@@ -356,8 +358,8 @@ class riscv_illegal_instr extends uvm_object;
     if (riscv_instr_pkg::RV32A inside {riscv_instr_pkg::supported_isa}) begin
       legal_opcode = {legal_opcode, 7'b0101111};
     end
-    if ((riscv_instr_pkg::RV64I inside {riscv_instr_pkg::supported_isa}) ||
-         riscv_instr_pkg::RV64M inside {riscv_instr_pkg::supported_isa}) begin
+    if (riscv_instr_pkg::RV64I inside {riscv_instr_pkg::supported_isa} ||
+        riscv_instr_pkg::RV64M inside {riscv_instr_pkg::supported_isa}) begin
       legal_opcode = {legal_opcode, 7'b0111011};
     end
     if (riscv_instr_pkg::RV64I inside {riscv_instr_pkg::supported_isa}) begin

--- a/vendor/google_riscv-dv/src/riscv_instr_pkg.sv
+++ b/vendor/google_riscv-dv/src/riscv_instr_pkg.sv
@@ -641,6 +641,7 @@ package riscv_instr_pkg;
     VLHUFF_V,
     VLWUFF_V,
     VLEFF_V,
+    // Segmented load/store instruction
     VLSEGE_V,
     VSSEGE_V,
     VLSEGB_V,
@@ -685,6 +686,27 @@ package riscv_instr_pkg;
     VSUXSEGH_V,
     VSUXSEGW_V,
     VSUXSEGE_V,
+    // Vector AMO instruction
+    // 32-bit vector AMOs
+    VAMOSWAPW_V,
+    VAMOADDW_V,
+    VAMOXORW_V,
+    VAMOANDW_V,
+    VAMOORW_V,
+    VAMOMINW_V,
+    VAMOMAXW_V,
+    VAMOMINUW_V,
+    VAMOMAXUW_V,
+    // SEW-bit vector AMOs
+    VAMOSWAPE_V,
+    VAMOADDE_V,
+    VAMOXORE_V,
+    VAMOANDE_V,
+    VAMOORE_V,
+    VAMOMINE_V,
+    VAMOMAXE_V,
+    VAMOMINUE_V,
+    VAMOMAXUE_V,
     // Supervisor instruction
     DRET,
     MRET,
@@ -747,7 +769,8 @@ package riscv_instr_pkg;
     VLX_FORMAT,
     VSX_FORMAT,
     VLS_FORMAT,
-    VSS_FORMAT
+    VSS_FORMAT,
+    VAMO_FORMAT
   } riscv_instr_format_t;
 
 

--- a/vendor/google_riscv-dv/src/riscv_load_store_instr_lib.sv
+++ b/vendor/google_riscv-dv/src/riscv_load_store_instr_lib.sv
@@ -519,7 +519,7 @@ class riscv_load_store_rand_addr_instr_stream extends riscv_load_store_base_inst
 
 endclass
 
-class riscv_vector_stride_load_store_instr_stream extends riscv_mem_access_stream;
+class riscv_vector_load_store_instr_stream extends riscv_mem_access_stream;
 
   typedef enum {B_ALIGNMENT, H_ALIGNMENT, W_ALIGNMENT, E_ALIGNMENT} alignment_e;
   typedef enum {UNIT_STRIDED, STRIDED, INDEXED} address_mode_e;
@@ -573,7 +573,7 @@ class riscv_vector_stride_load_store_instr_stream extends riscv_mem_access_strea
   int max_load_store_addr;
   riscv_vector_instr load_store_instr;
 
-  `uvm_object_utils(riscv_vector_stride_load_store_instr_stream)
+  `uvm_object_utils(riscv_vector_load_store_instr_stream)
   `uvm_object_new
 
   virtual function int get_addr_alignment_mask(int alignment_bytes);
@@ -590,6 +590,7 @@ class riscv_vector_stride_load_store_instr_stream extends riscv_mem_access_strea
     if (address_mode == STRIDED) begin
       instr_list.push_front(get_init_gpr_instr(rs2_reg, stride_byte_offset));
     end else if (address_mode == INDEXED) begin
+      // TODO: Support different index address for each element
       add_init_vector_gpr_instr(vs2_reg, index_addr);
     end
     super.post_randomize();

--- a/vendor/google_riscv-dv/src/riscv_privil_reg.sv
+++ b/vendor/google_riscv-dv/src/riscv_privil_reg.sv
@@ -282,15 +282,8 @@ class riscv_privil_reg extends riscv_reg#(privileged_reg_t);
       // Physical Memory Protection Configuration Register
       PMPCFG1: begin
         privil_level = M_LEVEL;
-        if(XLEN==64) begin
-          add_field("PMP8CFG", 8, WARL);
-          add_field("PMP9CFG", 8, WARL);
-          add_field("PMP10CFG", 8, WARL);
-          add_field("PMP11CFG", 8, WARL);
-          add_field("PMP12CFG", 8, WARL);
-          add_field("PMP13CFG", 8, WARL);
-          add_field("PMP14CFG", 8, WARL);
-          add_field("PMP15CFG", 8, WARL);
+        if(XLEN!=32) begin
+          `uvm_fatal(`gfn, "CSR PMPCFG1 only exists in RV32.")
         end else begin
           add_field("PMP4CFG", 8, WARL);
           add_field("PMP5CFG", 8, WARL);
@@ -300,14 +293,17 @@ class riscv_privil_reg extends riscv_reg#(privileged_reg_t);
       end
       // Physical Memory Protection Configuration Register
       PMPCFG2: begin
-        if(XLEN!=32) begin
-          `uvm_fatal(get_full_name(), "CSR PMPCFG2 only exists in RV32.")
-        end
         privil_level = M_LEVEL;
         add_field("PMP8CFG", 8, WARL);
         add_field("PMP9CFG", 8, WARL);
         add_field("PMP10CFG", 8, WARL);
         add_field("PMP11CFG", 8, WARL);
+        if(XLEN==64) begin
+          add_field("PMP12CFG", 8, WARL);
+          add_field("PMP13CFG", 8, WARL);
+          add_field("PMP14CFG", 8, WARL);
+          add_field("PMP15CFG", 8, WARL);
+        end
       end
       // Physical Memory Protection Configuration Register
       PMPCFG3: begin

--- a/vendor/google_riscv-dv/target/rv64gcv/testlist.yaml
+++ b/vendor/google_riscv-dv/target/rv64gcv/testlist.yaml
@@ -74,8 +74,23 @@
     +num_of_sub_program=0
     +enable_floating_point=1
     +enable_vector_extension=1
-    +directed_instr_0=riscv_vector_stride_load_store_instr_stream,4
-    +enable_fault_only_first_load=1
+    +directed_instr_0=riscv_vector_load_store_instr_stream,10
+    +no_branch_jump=1
+    +boot_mode=m
+    +no_csr_instr=1
+  iterations: 5
+  gen_test: riscv_instr_base_test
+  rtl_test: core_base_test
+
+- test: riscv_vector_amo_test
+  description: >
+    Vector AMO random test
+  gen_opts: >
+    +instr_cnt=10000
+    +num_of_sub_program=0
+    +enable_floating_point=1
+    +enable_vector_extension=1
+    +directed_instr_0=riscv_vector_amo_instr_stream,10
     +no_branch_jump=1
     +boot_mode=m
     +no_csr_instr=1


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision 61755c001bec0433fb69458f74d95476d2101cf3

* Adds new PMP directed sequence. (Udi Jonnalagadda)
* Fix typo (aneels3)
* Add gpr_c constraint (aneels3)
* Corrections of a code formatting. (Dariusz Stachanczyk)
* Modify asm, config and pkg files. (aneels3)
* fix riscv_privil_reg compile error (google/riscv-dv#666) (udinator)
* Added methods to the coverage test file (Hodjat Asghari Esfeden)
* Constraints should contain only intergral types - fix added for a
  string variable used in nfields_c constraint. (Dariusz Stachanczyk)
* Minor fixes on coverage test (Hodjat Asghari Esfeden)
* fix pmpcfg csr definitions (Udi Jonnalagadda)
* Pygen: minor fix (danghai)
* Pre_sampling extension (Hodjat Asghari Esfeden)
* Fix opcode in b_extension_c constraint (google/riscv-dv#659)
  (udinator)
* Add vector AMO instruction support (google/riscv-dv#658) (taoliug)
* Terminate when it cannot insert instruction (danghai)
* Riscv_instr_cov added, riscv_instr_cov_test extended, comment
  applied (except for csv_dir) (Hodjat Asghari Esfeden)
* Fix Indentation (aneels3)
* fix imm constraint issue (aneels3)
* fix typo in extend_imm() (aneels3)
* Hodjat (Hodjat Asghari Esfeden)

Signed-off-by: Udi <udij@google.com>