### PR TITLE
[ibex/dv] Update Ibex PMP tests

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -640,6 +640,7 @@
   gen_opts: >
     +instr_cnt=6000
     +pmp_max_offset=00024000
+    +enable_write_pmp_csr=1
   rtl_test: core_ibex_base_test
 
 - test: riscv_pmp_disable_all_regions_test
@@ -668,6 +669,7 @@
     +pmp_region_13=X:0,W:0,R:0
     +pmp_region_14=X:0,W:0,R:0
     +pmp_region_15=X:0,W:0,R:0
+    +enable_write_pmp_csr=1
   rtl_test: core_ibex_base_test
 
 - test: riscv_pmp_out_of_bounds_test
@@ -680,6 +682,7 @@
   gen_opts: >
     +instr_cnt=6000
     +pmp_max_offset=00024000
+    +enable_write_pmp_csr=1
     +directed_instr_0=riscv_load_store_rand_addr_instr_stream,50
   rtl_test: core_ibex_base_test
 
@@ -696,6 +699,7 @@
     +pmp_max_offset=00024000
     +pmp_randomize=1
     +pmp_allow_addr_overlap=1
+    +enable_write_pmp_csr=1
   rtl_test: core_ibex_base_test
 
 - test: riscv_bitmanip_full_test


### PR DESCRIPTION
This PR adds a new riscv-dv option `enable_write_pmp_csr=1` to each of the
tests in the existing PMP test suite.

This will enable the core to execute a directed test sequence to write
random values to each `pmpaddr` and `pmpcfg` CSR in order to explicitly test write
accessibility and spec compliance.

The original values stored in these CSRs are restored afterwards.

Note: This patch has exposed what looks like a bug in OVPsim,
for the time being please run all PMP tests with Spike.

Signed-off-by: Udi <udij@google.com>