### PR TITLE
[ibex/dv] Update OVPsim to use 34-bit address range

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/riscvOVPsim.ic
+++ b/dv/uvm/core_ibex/riscv_dv_extension/riscvOVPsim.ic
@@ -21,3 +21,4 @@
 --override riscvOVPsim/cpu/defaultsemihost=F
 --override riscvOVPsim/cpu/wfi_is_nop=T
 --override riscvOVPsim/cpu/tval_ii_code=T
+--addressbits 34


### PR DESCRIPTION
This patch updates the OVPsim config file to use a 34-bit address space, as per discussion in https://github.com/riscv/riscv-ovpsim/issues/15.
Needed to resolve bugs in PMP tests that are popping up due to OVPsim currently only being configured for a 32-bit address space (PMP uses a 34-bit space).

Signed-off-by: Udi <udij@google.com>