### PR TITLE
[ibex/dv] Add dependency on bus_params_pkg

### DIFF
--- a/dv/uvm/core_ibex/ibex_dv.f
+++ b/dv/uvm/core_ibex/ibex_dv.f
@@ -63,7 +63,7 @@ ${PRJ_DIR}/ibex/vendor/google_riscv-dv/src/riscv_signature_pkg.sv
 +incdir+${PRJ_DIR}/ibex/dv/uvm/core_ibex/common/irq_agent
 +incdir+${PRJ_DIR}/ibex/vendor/lowrisc_ip/mem_model
 +incdir+${PRJ_DIR}/ibex/vendor/lowrisc_ip/dv_utils
-${PRJ_DIR}/ibex/dv/uvm/top_pkg/top_pkg.sv
+${PRJ_DIR}/ibex/dv/uvm/bus_params_pkg/bus_params_pkg.sv
 ${PRJ_DIR}/ibex/vendor/lowrisc_ip/common_ifs/clk_rst_if.sv
 ${PRJ_DIR}/ibex/vendor/lowrisc_ip/common_ifs/pins_if.sv
 ${PRJ_DIR}/ibex/vendor/lowrisc_ip/dv_utils/dv_utils_pkg.sv


### PR DESCRIPTION
This patch updates the Ibex environment's dependency on the old top_pkg
to now depend on bus_params_pkg.

Signed-off-by: Udi <udij@google.com>