### PR TITLE
Add UVM regression runs in private CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,11 +6,7 @@
 # Documentation at https://aka.ms/yaml
 
 variables:
-  VERILATOR_VERSION: 4.032
-  RISCV_TOOLCHAIN_TAR_VERSION: 20200626-1
-  RISCV_TOOLCHAIN_TAR_VARIANT: lowrisc-toolchain-gcc-rv32imcb
-  RISCV_COMPLIANCE_GIT_VERSION: 844c6660ef3f0d9b96957991109dfd80cc4938e2
-  VERIBLE_VERSION: v0.0-493-g617b404
+- template: ci/vars.yml
 
 trigger:
   batch: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,60 +32,9 @@ jobs:
   pool:
     vmImage: "ubuntu-16.04"
   steps:
-  # Installing six is a workaround for pip dependency resolution: six is already
-  # installed as system package with a version below the required one.
-  # Explicitly installing six through pip gets us a supported version.
-  #
-  # Updating pip and setuptools is required to have these tools properly parse
-  # Python-version metadata, which some packages uses to specify that an older
-  # version of a package must be used for a certain Python version. If that
-  # information is not read, pip installs the latest version, which then fails
-  # to run.
   - bash: |
-      curl -L https://download.opensuse.org/repositories/home:phiwag:edatools/xUbuntu_16.04/Release.key | sudo apt-key add -
-      sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/xUbuntu_16.04/ /' > /etc/apt/sources.list.d/edatools.list"
-      # Uninstall distribution-provided version to get a newer version through pip
-      sudo apt-get remove -y python3-yaml
-      sudo apt-get update
-      sudo apt-get install -y \
-          python3 \
-          python3-pip \
-          python3-setuptools \
-          python3-wheel \
-          srecord \
-          zlib1g-dev \
-          git \
-          make \
-          autoconf \
-          g++ \
-          flex \
-          bison \
-          curl \
-          libelf-dev \
-          clang-format \
-          verilator-$(VERILATOR_VERSION) \
-        && sudo pip3 install -U setuptools pip six \
-        && sudo pip3 install -U -r python-requirements.txt
-    displayName: Install dependencies
-
-  - bash: |
-      set -e
-      mkdir -p build/verible
-      cd build/verible
-      curl -Ls -o verible.tar.gz https://github.com/google/verible/releases/download/$(VERIBLE_VERSION)/verible-$(VERIBLE_VERSION)-Ubuntu-16.04-xenial-x86_64.tar.gz
-      sudo mkdir -p /tools/verible && sudo chmod 777 /tools/verible
-      tar -C /tools/verible -xf verible.tar.gz --strip-components=1
-      echo "##vso[task.setvariable variable=PATH]/tools/verible/bin:$PATH"
-    displayName: Install Verible
-
-  - bash: |
-      export TOOLCHAIN_URL=https://github.com/lowRISC/lowrisc-toolchains/releases/download/${RISCV_TOOLCHAIN_TAR_VERSION}/${RISCV_TOOLCHAIN_TAR_VARIANT}-${RISCV_TOOLCHAIN_TAR_VERSION}.tar.xz
-      mkdir -p build/toolchain
-      curl -Ls -o build/toolchain/rv32-toolchain.tar.xz $TOOLCHAIN_URL
-      sudo mkdir -p /tools/riscv && sudo chmod 777 /tools/riscv
-      tar -C /tools/riscv -xf build/toolchain/rv32-toolchain.tar.xz --strip-components=1
-      echo "##vso[task.setvariable variable=PATH]/tools/riscv/bin:$PATH"
-    displayName: Get precompiled RISC-V toolchain
+      ci/install-build-deps.sh
+    displayName: Install build dependencies
 
   - bash: |
       echo $PATH
@@ -136,7 +85,7 @@ jobs:
       cd build
       git clone https://github.com/riscv/riscv-compliance.git
       cd riscv-compliance
-      git checkout "$(RISCV_COMPLIANCE_GIT_VERSION)"
+      git checkout "$RISCV_COMPLIANCE_GIT_VERSION"
     displayName: Get RISC-V Compliance test suite
 
   # Run Ibex RTL CI per supported configuration

--- a/ci/azp-private.yml
+++ b/ci/azp-private.yml
@@ -1,0 +1,31 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Private CI trigger.  Used to run tooling that can't currently be shared
+# publicly.
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - '*'
+  tags:
+    include:
+    - "*"
+pr:
+  branches:
+    include:
+    - '*'
+
+# The runner used for private CI enforces the use of the template below. All
+# build steps need to be placed into the template.
+resources:
+  repositories:
+  - repository: lowrisc-private-ci
+    type: github
+    endpoint: lowRISC
+    name: lowrisc/lowrisc-private-ci
+
+extends:
+  template: jobs-ibex.yml@lowrisc-private-ci

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install development build dependencies for different Linux distributions
+#
+
+set -e
+
+[ -f /etc/os-release ] || (echo "/etc/os-release doesn't exist."; exit 1)
+. /etc/os-release
+
+[ ! -z "$VERILATOR_VERSION" ] || (echo "VERILATOR_VERSION must be set."; exit 1)
+[ ! -z "$VERIBLE_VERSION" ] || (echo "VERIBLE_VERSION must be set."; exit 1)
+[ ! -z "$RISCV_TOOLCHAIN_TAR_VERSION" ] || (echo "RISCV_TOOLCHAIN_TAR_VERSION must be set."; exit 1)
+[ ! -z "$RISCV_TOOLCHAIN_TAR_VARIANT" ] || (echo "RISCV_TOOLCHAIN_TAR_VARIANT must be set."; exit 1)
+
+SUDO_CMD=""
+if [ $(id -u) -ne 0 ]; then
+  SUDO_CMD="sudo "
+fi
+
+case "$ID-$VERSION_ID" in
+  ubuntu-16.04)
+    # Curl must be available to get the repo key below.
+    $SUDO_CMD apt-get update
+    $SUDO_CMD apt-get install -y curl
+
+    # Make Verilator repository available
+    curl -Ls https://download.opensuse.org/repositories/home:phiwag:edatools/xUbuntu_16.04/Release.key | $SUDO_CMD apt-key add -
+    $SUDO_CMD sh -c "echo 'deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/xUbuntu_16.04/ /' > /etc/apt/sources.list.d/edatools.list"
+    $SUDO_CMD apt-get update
+
+    # Uninstall distribution-provided version to get a newer version through pip
+    $SUDO_CMD apt-get remove -y python3-yaml
+
+    # Packaged dependencies
+    $SUDO_CMD apt-get install -y \
+        device-tree-compiler \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
+        srecord \
+        zlib1g-dev \
+        git \
+        make \
+        autoconf \
+        g++ \
+        flex \
+        bison \
+        libelf-dev \
+        clang-format \
+        "verilator-$VERILATOR_VERSION" \
+        xz-utils
+
+      # Python dependencies
+      #
+      # Installing six is a workaround for pip dependency resolution: six is
+      # already installed as system package with a version below the required
+      # one. Explicitly installing six through pip gets us a supported version.
+      #
+      # Updating pip and setuptools is required to have these tools properly
+      # parse Python-version metadata, which some packages uses to specify that
+      # an older version of a package must be used for a certain Python version.
+      # If that information is not read, pip installs the latest version, which
+      # then fails to run.
+      $SUDO_CMD pip3 install -U setuptools pip six
+      $SUDO_CMD pip3 install -U -r python-requirements.txt
+
+      # Install Verible
+      mkdir -p build/verible
+      cd build/verible
+      curl -Ls -o verible.tar.gz "https://github.com/google/verible/releases/download/$VERIBLE_VERSION/verible-$VERIBLE_VERSION-Ubuntu-16.04-xenial-x86_64.tar.gz"
+      $SUDO_CMD mkdir -p /tools/verible && $SUDO_CMD chmod 777 /tools/verible
+      tar -C /tools/verible -xf verible.tar.gz --strip-components=1
+      echo "##vso[task.prependpath]/tools/verible/bin"
+    ;;
+
+  *)
+    echo Unknown distribution. Please extend this script!
+    exit 1
+    ;;
+esac
+
+# Install pre-compiled toolchain (for all distributions)
+TOOLCHAIN_URL="https://github.com/lowRISC/lowrisc-toolchains/releases/download/$RISCV_TOOLCHAIN_TAR_VERSION/$RISCV_TOOLCHAIN_TAR_VARIANT-$RISCV_TOOLCHAIN_TAR_VERSION.tar.xz"
+mkdir -p build/toolchain
+curl -Ls -o build/toolchain/rv32-toolchain.tar.xz "$TOOLCHAIN_URL"
+$SUDO_CMD mkdir -p /tools/riscv && $SUDO_CMD chmod 777 /tools/riscv
+tar -C /tools/riscv -xf build/toolchain/rv32-toolchain.tar.xz --strip-components=1
+echo "##vso[task.prependpath]/tools/riscv/bin"

--- a/ci/vars.yml
+++ b/ci/vars.yml
@@ -11,3 +11,5 @@ variables:
   RISCV_TOOLCHAIN_TAR_VARIANT: "lowrisc-toolchain-gcc-rv32imcb"
   RISCV_COMPLIANCE_GIT_VERSION: "844c6660ef3f0d9b96957991109dfd80cc4938e2"
   VERIBLE_VERSION: "v0.0-493-g617b404"
+  # lowRISC-internal version numbers of Ibex-specific Spike builds.
+  SPIKE_IBEX_VERSION: "20200819-git-57023895458bc5206fe59fa229e0be6b05aa2f25"

--- a/ci/vars.yml
+++ b/ci/vars.yml
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Pipeline variables, used by the public and private CI pipelines
+# Quote values to ensure they are parsed as string (version numbers might
+# end up as float otherwise).
+variables:
+  VERILATOR_VERSION: "4.032"
+  RISCV_TOOLCHAIN_TAR_VERSION: "20200626-1"
+  RISCV_TOOLCHAIN_TAR_VARIANT: "lowrisc-toolchain-gcc-rv32imcb"
+  RISCV_COMPLIANCE_GIT_VERSION: "844c6660ef3f0d9b96957991109dfd80cc4938e2"
+  VERIBLE_VERSION: "v0.0-493-g617b404"

--- a/ci/vars_to_logging_cmd.py
+++ b/ci/vars_to_logging_cmd.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Read an Azure Pipelines-compatible variables file, and convert it into
+# logging commands that Azure Pipelines understands, effectively setting the
+# variables at runtime.
+#
+# This script can be used as a workaround if variables cannot be included in the
+# Pipeline definition directly.
+#
+# See https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands
+# for more information on logging commands.
+
+import sys
+import yaml
+
+def vars_to_logging_cmd(vars_file):
+    data = {}
+    print(vars_file)
+    with open(vars_file, 'r', encoding="utf-8") as fp:
+        data = yaml.load(fp, Loader=yaml.SafeLoader)
+
+    if not (isinstance(data, dict) and 'variables' in data):
+        print("YAML file wasn't a dictionary with a 'variables' key. Got: {}"
+            .format(data))
+
+    print("Setting variables from {}".format(vars_file))
+    for key, value in data['variables'].items():
+        # Note: These lines won't show up in the Azure Pipelines output unless
+        # "System Diagnostics" are enabled (go to the Azure Pipelines web UI,
+        # click on "Run pipeline" to manually run a pipeline, and check "Enable
+        # system diagnostics".)
+        print("##vso[task.setvariable variable={}]{}".format(key, value))
+
+    return 0
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: {} VARS_FILE".format(sys.argv[0]))
+        sys.exit(1)
+    sys.exit(vars_to_logging_cmd(sys.argv[1]))


### PR DESCRIPTION
Add necessary configuration to be able to run RISC-V DV-based UVM regressions in CI. Due to licensing concerns these runs won't be publicly available. We therefore use the same setup as we do in OpenTitan, and add these runs as a second pipeline. The pipeline configuration and detailed results will only be visible to the core team, success/failure status will be available to everybody in the GitHub pull request view.

This PR is therefore mostly refactoring, the job configuration itself is in a separate repository.