### PR TITLE
List all Python requirements for dvsim

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -12,6 +12,8 @@ pyyaml
 mako
 
 # Needed by dvsim.py (not actually used in Ibex)
+hjson
+mistletoe>=0.7.2
 premailer
 
 # Recurse to get any requirements from riscv-dv


### PR DESCRIPTION
dvsim needs two more Python packages to run, which are not yet listed in
the python-requirements.txt file.