### PR TITLE
Port ICache formal core file to final Edalize design

### DIFF
--- a/formal/icache/ibex_icache_fpv.core
+++ b/formal/icache/ibex_icache_fpv.core
@@ -12,7 +12,7 @@ filesets:
       - lowrisc:ibex:ibex_icache
       - lowrisc:prim:assert
     files:
-      - run.sby : {file_type: sbyConfig}
+      - run.sby.j2 : {file_type: sbyConfigTemplate}
       - formal_tb_frag.svh : {file_type: systemVerilogSource, is_include_file: true}
       - formal_tb.sv : {file_type: systemVerilogSource}
       - sv2v_in_place.py : { copyto: sv2v_in_place.py }

--- a/formal/icache/run.sby.j2
+++ b/formal/icache/run.sby.j2
@@ -17,11 +17,14 @@ cv: depth 32
 smtbmc boolector
 
 [script]
-read -sv @INPUT@
+{{"-sv"|gen_reads}}
 
 # Our formal properties are currently just about control logic, which
 # isn't affected by the exact behaviour of the memories in the design.
 # Blackbox them.
 blackbox $abstract\prim_generic_ram_1p
 
-prep -top ibex_icache
+prep -top {{top_level}}
+
+[files]
+{{files}}


### PR DESCRIPTION
The PR that I pushed up to add sby support to
Edalize (https://github.com/olofk/edalize/pull/173) ended up with a
different input format from the one it started with.

That's now merged into master, so this patch updates the Ibex code to
match the final syntax.