### PR TITLE
[ci] Force setuptools not to use version 50.0.0 for now

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -66,7 +66,13 @@ case "$ID-$VERSION_ID" in
       # an older version of a package must be used for a certain Python version.
       # If that information is not read, pip installs the latest version, which
       # then fails to run.
-      $SUDO_CMD pip3 install -U setuptools pip six
+      $SUDO_CMD pip3 install -U pip six
+
+      # There's been a bit of a kerfuffle about setuptools version 50, which
+      # breaks importing distutils on Debian/Ubuntu systems. Make sure we don't
+      # pick it up until the dust has settled and things work again.
+      $SUDO_CMD pip3 install -U 'setuptools < 50.0.0'
+
       $SUDO_CMD pip3 install -U -r python-requirements.txt
 
       # Install Verible


### PR DESCRIPTION
There's a long and painful discussion on the setuptools issues
list (I count 9 issues raised the day after the release). This is all
to do with how Debian/Ubuntu installs stuff with pip.

There's an "official" workaround that involves setting things in your
environment, but that looks a bit fiddly with the Azure pipelines
stuff and this has been such a disaster that I'm pretty certain the
setuptools maintainers will release something more sensible soon.

See e.g.
https://github.com/pypa/setuptools/issues/2350#issuecomment-683512526
for a careful description of what's going on.