### PR TITLE
[rtl] Fix debug step over EBREAK issue

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -766,7 +766,10 @@ module ibex_controller #(
         // Leave all other signals as is to ensure CSRs and PC get set as if
         // core was entering exception handler, entry to debug mode will then
         // see the appropriate state and setup dpc correctly.
-        if (enter_debug_mode) begin
+        // If an EBREAK instruction is causing us to enter debug mode on the
+        // same cycle as a debug_req or single step, honor the EBREAK and
+        // proceed to DBG_TAKEN_ID.
+        if (enter_debug_mode && !(ebrk_insn_prio && ebreak_into_debug)) begin
           ctrl_fsm_ns = DBG_TAKEN_IF;
         end
       end // FLUSH


### PR DESCRIPTION
- If there is a request to enter debug mode (either due to a halt
  request or single stepping mode) on the same cycle as an EBREAK
  instruction, continue with the EBREAK and capture the ID PC rather
  than the IF PC.
- relates to #1106

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>