### PR TITLE
Instantiate CSR module

### DIFF
--- a/dv/uvm/core_ibex/ibex_dv.f
+++ b/dv/uvm/core_ibex/ibex_dv.f
@@ -37,6 +37,7 @@ ${PRJ_DIR}/rtl/ibex_alu.sv
 ${PRJ_DIR}/rtl/ibex_branch_predict.sv
 ${PRJ_DIR}/rtl/ibex_compressed_decoder.sv
 ${PRJ_DIR}/rtl/ibex_controller.sv
+${PRJ_DIR}/rtl/ibex_csr.sv
 ${PRJ_DIR}/rtl/ibex_cs_registers.sv
 ${PRJ_DIR}/rtl/ibex_counter.sv
 ${PRJ_DIR}/rtl/ibex_decoder.sv

--- a/ibex_core.core
+++ b/ibex_core.core
@@ -19,6 +19,7 @@ filesets:
       - rtl/ibex_compressed_decoder.sv
       - rtl/ibex_controller.sv
       - rtl/ibex_cs_registers.sv
+      - rtl/ibex_csr.sv
       - rtl/ibex_counter.sv
       - rtl/ibex_decoder.sv
       - rtl/ibex_ex_block.sv

--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -161,7 +161,7 @@ lint_off -rule UNUSED -file "*/rtl/ibex_decoder.sv" -match "*instr_alu*"
 // Signal unoptimizable: Feedback to clock or circular logic:
 // ibex_core.cs_registers_i.mie_q
 // Issue lowrisc/ibex#212
-lint_off -rule UNOPTFLAT -file "*/rtl/ibex_cs_registers.sv" -match "*ibex_core.cs_registers_i.mie_q*"
+lint_off -rule UNOPTFLAT -file "*/rtl/ibex_csr.sv" -match "*ibex_core.cs_registers_i.u_mie_csr.rdata_q*"
 
 // Temporary waivers until OpenTitan primitives are lint-clean
 // https://github.com/lowRISC/opentitan/issues/2313

--- a/rtl/ibex_csr.sv
+++ b/rtl/ibex_csr.sv
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Control / status register primitive
+ */
+
+`include "prim_assert.sv"
+
+module ibex_csr #(
+    parameter int unsigned    Width      = 32,
+    parameter bit             ShadowCopy = 1'b0,
+    parameter bit [Width-1:0] ResetValue = '0
+ ) (
+    input  logic             clk_i,
+    input  logic             rst_ni,
+
+    input  logic [Width-1:0] wr_data_i,
+    input  logic             wr_en_i,
+    output logic [Width-1:0] rd_data_o,
+
+    output logic             rd_error_o
+);
+
+  logic [Width-1:0] rdata_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rdata_q <= ResetValue;
+    end else if (wr_en_i) begin
+      rdata_q <= wr_data_i;
+    end
+  end
+
+  assign rd_data_o = rdata_q;
+
+  if (ShadowCopy) begin : gen_shadow
+    logic [Width-1:0] shadow_q;
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        shadow_q <= ~ResetValue;
+      end else if (wr_en_i) begin
+        shadow_q <= ~wr_data_i;
+      end
+    end
+
+    assign rd_error_o = rdata_q != ~shadow_q;
+
+  end else begin : gen_no_shadow
+    assign rd_error_o = 1'b0;
+  end
+
+  `ASSERT_KNOWN(IbexCSREnValid, wr_en_i)
+
+endmodule


### PR DESCRIPTION
This PR is an example to discuss how we might move the CSRs to separate modules. The objective is mostly to allow parameterized addition of shadow copies, but there should be some other side benefits (clock gating, tidy-up etc.).

* I have only converted two CSRs here as an example to gather feedback.
* There is more scope for tidy-up and rationalization of the write muxing etc. once all CSRs are converted.
* There is also the option of making the CSR module type-parametrizable, rather than casting at the module boundaries. It's not currently supported by sv2v but I'll file that as an issue separately.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>