### PR TITLE
In util, restrict mypy linting to sv2v_in_place.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,4 +114,4 @@ test-cfg:
 
 .PHONY: python-lint
 python-lint:
-	mypy --strict util
+	$(MAKE) -C util lint

--- a/util/Makefile
+++ b/util/Makefile
@@ -1,0 +1,3 @@
+.PHONY: lint
+lint:
+	mypy --strict sv2v_in_place.py


### PR DESCRIPTION
The other scripts in the directory don't have typing annotations.