### PR TITLE
[simple_system] Update CSR Access for LLVM and GCC

### DIFF
--- a/examples/sw/simple_system/common/simple_system_common.c
+++ b/examples/sw/simple_system/common/simple_system_common.c
@@ -105,9 +105,13 @@ void pcount_reset() {
 void pcount_enable(int enable) {
   // Note cycle is disabled with everything else
   unsigned int inhibit_val = enable ? 0x0 : 0xFFFFFFFF;
-  // mucounteren == mcountinhibit but binutils doesn't seem to known the
-  // mcountinhibit name
-  asm volatile("csrw  mucounteren, %0\n" : : "r"(inhibit_val));
+  // CSR 0x320 was called `mucounteren` in the privileged spec v1.9.1, it was
+  // then dropped in v1.10, and then re-added in v1.11 with the name
+  // `mcountinhibit`. Unfortunately, the version of binutils we use only allows
+  // the old name, and LLVM only supports the new name (though this is changed
+  // on trunk to support both), so we use the numeric value here for maximum
+  // compatibility.
+  asm volatile("csrw  0x320, %0\n" : : "r"(inhibit_val));
 }
 
 unsigned int get_mepc() {

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -391,9 +391,7 @@ module ibex_tracer (
       12'd899: return "mibound";
       12'd900: return "mdbase";
       12'd901: return "mdbound";
-      12'd800: return "mucounteren";
-      12'd801: return "mscounteren";
-      12'd802: return "mhcounteren";
+      12'd800: return "mcountinhibit";
       default: return $sformatf("0x%x", csr_addr);
     endcase
   endfunction


### PR DESCRIPTION
At some point in the future, the version of binutils we're using, and
the released version of LLVM, will coincide to use the correct name. In
the meantime, this change just uses the number which is supported by
both compilers.

This is, as I understand it, the only stumbling block to compiling the
in-repo C benchmark code with both GCC and LLVM. Being able to do so
would make it much easier for us to do comparisons on the benchmarks for
both compilers.

---

I'm not sure if the changes to `ibex_tracer.sv` are correct, it seems `0x321` and `0x322` are not defined in the privileged spec v1.11, and nor are they defined in https://ibex-core.readthedocs.io/en/latest/cs_registers.html

@luismarques are there other stumbling blocks to running ibex simple system with LLVM? I think this is the only one Yuichi told us about during the pointer authentication work.