### PR TITLE
[simple-system] Add missing linker sections

### DIFF
--- a/examples/sw/simple_system/common/link.ld
+++ b/examples/sw/simple_system/common/link.ld
@@ -47,12 +47,18 @@ SECTIONS
 
     .rodata : {
         . = ALIGN(4);
+        /* Small RO data before large RO data */
+        *(.srodata)
+        *(.srodata.*)
         *(.rodata);
         *(.rodata.*)
     } > ram
 
     .data : {
         . = ALIGN(4);
+        /* Small data before large data */
+        *(.sdata)
+        *(.sdata.*)
         *(.data);
         *(.data.*)
     } > ram
@@ -61,6 +67,9 @@ SECTIONS
     {
         . = ALIGN(4);
         _bss_start = .;
+        /* Small BSS before large BSS */
+        *(.sbss)
+        *(.sbss.*)
         *(.bss)
         *(.bss.*)
         *(COMMON)


### PR DESCRIPTION
Adding the "small" sections to the example linker script. This ensures
that all sections of memory needing to be zeroed are captured.

Fixes #1092

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>