### PR TITLE
[doc] Fix broken link to examples description

### DIFF
--- a/examples/fpga/artya7/README.md
+++ b/examples/fpga/artya7/README.md
@@ -1,6 +1,6 @@
 # Ibex RISC-V Core SoC Example
 
-Please see [examples](https://ibex-core.readthedocs.io/en/latest/examples.html "Ibex User Manual") for a description of this example.
+Please see [examples](https://ibex-core.readthedocs.io/en/latest/02_user/examples.html "Ibex User Manual") for a description of this example.
 
 ## Requirements
 


### PR DESCRIPTION
The documentation restructure in #1119 resulted in a new URL for the
documentation on Ibex system examples. This commit updates the in-tree
link to reference that new URL.