### PR TITLE
[rtl] Various small lint fixes

### DIFF
--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -31,43 +31,6 @@ lint_off -rule WIDTH -file "*/rtl/ibex_core_tracing.sv"
 // waiver doesn't work.
 lint_off -rule WIDTH -file "*/rtl/ibex_core_tracing.sv" -match "*'RV32B'*"
 
-// Bits of signal are not used: shift_amt_compl[5]
-// cleaner to write all bits even if not all are used
-lint_off -rule UNUSED -file "*/rtl/ibex_alu.sv" -match "*'shift_amt_compl'[5]*"
-
-// Bits of signal are not used: shift_result_ext[32]
-// cleaner to write all bits even if not all are used
-lint_off -rule UNUSED -file "*/rtl/ibex_alu.sv" -match "*'shift_result_ext'[32]*"
-
-// Signal is not used for RV32B == RV32BNone: imd_val_q_i
-//
-// No ALU multicycle instructions exist to use the intermediate value register,
-// if bitmanipulation extension is not enabled.
-lint_off -rule UNUSED -file "*/rtl/ibex_alu.sv" -match "*'imd_val_q_i'"
-
-// Signal is not used for RV32B == RV32BNone: butterfly_result, invbutterfly_result
-//
-// Need to be declared; referenced in unused if-generate block
-lint_off -rule UNUSED -file "*/rtl/ibex_alu.sv" -match "*'butterfly_result'"
-lint_off -rule UNUSED -file "*/rtl/ibex_alu.sv" -match "*'invbutterfly_result'"
-
-// Bits of signal are not used: fetch_addr_n[0]
-// cleaner to write all bits even if not all are used
-lint_off -rule UNUSED -file "*/rtl/ibex_if_stage.sv" -match "*'fetch_addr_n'[0]*"
-
-// Bits of signal are not used: alu_adder_ext_i[0]
-// Bottom bit is round, not needed
-lint_off -rule UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -match "*'alu_adder_ext_i'[0]*"
-
-// Bits of signal are not used: mac_res_ext[34], mult1_res[33:32]
-// cleaner to write all bits even if not all are used
-lint_off -rule UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -match "*mac_res_ext*"
-lint_off -rule UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -match "*mult1_res*"
-
-// Bits of signal are not used: res_adder_h[32]
-// cleaner to write all bits even if not all are used
-lint_off -rule UNUSED -file "*/rtl/ibex_multdiv_fast.sv" -match "*'res_adder_h'[32]*"
-
 // Bits of signal are not used: be_i[3:1]
 // Bits of signal are not used: addr_i[31:10,1:0]
 // Bits of signal are not used: wdata_i[31:8]
@@ -87,57 +50,6 @@ lint_off -rule UNUSED -file "*/rtl/sim/simulator_ctrl.sv" -match "*'wdata_i'[31:
 // entire 32-bit address around to make the code a bit cleaner.
 lint_off -rule UNUSED -file "*/rtl/timer.sv" -match "*'timer_addr_i'[31:10]*"
 
-// Bits of signal are not used for MHPMCounterNum < 29: mhpmcounter_we[31:MHPMCounterNum+3]
-// cleaner to write all bits even if not all are used
-lint_off -rule UNUSED -file "*/rtl/ibex_cs_registers.sv" -match "*'mhpmcounter_we'[31:MHPMCounterNum+3]*"
-
-// Bits of signal are not used: mhpmcounter_we[1]
-// Bits of signal are not used: mhpmcounterh_we[1]
-// Bits of signal are not used: mhpmcounter_incr[1]
-//
-// cleaner to write all bits even if not all are used
-//
-lint_off -rule UNUSED -file "*/rtl/ibex_cs_registers.sv" -match "*'mhpmcounter_we'[1]*"
-lint_off -rule UNUSED -file "*/rtl/ibex_cs_registers.sv" -match "*'mhpmcounterh_we'[1]*"
-lint_off -rule UNUSED -file "*/rtl/ibex_cs_registers.sv" -match "*'mhpmcounter_incr'[1]*"
-
-// Signals are unused if MHPMCounterNum == 0: clk_i, rst_ni
-// Signal is unused if MHPMCounterNum == 0: counter_val_i[31:0]
-//
-// If no counters are implemented, no flops are elaborated. No clock, reset or
-// next-state logic is used.
-//
-lint_off -rule UNUSED -file "*/rtl/ibex_counters.sv" -match "*'clk_i'"
-lint_off -rule UNUSED -file "*/rtl/ibex_counters.sv" -match "*'rst_ni'"
-lint_off -rule UNUSED -file "*/rtl/ibex_counters.sv" -match "*'counter_val_i'"
-
-// Bits of signal are not used for MHPMCounterNum < 29: counter_inc_i[28:MHPMCounterNum]
-// Bits of signal are not used for MHPMCounterNum < 29: counterh_we_i[28:MHPMCounterNum]
-// Bits of signal are not used for MHPMCounterNum < 29: counter_we_i[28:MHPMCounterNum]
-//
-// cleaner to write all bits even if not all are used
-//
-// lint_off -rule UNUSED -file "*/rtl/ibex_counters.sv" -match "*'counter_inc_i'[28:*]*"
-// lint_off -rule UNUSED -file "*/rtl/ibex_counters.sv" -match "*'counterh_we_i'[28:*]*"
-// lint_off -rule UNUSED -file "*/rtl/ibex_counters.sv" -match "*'counter_we_i'[28:*]*"
-
-lint_off -rule UNUSED -file "*/rtl/ibex_counters.sv" -match "*counter_inc_i*"
-lint_off -rule UNUSED -file "*/rtl/ibex_counters.sv" -match "*counterh_we_i*"
-lint_off -rule UNUSED -file "*/rtl/ibex_counters.sv" -match "*counter_we_i*"
-
-// Bits of signal are not used for MHPMCounterWidth < 64: counter_upd[63:MHPMCounterWidth]
-// Bits of signal are not used for MHPMCounterWidth < 64: counter_load[63:MHPMCounterWidth]
-//
-// cleaner to write all bits even if not all are used
-//
-lint_off -rule UNUSED -file "*/rtl/ibex_counters.sv" -match "*'counter_upd'[63:*]*"
-lint_off -rule UNUSED -file "*/rtl/ibex_counters.sv" -match "*'counter_load'[63:*]*"
-
-// Signal is not used: test_en_i
-// testability signal
-lint_off -rule UNUSED -file "*/rtl/ibex_register_file_ff.sv" -match "*test_en_i*"
-lint_off -rule UNUSED -file "*/rtl/ibex_register_file_fpga.sv" -match "*test_en_i*"
-
 // Signal is not used: clk_i
 // leaving clk and reset connected in-case we want to add assertions
 lint_off -rule UNUSED -file "*/rtl/ibex_pmp.sv" -match "*clk_i*"
@@ -151,12 +63,6 @@ lint_off -rule UNUSED -file "*/rtl/ibex_pmp.sv" -match "*rst_ni*"
 lint_off -rule UNUSED -file "*/rtl/ibex_compressed_decoder.sv" -match "*rst_ni*"
 lint_off -rule UNUSED -file "*/rtl/ibex_decoder.sv" -match "*rst_ni*"
 lint_off -rule UNUSED -file "*/rtl/ibex_branch_predict.sv" -match "*rst_ni*"
-
-// Bits of signal are not used: instr_alu[24:15,11:7]
-// instr flops are duplicated to reduce fan-out, neater to just leave unused
-// bits in fully duplicated instr for synthesiser to optimise out rather than
-// explicitly flopping only the bits we want.
-lint_off -rule UNUSED -file "*/rtl/ibex_decoder.sv" -match "*instr_alu*"
 
 // Signal unoptimizable: Feedback to clock or circular logic:
 // ibex_core.cs_registers_i.mie_q

--- a/rtl/ibex_alu.sv
+++ b/rtl/ibex_alu.sv
@@ -192,8 +192,8 @@ module ibex_alu #(
   //  shift_amt = rs2 & 63;
   //  shift_amt_compl = 32 - shift_amt[4:0]
   //  if (shift_amt >=33):
-  //     multicycle_result = (rs1 >> shift_amt_cmpl[4:0]) | (rs3 << shift_amt[4:0]);
-  //                         ^-- cycle 0 ---------------^ ^-- cycle 1 ------------^
+  //     multicycle_result = (rs1 >> shift_amt_compl[4:0]) | (rs3 << shift_amt[4:0]);
+  //                         ^-- cycle 0 ----------------^ ^-- cycle 1 ------------^
   //  else if (shift_amt <= 31 && shift_amt > 0):
   //     multicycle_result = (rs1 << shift_amt[4:0]) | (rs3 >> shift_amt_compl[4:0]);
   //                         ^-- cycle 0 ----------^ ^-- cycle 1 -------------------^
@@ -228,8 +228,10 @@ module ibex_alu #(
   logic [5:0] shift_amt;
   logic [5:0] shift_amt_compl; // complementary shift amount (32 - shift_amt)
 
-  logic [31:0] shift_result;
+  logic [31:0] shift_operand;
   logic [32:0] shift_result_ext;
+  logic        unused_shift_result_ext;
+  logic [31:0] shift_result;
   logic [31:0] shift_result_rev;
 
   // zbf
@@ -308,19 +310,21 @@ module ibex_alu #(
     // select shifter input
     // for bfp, sbmode and shift_left the corresponding bit-reversed input is chosen.
     if (RV32B == RV32BNone) begin
-      shift_result = shift_left ? operand_a_rev : operand_a_i;
+      shift_operand = shift_left ? operand_a_rev : operand_a_i;
     end else begin
       unique case (1'b1)
-        bfp_op:       shift_result = bfp_mask_rev;
-        shift_sbmode: shift_result = 32'h8000_0000;
-        default:      shift_result = shift_left ? operand_a_rev : operand_a_i;
+        bfp_op:       shift_operand = bfp_mask_rev;
+        shift_sbmode: shift_operand = 32'h8000_0000;
+        default:      shift_operand = shift_left ? operand_a_rev : operand_a_i;
       endcase
     end
 
     shift_result_ext =
-        $signed({shift_ones | (shift_arith & shift_result[31]), shift_result}) >>> shift_amt[4:0];
+        $unsigned($signed({shift_ones | (shift_arith & shift_operand[31]), shift_operand}) >>>
+                  shift_amt[4:0]);
 
-    shift_result = shift_result_ext[31:0];
+    shift_result            = shift_result_ext[31:0];
+    unused_shift_result_ext = shift_result_ext[32];
 
     for (int unsigned i=0; i<32; i++) begin
       shift_result_rev[i] = shift_result[31-i];
@@ -656,10 +660,14 @@ module ibex_alu #(
 
         if (shuffle_flip) begin
           shuffle_result = (shuffle_result & 32'h8822_4411) |
-              ((shuffle_result << 6)  & FLIP_MASK_L[0]) | ((shuffle_result >> 6)  & FLIP_MASK_R[0]) |
-              ((shuffle_result << 9)  & FLIP_MASK_L[1]) | ((shuffle_result >> 9)  & FLIP_MASK_R[1]) |
-              ((shuffle_result << 15) & FLIP_MASK_L[2]) | ((shuffle_result >> 15) & FLIP_MASK_R[2]) |
-              ((shuffle_result << 21) & FLIP_MASK_L[3]) | ((shuffle_result >> 21) & FLIP_MASK_R[3]);
+              ((shuffle_result << 6)  & FLIP_MASK_L[0]) |
+              ((shuffle_result >> 6)  & FLIP_MASK_R[0]) |
+              ((shuffle_result << 9)  & FLIP_MASK_L[1]) |
+              ((shuffle_result >> 9)  & FLIP_MASK_R[1]) |
+              ((shuffle_result << 15) & FLIP_MASK_L[2]) |
+              ((shuffle_result >> 15) & FLIP_MASK_R[2]) |
+              ((shuffle_result << 21) & FLIP_MASK_L[3]) |
+              ((shuffle_result >> 21) & FLIP_MASK_R[3]);
         end
 
         if (shuffle_mode[3]) begin
@@ -685,10 +693,14 @@ module ibex_alu #(
 
         if (shuffle_flip) begin
           shuffle_result = (shuffle_result & 32'h8822_4411) |
-              ((shuffle_result << 6)  & FLIP_MASK_L[0]) | ((shuffle_result >> 6) & FLIP_MASK_R[0])  |
-              ((shuffle_result << 9)  & FLIP_MASK_L[1]) | ((shuffle_result >> 9) & FLIP_MASK_R[1])  |
-              ((shuffle_result << 15) & FLIP_MASK_L[2]) | ((shuffle_result >> 15) & FLIP_MASK_R[2]) |
-              ((shuffle_result << 21) & FLIP_MASK_L[3]) | ((shuffle_result >> 21) & FLIP_MASK_R[3]);
+              ((shuffle_result << 6)  & FLIP_MASK_L[0]) |
+              ((shuffle_result >> 6)  & FLIP_MASK_R[0]) |
+              ((shuffle_result << 9)  & FLIP_MASK_L[1]) |
+              ((shuffle_result >> 9)  & FLIP_MASK_R[1]) |
+              ((shuffle_result << 15) & FLIP_MASK_L[2]) |
+              ((shuffle_result >> 15) & FLIP_MASK_R[2]) |
+              ((shuffle_result << 21) & FLIP_MASK_L[3]) |
+              ((shuffle_result >> 21) & FLIP_MASK_R[3]);
         end
       end
 
@@ -1048,6 +1060,8 @@ module ibex_alu #(
         endcase
       end
     end else begin : gen_alu_rvb_notfull
+      logic [31:0] unused_imd_val_q_1;
+      assign unused_imd_val_q_1   = imd_val_q_i[1];
       assign shuffle_result       = '0;
       assign butterfly_result     = '0;
       assign invbutterfly_result  = '0;
@@ -1070,8 +1084,8 @@ module ibex_alu #(
     always_comb begin
       unique case (operator_i)
         ALU_CMOV: begin
-            multicycle_result = (operand_b_i == 32'h0) ? operand_a_i : imd_val_q_i[0];
-            imd_val_d_o = '{operand_a_i, 32'h0};
+          multicycle_result = (operand_b_i == 32'h0) ? operand_a_i : imd_val_q_i[0];
+          imd_val_d_o = '{operand_a_i, 32'h0};
           if (instr_first_cycle_i) begin
             imd_val_we_o = 2'b01;
           end else begin
@@ -1152,6 +1166,12 @@ module ibex_alu #(
 
 
   end else begin : g_no_alu_rvb
+    logic [31:0] unused_imd_val_q[2];
+    assign unused_imd_val_q           = imd_val_q_i;
+    logic [31:0] unused_butterfly_result;
+    assign unused_butterfly_result    = butterfly_result;
+    logic [31:0] unused_invbutterfly_result;
+    assign unused_invbutterfly_result = invbutterfly_result;
     // RV32B result signals
     assign bitcnt_result       = '0;
     assign minmax_result       = '0;
@@ -1244,5 +1264,8 @@ module ibex_alu #(
       default: ;
     endcase
   end
+
+  logic unused_shift_amt_compl;
+  assign unused_shift_amt_compl = shift_amt_compl[5];
 
 endmodule

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -304,7 +304,7 @@ module ibex_controller #(
                       ebrk_insn_prio,
                       store_err_prio,
                       load_err_prio}),
-             (ctrl_fsm_cs == FLUSH) & exc_req_q);
+             (ctrl_fsm_cs == FLUSH) & exc_req_q)
 
   ////////////////
   // Interrupts //
@@ -833,7 +833,7 @@ module ibex_controller #(
   // Assertions //
   ////////////////
 
-  `ASSERT(AlwaysInstrClearOnMispredict, nt_branch_mispredict_o -> instr_valid_clear_o);
+  `ASSERT(AlwaysInstrClearOnMispredict, nt_branch_mispredict_o -> instr_valid_clear_o)
 
   // Selectors must be known/valid.
   `ASSERT(IbexCtrlStateValid, ctrl_fsm_cs inside {

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -1432,6 +1432,10 @@ module ibex_core #(
     end
   end
 
+`else
+  logic unused_instr_new_id, unused_instr_done_wb;
+  assign unused_instr_new_id = instr_new_id;
+  assign unused_instr_done_wb = instr_done_wb;
 `endif
 
   // Certain parameter combinations are not supported

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -106,6 +106,7 @@ module ibex_decoder #(
 
   logic [31:0] instr;
   logic [31:0] instr_alu;
+  logic [9:0]  unused_instr_alu;
   // Source/Destination register instruction index
   logic [4:0] instr_rs1;
   logic [4:0] instr_rs2;
@@ -140,13 +141,18 @@ module ibex_decoder #(
   // immediate for CSR manipulation (zero extended)
   assign zimm_rs1_type_o = { 27'b0, instr_rs1 }; // rs1
 
-  // the use of rs3 is known one cycle ahead.
-  always_ff  @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      use_rs3_q <= 1'b0;
-    end else begin
-      use_rs3_q <= use_rs3_d;
+  if (RV32B != RV32BNone) begin : gen_rs3_flop
+    // the use of rs3 is known one cycle ahead.
+    always_ff  @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        use_rs3_q <= 1'b0;
+      end else begin
+        use_rs3_q <= use_rs3_d;
+      end
     end
+  end else begin : gen_no_rs3_flop
+    // always zero
+    assign use_rs3_q = use_rs3_d;
   end
 
   // source registers
@@ -1135,6 +1141,9 @@ module ibex_decoder #(
 
   // do not propgate regfile write enable if non-available registers are accessed in RV32E
   assign rf_we_o = rf_we & ~illegal_reg_rv32e;
+
+  // Not all bits are used
+  assign unused_instr_alu = {instr_alu[19:15],instr_alu[11:7]};
 
   ////////////////
   // Assertions //

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -405,7 +405,7 @@ module ibex_id_stage #(
       RF_WD_EX:  rf_wdata_id_o = result_ex_i;
       RF_WD_CSR: rf_wdata_id_o = csr_rdata_i;
       default:   rf_wdata_id_o = result_ex_i;
-    endcase;
+    endcase
   end
 
   /////////////
@@ -957,7 +957,6 @@ module ibex_id_stage #(
     // Assign inputs and internal wiring to unused signals to satisfy lint checks
     // Tie-off outputs to constant values
     logic unused_data_req_done_ex;
-    logic unused_lsu_load;
     logic [4:0] unused_rf_waddr_wb;
     logic unused_rf_write_wb;
     logic unused_outstanding_load_wb;

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -104,6 +104,7 @@ module ibex_if_stage #(
   logic              branch_spec;
   logic              predicted_branch;
   logic       [31:0] fetch_addr_n;
+  logic              unused_fetch_addr_n0;
 
   logic              fetch_valid;
   logic              fetch_ready;
@@ -251,6 +252,8 @@ module ibex_if_stage #(
     assign unused_icen  = icache_enable_i;
     assign unused_icinv = icache_inval_i;
   end
+
+  assign unused_fetch_addr_n0 = fetch_addr_n[0];
 
   assign branch_req  = pc_set_i | predict_branch_taken;
   assign branch_spec = pc_set_spec_i | predict_branch_taken;
@@ -571,17 +574,18 @@ module ibex_if_stage #(
     // Must only see mispredict after we've performed a predicted branch but before we've accepted
     // any instruction (with fetch_ready & fetch_valid) that follows that predicted branch.
     `ASSERT(MispredictOnlyImmediatelyAfterPredictedBranch,
-      nt_branch_mispredict_i |-> predicted_branch_live_q);
+      nt_branch_mispredict_i |-> predicted_branch_live_q)
     // Check that on mispredict we get the correct PC for the non-taken side of the branch when
     // prefetch buffer/icache makes that PC available.
     `ASSERT(CorrectPCOnMispredict,
-      predicted_branch_live_q & mispredicted_d & fetch_valid |-> fetch_addr == predicted_branch_nt_pc_q);
+      predicted_branch_live_q & mispredicted_d & fetch_valid |->
+      fetch_addr == predicted_branch_nt_pc_q)
     // Must not signal mispredict over multiple cycles but it's possible to have back to back
     // mispredicts for different branches (core signals mispredict, prefetch buffer/icache immediate
     // has not-taken side of the mispredicted branch ready, which itself is a predicted branch,
     // following cycle core signal that that branch has mispredicted).
     `ASSERT(MispredictSingleCycle,
-      nt_branch_mispredict_i & ~(fetch_valid & fetch_ready) |=> ~nt_branch_mispredict_i);
+      nt_branch_mispredict_i & ~(fetch_valid & fetch_ready) |=> ~nt_branch_mispredict_i)
 `endif
 
   end else begin : g_no_branch_predictor_asserts

--- a/rtl/ibex_multdiv_fast.sv
+++ b/rtl/ibex_multdiv_fast.sv
@@ -73,7 +73,7 @@ module ibex_multdiv_fast #(
   logic [31:0] op_quotient_d;
   logic [31:0] next_remainder;
   logic [32:0] next_quotient;
-  logic [32:0] res_adder_h;
+  logic [31:0] res_adder_h;
   logic        div_valid;
   logic [ 4:0] div_counter_q, div_counter_d;
   logic        multdiv_en;
@@ -111,9 +111,9 @@ module ibex_multdiv_fast #(
     end
   end
 
-  `ASSERT_KNOWN(DivEnKnown, div_en_internal);
-  `ASSERT_KNOWN(MultEnKnown, mult_en_internal);
-  `ASSERT_KNOWN(MultDivEnKnown, multdiv_en);
+  `ASSERT_KNOWN(DivEnKnown, div_en_internal)
+  `ASSERT_KNOWN(MultEnKnown, mult_en_internal)
+  `ASSERT_KNOWN(MultDivEnKnown, multdiv_en)
 
   assign multdiv_en = mult_en_internal | div_en_internal;
 
@@ -126,6 +126,8 @@ module ibex_multdiv_fast #(
   assign op_denominator_q = imd_val_q_i[1][31:0];
   logic [1:0] unused_imd_val;
   assign unused_imd_val = imd_val_q_i[1][33:32];
+  logic unused_mac_res_ext;
+  assign unused_mac_res_ext = mac_res_ext[34];
 
   assign signed_mult      = (signed_mode_i != 2'b00);
   assign multdiv_result_o = div_sel_i ? imd_val_q_i[0][31:0] : mac_res_d[31:0];
@@ -140,6 +142,8 @@ module ibex_multdiv_fast #(
     mult_fsm_e mult_state_q, mult_state_d;
 
     logic signed [33:0] mult1_res, mult2_res, mult3_res;
+    logic [33:0]        mult1_res_uns;
+    logic [33:32]       unused_mult1_res_uns;
     logic [15:0]        mult1_op_a, mult1_op_b;
     logic [15:0]        mult2_op_a, mult2_op_b;
     logic [15:0]        mult3_op_a, mult3_op_b;
@@ -154,6 +158,7 @@ module ibex_multdiv_fast #(
 
     assign mac_res_signed = $signed(summand1) + $signed(summand2) + $signed(summand3);
 
+    assign mult1_res_uns  = $unsigned(mult1_res);
     assign mac_res_ext    = $unsigned(mac_res_signed);
     assign mac_res        = mac_res_ext[33:0];
 
@@ -186,12 +191,12 @@ module ibex_multdiv_fast #(
       mult3_op_a = op_a_i[`OP_H];
       mult3_op_b = op_b_i[`OP_L];
 
-      summand1 = {18'h0, mult1_res[`OP_H]};
-      summand2 = mult2_res;
-      summand3 = mult3_res;
+      summand1 = {18'h0, mult1_res_uns[`OP_H]};
+      summand2 = $unsigned(mult2_res);
+      summand3 = $unsigned(mult3_res);
 
       // mac_res = A*B[47:16], mult1_res = A*B[15:0]
-      mac_res_d = {2'b0, mac_res[`OP_L], mult1_res[`OP_L]};
+      mac_res_d = {2'b0, mac_res[`OP_L], mult1_res_uns[`OP_L]};
       mult_valid = mult_en_i;
       mult_state_d = MULL;
 
@@ -243,6 +248,8 @@ module ibex_multdiv_fast #(
         end
       end
     end
+
+    assign unused_mult1_res_uns = mult1_res[33:32];
 
     // States must be knwon/valid.
     `ASSERT_KNOWN(IbexMultStateKnown, mult_state_q)
@@ -297,7 +304,7 @@ module ibex_multdiv_fast #(
           mult_op_b = op_b_i[`OP_H];
           sign_a    = 1'b0;
           sign_b    = signed_mode_i[1] & op_b_i[31];
-          // result of AL*BL (in imd_val_q_i[0]) always unsigned with no carry, so carries_q always 00
+          // result of AL*BL (in imd_val_q_i[0]) always unsigned with no carry
           accum     = {18'b0, imd_val_q_i[0][31:16]};
           if (operator_i == MD_OP_MULL) begin
             mac_res_d = {2'b0, mac_res[`OP_L], imd_val_q_i[0][`OP_L]};
@@ -368,7 +375,9 @@ module ibex_multdiv_fast #(
   end // gen_mult_fast
 
   // Divider
-  assign res_adder_h    = alu_adder_ext_i[33:1];
+  assign res_adder_h    = alu_adder_ext_i[32:1];
+  logic [1:0] unused_alu_adder_ext;
+  assign unused_alu_adder_ext = {alu_adder_ext_i[33],alu_adder_ext_i[0]};
 
   assign next_remainder = is_greater_equal ? res_adder_h[31:0] : imd_val_q_i[0][31:0];
   assign next_quotient  = is_greater_equal ? {1'b0, op_quotient_q} | {1'b0, one_shift} :

--- a/rtl/ibex_register_file_ff.sv
+++ b/rtl/ibex_register_file_ff.sv
@@ -95,4 +95,8 @@ module ibex_register_file_ff #(
   assign rdata_a_o = rf_reg[raddr_a_i];
   assign rdata_b_o = rf_reg[raddr_b_i];
 
+  // Signal not used in FF register file
+  logic unused_test_en;
+  assign unused_test_en = test_en_i;
+
 endmodule

--- a/rtl/ibex_register_file_fpga.sv
+++ b/rtl/ibex_register_file_fpga.sv
@@ -63,5 +63,8 @@ module ibex_register_file_fpga #(
   // Dummy instruction changes not relevant for FPGA implementation
   logic unused_dummy_instr;
   assign unused_dummy_instr = dummy_instr_id_i;
+  // Test enable signal not used in FPGA implementation
+  logic unused_test_en;
+  assign unused_test_en = test_en_i;
 
 endmodule


### PR DESCRIPTION
- Move various unused signal fixes from the waiver file to the rtl, so
  that all tools can pick them up.
- Fix some oversize line issues.
- Fix some signed / unsigned casting issues.
- Remove some extraneous semicolons.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>