### PR TITLE
[rtl] Fix illegal write to DCSR cause field

### DIFF
--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -532,6 +532,9 @@ module ibex_cs_registers #(
             dcsr_d.prv = PRIV_LVL_M;
           end
 
+          // Read-only for SW
+          dcsr_d.cause = dcsr_q.cause;
+
           // currently not supported:
           dcsr_d.nmip = 1'b0;
           dcsr_d.mprven = 1'b0;


### PR DESCRIPTION
- This field is read-only to software, and so should retain its previous
  value on a write. This fixes #1134.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>