### PR TITLE
[rtl] Fix performance counter bug

### DIFF
--- a/rtl/ibex_wb_stage.sv
+++ b/rtl/ibex_wb_stage.sv
@@ -22,12 +22,16 @@ module ibex_wb_stage #(
   input  logic                     en_wb_i,
   input  ibex_pkg::wb_instr_type_e instr_type_wb_i,
   input  logic [31:0]              pc_id_i,
+  input  logic                     instr_is_compressed_id_i,
+  input  logic                     instr_perf_count_id_i,
 
   output logic                     ready_wb_o,
   output logic                     rf_write_wb_o,
   output logic                     outstanding_load_wb_o,
   output logic                     outstanding_store_wb_o,
   output logic [31:0]              pc_wb_o,
+  output logic                     perf_instr_ret_wb_o,
+  output logic                     perf_instr_ret_compressed_wb_o,
 
   input  logic [4:0]               rf_waddr_id_i,
   input  logic [31:0]              rf_wdata_id_i,
@@ -43,6 +47,7 @@ module ibex_wb_stage #(
   output logic                     rf_we_wb_o,
 
   input logic                      lsu_resp_valid_i,
+  input logic                      lsu_resp_err_i,
 
   output logic                     instr_done_wb_o
 );
@@ -63,6 +68,8 @@ module ibex_wb_stage #(
 
     logic           wb_valid_q;
     logic [31:0]    wb_pc_q;
+    logic           wb_compressed_q;
+    logic           wb_count_q;
     wb_instr_type_e wb_instr_type_q;
 
     logic           wb_valid_d;
@@ -91,6 +98,8 @@ module ibex_wb_stage #(
         rf_wdata_wb_q   <= rf_wdata_id_i;
         wb_instr_type_q <= instr_type_wb_i;
         wb_pc_q         <= pc_id_i;
+        wb_compressed_q <= instr_is_compressed_id_i;
+        wb_count_q      <= instr_perf_count_id_i;
       end
     end
 
@@ -111,6 +120,11 @@ module ibex_wb_stage #(
 
     assign instr_done_wb_o = wb_valid_q & wb_done;
 
+    // Increment instruction retire counters for valid instructions which are not lsu errors
+    assign perf_instr_ret_wb_o            = instr_done_wb_o & wb_count_q &
+                                            ~(lsu_resp_valid_i & lsu_resp_err_i);
+    assign perf_instr_ret_compressed_wb_o = perf_instr_ret_wb_o & wb_compressed_q;
+
     // Forward data that will be written to the RF back to ID to resolve data hazards. The flopped
     // rf_wdata_wb_q is used rather than rf_wdata_wb_o as the latter includes read data from memory
     // that returns too late to be used on the forwarding path.
@@ -121,6 +135,11 @@ module ibex_wb_stage #(
     assign rf_wdata_wb_mux[0]    = rf_wdata_id_i;
     assign rf_wdata_wb_mux_we[0] = rf_we_id_i;
 
+    // Increment instruction retire counters for valid instructions which are not lsu errors
+    assign perf_instr_ret_wb_o            = instr_perf_count_id_i & en_wb_i &
+                                            ~(lsu_resp_valid_i & lsu_resp_err_i);
+    assign perf_instr_ret_compressed_wb_o = perf_instr_ret_wb_o & instr_is_compressed_id_i;
+
     // ready needs to be constant 1 without writeback stage (otherwise ID/EX stage will stall)
     assign ready_wb_o    = 1'b1;
 
@@ -129,17 +148,13 @@ module ibex_wb_stage #(
     // Tie-off outputs to constant values
     logic           unused_clk;
     logic           unused_rst;
-    logic           unused_en_wb;
     wb_instr_type_e unused_instr_type_wb;
     logic [31:0]    unused_pc_id;
-    logic           unused_lsu_resp_valid;
 
     assign unused_clk            = clk_i;
     assign unused_rst            = rst_ni;
-    assign unused_en_wb          = en_wb_i;
     assign unused_instr_type_wb  = instr_type_wb_i;
     assign unused_pc_id          = pc_id_i;
-    assign unused_lsu_resp_valid = lsu_resp_valid_i;
 
     assign outstanding_load_wb_o  = 1'b0;
     assign outstanding_store_wb_o = 1'b0;


### PR DESCRIPTION
- Make sure performance counters only count retired, non-trapping
  instructions excluding ebrk/ecall
- Rewire some signalling through the writeback stage to allow
  instruction retire to be signalled from one place
- Relates to #1132

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>