### PR TITLE
[ibex/dv] return non-zero exit code upon failure

### DIFF
--- a/dv/uvm/core_ibex/sim.py
+++ b/dv/uvm/core_ibex/sim.py
@@ -618,7 +618,8 @@ def main():
 
     # Compare RTL & ISS simulation result.
     if steps['compare']:
-        compare(matched_list, args.iss, args.o)
+        if not compare(matched_list, args.iss, args.o):
+            return RET_FAIL
 
     # Generate merged coverage directory and load it into appropriate GUI
     if steps['cov']:


### PR DESCRIPTION
Currently the Ibex run scripts return 0 no matter what the test result
is.
To get Ibex sims correctly integrated into CI, the Makefile needs to
return 1 upon seeing a log comparison failure to indicate an error.

Signed-off-by: Udi Jonnalagadda <udij@google.com>