### PR TITLE
Enable configuration with Icache in public CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,6 +95,7 @@ jobs:
         - small
         - experimental-maxperf-pmp
         - experimental-maxperf-pmp-bmfull
+        - experimental-maxperf-pmp-bmfull-icache
         - experimental-branch-predictor
 
   # Run lint on simple system

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -213,6 +213,10 @@ module ibex_if_stage #(
         .icache_inval_i    ( icache_inval_i              ),
         .busy_o            ( prefetch_busy               )
     );
+    // Branch predictor tie-offs (which are unused when the instruction cache is enabled)
+    logic unused_nt_branch_mispredict, unused_predicted_branch;
+    assign unused_nt_branch_mispredict  = nt_branch_mispredict_i;
+    assign unused_predicted_branch = predicted_branch;
   end else begin : gen_prefetch_buffer
     // prefetch buffer, caches a fixed number of instructions
     ibex_prefetch_buffer #(


### PR DESCRIPTION
We now have an Ibex configuration
experimental-maxperf-pmp-bmfull-icache, which also enables the
instruction cache. Enable this configuration in public CI, which makes
it run the lint and RISC-V compliance jobs.