### PR TITLE
Enable Verible lint

### DIFF
--- a/ci/ibex-rtl-ci-steps.yml
+++ b/ci/ibex-rtl-ci-steps.yml
@@ -14,7 +14,7 @@ steps:
       displayName: Test and display fusesoc config for ${{ config }}
 
     - bash: |
-        fusesoc --cores-root . run --target=lint lowrisc:ibex:ibex_core_tracing $IBEX_CONFIG_OPTS
+        fusesoc --cores-root . run --target=lint --tool=verilator lowrisc:ibex:ibex_core_tracing $IBEX_CONFIG_OPTS
         if [ $? != 0 ]; then
           echo -n "##vso[task.logissue type=error]"
           echo "Verilog lint failed. Run 'fusesoc --cores-root . run --target=lint --tool=verilator lowrisc:ibex:ibex_core_tracing $IBEX_CONFIG_OPTS' to check and fix all errors."
@@ -23,7 +23,7 @@ steps:
       displayName: Lint Verilog source files with Verilator for ${{ config }}
 
     - bash: |
-        fusesoc --cores-root . run --target=lint lowrisc:ibex:ibex_core_tracing $IBEX_CONFIG_OPTS
+        fusesoc --cores-root . run --target=lint --tool=veriblelint lowrisc:ibex:ibex_core_tracing $IBEX_CONFIG_OPTS
         if [ $? != 0 ]; then
           echo -n "##vso[task.logissue type=error]"
           echo "Verilog lint failed. Run 'fusesoc --cores-root . run --target=lint --tool=veriblelint lowrisc:ibex:ibex_core_tracing $IBEX_CONFIG_OPTS' to check and fix all errors."


### PR DESCRIPTION
Turns out, just having a nice error message with the correct tool
invocation isn't enough: you actually need to call the tool with the
arguments you document.

Let's do that and actually run Verilator lint and Verible lint, and not
just Verilator lint twice.