### PR TITLE
[ci] Add a comment on private CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,6 +92,8 @@ jobs:
   - template : ci/ibex-rtl-ci-steps.yml
     parameters:
       ibex_configs:
+        # Note: Try to keep the list of configurations in sync with the one used
+        # in Private CI.
         - small
         - experimental-maxperf-pmp
         - experimental-maxperf-pmp-bmfull


### PR DESCRIPTION
Private CI has a separate list of ibex configurations it runs (there's
no sane way around that). Add a note to the pipeline configuration to
hopefully remember to keep them in sync, if that's desired (they don't
*have to* be in sync).