### PR TITLE
Pass -fno-extended-identifiers to VCS

### DIFF
--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -25,6 +25,7 @@
          -o <out>/vcs_simv
          -debug_access+pp
          -xlrm uniq_prior_final
+         -CFLAGS '--std=c99 -fno-extended-identifiers'
          -lca -kdb <cmp_opts> <wave_opts> <cov_opts>"
     cov_opts: >
       -cm line+tgl+assert+fsm+branch


### PR DESCRIPTION
For some bizarre reason VCS includes DPI code that has smart
quotes (yes, smart quotes) around some #error macros. Recent GCC
versions (g++ >= 10.2) have got proper support for UTF-8, which is
nice but makes them choke on these input files.

Passing -fno-extended-identifiers tells GCC to go back to the days of
yore and pretend that everything is ASCII, and all is well again!

Obviously the right fix is not to embed smart quotes in C++ code, but
that's not something in our control :-(