### PR TITLE
[ibex/dv/rtl] Updates to run Cadence Xcelium

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf.sv
@@ -9,16 +9,16 @@ interface ibex_mem_intf#(
   input clk
 );
 
-  logic                    reset;
-  logic                    request;
-  logic                    grant;
-  logic [ADDR_WIDTH-1:0]   addr;
-  logic                    we;
-  logic [DATA_WIDTH/8-1:0] be;
-  logic                    rvalid;
-  logic [DATA_WIDTH-1:0]   wdata;
-  logic [DATA_WIDTH-1:0]   rdata;
-  logic                    error;
+  wire                     reset;
+  wire                     request;
+  wire                     grant;
+  wire  [ADDR_WIDTH-1:0]   addr;
+  wire                     we;
+  wire  [DATA_WIDTH/8-1:0] be;
+  wire                     rvalid;
+  wire  [DATA_WIDTH-1:0]   wdata;
+  wire  [DATA_WIDTH-1:0]   rdata;
+  wire                     error;
 
   clocking request_driver_cb @(posedge clk);
     input   reset;

--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -136,6 +136,7 @@
               -q
               -f ibex_dv.f
               -sv
+              -licqueue
               -uvm
               -uvmhome CDNS-1.2
               -define UVM_REGEX_NO_DPI
@@ -152,6 +153,7 @@
            -R
            -xmlibdirpath <out>
            -l <sim_dir>/sim.log
+           -licqueue
            -svseed <seed>
            -svrnc rand_struct
            +UVM_TESTNAME=<rtl_test>
@@ -162,5 +164,5 @@
            <wave_opts>
     wave_opts: >
       -input @"database -open <sim_dir>/waves -shm -default"
-      -input @"probe -create -all -depth all"
+      -input @"probe -create core_ibex_tb_top -all -depth all -variables"
       -input @"run"

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -1285,7 +1285,9 @@ module ibex_cs_registers #(
 
     // Assign read data
     // TSELECT - number of supported triggers defined by parameter DbgHwBreakNum
-    assign tselect_rdata = {'b0, tselect_q};
+    localparam int unsigned TSelectRdataPadlen = DbgHwNumLen >= 32 ? 0 : (32-DbgHwNumLen);
+    assign tselect_rdata = {{TSelectRdataPadlen{1'b0}}, tselect_q};
+
     // TDATA0 - only support simple address matching
     assign tmatch_control_rdata = {4'h2,                         // type    : address/data match
                                    1'b1,                         // dmode   : access from D mode only


### PR DESCRIPTION
This PR makes changes to support Cadence Xcelium 20.09.001

Compile error 1: Fixed the following rtl compile error in ibex_cs_registers.sv

assign tselect_rdata = {'b0, tselect_q};
                          |
xmvlog: *E,NONOWD (/proj/riscv_ibex/users/paulok/lowRISC/ibex_1/rtl/ibex_cs_registers.sv,1288|30): Illegal use of a constant without an explicit width specification [4.1.14(IEEE)].

Compile error 2: Fixed the following DV compile error in ibex_mem_intf.sv
.data_req_o (data_mem_vif.request ),
|
xmelab: *E,ICDCBA (./tb/core_ibex_tb_top.sv,89|14): Illegal combination of driver and output clockvar to variable 'request' detected (output clockvar found in clocking block at line 25 in file ./common/ibex_mem_intf_agent/ibex_mem_intf.sv).

Simulation probes: Fixed issue with probing in yaml for xrun and added licqueue.

Signed-off-by: Paul OKeeffe <paul_okeeffe@crevinn.com>