### PR TITLE
Add VCS compile option for unicode

### DIFF
--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The -CFLAGS option is required as some VCS DPI code contains smart quotes
+# around some preprocessor macros, making G++ throw errors during compilation.
+# As a result, passing -fno-extended-identifiers tells G++ to pretend that
+# everything is ASCII, preventing strange compilation errors.
 - tool: vcs
   compile:
     cmd:
@@ -21,6 +25,7 @@
          +define+UVM
          +define+UVM_REGEX_NO_DPI -timescale=1ns/10ps -licqueue
          -LDFLAGS '-Wl,--no-as-needed'
+         -CFLAGS '--std=c99 -fno-extended-identifiers'
          -Mdir=<out>/vcs_simv.csrc
          -o <out>/vcs_simv
          -debug_access+pp


### PR DESCRIPTION
Similar to simulator.yaml, this changes has to be applied to rtl_simulation as well to avoid weird compilation errors.