### PR TITLE
[dv] Fix riscv_debug_single_step_test

### DIFF
--- a/dv/uvm/core_ibex/env/core_ibex_instr_monitor_if.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_instr_monitor_if.sv
@@ -21,6 +21,8 @@ interface core_ibex_instr_monitor_if #(
   logic [DATA_WIDTH-1:0]  pc_id;
   logic                   branch_taken_id;
   logic [DATA_WIDTH-1:0]  branch_target_id;
+  logic                   stall_id;
+  logic                   jump_set_id;
 
   clocking instr_cb @(posedge clk);
     input valid_id;
@@ -31,6 +33,8 @@ interface core_ibex_instr_monitor_if #(
     input pc_id;
     input branch_taken_id;
     input branch_target_id;
+    input stall_id;
+    input jump_set_id;
   endclocking
 
 endinterface

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -151,6 +151,8 @@ module core_ibex_tb_top;
   assign instr_monitor_if.pc_id               = dut.u_ibex_core.pc_id;
   assign instr_monitor_if.branch_taken_id     = dut.u_ibex_core.id_stage_i.controller_i.branch_set_i;
   assign instr_monitor_if.branch_target_id    = dut.u_ibex_core.branch_target_ex;
+  assign instr_monitor_if.stall_id            = dut.u_ibex_core.id_stage_i.stall_id;
+  assign instr_monitor_if.jump_set_id         = dut.u_ibex_core.id_stage_i.jump_set;
   // CSR interface connections
   assign csr_if.csr_access                    = dut.u_ibex_core.csr_access;
   assign csr_if.csr_addr                      = dut.u_ibex_core.csr_addr;


### PR DESCRIPTION
Testbench computation of next PC when single stepping was broken. A
branch may stall before branch_set is asserted and this wasn't being
taken into account. Where the branch target ALU is present branch_set
can be set on the first cycle of the branch so this bug wasn't apparent.
Even with the branch target ALU the branch may stall awaiting the result
of a load when the writeback stage is present.

To make matters more complicated for a jump the PC being jumped to is
only available when jump_set is asserted which happens whilst the jump
instruction is stalling.

This alters the riscv_debug_single_step_test so when waiting for a
single step it looks for either a branch_set or jump_set signal being
asserted. Otherwise it waits until the instruction has unstalled. This
should give correct behaviour in all scenarios (potentially further
thought required where exceptions and interrupts occur).

Fixes #1167

Signed-off-by: Greg Chadwick <gac@lowrisc.org>