### PR TITLE
[dv] Fixes for disabling forks, for Cadence Xcelium

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_monitor.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_monitor.sv
@@ -36,7 +36,7 @@ class ibex_mem_intf_monitor extends uvm_monitor;
         wait (vif.monitor_cb.reset === 1'b1);
       join_any
       // Will only reach this point when mid-test reset is asserted
-      disable check_mem_intf;
+      disable fork;
       handle_reset();
     end
   endtask : run_phase

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_driver.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_driver.sv
@@ -35,7 +35,7 @@ class ibex_mem_intf_response_driver extends uvm_driver #(ibex_mem_intf_seq_item)
         wait (vif.response_driver_cb.reset === 1'b1);
       join_any
       // Will only be reached after mid-test reset
-      disable drive_stimulus;
+      disable fork;
       handle_reset();
     end
   endtask : run_phase

--- a/dv/uvm/core_ibex/common/irq_agent/irq_monitor.sv
+++ b/dv/uvm/core_ibex/common/irq_agent/irq_monitor.sv
@@ -29,7 +29,7 @@ class irq_monitor extends uvm_monitor;
         wait (vif.monitor_cb.reset === 1'b1);
       join_any
       // Will only reach here on mid-test reset
-      disable monitor_irq;
+      disable fork;
     end
   endtask : run_phase
 

--- a/dv/uvm/core_ibex/common/irq_agent/irq_request_driver.sv
+++ b/dv/uvm/core_ibex/common/irq_agent/irq_request_driver.sv
@@ -24,7 +24,7 @@ class irq_request_driver extends uvm_driver #(irq_seq_item);
         wait (vif.driver_cb.reset === 1'b1);
       join_any
       // Will only reach here on mid-test reset
-      disable drive_irq;
+      disable fork;
       handle_reset();
     end
   endtask : run_phase

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -210,7 +210,7 @@ class core_ibex_base_test extends uvm_test;
       end
     join_any
     // Will only get here if we successfully beat the timeout period
-    disable wait_timeout;
+    disable fork;
     run.drop_objection(this);
   endtask
 
@@ -234,7 +234,7 @@ class core_ibex_base_test extends uvm_test;
       end
     join_any
     // Will only get here if we successfully beat the timeout period
-    disable wait_timeout;
+    disable fork;
     run.drop_objection(this);
   endtask
 

--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -348,7 +348,7 @@ class core_ibex_debug_intr_basic_test extends core_ibex_base_test;
       end
     join_any
     // Will only get here if dret successfully detected within timeout period
-    disable ret_timeout;
+    disable fork;
     run.drop_objection(this);
   endtask
 
@@ -400,17 +400,13 @@ class core_ibex_directed_test extends core_ibex_debug_intr_basic_test;
           // Should be extended by derived classes.
           // DO NOT use this test class directly.
           fork
-            begin : stimulus
-              check_stimulus();
-            end : stimulus
-            begin
-              wait (dut_vif.dut_cb.ecall === 1'b1);
-              disable stimulus;
-              if (run.get_objection_count(this) > 1) begin
-                run.drop_objection(this);
-              end
-            end
-          join
+            check_stimulus();
+          join_none
+          wait (dut_vif.dut_cb.ecall === 1'b1);
+          disable fork;
+          if (run.get_objection_count(this) > 1) begin
+            run.drop_objection(this);
+          end
         end
       end
     join_none
@@ -743,9 +739,9 @@ class core_ibex_irq_in_debug_test extends core_ibex_directed_test;
         end
         begin
           clk_vif.wait_clks(100);
-          disable wait_irq;
         end
-      join
+      join_any
+      disable fork;
       vseq.start_irq_drop_seq();
       wait_ret("dret", 5000);
       clk_vif.wait_clks($urandom_range(250, 500));
@@ -1196,7 +1192,7 @@ class core_ibex_mem_error_test extends core_ibex_directed_test;
               clk_vif.wait_clks(750);
             end
           join_any
-          disable imem_fork;
+          disable fork;
         end
       join
       if (latched_imem_err === 1'b0) begin


### PR DESCRIPTION
This makes changes to support Cadence Xcelium 20.09.001.

Cadence recommends that disabling forks should be done using a *"disable fork;"* statement, not the *"disable fork_process_label;"* construct.
The *"disable fork_process_label"* construct for forks is not defined in the IEEE Std 1800-2017 LRM. See section 9.6.2 of the LRM (2017).
For a more detailed explanation, please see the description from my colleague in Issue #1174.

In many cases, Xcelium will ignore a disable statement if it is not in the *"disable fork;"* form.
This causes problems in many tests, most notably in the riscv_reset_test.
Processes not being disabled when reset is asserted cause not just test failures, but the entire regression to crash.

Most changes here are simple substitutes of *"disable fork;"* where *"disable label;"* was.
Some changes in core_ibex_test_lib.sv require the layout of the fork to be adjusted.

Signed-off-by: CathalMCrevinn <cathal_minnock@crevinn.com>