### PR TITLE
[ibex/dv] Modify EOT ecall check

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -122,7 +122,7 @@ class core_ibex_base_test extends uvm_test;
   virtual task wait_for_test_done();
     fork
       begin
-        wait (dut_vif.dut_cb.ecall === 1'b1);
+        wait (dut_vif.ecall === 1'b1);
         vseq.stop();
         `uvm_info(`gfn, "ECALL instruction is detected, test done", UVM_LOW)
         // De-assert fetch enable to finish the test


### PR DESCRIPTION
This PR slightly modifies how we wait for the end of an Ibex sim.
Currently we wait on dut_vif.dut_cb.ecall, which will be delayed by a
cycle as it is in a clocking block.
However we should end the test immediately when an ecall is seen, so we
should rather wait on dut_vif.ecall instead to be more accurate and
prevent potential race conditions caused by irq/debug stimulus being
sent on the same cycle as an ecall instruction is executed by the core.

Addresses #1177 and #1159.

Signed-off-by: Udi Jonnalagadda <udij@google.com>