### PR TITLE
Update google_riscv-dv to google/riscv-dv@3da32bb

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: 3467c3777cb428b2e30b30b7f895a8fd73873d4f
+    rev: 3da32bbf6080d3bf252a7f71c5e3a32ea4924e49
   }
 }

--- a/vendor/google_riscv-dv/src/riscv_asm_program_gen.sv
+++ b/vendor/google_riscv-dv/src/riscv_asm_program_gen.sv
@@ -751,10 +751,10 @@ class riscv_asm_program_gen extends uvm_object;
     end
     // Setup mepc register, jump to init entry
     setup_epc(hart);
-    // Setup initial privilege mode
-    gen_privileged_mode_switch_routine(hart);
     // Initialization of any implementation-specific custom CSRs
     setup_custom_csrs(hart);
+    // Setup initial privilege mode
+    gen_privileged_mode_switch_routine(hart);
   endfunction
 
   virtual function void gen_privileged_mode_switch_routine(int hart);


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision 3da32bbf6080d3bf252a7f71c5e3a32ea4924e49

* fix location of custom CSR setup (google/riscv-dv#747) (udinator)

Signed-off-by: Udi Jonnalagadda <udij@google.com>