### PR TITLE
bugfix tracer irq_x_i

### DIFF
--- a/rtl/ibex_core_tracing.sv
+++ b/rtl/ibex_core_tracing.sv
@@ -59,7 +59,7 @@ module ibex_core_tracing #(
     input  logic        irq_external_i,
     input  logic [14:0] irq_fast_i,
     input  logic        irq_nm_i,       // non-maskeable interrupt
-    output logic [31:0] irq_x_i,
+    input  logic [31:0] irq_x_i,
     output logic        irq_x_ack_o,
     output logic [3:0]  irq_x_ack_id_o,
 


### PR DESCRIPTION
Hi @vogelpi,
When using ibex_core_tracing in PULP, the irq_x_i lines were in an X state due to this bug.