### PR TITLE
Fix Jump Latency for Configuration with BTALU

### DIFF
--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -776,10 +776,8 @@ module ibex_id_stage #(
               perf_branch_o = 1'b1;
             end
             jump_in_dec: begin
-              // uncond branch operation
-              // BTALU means jumps only need one cycle
-              id_fsm_d      = BranchTargetALU ? FIRST_CYCLE : MULTI_CYCLE;
-              stall_jump    = ~BranchTargetALU;
+              id_fsm_d      = MULTI_CYCLE;
+              stall_jump    = 1'b1;
               jump_set      = jump_set_dec;
             end
             alu_multicycle_dec: begin


### PR DESCRIPTION
The jump latency is not affected by the presence of a a branch target
ALU. The pipeline must stall for an instruction fetch from the new
address and flushing the prefetch buffer.

Signed-off-by: ganoam <gnoam@live.com>