### PR TITLE
Add issue templates to GitHub project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,57 @@
+---
+name: bug
+title: Report a bug in Ibex
+about: Have you found a bug in Ibex or associated tooling?
+labels: Type:Bug
+---
+
+<!--
+Thank you for your interest in Ibex. We are continuously improving Ibex, and your bug report will help us with that. To help us understand and reproduce your problem as quickly as possible we have prepared a little template below.
+
+No text in blocks starting with < !-- will be shown in the final bug report.
+
+You can also copy/paste images into the bug report, and you can attach files to it by simply dragging them into the issue window.
+-->
+
+## Observed Behavior
+<!--
+Please describe the problem you saw. Include waveforms (in VCD or Verilator/GtkWave FST format only please) and log files if possible.
+-->
+
+## Expected Behavior
+<!-- Please describe the behavior you expected to see instead. -->
+
+## Steps to reproduce the issue
+<!--
+Please help us to reproduce the issue you're seeing by including a detailed description of what you did to get to the problem.
+
+For example:
+* What command did you run? (Also include the output of the command.)
+* What parameters/defines did you set?
+* Did you make modifications to the source code?
+-->
+
+## My Environment
+
+<!--
+Let us know how you're using Ibex. This helps us to better understand your problem and find a solution more quickly.
+-->
+
+**EDA tool and version:**
+<!--
+If you are using an EDA tool to work with Ibex let us know which tool and which version you're using.
+For example, "Xilinx Vivado 2020.1" or "Synopsys VCS 2020.03-SP1"
+-->
+
+**Operating system:**
+<!--
+Please let us know the operating system/Linux distribution you're using.
+For example "Ubuntu Linux 18.04" or "CentOS 7.3".
+-->
+
+**Version of the Ibex source code:**
+<!--
+Which version of the Ibex source code are you using?
+You can call `git rev-parse HEAD` in your Ibex source directory to get this information.
+Please also let us know if you have made changes to the code.
+-->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,45 @@
+---
+name: question
+title: Ask a question related to Ibex
+about: Do you have a question about (the use of) Ibex?
+labels: Type:Question
+---
+
+<!--
+Thank you for your interest in Ibex. To help us understand your question as quickly as possible we have prepared a little template below.
+
+No text in blocks starting with < !-- will be shown in the final bug report.
+
+You can also copy/paste images into the question, and you can attach files to it by simply dragging them into the issue window.
+-->
+
+<!--
+Please ask your question after this block of text, adding as much detail as possible.
+If your question is related to a specification (e.g. the RISC-V Specification), a part of our source code, or our documentation we appreciate a link or a quote from the relevant text.
+-->
+
+
+## My Environment
+
+<!--
+Let us know how you're using Ibex. This helps us to better understand your problem and find a solution more quickly.
+-->
+
+**EDA tool and version:**
+<!--
+If you are using an EDA tool to work with Ibex let us know which tool and which version you're using.
+For example, "Xilinx Vivado 2020.1" or "Synopsys VCS 2020.03-SP1"
+-->
+
+**Operating system:**
+<!--
+Please let us know the operating system/Linux distribution you're using.
+For example "Ubuntu Linux 18.04" or "CentOS 7.3".
+-->
+
+**Version of the Ibex source code:**
+<!--
+Which version of the Ibex source code are you using?
+You can call `git rev-parse HEAD` in your Ibex source directory to get this information.
+Please also let us know if you have made changes to the code.
+-->


### PR DESCRIPTION
Add two issue templates to the GitHub project: one for questions, and
one for reporting bugs. These templates are not mandatory, users can
freely change them, or get a blank issue template instead.

To avoid having too much description/example text in the final issue the
instructions are written in HTML comments (which is not beautiful, but
should do the trick and seen commonly in projects).