### PR TITLE
Use more descriptive issue template names

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,5 +1,5 @@
 ---
-name: bug
+name: Report a bug in Ibex
 title: Report a bug in Ibex
 about: Have you found a bug in Ibex or associated tooling?
 labels: Type:Bug

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,5 +1,5 @@
 ---
-name: question
+name: Ask a question related to Ibex
 title: Ask a question related to Ibex
 about: Do you have a question about (the use of) Ibex?
 labels: Type:Question


### PR DESCRIPTION
The GitHub UI shows apparently the name of the template at
https://github.com/lowRISC/ibex/issues/new/choose, which I thought was
just an internal identifier. Use the longer-form version there as well.