### PR TITLE
Revert "Clear MAKEFLAGS when running dvsim.py"

### DIFF
--- a/dv/uvm/icache/dv/Makefile
+++ b/dv/uvm/icache/dv/Makefile
@@ -44,11 +44,6 @@ dvsim-mk-args := \
   $(waves-arg) $(coverage-arg) $(verbosity-arg) \
   $(reseed-arg) $(seed-arg) $(tests-arg)
 
-run-cmd := $(dvsim-py) ibex_icache_sim_cfg.hjson $(dvsim-std-args) $(dvsim-mk-args)
-
-# Clear MAKEFLAGS when running dvsim.py: it contains an internal call
-# to Make and things get confused if they are set.
 .PHONY: run
 run:
-	@echo $(run-cmd)
-	@env MAKEFLAGS= $(run-cmd)
+	$(dvsim-py) ibex_icache_sim_cfg.hjson $(dvsim-std-args) $(dvsim-mk-args)


### PR DESCRIPTION
This reverts commit 31a18ad: the problem that it was working around
was fixed in OpenTitan with commit 249a544, vendored into Ibex as
b1daf9e.