### PR TITLE
CI: The distro-provided pyyaml package is enough

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -32,16 +32,16 @@ case "$ID-$VERSION_ID" in
     $SUDO_CMD sh -c "echo 'deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/xUbuntu_$VERSION_ID/ /' > /etc/apt/sources.list.d/edatools.list"
     $SUDO_CMD apt-get update
 
-    # Uninstall distribution-provided version to get a newer version through pip
-    $SUDO_CMD apt-get remove -y python3-yaml
-
     # Packaged dependencies
+    # Install python3-yaml through apt to get a version with libyaml bindings,
+    # which is significantly faster than the pure Python version.
     $SUDO_CMD apt-get install -y \
         device-tree-compiler \
         python3 \
         python3-pip \
         python3-setuptools \
         python3-wheel \
+        python3-yaml \
         srecord \
         zlib1g-dev \
         git \
@@ -64,7 +64,7 @@ case "$ID-$VERSION_ID" in
       # then fails to run.
       $SUDO_CMD pip3 install -U pip setuptools
 
-      $SUDO_CMD pip3 install -U -r python-requirements.txt
+      $SUDO_CMD pip3 install -r python-requirements.txt
 
       # Install Verible
       mkdir -p build/verible


### PR DESCRIPTION
In the past, we did explicitly install pyyaml through PIP to get a
version newer than the one provided in Ubuntu 18.04. Since then we
changed the calling code to not rely on newer pyyaml features and
are thus able to rely on an older version of pyyaml.

The distro-provided version of pyyaml is built with C bindings, which
are significantly faster than the pip-installed version, which uses a
pure Python-implementation of the parser/dumper.