### PR TITLE
Verilator warnings

### DIFF
--- a/dv/riscv_compliance/rtl/riscv_testutil.sv
+++ b/dv/riscv_compliance/rtl/riscv_testutil.sv
@@ -116,6 +116,7 @@ module riscv_testutil (
   logic [31:0] read_addr_d, read_addr_q;
   always_comb begin
     state_d = state_q;
+    read_addr_d = read_addr_q;
     unique case (state_q)
       WAIT: begin
         if (read_signature_and_terminate) begin

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -759,17 +759,17 @@ module ibex_tracer (
     if (rvfi_insn[1:0] != 2'b11) begin
       insn_is_compressed = 1;
       // Separate case to avoid overlapping decoding
-      if (rvfi_insn[15:13] == 3'b100 && rvfi_insn[1:0] == 2'b10) begin
-        if (rvfi_insn[12]) begin
-          if (rvfi_insn[11:2] == 10'h0) begin
+      if (rvfi_insn[15:13] == INSN_CMV[15:13] && rvfi_insn[1:0] == OPCODE_C2) begin
+        if (rvfi_insn[12] == INSN_CADD[12]) begin
+          if (rvfi_insn[11:2] == INSN_CEBREAK[11:2]) begin
             decode_mnemonic("c.ebreak");
-          end else if (rvfi_insn[6:2] == 5'b0) begin
+          end else if (rvfi_insn[6:2] == INSN_CJALR[6:2]) begin
             decode_cr_insn("c.jalr");
           end else begin
             decode_cr_insn("c.add");
           end
         end else begin
-          if (rvfi_insn[6:2] == 5'h0) begin
+          if (rvfi_insn[6:2] == INSN_CJR[6:2]) begin
             decode_cr_insn("c.jr");
           end else begin
             decode_cr_insn("c.mv");

--- a/rtl/ibex_tracer_pkg.sv
+++ b/rtl/ibex_tracer_pkg.sv
@@ -23,7 +23,6 @@ parameter logic [31:0] INSN_BLT     = { 17'h?,             3'b100, 5'h?, {OPCODE
 parameter logic [31:0] INSN_BGE     = { 17'h?,             3'b101, 5'h?, {OPCODE_BRANCH} };
 parameter logic [31:0] INSN_BLTU    = { 17'h?,             3'b110, 5'h?, {OPCODE_BRANCH} };
 parameter logic [31:0] INSN_BGEU    = { 17'h?,             3'b111, 5'h?, {OPCODE_BRANCH} };
-parameter logic [31:0] INSN_BALL    = { 17'h?,             3'b010, 5'h?, {OPCODE_BRANCH} };
 
 // OPIMM
 parameter logic [31:0] INSN_ADDI    = { 17'h?,             3'b000, 5'h?, {OPCODE_OP_IMM} };

--- a/rtl/ibex_tracer_pkg.sv
+++ b/rtl/ibex_tracer_pkg.sv
@@ -80,10 +80,13 @@ parameter logic [31:0] INSN_CTZ  = { 12'b011000000001, 5'h?,  3'b001, 5'h?, {OPC
 parameter logic [31:0] INSN_PCNT = { 12'b011000000010, 5'h?,  3'b001, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_SEXTB = { 12'b011000000100, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
 parameter logic [31:0] INSN_SEXTH = { 12'b011000000101, 5'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
+// The ZEXT.B and ZEXT.H pseudo-instructions are currently not emitted by the tracer due to a lack
+// of support in the LLVM and GCC toolchains. Enabling this functionality when the time is right is
+// tracked in https://github.com/lowRISC/ibex/issues/1228
 // sext -- pseudoinstruction: andi rd, rs 255
-parameter logic [31:0] INSN_ZEXTB = { 4'b0000, 8'b11111111, 5'h?, 3'b111, 5'h?, {OPCODE_OP_IMM} };
+// parameter logic [31:0] INSN_ZEXTB = { 4'b0000, 8'b11111111, 5'h?, 3'b111, 5'h?, {OPCODE_OP_IMM} };
 // sext -- pseudoinstruction: pack rd, rs zero
-parameter logic [31:0] INSN_ZEXTH = { 7'b0000100, 5'b00000, 5'h?, 3'b100, 5'h?, {OPCODE_OP} };
+// parameter logic [31:0] INSN_ZEXTH = { 7'b0000100, 5'b00000, 5'h?, 3'b100, 5'h?, {OPCODE_OP} };
 
 parameter logic [31:0] INSN_SLO   = { 7'b0010000, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
 parameter logic [31:0] INSN_SRO   = { 7'b0010000, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };

--- a/shared/rtl/bus.sv
+++ b/shared/rtl/bus.sv
@@ -59,6 +59,7 @@ module bus #(
 
   // Master select prio arbiter
   always_comb begin
+    host_sel_req = '0;
     for (integer host = NrHosts - 1; host >= 0; host = host - 1) begin
       if (host_req_i[host]) begin
         host_sel_req = NumBitsHostSel'(host);
@@ -68,6 +69,7 @@ module bus #(
 
   // Device select
   always_comb begin
+    device_sel_req = '0;
     for (integer device = 0; device < NrDevices; device = device + 1) begin
       if ((host_addr_i[host_sel_req] & cfg_device_addr_mask[device])
           == cfg_device_addr_base[device]) begin


### PR DESCRIPTION
Not sure about the rules we have for turning of the lint warnings. Are they allowed inline? For this temporary situation it seems like a good case not to the the `vlt` file.

Feedback to using the defines in the tracer is also welcome :)

Relates to #1227 #1228 #1219 