### PR TITLE
Add misa b extension

### DIFF
--- a/dv/cs_registers/tb/tb_cs_registers.sv
+++ b/dv/cs_registers/tb/tb_cs_registers.sv
@@ -11,7 +11,8 @@ module tb_cs_registers #(
     parameter int unsigned      PMPGranularity   = 0,
     parameter int unsigned      PMPNumRegions    = 4,
     parameter bit               RV32E            = 1'b0,
-    parameter ibex_pkg::rv32m_e RV32M            = ibex_pkg::RV32MFast
+    parameter ibex_pkg::rv32m_e RV32M            = ibex_pkg::RV32MFast,
+    parameter ibex_pkg::rv32b_e RV32B            = ibex_pkg::RV32BNone
 ) (
     // Clock and Reset
     inout  logic                clk_i,
@@ -64,7 +65,8 @@ module tb_cs_registers #(
     .PMPGranularity   (PMPGranularity),
     .PMPNumRegions    (PMPNumRegions),
     .RV32E            (RV32E),
-    .RV32M            (RV32M)
+    .RV32M            (RV32M),
+    .RV32B            (RV32B)
   ) i_cs_regs (
     .clk_i              (clk_i),
     .rst_ni             (rst_ni),

--- a/dv/cs_registers/tb/tb_cs_registers.sv
+++ b/dv/cs_registers/tb/tb_cs_registers.sv
@@ -59,6 +59,7 @@ module tb_cs_registers #(
   /* verilator lint_off PINMISSING */
   ibex_cs_registers #(
     .DbgTriggerEn     (DbgTriggerEn),
+    .ICache           (ICache),
     .MHPMCounterNum   (MHPMCounterNum),
     .MHPMCounterWidth (MHPMCounterWidth),
     .PMPEnable        (PMPEnable),

--- a/dv/cs_registers/tb_cs_registers.core
+++ b/dv/cs_registers/tb_cs_registers.core
@@ -124,3 +124,4 @@ targets:
           - '-CFLAGS "-std=c++14 -Wall -DTOPLEVEL_NAME=tb_cs_registers -DVM_TRACE_FMT_FST -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
+          - '-Wno-fatal' # Do not fail on (style) issues, only warn about them.

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -977,7 +977,8 @@ module ibex_core #(
       .PMPGranularity    ( PMPGranularity    ),
       .PMPNumRegions     ( PMPNumRegions     ),
       .RV32E             ( RV32E             ),
-      .RV32M             ( RV32M             )
+      .RV32M             ( RV32M             ),
+      .RV32B             ( RV32B             )
   ) cs_registers_i (
       .clk_i                   ( clk                          ),
       .rst_ni                  ( rst_ni                       ),

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -25,7 +25,8 @@ module ibex_cs_registers #(
     parameter int unsigned      PMPGranularity    = 0,
     parameter int unsigned      PMPNumRegions     = 4,
     parameter bit               RV32E             = 0,
-    parameter ibex_pkg::rv32m_e RV32M             = ibex_pkg::RV32MFast
+    parameter ibex_pkg::rv32m_e RV32M             = ibex_pkg::RV32MFast,
+    parameter ibex_pkg::rv32b_e RV32B             = ibex_pkg::RV32BNone
 ) (
     // Clock and Reset
     input  logic                 clk_i,
@@ -119,12 +120,14 @@ module ibex_cs_registers #(
 
   import ibex_pkg::*;
 
+  localparam int unsigned RV32BEnabled = (RV32B == RV32BNone) ? 0 : 1;
   localparam int unsigned RV32MEnabled = (RV32M == RV32MNone) ? 0 : 1;
   localparam int unsigned PMPAddrWidth = (PMPGranularity > 0) ? 33 - PMPGranularity : 32;
 
   // misa
   localparam logic [31:0] MISA_VALUE =
       (0                 <<  0)  // A - Atomic Instructions extension
+    | (RV32BEnabled      <<  1)  // B - Bit-Manipulation extension
     | (1                 <<  2)  // C - Compressed extension
     | (0                 <<  3)  // D - Double precision floating-point extension
     | (32'(RV32E)        <<  4)  // E - RV32E base ISA


### PR DESCRIPTION
I am not 100% sure if this should be done as the B extension bit is still "Tentatively reserved for Bit-Manipulation extension".

As I made changes to the testbench I checked it with Verilator and added some minor changes to it as well into this PR.