### PR TITLE
[syn] Fix timing reports in synthesis flow

### DIFF
--- a/syn/README.md
+++ b/syn/README.md
@@ -31,8 +31,9 @@ The following must be installed:
 * Yosys - https://github.com/YosysHQ/yosys
 * OpenSTA - https://github.com/The-OpenROAD-Project/OpenSTA
 
-A standard cell library is also required in the liberty (.lib) format. The
-following Open Libraries can be used:
+The flow was tested with yosys 0.9 and OpenSTA 2.2 but may work with other
+versions.  A standard cell library is also required in the liberty (.lib)
+format. The following Open Libraries can be used:
 
 * Nangate45 - https://github.com/The-OpenROAD-Project/OpenROAD-flow/tree/master/flow/platforms/nangate45
 

--- a/syn/tcl/sta_utils.tcl
+++ b/syn/tcl/sta_utils.tcl
@@ -40,8 +40,8 @@ proc timing_report {path_group rpt_out path_count} {
   set sta_csv_out [open $sta_csv_out_filename "w"]
 
   foreach path $paths {
-    set startpoint_name [get_name [get_property $path startpoint]]
-    set endpoint_name [get_name [get_property $path endpoint]]
+    set startpoint_name [get_property [get_property $path startpoint] full_name]
+    set endpoint_name [get_property [get_property $path endpoint] full_name]
     set slack [get_property $path slack]
     puts $sta_csv_out [format "$startpoint_name,$endpoint_name,%.4f" $slack]
   }


### PR DESCRIPTION
This fixes a bug where .csv.rpt files weren't being generated properly.
OpenSTA was outputting a simple 'Q' or 'D' for start and end path points
where the full instance name was required (which is then fed to yosys to
translate to a human readable name). The issue was in the `timing_report`
proc in syn/tcl/sta_utils.tcl which needed to request the full name of
the start and end points.

The syn README is updated to note which tool versions have been used to
test the flow.

Fixes #1193