### PR TITLE
[rtl] Fix lint "fix" with DbgTriggerEn

### DIFF
--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -1225,7 +1225,7 @@ module ibex_cs_registers #(
 
   if (DbgTriggerEn) begin : gen_trigger_regs
     localparam int unsigned DbgHwNumLen = DbgHwBreakNum > 1 ? $clog2(DbgHwBreakNum) : 1;
-    localparam bit [DbgHwNumLen-1:0] MaxTselect = DbgHwBreakNum[DbgHwNumLen-1:0] - '1;
+    localparam int MaxTselect = DbgHwBreakNum - 1;
 
     // Register values
     logic [DbgHwNumLen-1:0]   tselect_d, tselect_q;
@@ -1252,7 +1252,7 @@ module ibex_cs_registers #(
     // Debug interface tests the available number of triggers by writing and reading the trigger
     // select register. Only allow changes to the register if it is within the supported region.
     assign tselect_d = (csr_wdata_int < DbgHwBreakNum) ? csr_wdata_int[DbgHwNumLen-1:0] :
-                                                         MaxTselect;
+                                                         MaxTselect[DbgHwNumLen-1:0];
     // tmatch_control is enabled when the execute bit is set
     assign tmatch_control_d = csr_wdata_int[2];
     assign tmatch_value_d   = csr_wdata_int[31:0];


### PR DESCRIPTION
The previous change was wrong: it was trying to define a signal with
`DbgHwNumLen` bits that contained `DbgHwBreakNum - 1`. Unfortunately, `'1`
is *not* the same as a zero-extended version of `1'b1`.