### PR TITLE
[verilator] Remove clock gating waiver and add extra warning

### DIFF
--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -166,6 +166,7 @@ targets:
           - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
+          - "-Wwarn-IMPERFECTSCH"
           # RAM primitives wider than 64bit (required for ECC) fail to build in
           # Verilator without increasing the unroll count (see Verilator#1266)
           - "--unroll-count 72"

--- a/lint/verilator_waiver.vlt
+++ b/lint/verilator_waiver.vlt
@@ -64,11 +64,6 @@ lint_off -rule UNUSED -file "*/rtl/ibex_compressed_decoder.sv" -match "*rst_ni*"
 lint_off -rule UNUSED -file "*/rtl/ibex_decoder.sv" -match "*rst_ni*"
 lint_off -rule UNUSED -file "*/rtl/ibex_branch_predict.sv" -match "*rst_ni*"
 
-// Signal unoptimizable: Feedback to clock or circular logic:
-// ibex_core.cs_registers_i.mie_q
-// Issue lowrisc/ibex#212
-lint_off -rule UNOPTFLAT -file "*/rtl/ibex_csr.sv" -match "*ibex_core.cs_registers_i.u_mie_csr.rdata_q*"
-
 // Temporary waivers until OpenTitan primitives are lint-clean
 // https://github.com/lowRISC/opentitan/issues/2313
 lint_off -file "*/lowrisc_prim_*/rtl/*.sv"


### PR DESCRIPTION
The `-Wwarn-IMPERFECTSCH` flag is suggested in the Verilator docs (to
help spot if we get a clock gating hint wrong). The waiver is no
longer needed because we now add the relevant hint in the
RTL (vendored in `prim_generic_clock_gating.sv` from OpenTitan).

Closes #212.