### PR TITLE
[doc] Update dependency descriptions for Spike/OVPsim

### DIFF
--- a/doc/03_reference/verification.rst
+++ b/doc/03_reference/verification.rst
@@ -90,18 +90,27 @@ Prerequisites & Environment Setup
 In order to run the co-simulation flow, you'll need:
 
 - A SystemVerilog simulator that supports UVM.
+
   The flow is currently tested with VCS.
 
-- A RISC-V instruction set simulator, such as Spike_ or OVPsim_.
-  Note that when building Spike the ``--enable-commitlog`` and ``--enable-misaligned`` options must be passed to the ``configure`` script.
+- A RISC-V instruction set simulator, such as Spike or OVPsim.
+
+  Ibex is tested using Spike.
+
+  To use Spike_, it must be built with the ``--enable-commitlog`` and ``--enable-misaligned`` options.
   ``--enable-commitlog`` is needed to produce log output to track the instructions that were executed.
   ``--enable-misaligned`` tells Spike to simulate a core that handles misaligned accesses in hardware (rather than jumping to a trap handler).
-  If it is desired to simulate the core with the Icache enabled, a `lowRISC-specific branch of Spike <https://github.com/lowRISC/riscv-isa-sim/tree/ibex>`_ must be used.
-  Ibex supports v0.92 of the Bitmanip specification.
-  The ``master`` branch of Spike_ and OVPSim_ may support a different version.
-  It is recommended the `lowRISC-specific branch of Spike <https://github.com/lowRISC/riscv-isa-sim/tree/ibex>`_ is used when using a configuration with Bitmanip to ensure the simulated version of the Bitmanip specification matches with the RTL implemented version.
+
+  Ibex supports version 0.92 of the draft Bitmanip specification.
+  The ``master`` branch of Spike may support a different version.
+  lowRISC maintains a `lowRISC-specific branch of Spike <LRSpike_>`_ that matches the supported Bitmanip specification.
+  This branch must also be used in order to to simulate the core with the Icache enabled.
+
+  OVPsim_ is a commercial instruction set simulator with RISC-V support.
+  To specify the v0.92 Bitmanip specification, you need "riscvOVPsimPlus", which can be downloaded free of charge with registration.
 
 - A working RISC-V toolchain (to compile / assemble the generated programs before simulating them).
+
   Either download a `pre-built toolchain <riscv-toolchain-releases_>`_ (quicker) or download and build the `RISC-V GNU compiler toolchain <riscv-toolchain-source_>`_.
   For the latter, the Bitmanip patches have to be manually installed to enable support for the Bitmanip draft extension.
   For further information, checkout the `Bitmanip Extension on GitHub <bitmanip_>`_ and `how we create the pre-built toolchains <bitmanip-patches_>`_.
@@ -121,7 +130,8 @@ to tell the RISCV-DV code where to find them:
 you have installed the corresponding instruction set simulator)
 
 .. _Spike: https://github.com/riscv/riscv-isa-sim
-.. _OVPsim: https://github.com/riscv/riscv-ovpsim
+.. _LRSpike: https://github.com/lowRISC/riscv-isa-sim/tree/ibex
+.. _OVPsim: https://www.ovpworld.org/riscvOVPsimPlus/
 .. _riscv-toolchain-source: https://github.com/riscv/riscv-gnu-toolchain
 .. _riscv-toolchain-releases: https://github.com/lowRISC/lowrisc-toolchains/releases
 .. _bitmanip-patches: https://github.com/lowRISC/lowrisc-toolchains#how-to-generate-the-bitmanip-patches


### PR DESCRIPTION
This should match what's going on a bit more accurately. The link to
OVPsim now points at the (free of cost) commercial tool: riscv-ovpsim
doesn't support the bitmanip specification that we're using at the
moment.

Fixes #1248.