### PR TITLE
[syn] Add missing include path

### DIFF
--- a/syn/syn_yosys.sh
+++ b/syn/syn_yosys.sh
@@ -32,6 +32,7 @@ for file in ../rtl/*.sv; do
     --define=SYNTHESIS \
     ../rtl/*_pkg.sv \
     -I../vendor/lowrisc_ip/ip/prim/rtl \
+    -I../dv/fcov \
     $file \
     > $LR_SYNTH_OUT_DIR/generated/${module}.v
 done


### PR DESCRIPTION
With the introduction of dv_fcov_macros.svh we need to add it as an
included path for sv2v.