### PR TITLE
[rtl] Remove paths between dmem and imem signals

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -142,8 +142,9 @@ module ibex_controller #(
   logic illegal_dret;
   logic illegal_umode;
   logic exc_req_lsu;
-  logic special_req_all;
-  logic special_req_branch;
+  logic special_req;
+  logic special_req_pc_change;
+  logic special_req_flush_only;
   logic enter_debug_mode_d;
   logic enter_debug_mode_q;
   logic ebreak_into_debug;
@@ -219,29 +220,18 @@ module ibex_controller #(
 
 
   // special requests: special instructions, pipeline flushes, exceptions...
+  // All terms in these expressions are qualified by instr_valid_i except exc_req_lsu which can come
+  // from the Writeback stage with no instr_valid_i from the ID stage
 
-  // To avoid creating a path from data_err_i -> instr_req_o and to help timing the below
-  // special_req_all has a version that only applies to branches. For a branch the controller needs
-  // to set pc_set_o but only if there is no special request. If the generic special_req_all signal
-  // is used then a variety of signals that will never cause a special request during a branch
-  // instruction end up factored into pc_set_o. The special_req_branch only considers the special
-  // request reasons that are relevant to a branch.
+  // These special requests only cause a pipeline flush and in particular don't cause a PC change
+  // that is outside the normal execution flow
+  assign special_req_flush_only = wfi_insn | csr_pipe_flush;
+
+  // These special requests cause a change in PC
+  assign special_req_pc_change = mret_insn | dret_insn | exc_req_d | exc_req_lsu;
 
   // generic special request signal, applies to all instructions
-  // All terms in this expression are qualified by instr_valid_i except exc_req_lsu which can come
-  // from the Writeback stage with no instr_valid_i from the ID stage
-  assign special_req_all = mret_insn | dret_insn | wfi_insn | csr_pipe_flush |
-      exc_req_d | exc_req_lsu;
-
-  // special request that can specifically occur during branch instructions
-  // All terms in this expression are qualified by instr_valid_i
-  assign special_req_branch = instr_fetch_err & (ctrl_fsm_cs != FLUSH);
-
-  `ASSERT(SpecialReqBranchGivesSpecialReqAll,
-    special_req_branch |-> special_req_all)
-
-  `ASSERT(SpecialReqAllGivesSpecialReqBranchIfBranchInst,
-    special_req_all && (branch_set_i || jump_set_i) |-> special_req_branch)
+  assign special_req = special_req_pc_change | special_req_flush_only;
 
   // Exception/fault prioritisation is taken from Table 3.7 of Priviledged Spec v1.11
   if (WritebackStage) begin : g_wb_exceptions
@@ -486,7 +476,7 @@ module ibex_controller #(
 
 
         // Get ready for special instructions, exceptions, pipeline flushes
-        if (special_req_all) begin
+        if (special_req) begin
           // Halt IF but don't flush ID. This leaves a valid instruction in
           // ID so controller can determine appropriate action in the
           // FLUSH state.
@@ -503,26 +493,24 @@ module ibex_controller #(
           end
         end
 
-        if (!special_req_branch) begin
-          if (branch_set_i || jump_set_i) begin
-            // Only set the PC if the branch predictor hasn't already done the branch for us
-            pc_set_o       = BranchPredictor ? ~instr_bp_taken_i : 1'b1;
+        if (branch_set_i || jump_set_i) begin
+          // Only set the PC if the branch predictor hasn't already done the branch for us
+          pc_set_o       = BranchPredictor ? ~instr_bp_taken_i : 1'b1;
 
-            perf_tbranch_o = branch_set_i;
-            perf_jump_o    = jump_set_i;
-          end
+          perf_tbranch_o = branch_set_i;
+          perf_jump_o    = jump_set_i;
+        end
 
-          if (BranchPredictor) begin
-            if (instr_bp_taken_i & branch_not_set_i) begin
-              // If the instruction is a branch that was predicted to be taken but was not taken
-              // signal a mispredict.
-              nt_branch_mispredict_o = 1'b1;
-            end
+        if (BranchPredictor) begin
+          if (instr_bp_taken_i & branch_not_set_i) begin
+            // If the instruction is a branch that was predicted to be taken but was not taken
+            // signal a mispredict.
+            nt_branch_mispredict_o = 1'b1;
           end
         end
 
         // pc_set signal excluding branch taken condition
-        if ((branch_set_spec_i || jump_set_i) && !special_req_branch) begin
+        if (branch_set_spec_i || jump_set_i) begin
           // Only speculatively set the PC if the branch predictor hasn't already done the branch
           // for us
           pc_set_spec_o = BranchPredictor ? ~instr_bp_taken_i : 1'b1;
@@ -535,7 +523,7 @@ module ibex_controller #(
           halt_if = 1'b1;
         end
 
-        if (!stall && !special_req_all) begin
+        if (!stall && !special_req) begin
           if (enter_debug_mode_d) begin
             // enter debug mode
             ctrl_fsm_ns = DBG_TAKEN_IF;
@@ -853,4 +841,77 @@ module ibex_controller #(
   // The speculative branch signal should be set whenever the actual branch signal is set
   `ASSERT(IbexSpecImpliesSetPC, pc_set_o |-> pc_set_spec_o)
 
+  `ifdef INC_ASSERT
+    // If something that causes a jump into an exception handler is seen that jump must occur before
+    // the next instruction executes. The logic tracks whether a jump into an exception handler is
+    // expected. Assertions check the jump occurs.
+
+    logic exception_req, exception_req_pending, exception_req_accepted, exception_req_done;
+    logic exception_pc_set, seen_exception_pc_set, expect_exception_pc_set;
+    logic exception_req_needs_pc_set;
+
+    assign exception_req = (special_req | enter_debug_mode_d | handle_irq);
+    // Any exception rquest will cause a transition out of DECODE, once the controller transitions
+    // back into DECODE we're done handling the request.
+    assign exception_req_done =
+      exception_req_pending & (ctrl_fsm_cs != DECODE) & (ctrl_fsm_ns == DECODE);
+
+    assign exception_req_needs_pc_set = enter_debug_mode_d | handle_irq | special_req_pc_change;
+
+    // An exception PC set uses specific PC types
+    assign exception_pc_set =
+      exception_req_pending & (pc_set_o & (pc_mux_o inside {PC_EXC, PC_ERET, PC_DRET}));
+
+    always @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        exception_req_pending   <= 1'b0;
+        exception_req_accepted  <= 1'b0;
+        expect_exception_pc_set <= 1'b0;
+        seen_exception_pc_set   <= 1'b0;
+      end else begin
+        // Keep `exception_req_pending` asserted once an exception_req is seen until it is done
+        exception_req_pending <= (exception_req_pending | exception_req) & ~exception_req_done;
+
+        // The exception req has been accepted once the controller transitions out of decode
+        exception_req_accepted <= (exception_req_accepted & ~exception_req_done) |
+          (exception_req & ctrl_fsm_ns != DECODE);
+
+        // Set `expect_exception_pc_set` if exception req needs one and keep it asserted until
+        // exception req is done
+        expect_exception_pc_set <= (expect_exception_pc_set | exception_req_needs_pc_set) &
+          ~exception_req_done;
+
+        // Keep `seen_exception_pc_set` asserted once an exception PC set is seen until the
+        // exception req is done
+        seen_exception_pc_set <= (seen_exception_pc_set | exception_pc_set) & ~exception_req_done;
+      end
+    end
+
+    // Once an exception request has been accepted it must be handled before controller goes back to
+    // DECODE
+    `ASSERT(IbexNoDoubleExceptionReq, exception_req_accepted |-> ctrl_fsm_cs != DECODE)
+
+    // Only signal ready, allowing a new instruction into ID, if there is no exception request
+    // pending or it is done this cycle.
+    `ASSERT(IbexDontSkipExceptionReq,
+      id_in_ready_o |-> !exception_req_pending || exception_req_done)
+
+    // Once a PC set has been performed for an exception request there must not be any other
+    // excepting those to move into debug mode.
+    `ASSERT(IbexNoDoubleSpecialReqPCSet,
+      seen_exception_pc_set &&
+        !((ctrl_fsm_cs inside {DBG_TAKEN_IF, DBG_TAKEN_ID}) &&
+          (pc_mux_o == PC_EXC) && (exc_pc_mux_o == EXC_PC_DBD))
+      |-> !pc_set_o)
+
+    // When an exception request is done there must have been an appropriate PC set (either this
+    // cycle or a previous one).
+    `ASSERT(IbexSetExceptionPCOnSpecialReqIfExpected,
+      exception_req_pending && expect_exception_pc_set && exception_req_done |->
+      seen_exception_pc_set || exception_pc_set)
+
+    // If there's a pending exception req that doesn't need a PC set we must not see one
+    `ASSERT(IbexNoPCSetOnSpecialReqIfNotExpected,
+      exception_req_pending && !expect_exception_pc_set |-> ~pc_set_o)
+  `endif
 endmodule


### PR DESCRIPTION
Prior to this change Ibex had multiple feedthrough paths from the data
memory interface to the instruction memory interface. This existed
because Ibex would hold off doing a instruction fetch for a jump or
branch if there was a outstanding memory request. It would wait for the
response to be available so either the jump or branch would occur or an
exception was taken.

With this change the branch or jump will speculatively begin the
instruction fetch whilst there is an outstanding memory request. Should
an exception result from the memory request the fetch will be discarded
and the exception taken as normal.

An alternative fix would not factor the data error response
(data_err_i) directly into the controller logic for branches and jumps.
With this option new stall cycles would be introduced anywhere a branch
or jump immediately follows a memory instruction which would have an
adverse impact on performance.