### PR TITLE
Specify boot address in hex to avoid 32-bit signed overflow

### DIFF
--- a/dv/uvm/core_ibex/ibex_dv.f
+++ b/dv/uvm/core_ibex/ibex_dv.f
@@ -2,9 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Boot address specified in decimal to avoid single quote in number, which
-// causes parsing errors of this file in Riviera.
-+define+BOOT_ADDR=2147483648 // 32'h8000_0000
+// The boot address is specified as a hex number and is used in SystemVerilog
+// code like this: 32'h `BOOT_ADDR.
+//
+// We can't put a ' character in the constant, because Riviera's TCL machinery
+// doesn't support them in defines. We also can't just use the decimal value
+// (2147483648), because an undecorated integer literal is interpreted as a
+// signed 32-bit integer.
++define+BOOT_ADDR=8000_0000
 +define+TRACE_EXECUTION
 +define+RVFI
 

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -59,8 +59,8 @@ module core_ibex_tb_top;
   parameter bit BranchPredictor          = 1'b0;
 
   ibex_core_tracing #(
-    .DmHaltAddr      (`BOOT_ADDR + 'h0 ),
-    .DmExceptionAddr (`BOOT_ADDR + 'h4 ),
+    .DmHaltAddr      (32'h`BOOT_ADDR + 'h0 ),
+    .DmExceptionAddr (32'h`BOOT_ADDR + 'h4 ),
     .PMPEnable       (PMPEnable        ),
     .PMPGranularity  (PMPGranularity   ),
     .PMPNumRegions   (PMPNumRegions    ),
@@ -78,7 +78,7 @@ module core_ibex_tb_top;
     .rst_ni         (rst_n                ),
     .test_en_i      (1'b0                 ),
     .hart_id_i      (32'b0                ),
-    .boot_addr_i    (`BOOT_ADDR           ), // align with spike boot address
+    .boot_addr_i    (32'h`BOOT_ADDR       ), // align with spike boot address
     .irq_software_i (irq_vif.irq_software ),
     .irq_timer_i    (irq_vif.irq_timer    ),
     .irq_external_i (irq_vif.irq_external ),

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -103,7 +103,7 @@ class core_ibex_base_test extends uvm_test;
   function void load_binary_to_mem();
     string      bin;
     bit [7:0]   r8;
-    bit [31:0]  addr = `BOOT_ADDR;
+    bit [31:0]  addr = 32'h`BOOT_ADDR;
     int         f_bin;
     void'($value$plusargs("bin=%0s", bin));
     if (bin == "")


### PR DESCRIPTION
I wonder whether we could use some form of quoting to allow
"32'h8000_0000" to get through Riviera's TCL, but we don't have any
way to test, so let's go with the easy option.

Fixes #1224.