### PR TITLE
[dv] Rename stored copy of run phase

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -325,7 +325,7 @@ class core_ibex_debug_intr_basic_test extends core_ibex_base_test;
 
   // Task that waits for xRET to be asserted within a certain number of cycles
   virtual task wait_ret(string ret, int timeout);
-    run.raise_objection(this);
+    cur_run_phase.raise_objection(this);
     fork
       begin
         case (ret)
@@ -349,7 +349,7 @@ class core_ibex_debug_intr_basic_test extends core_ibex_base_test;
     join_any
     // Will only get here if dret successfully detected within timeout period
     disable fork;
-    run.drop_objection(this);
+    cur_run_phase.drop_objection(this);
   endtask
 
   virtual function void check_priv_mode(priv_lvl_e mode);
@@ -404,8 +404,8 @@ class core_ibex_directed_test extends core_ibex_debug_intr_basic_test;
           join_none
           wait (dut_vif.dut_cb.ecall === 1'b1);
           disable fork;
-          if (run.get_objection_count(this) > 1) begin
-            run.drop_objection(this);
+          if (cur_run_phase.get_objection_count(this) > 1) begin
+            cur_run_phase.drop_objection(this);
           end
         end
       end
@@ -1196,7 +1196,7 @@ class core_ibex_mem_error_test extends core_ibex_directed_test;
         end
       join
       if (latched_imem_err === 1'b0) begin
-        run.drop_objection(this);
+        cur_run_phase.drop_objection(this);
         inject_imem_error();
       end
     end while (latched_imem_err === 1'b0);


### PR DESCRIPTION
In UVM 1.2, at least, `uvm_component` (a base class of
`core_ibex_base_test`) still has a method called run(). Ironically, this
has been renamed to `run_phase` to avoid conflicting with user names,
but the old-style phase names still exist at the moment.

Rename our copy of the phase object to `cur_run_phase`, which doesn't
conflict. Also, set it back to null at the end of the `run_phase()`
task. We shouldn't ever use it afterwards, and it's probably a good
idea to explode with a null object error if we do.