### PR TITLE
[dv] Be explicit about the target priv_mode in wait_ret test

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -328,6 +328,7 @@ class core_ibex_debug_intr_basic_test extends core_ibex_base_test;
     run.raise_objection(this);
     fork
       begin
+        priv_lvl_e tgt_mode;
         case (ret)
           "dret": begin
             wait (dut_vif.dut_cb.dret === 1'b1);
@@ -339,7 +340,8 @@ class core_ibex_debug_intr_basic_test extends core_ibex_base_test;
             `uvm_fatal(`gfn, $sformatf("Invalid xRET instruction %0s", ret))
           end
         endcase
-        wait (dut_vif.dut_cb.priv_mode === select_mode());
+        tgt_mode = select_mode();
+        wait (dut_vif.dut_cb.priv_mode === tgt_mode);
       end
       begin : ret_timeout
         clk_vif.wait_clks(timeout);


### PR DESCRIPTION
The previous code contained

    wait (dut_vif.dut_cb.priv_mode === select_mode())

and VCS warns that this `wait` block will only trigger on changes to
explicit arguments. That is, if the `in_nested_trap` field changes, so
the return value of the `select_mode()` method would change to match
priv_mode, the `wait` statement won't finish.

This patch explicitly stores a snapshot of the value of `select_mode()`
just before the wait line. I think this is the intended behaviour, and
will no longer trigger warnings from VCS.

@udinator: Have I understood this code correctly? This change isn't right if we expect `in_nested_trap` to change "behind our backs".