### PR TITLE
Don't automatically generate disassembly in the example Makefile

### DIFF
--- a/examples/sw/simple_system/common/common.mk
+++ b/examples/sw/simple_system/common/common.mk
@@ -33,15 +33,20 @@ OBJS := ${C_SRCS:.c=.o} ${ASM_SRCS:.S=.o} ${CRT:.S=.o}
 DEPS = $(OBJS:%.o=%.d)
 
 ifdef PROGRAM
-OUTFILES := $(PROGRAM).elf $(PROGRAM).vmem $(PROGRAM).bin $(PROGRAM).dis
+OUTFILES := $(PROGRAM).elf $(PROGRAM).vmem $(PROGRAM).bin
 else
 OUTFILES := $(OBJS)
 endif
 
 all: $(OUTFILES)
 
+ifdef PROGRAM
 $(PROGRAM).elf: $(OBJS) $(LINKER_SCRIPT)
 	$(CC) $(CFLAGS) -T $(LINKER_SCRIPT) $(OBJS) -o $@ $(LIBS)
+
+.PHONY: disassemble
+disassemble: $(PROGRAM).dis
+endif
 
 %.dis: %.elf
 	$(OBJDUMP) -fhSD $^ > $@


### PR DESCRIPTION
Anyone who needs to disassemble their generated ELF can probably just
call objdump directly and the precise set of flags have already
confused at least one potential contributor[1].

We're keeping the canned objdump command for "engineers that know
where to look" because some have said they find it useful.

[1] https://github.com/lowRISC/ibex/issues/1263

Fixes #1263 (marking as a fix because the question becomes moot!)