### PR TITLE
Fix deprecated sphinx html_context usage in conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -105,11 +105,9 @@ html_logo = 'images/logo.svg'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-html_context = {
-    'css_files' : [
-        '_static/theme_overrides.css', # Fix wide tables in RTD theme
-        ],
-    }
+html_css_files = [
+    '_static/theme_overrides.css', # Fix wide tables in RTD theme
+]
 
 # -- Options for LaTeX output ---------------------------------------------
 


### PR DESCRIPTION
We were using the old html_context which has been deprecated
for a while. This PR switches to html_css_files instead.
See sphinx-doc/sphinx#8885 for more information.