### PR TITLE
[simple_system] Fix type for mhpmcounter_get

### DIFF
--- a/dv/verilator/pcount/cpp/ibex_pcounts.cc
+++ b/dv/verilator/pcount/cpp/ibex_pcounts.cc
@@ -10,7 +10,7 @@
 #include <svdpi.h>
 
 extern "C" {
-extern long long mhpmcounter_get(int index);
+extern unsigned long long mhpmcounter_get(int index);
 }
 
 #include "ibex_pcounts.h"

--- a/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/examples/simple_system/rtl/ibex_simple_system.sv
@@ -279,7 +279,7 @@ module ibex_simple_system (
 
   export "DPI-C" function mhpmcounter_get;
 
-  function automatic longint mhpmcounter_get(int index);
+  function automatic longint unsigned mhpmcounter_get(int index);
     return u_core.u_ibex_core.cs_registers_i.mhpmcounter[index];
   endfunction
 


### PR DESCRIPTION
It's probably clearer if this 64-bit counter is treated as a uint64_t,
not an int64_t (the code using it downstream expects non-negative
values).

Fixes #1282.