### PR TITLE
[dv/ibex] update how coverage is merged

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -92,7 +92,7 @@ all: sim
 
 instr: iss_sim
 
-sim: post_compare cov
+sim: post_compare gen_cov
 
 .PHONY: clean
 clean:
@@ -417,7 +417,8 @@ post_compare: $(OUT-SEED)/regr.log
 ###############################################################################
 # Generate RISCV-DV functional coverage
 # TODO(udi) - add B extension
-fcov:
+.PHONY: riscv_dv_cov
+riscv_dv_fcov:
 	$(verb)python3 ${GEN_DIR}/cov.py \
           --core ibex \
           --dir ${OUT-SEED}/rtl_sim \
@@ -426,7 +427,10 @@ fcov:
           --custom_target riscv_dv_extension
 
 # Merge all output coverage directories into the <out>/rtl_sim directory
-cov:
+#
+# Any coverage databases generated from the riscv_dv_fcov target will be merged as well.
+.PHONY: gen_cov
+gen_cov: riscv_dv_fcov
 	$(verb)rm -rf $(OUT-DIR)rtl_sim/test.vdb
 	$(verb)./sim.py \
 		--steps=cov \

--- a/dv/uvm/core_ibex/sim.py
+++ b/dv/uvm/core_ibex/sim.py
@@ -478,13 +478,16 @@ def gen_cov(base_dir, simulator, lsf_cmd):
     """
     # Compile a list of all output seed-###/rtl_sim/test.vdb directories
     dir_list = []
-    for entry in os.scandir(base_dir):
-        vdb_path = "%s/%s/rtl_sim/test.vdb" % (base_dir, entry.name)
-        if 'seed' in entry.name:
-            logging.info("Searching %s/%s for coverage database" %
-                         (base_dir, entry.name))
-            if os.path.exists(vdb_path):
-                dir_list.append(vdb_path)
+
+    # All generated coverage databases will be named "test.vdb"
+    vdb_dir_name = "test.vdb"
+
+    for path, dirs, files in os.walk(base_dir):
+        if vdb_dir_name in dirs:
+            vdb_path = os.path.join(path, vdb_dir_name)
+            logging.info("Found coverage database at %s" % vdb_path)
+            dir_list.append(vdb_path)
+
     if dir_list == []:
         logging.info("No coverage data available, exiting...")
         sys.exit(RET_SUCCESS)


### PR DESCRIPTION
Currently, the `cov` step in the DV Makefile will only merge coverage
databases emitted directly from Ibex simulations, and will not pick up
any coverage databases generated by the RISCV-DV functional coverage
flow.

This PR updates the `gen_cov()` function in `sim.py` to recursively
search for any generated coverage directories and then merges them all.

Resultant coverage reports include all code coverage, Ibex functional
coverage, and RISCV-DV functional coverage.

The coverage-related targets in the Makefile have also been renamed to
improve clarity.

Signed-off-by: Udi Jonnalagadda <udij@google.com>