### PR TITLE
[dv/ibex] filter out tests on a per-config basis

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -353,6 +353,7 @@ $(OUT-DIR)rtl_sim/.compile.stamp: \
 	$(verb)./sim.py \
 	 --o=$(OUT-DIR) \
 	 --steps=compile \
+	 --ibex_config=$(IBEX_CONFIG) \
 	 ${COMMON_OPTS} \
 	 --simulator="${SIMULATOR}" --simulator_yaml=yaml/rtl_simulation.yaml \
 	 $(cov-arg) $(wave-arg) $(lsf-arg) \
@@ -389,6 +390,7 @@ $(metadata)/rtl_sim.run.stamp: \
 	$(verb)./sim.py \
 	 --o=$(OUT-SEED) \
 	 --steps=sim \
+	 --ibex_config=$(IBEX_CONFIG) \
 	 ${TEST_OPTS} \
 	 --simulator="${SIMULATOR}" --simulator_yaml=yaml/rtl_simulation.yaml \
 	 $(cov-arg) $(wave-arg) $(lsf-arg) \
@@ -407,6 +409,7 @@ $(OUT-SEED)/regr.log: \
 	$(verb)./sim.py \
      --o=$(OUT-SEED) \
      --steps=compare \
+     --ibex_config=$(IBEX_CONFIG) \
      ${TEST_OPTS} \
      --simulator="${SIMULATOR}" \
      --iss="${ISS}"

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -642,6 +642,8 @@
     +pmp_max_offset=00024000
     +enable_write_pmp_csr=1
   rtl_test: core_ibex_base_test
+  rtl_params:
+    PMPEnable: 1
 
 - test: riscv_pmp_disable_all_regions_test
   desc: >
@@ -671,6 +673,8 @@
     +pmp_region_15=X:0,W:0,R:0
     +enable_write_pmp_csr=1
   rtl_test: core_ibex_base_test
+  rtl_params:
+    PMPEnable: 1
 
 - test: riscv_pmp_out_of_bounds_test
   desc: >
@@ -685,6 +689,8 @@
     +enable_write_pmp_csr=1
     +directed_instr_0=riscv_load_store_rand_addr_instr_stream,50
   rtl_test: core_ibex_base_test
+  rtl_params:
+    PMPEnable: 1
 
 - test: riscv_pmp_full_random_test
   desc: >
@@ -701,6 +707,8 @@
     +pmp_allow_addr_overlap=1
     +enable_write_pmp_csr=1
   rtl_test: core_ibex_base_test
+  rtl_params:
+    PMPEnable: 1
 
 - test: riscv_bitmanip_full_test
   desc: >
@@ -711,6 +719,8 @@
     +enable_b_extension=1
     +enable_bitmanip_groups=zbb,zb_tmp,zbt,zbs,zbp,zbf,zbe,zbc,zbr
   rtl_test: core_ibex_base_test
+  rtl_params:
+    RV32B: "ibex_pkg::RV32BFull"
 
 - test: riscv_bitmanip_balanced_test
   desc: >
@@ -721,3 +731,5 @@
     +enable_b_extension=1
     +enable_bitmanip_groups=zbb,zb_tmp,zbt,zbs,zbf
   rtl_test: core_ibex_base_test
+  rtl_params:
+    RV32B: ["ibex_pkg::RV32BFull", "ibex_pkg::RV32BBalanced"]


### PR DESCRIPTION
This PR adds functionality to filter out tests during regressions for a
particular config.

e.g. if a full regression is kicked off using the `small` config, we
don't want to attempt to run any PMP and bitmanip tests as the RTL
parameter-set will not support it.

To do this, a new YAML field called `rtl_params` is added to relevant
test entries, to indicate what parameters (if any) are required to be
able to run the particular test, along with the required value of said
parameters.

`sim.py` will then parse this field (if it exists), and using
information from `ibex_configs.yaml` pertaining to the current config,
will remove tests from being run on-the-fly.

This also gives us the convenient side effect of not having to re-run
instruction generation if there is a parameter/config mismatch, we can
just rerun the RTL compilation and simulation stages safely.

Signed-off-by: Udi Jonnalagadda <udij@google.com>