### PR TITLE
[ci/ibex] temporarily remove pmp_full_random_test

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -692,23 +692,24 @@
   rtl_params:
     PMPEnable: 1
 
-- test: riscv_pmp_full_random_test
-  desc: >
-    Completely randomize the boot mode, mstatus.mprv, and all PMP configuration,
-    and allow PMP regions to overlap.
-    A large number of iterations will be required since this introduces a huge
-    state space of configurations.
-  iterations: 100
-  gen_test: riscv_rand_instr_test
-  gen_opts: >
-    +instr_cnt=6000
-    +pmp_max_offset=00024000
-    +pmp_randomize=1
-    +pmp_allow_addr_overlap=1
-    +enable_write_pmp_csr=1
-  rtl_test: core_ibex_base_test
-  rtl_params:
-    PMPEnable: 1
+    # TODO(udinator) this test is failing with arbitrary timeouts, need to fix this.
+    #- test: riscv_pmp_full_random_test
+    #  desc: >
+    #    Completely randomize the boot mode, mstatus.mprv, and all PMP configuration,
+    #    and allow PMP regions to overlap.
+    #    A large number of iterations will be required since this introduces a huge
+    #    state space of configurations.
+    #  iterations: 100
+    #  gen_test: riscv_rand_instr_test
+    #  gen_opts: >
+    #    +instr_cnt=6000
+    #    +pmp_max_offset=00024000
+    #    +pmp_randomize=1
+    #    +pmp_allow_addr_overlap=1
+    #    +enable_write_pmp_csr=1
+    #  rtl_test: core_ibex_base_test
+    #  rtl_params:
+    #    PMPEnable: 1
 
 - test: riscv_bitmanip_full_test
   desc: >


### PR DESCRIPTION
this test is arbitrarily failing in regressions on a Spike timeout,
temporarily remove this to avoid blocking.

@udinator to fix this in the near future.

Signed-off-by: Udi Jonnalagadda <udij@google.com>