### PR TITLE
Fix spacing for bullet points to appear

### DIFF
--- a/doc/03_reference/security.rst
+++ b/doc/03_reference/security.rst
@@ -21,6 +21,7 @@ This makes it more difficult for an external observer to infer secret data by ob
 
 In Ibex, most instructions already execute independent of their input operands.
 When data-independent timing is enabled:
+
 * Branches execute identically regardless of their taken/not-taken status
 * Early completion of multiplication by zero/one is removed
 * Early completion of divide by zero is removed


### PR DESCRIPTION
Bullet points now appear properly for the last paragraph under the Data Independent Timing section in `security.rst`.