### PR TITLE
[rtl] Add MSECCFGH CSR

### DIFF
--- a/doc/03_reference/cs_registers.rst
+++ b/doc/03_reference/cs_registers.rst
@@ -36,6 +36,8 @@ Ibex implements all the Control and Status Registers (CSRs) listed in the follow
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x390  | ``mseccfg``        | WARL   | Machine Security Configuration                |
 +---------+--------------------+--------+-----------------------------------------------+
+|  0x391  | ``mseccfgh``       | WARL   | Upper 32 bits of ``mseccfg``                  |
++---------+--------------------+--------+-----------------------------------------------+
 |  0x3A0  | ``pmpcfg0``        | WARL   | PMP Configuration Register                    |
 +---------+--------------------+--------+-----------------------------------------------+
 |     .             .               .                    .                              |
@@ -248,12 +250,12 @@ A particular bit in the register reads as one if the corresponding interrupt inp
 | 3     | **Machine Software Interrupt Pending (MSIP):** if set, ``irq_software_i`` is pending. |
 +-------+---------------------------------------------------------------------------------------+
 
-Machine Security Configuration (mseccfg)
+Machine Security Configuration (mseccfg/mseccfgh)
 ----------------------------------------
 
-CSR Address: ``0x390``
+CSR Address: ``0x390 - 0x391``
 
-Reset Value: ``0x0000_0000``
+Reset Value: ``0x0000_0000_0000_0000``
 
 +------+-----------------------------------------------------------------------------------------------------------------------------------+
 | Bit# | Definition                                                                                                                        |
@@ -268,6 +270,8 @@ Reset Value: ``0x0000_0000``
 ``mseccfg`` is specified in the Trusted Execution Environment (TEE) working group proposal :download:`PMP Enhancements for memory access and execution prevention on Machine mode <../03_reference/pdfs/riscv-epmp.pdf>`, which gives the full details of it's functionality including the new PMP behaviour when ``mseccfg.MML`` is set.
 Note that the reset value means PMP behavior out of reset matches the RISC-V Privileged Architecture.
 A write to ``mseccfg`` is required to change it.
+Note ``mseccfgh`` reads as all 0s and ignores all writes.
+Any access to ``mseccfg`` or ``mseccfgh`` when using an Ibex configuration without PMP (``PMPEnable`` is 0) will trigger an illegal instruction exception.
 
 PMP Configuration Register (pmpcfgx)
 ------------------------------------

--- a/doc/03_reference/cs_registers.rst
+++ b/doc/03_reference/cs_registers.rst
@@ -264,7 +264,7 @@ Reset Value: ``0x0000_0000_0000_0000``
 +------+-----------------------------------------------------------------------------------------------------------------------------------+
 | 1    | **Machine Mode Whitelist Policy (MMWP):** If set default policy for PMP is deny for M-Mode accesses that don't match a PMP region |
 +------+-----------------------------------------------------------------------------------------------------------------------------------+
-| 0    | **Machine Mode Lockdown (MML):** Alters behaviour of ``pmpcfgX`` bits                                                               |
+| 0    | **Machine Mode Lockdown (MML):** Alters behaviour of ``pmpcfgX`` bits                                                             |
 +------+-----------------------------------------------------------------------------------------------------------------------------------+
 
 ``mseccfg`` is specified in the Trusted Execution Environment (TEE) working group proposal :download:`PMP Enhancements for memory access and execution prevention on Machine mode <../03_reference/pdfs/riscv-epmp.pdf>`, which gives the full details of it's functionality including the new PMP behaviour when ``mseccfg.MML`` is set.

--- a/dv/cs_registers/model/register_model.cc
+++ b/dv/cs_registers/model/register_model.cc
@@ -9,6 +9,8 @@
 RegisterModel::RegisterModel(SimCtrl *sc, CSRParams *params) : simctrl_(sc) {
   register_map_.push_back(
       std::make_unique<MSeccfgRegister>(kCSRMSeccfg, &register_map_));
+  register_map_.push_back(
+      std::make_unique<NonImpRegister>(kCSRMSeccfgh, &register_map_));
   // Instantiate all the registers
   for (unsigned int i = 0; i < 4; i++) {
     uint32_t reg_addr = 0x3A0 + i;

--- a/dv/cs_registers/reg_driver/csr_listing.def
+++ b/dv/cs_registers/reg_driver/csr_listing.def
@@ -9,6 +9,7 @@
 #endif
 
 CSR(MSeccfg, 0x390)
+CSR(MSeccfgh, 0x391)
 CSR(PMPCfg0, 0x3A0)
 CSR(PMPCfg1, 0x3A1)
 CSR(PMPCfg2, 0x3A2)

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -349,10 +349,22 @@ module ibex_cs_registers #(
       end
 
       CSR_MSECCFG: begin
-        csr_rdata_int                       = '0;
-        csr_rdata_int[CSR_MSECCFG_MML_BIT]  = pmp_mseccfg.mml;
-        csr_rdata_int[CSR_MSECCFG_MMWP_BIT] = pmp_mseccfg.mmwp;
-        csr_rdata_int[CSR_MSECCFG_RLB_BIT]  = pmp_mseccfg.rlb;
+        if (PMPEnable) begin
+          csr_rdata_int                       = '0;
+          csr_rdata_int[CSR_MSECCFG_MML_BIT]  = pmp_mseccfg.mml;
+          csr_rdata_int[CSR_MSECCFG_MMWP_BIT] = pmp_mseccfg.mmwp;
+          csr_rdata_int[CSR_MSECCFG_RLB_BIT]  = pmp_mseccfg.rlb;
+        end else begin
+          illegal_csr = 1'b1;
+        end
+      end
+
+      CSR_MSECCFGH: begin
+        if (PMPEnable) begin
+          csr_rdata_int = '0;
+        end else begin
+          illegal_csr = 1'b1;
+        end
       end
 
       // PMP registers

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -368,6 +368,7 @@ typedef enum logic[11:0] {
   CSR_MIP       = 12'h344,
 
   CSR_MSECCFG   = 12'h390,
+  CSR_MSECCFGH  = 12'h391,
 
   // Physical memory protection
   CSR_PMPCFG0   = 12'h3A0,


### PR DESCRIPTION
This is the top 32 bits of MSECCFG. It currently has no specified bits
so reads as 0 and ignores writes.

Fixes #1297