### PR TITLE
Update lowrisc_ip to lowRISC/opentitan@fd9f58c7d

### DIFF
--- a/dv/riscv_compliance/ibex_riscv_compliance.cc
+++ b/dv/riscv_compliance/ibex_riscv_compliance.cc
@@ -13,9 +13,11 @@ int main(int argc, char **argv) {
   simctrl.SetTop(&top, &top.IO_CLK, &top.IO_RST_N,
                  VerilatorSimCtrlFlags::ResetPolarityNegative);
 
-  memutil.RegisterMemoryArea(
-      "ram",
-      "TOP.ibex_riscv_compliance.u_ram.u_ram.gen_generic.u_impl_generic");
+  MemArea ram(
+      "TOP.ibex_riscv_compliance.u_ram.u_ram.gen_generic.u_impl_generic",
+      64 * 1024 / 4, 4);
+
+  memutil.RegisterMemoryArea("ram", 0x0, &ram);
   simctrl.RegisterExtension(&memutil);
 
   return simctrl.Exec(argc, argv).first;

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_monitor.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_monitor.sv
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class ibex_icache_core_monitor extends dv_base_monitor #(
-    .ITEM_T (ibex_icache_core_bus_item),
-    .CFG_T  (ibex_icache_core_agent_cfg),
-    .COV_T  (ibex_icache_core_agent_cov)
+    .ITEM_T     (ibex_icache_core_bus_item),
+    .REQ_ITEM_T (ibex_icache_core_req_item),
+    .RSP_ITEM_T (ibex_icache_core_rsp_item),
+    .CFG_T      (ibex_icache_core_agent_cfg),
+    .COV_T      (ibex_icache_core_agent_cov)
   );
   `uvm_component_utils(ibex_icache_core_monitor)
 

--- a/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_monitor.sv
+++ b/dv/uvm/icache/dv/ibex_icache_ecc_agent/ibex_icache_ecc_monitor.sv
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class ibex_icache_ecc_monitor extends dv_base_monitor #(
-    .ITEM_T (ibex_icache_ecc_bus_item),
-    .CFG_T  (ibex_icache_ecc_agent_cfg)
+    .ITEM_T     (ibex_icache_ecc_bus_item),
+    .REQ_ITEM_T (ibex_icache_ecc_item),
+    .RSP_ITEM_T (ibex_icache_ecc_item),
+    .CFG_T      (ibex_icache_ecc_agent_cfg)
   );
   `uvm_component_utils(ibex_icache_ecc_monitor)
 

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_monitor.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_monitor.sv
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class ibex_icache_mem_monitor
-  extends dv_base_monitor #(.ITEM_T (ibex_icache_mem_bus_item),
-                            .CFG_T  (ibex_icache_mem_agent_cfg),
-                            .COV_T  (ibex_icache_mem_agent_cov));
+  extends dv_base_monitor #(.ITEM_T     (ibex_icache_mem_bus_item),
+                            .REQ_ITEM_T (ibex_icache_mem_resp_item),
+                            .RSP_ITEM_T (ibex_icache_mem_resp_item),
+                            .CFG_T      (ibex_icache_mem_agent_cfg),
+                            .COV_T      (ibex_icache_mem_agent_cov));
 
   `uvm_component_utils(ibex_icache_mem_monitor)
   `uvm_component_new

--- a/examples/simple_system/ibex_simple_system.cc
+++ b/examples/simple_system/ibex_simple_system.cc
@@ -17,8 +17,10 @@ int main(int argc, char **argv) {
   simctrl.SetTop(&top, &top.IO_CLK, &top.IO_RST_N,
                  VerilatorSimCtrlFlags::ResetPolarityNegative);
 
-  memutil.RegisterMemoryArea(
-      "ram", "TOP.ibex_simple_system.u_ram.u_ram.gen_generic.u_impl_generic");
+  MemArea ram("TOP.ibex_simple_system.u_ram.u_ram.gen_generic.u_impl_generic",
+              1024 * 1024 / 4, 4);
+
+  memutil.RegisterMemoryArea("ram", 0x0, &ram);
   simctrl.RegisterExtension(&memutil);
 
   bool exit_app = false;

--- a/vendor/lowrisc_ip.lock.hjson
+++ b/vendor/lowrisc_ip.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/opentitan
-    rev: 1ae03937f0bb4b146bb6e736bccb4821bfda556b
+    rev: f29a0f7a7115e03fba734b1c00691c253aceb07e
   }
 }

--- a/vendor/lowrisc_ip/dv/sv/common_ifs/clk_rst_if.sv
+++ b/vendor/lowrisc_ip/dv/sv/common_ifs/clk_rst_if.sv
@@ -191,7 +191,7 @@ interface clk_rst_if #(
                              int post_reset_dly_clks  = 0,
                              int rst_n_scheme         = 1);
     int dly_ps;
-    if ($isunknown(reset_width_clks)) reset_width_clks = $urandom_range(4, 20);
+    if ($isunknown(reset_width_clks)) reset_width_clks = $urandom_range(50, 100);
     dly_ps = $urandom_range(0, clk_period_ps);
     wait_clks(pre_reset_dly_clks);
     case (rst_n_scheme)

--- a/vendor/lowrisc_ip/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/vendor/lowrisc_ip/dv/sv/csr_utils/csr_seq_lib.sv
@@ -169,8 +169,16 @@ class csr_write_seq extends csr_base_seq;
 
     // check all hdl paths are valid
     if (!test_backdoor_path_done) begin
+      bkdr_reg_path_e path_kind;
       uvm_reg_mem_hdl_paths_seq hdl_check_seq;
       hdl_check_seq = uvm_reg_mem_hdl_paths_seq::type_id::create("hdl_check_seq");
+
+      // add all the supported path types
+      do begin
+        hdl_check_seq.abstractions.push_back(path_kind.name);
+        path_kind = path_kind.next;
+      end while (path_kind != path_kind.first);
+
       foreach (models[i]) begin
         hdl_check_seq.model = models[i];
         hdl_check_seq.start(null);
@@ -200,7 +208,7 @@ class csr_write_seq extends csr_base_seq;
                                            backdoor dist {0 :/ 7, 1 :/ 3};)
       end
 
-      csr_wr(.csr(test_csrs[i]), .value(wdata), .blocking(0), .backdoor(backdoor));
+      csr_wr(.ptr(test_csrs[i]), .value(wdata), .blocking(0), .backdoor(backdoor));
     end
   endtask
 
@@ -243,7 +251,7 @@ class csr_rw_seq extends csr_base_seq;
       // might pick up stale mirrored value
       // the pre-predict also needs to happen after the register is being written, to make sure the
       // register is getting the updated access information.
-      csr_wr(.csr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
+      csr_wr(.ptr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
 
       do_check_csr_or_field_rd(.csr(test_csrs[i]),
                               .blocking(0),
@@ -364,7 +372,7 @@ class csr_bit_bash_seq extends csr_base_seq;
       val = rg.get();
       val[k]  = ~val[k];
       err_msg = $sformatf("Wrote %0s[%0d]: %0b", rg.get_full_name(), k, val[k]);
-      csr_wr(.csr(rg), .value(val), .blocking(1), .predict(!external_checker));
+      csr_wr(.ptr(rg), .value(val), .blocking(1), .predict(!external_checker));
 
       // TODO, outstanding access to same reg isn't supported in uvm_reg. Need to add another seq
       // uvm_reg waits until transaction is completed, before start another read/write in same reg
@@ -407,9 +415,14 @@ class csr_aliasing_seq extends csr_base_seq;
 
       `DV_CHECK_STD_RANDOMIZE_FATAL(wdata)
       wdata &= get_mask_excl_fields(test_csrs[i], CsrExclWrite, CsrAliasingTest, m_csr_excl_item);
-      csr_wr(.csr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
+      csr_wr(.ptr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
 
       all_csrs.shuffle();
+
+      // If all_csrs queue size is larger than 100, randomly pick 100 CSRs to avoid chip level test
+      // runtime too long.
+      if (all_csrs.size() > 100) all_csrs = all_csrs[0 : 99];
+
       foreach (all_csrs[j]) begin
         uvm_reg_data_t compare_mask;
 

--- a/vendor/lowrisc_ip/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/vendor/lowrisc_ip/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -230,7 +230,7 @@ package csr_utils_pkg;
     join
   endtask
 
-  task automatic csr_wr(input uvm_reg        csr,
+  task automatic csr_wr(input uvm_object     ptr,
                         input uvm_reg_data_t value,
                         input uvm_check_e    check = default_csr_check,
                         input uvm_path_e     path = UVM_DEFAULT_PATH,
@@ -241,17 +241,27 @@ package csr_utils_pkg;
                         input uvm_reg_map    map = null,
                         input bit            en_shadow_wr = 1);
     if (backdoor) begin
-      csr_poke(csr, value, check, predict);
-    end else if (blocking) begin
-      csr_wr_sub(csr, value, check, path, timeout_ns, predict, map, en_shadow_wr);
+      csr_poke(ptr, value, check, predict);
     end else begin
-      fork
-        begin
-          csr_wr_sub(csr, value, check, path, timeout_ns, predict, map, en_shadow_wr);
-        end
-      join_none
-      // Add #0 to ensure that this thread starts executing before any subsequent call
-      #0;
+      csr_field_t csr_or_fld = decode_csr_or_field(ptr);
+
+      // if it's a field write, still do full CSR write and use mirrored value for the other fields
+      if (csr_or_fld.field != null) begin
+        // get full CSR value
+        value = get_csr_val_with_updated_field(csr_or_fld.field, `gmv(csr_or_fld.csr), value);
+      end
+
+      if (blocking) begin
+        csr_wr_sub(csr_or_fld.csr, value, check, path, timeout_ns, predict, map, en_shadow_wr);
+      end else begin
+        fork
+          begin
+            csr_wr_sub(csr_or_fld.csr, value, check, path, timeout_ns, predict, map, en_shadow_wr);
+          end
+        join_none
+        // Add #0 to ensure that this thread starts executing before any subsequent call
+        #0;
+      end
     end
   endtask
 
@@ -323,27 +333,40 @@ package csr_utils_pkg;
   endtask
 
   // backdoor write csr
-  task automatic csr_poke(input uvm_reg         csr,
+  task automatic csr_poke(input uvm_object      ptr,
                           input uvm_reg_data_t  value,
                           input uvm_check_e     check = default_csr_check,
                           input bit             predict = 0,
                           input bkdr_reg_path_e kind = BkdrRegPathRtl);
+    csr_field_t   csr_or_fld = decode_csr_or_field(ptr);
     uvm_status_e  status;
     string        msg_id = {csr_utils_pkg::msg_id, "::csr_poke"};
-    uvm_reg_data_t old_mirrored_val = csr.get_mirrored_value();
+    uvm_reg_data_t old_mirrored_val;
 
-    csr.poke(.status(status), .value(value), .kind(kind.name));
+    if (csr_or_fld.field != null) begin
+      old_mirrored_val = csr_or_fld.field.get_mirrored_value();
+      csr_or_fld.field.poke(.status(status), .value(value), .kind(kind.name));
+    end else begin
+      old_mirrored_val = csr_or_fld.csr.get_mirrored_value();
+      csr_or_fld.csr.poke(.status(status), .value(value), .kind(kind.name));
+    end
     if (check == UVM_CHECK && status != UVM_IS_OK) begin
       string str;
       uvm_hdl_path_concat paths[$];
-      csr.get_full_hdl_path(paths);
+      csr_or_fld.csr.get_full_hdl_path(paths, kind.name);
       foreach (paths[0].slices[i]) str = $sformatf("%0s\n%0s", str, paths[0].slices[i].path);
       `uvm_fatal(msg_id, $sformatf("poke failed for %0s, check below paths %0s",
-                                   csr.get_full_name(), str))
+                                   ptr.get_full_name(), str))
     end
     // poke always updates predict value, if predict == 0, revert back to old mirrored value
     if (!predict || kind == BkdrRegPathRtlShadow) begin
-      void'(csr.predict(.value(old_mirrored_val), .kind(UVM_PREDICT_DIRECT), .path(UVM_BACKDOOR)));
+      if (csr_or_fld.field != null) begin
+        void'(csr_or_fld.field.predict(.value(old_mirrored_val), .kind(UVM_PREDICT_DIRECT),
+                                       .path(UVM_BACKDOOR)));
+      end else begin
+        void'(csr_or_fld.csr.predict(.value(old_mirrored_val), .kind(UVM_PREDICT_DIRECT),
+                                     .path(UVM_BACKDOOR)));
+      end
     end
   endtask
 

--- a/vendor/lowrisc_ip/dv/sv/dv_base_reg/dv_base_reg_field.sv
+++ b/vendor/lowrisc_ip/dv/sv/dv_base_reg/dv_base_reg_field.sv
@@ -50,7 +50,7 @@ class dv_base_reg_field extends uvm_reg_field;
     if (is_intr_test_fld) begin
       uvm_reg_field intr_state_fld = get_intr_state_field();
       // use UVM_PREDICT_READ to avoid uvm_warning due to UVM_PREDICT_DIRECT
-      intr_state_fld.predict(field_val | `gmv(intr_state_fld), .kind(UVM_PREDICT_READ));
+      void'(intr_state_fld.predict(field_val | `gmv(intr_state_fld), .kind(UVM_PREDICT_READ)));
     end
 
     super.do_predict(rw, kind, be);

--- a/vendor/lowrisc_ip/dv/sv/dv_lib/dv_base_agent.sv
+++ b/vendor/lowrisc_ip/dv/sv/dv_lib/dv_base_agent.sv
@@ -43,16 +43,24 @@ class dv_base_agent #(type CFG_T            = dv_base_agent_cfg,
       sequencer = SEQUENCER_T::type_id::create("sequencer", this);
       sequencer.cfg = cfg;
 
-      if (cfg.if_mode == Host)  driver = HOST_DRIVER_T::type_id::create("driver", this);
-      else                      driver = DEVICE_DRIVER_T::type_id::create("driver", this);
-      driver.cfg = cfg;
+      if (cfg.has_driver) begin
+        if (cfg.if_mode == Host)  driver = HOST_DRIVER_T::type_id::create("driver", this);
+        else                      driver = DEVICE_DRIVER_T::type_id::create("driver", this);
+        driver.cfg = cfg;
+      end
     end
   endfunction
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
-    if (cfg.is_active) begin
+    if (cfg.is_active && cfg.has_driver) begin
       driver.seq_item_port.connect(sequencer.seq_item_export);
+    end
+    if (cfg.has_req_fifo) begin
+      monitor.req_analysis_port.connect(sequencer.req_analysis_fifo.analysis_export);
+    end
+    if (cfg.has_rsp_fifo) begin
+      monitor.rsp_analysis_port.connect(sequencer.rsp_analysis_fifo.analysis_export);
     end
   endfunction
 

--- a/vendor/lowrisc_ip/dv/sv/dv_lib/dv_base_agent_cfg.sv
+++ b/vendor/lowrisc_ip/dv/sv/dv_lib/dv_base_agent_cfg.sv
@@ -5,17 +5,27 @@
 class dv_base_agent_cfg extends uvm_object;
 
   // agent cfg knobs
-  bit         is_active = 1'b1;   // active driver or passive monitor
+  bit         is_active = 1'b1;   // active driver/sequencer or passive monitor
   bit         en_cov    = 1'b1;   // enable coverage
   if_mode_e   if_mode;            // interface mode - Host or Device
+
+  // indicate to create and connet driver to sequencer or not
+  // if this is a high-level agent, we may just call lower-level agent to send item in seq, then
+  // driver isn't needed
+  bit         has_driver = 1'b1;
+  // indicate if these fifo and ports exist or not
+  bit         has_req_fifo = 1'b0;
+  bit         has_rsp_fifo = 1'b0;
 
   // use for phase_ready_to_end to add additional delay after ok_to_end is set
   int ok_to_end_delay_ns = 1000;
 
   `uvm_object_utils_begin(dv_base_agent_cfg)
-    `uvm_field_int (is_active,          UVM_DEFAULT)
-    `uvm_field_int (en_cov,             UVM_DEFAULT)
-    `uvm_field_enum(if_mode_e, if_mode, UVM_DEFAULT)
+    `uvm_field_int (is_active,            UVM_DEFAULT)
+    `uvm_field_int (en_cov,               UVM_DEFAULT)
+    `uvm_field_enum(if_mode_e, if_mode,   UVM_DEFAULT)
+    `uvm_field_int (has_req_fifo,         UVM_DEFAULT)
+    `uvm_field_int (has_rsp_fifo,         UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/vendor/lowrisc_ip/dv/sv/dv_lib/dv_base_monitor.sv
+++ b/vendor/lowrisc_ip/dv/sv/dv_lib/dv_base_monitor.sv
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class dv_base_monitor #(type ITEM_T = uvm_sequence_item,
+                        type REQ_ITEM_T = ITEM_T,
+                        type RSP_ITEM_T = ITEM_T,
                         type CFG_T  = dv_base_agent_cfg,
                         type COV_T  = dv_base_agent_cov) extends uvm_monitor;
   `uvm_component_param_utils(dv_base_monitor #(ITEM_T, CFG_T, COV_T))
@@ -20,11 +22,18 @@ class dv_base_monitor #(type ITEM_T = uvm_sequence_item,
   // Analysis port for the collected transfer.
   uvm_analysis_port #(ITEM_T) analysis_port;
 
+  // item will be sent to this port for seq when req phase is done (last is set)
+  uvm_analysis_port #(REQ_ITEM_T) req_analysis_port;
+  // item will be sent to this port for seq when rsp phase is done (rsp_done is set)
+  uvm_analysis_port #(RSP_ITEM_T) rsp_analysis_port;
+
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     analysis_port = new("analysis_port", this);
+    req_analysis_port = new("req_analysis_port", this);
+    rsp_analysis_port = new("rsp_analysis_port", this);
   endfunction
 
   virtual task run_phase(uvm_phase phase);

--- a/vendor/lowrisc_ip/dv/sv/dv_lib/dv_base_sequencer.sv
+++ b/vendor/lowrisc_ip/dv/sv/dv_lib/dv_base_sequencer.sv
@@ -11,8 +11,21 @@ class dv_base_sequencer #(type ITEM_T     = uvm_sequence_item,
                                                  .CFG_T      (CFG_T),
                                                  .RSP_ITEM_T (RSP_ITEM_T)))
 
+  // These fifos collects items when req/rsp is received, which are used to communicate between
+  // monitor and sequences. These fifos are optional
+  // When device is re-active, it gets items from req_analysis_fifo and send rsp to driver
+  // When this is a high-level agent, monitors put items to these 2 fifos for high-level seq
+  uvm_tlm_analysis_fifo #(ITEM_T)     req_analysis_fifo;
+  uvm_tlm_analysis_fifo #(RSP_ITEM_T) rsp_analysis_fifo;
+
   CFG_T cfg;
 
   `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (cfg.has_req_fifo) req_analysis_fifo = new("req_analysis_fifo", this);
+    if (cfg.has_rsp_fifo) rsp_analysis_fifo = new("rsp_analysis_fifo", this);
+  endfunction : build_phase
 
 endclass

--- a/vendor/lowrisc_ip/dv/tools/common.tcl
+++ b/vendor/lowrisc_ip/dv/tools/common.tcl
@@ -16,6 +16,11 @@ if {[info exists ::env(WAVES)]} {
   set waves "$::env(WAVES)"
 }
 
+set gui 0
+if {[info exists ::env(GUI)]} {
+  set gui "$::env(GUI)"
+}
+
 set tb_top "tb"
 if {[info exists ::env(TB_TOP)]} {
   set tb_top "$::env(TB_TOP)"

--- a/vendor/lowrisc_ip/dv/tools/dvsim/common_modes.hjson
+++ b/vendor/lowrisc_ip/dv/tools/dvsim/common_modes.hjson
@@ -8,6 +8,11 @@
   // options are appended to actual build_modes
   build_modes: [
     {
+      name: gui
+      is_sim_mode: 1
+      en_build_modes: ["{tool}_gui"]
+    }
+    {
       name: waves
       is_sim_mode: 1
       en_build_modes: ["{tool}_waves"]

--- a/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/vendor/lowrisc_ip/dv/tools/dvsim/common_sim_cfg.hjson
@@ -72,6 +72,7 @@
   exports: [
     { dv_root: "{dv_root}" },
     { SIMULATOR: "{tool}" },
+    { GUI: "{gui}"},
     { WAVES: "{waves}" },
     { DUT_TOP: "{dut}" },
     { TB_TOP: "{tb}" },
@@ -142,6 +143,7 @@
   // Project defaults for Xcelium
   xcelium_cov_cfg_file: "{dv_root}/tools/xcelium/xcelium.ccf"
   xcelium_cov_refine_files: []
+  xcelium_unr_cfg_file:  "{dv_root}/tools/xcelium/unr.cfg"
   xcelium_common_excl_file: ["{dv_root}/tools/xcelium/exclude.tcl"]
 
   // Build-specific coverage cfg files for Xcelium.

--- a/vendor/lowrisc_ip/dv/tools/dvsim/dsim.hjson
+++ b/vendor/lowrisc_ip/dv/tools/dvsim/dsim.hjson
@@ -93,6 +93,12 @@
 
   build_modes: [
     {
+      name: dsim_gui
+      is_sim_mode: 1
+      build_opts: []
+      run_opts: []
+    }
+    {
       name: dsim_waves
       is_sim_mode: 1
       build_opts: ["+acc+b"]

--- a/vendor/lowrisc_ip/dv/tools/dvsim/riviera.hjson
+++ b/vendor/lowrisc_ip/dv/tools/dvsim/riviera.hjson
@@ -64,6 +64,12 @@
 
   build_modes: [
     {
+      name: riviera_gui
+      is_sim_mode: 1
+      build_opts: []
+      run_opts: []
+    }
+    {
       name: riviera_waves
       is_sim_mode: 1
     }

--- a/vendor/lowrisc_ip/dv/tools/dvsim/sim.mk
+++ b/vendor/lowrisc_ip/dv/tools/dvsim/sim.mk
@@ -49,16 +49,11 @@ ifneq (${pre_run_cmds},)
 	cd ${run_dir} && ${pre_run_cmds}
 endif
 
-.ONESHELL:
 sw_build: pre_run
 	@echo "[make]: sw_build"
 ifneq (${sw_images},)
-	set -e
-	mkdir -p ${sw_build_dir}
 	# Initialize meson build system.
-	${LOCK_SW_BUILD_DIR} "cd ${proj_root} && \
-		env BUILD_ROOT=${sw_build_dir} ${proj_root}/meson_init.sh"
-
+	#
 	# Loop through the list of sw_images and invoke meson on each item.
 	# `sw_images` is a space-separated list of tests to be built into an image.
 	# Optionally, each item in the list can have additional metadata / flags using
@@ -68,7 +63,11 @@ ifneq (${sw_images},)
 	# If no delimiter is detected, then the full string is considered to be the
 	# <path-to-sw-test>. If 1 delimiter is detected, then it must be <path-to-sw-
 	# test> followed by <index>. The <flag> is considered optional.
-	@for sw_image in ${sw_images}; do \
+	set -e; \
+	mkdir -p ${sw_build_dir}; \
+	${LOCK_SW_BUILD_DIR} "cd ${proj_root} && \
+		env BUILD_ROOT=${sw_build_dir} ${proj_root}/meson_init.sh"; \
+	for sw_image in ${sw_images}; do \
 		image=`echo $$sw_image | cut -d: -f 1`;  \
 		index=`echo $$sw_image | cut -d: -f 2`; \
 		flags=(`echo $$sw_image | cut -d: -f 3- --output-delimiter " "`); \

--- a/vendor/lowrisc_ip/dv/tools/dvsim/vcs.hjson
+++ b/vendor/lowrisc_ip/dv/tools/dvsim/vcs.hjson
@@ -11,12 +11,16 @@
                "-Mdir={build_ex}.csrc",
                "-o {build_ex}",
                "-f {sv_flist}",
+               // Enable LCA features. It does not require separate licenses.
+               "-lca",
                // List multiple tops for the simulation. Prepend each top level with `-top`.
                "{eval_cmd} echo {sim_tops} | sed -E 's/(\\S+)/-top \\1/g'",
                "+incdir+{build_dir}",
                // Turn on warnings for non-void functions called with return values ignored
                "+warn=SV-NFIVC",
                "+warn=noUII-L",
+               // Disable unnecessary LCA warning.
+               "+warn=noLCA_FEATURES_ENABLED",
                // Below option required for $error/$fatal system calls
                "-assert svaext",
                // Force unique and priority to evaluate compliance checking only on the stable
@@ -29,7 +33,7 @@
                // otherwise. The double-escaped quotes are because this needs to go inside a string
                // that gets passed to Make (stripping one level of quotes), and then needs to
                // result in an argument with an embedded space (the other one).
-               "-CFLAGS \\\"--std=c99 -fno-extended-identifiers\\\"",
+               "-CFLAGS --std=c99 -CFLAGS -fno-extended-identifiers",
                // C++11 standard is enforced for all sources, including the DPI-C constructs.
                // TODO, may need to update to c++14 to meet our requirements
                // Refer to https://docs.opentitan.org/doc/ug/install_instructions
@@ -192,7 +196,7 @@
 
   // Vars that need to exported to the env.
   exports: [
-    { FLEXLM_DIAGNOSTICS: 4 },
+    { VCS_LICENSE_WAIT: 1 },
     { VCS_ARCH_OVERRIDE: "linux" },
     { VCS_LIC_EXPIRE_WARNING: 1 }
   ]
@@ -217,6 +221,12 @@
   run_fail_patterns:   ["^Error-.*$"] // Null pointer error
 
   build_modes: [
+    {
+      name: vcs_gui
+      is_sim_mode: 1
+      build_opts: ["-debug_access+all+reverse"]
+      run_opts: ["-gui", "-l {run_dir}/simv.log"]
+    }
     {
       name: vcs_waves
       is_sim_mode: 1

--- a/vendor/lowrisc_ip/dv/tools/dvsim/verilator.hjson
+++ b/vendor/lowrisc_ip/dv/tools/dvsim/verilator.hjson
@@ -108,6 +108,14 @@
   cov_db_test_dir: ""
 
   build_modes: [
+    // TODO: Verilator will likely never have GUI. Find a better way to support
+    // --gui when the tool itself doesn't support it.
+    {
+      name: verilator_gui
+      is_sim_mode: 1
+      build_opts: []
+      run_opts: []
+    }
     {
       name: verilator_waves
       is_sim_mode: 1

--- a/vendor/lowrisc_ip/dv/tools/dvsim/xcelium.hjson
+++ b/vendor/lowrisc_ip/dv/tools/dvsim/xcelium.hjson
@@ -5,7 +5,7 @@
   build_cmd:  "{job_prefix} xrun"
   run_cmd:    "{job_prefix} xrun"
 
-  build_opts: ["-elaborate -64bit -access +r -sv",
+  build_opts: ["-elaborate -64bit -sv",
                "-licqueue",
                // TODO: duplicate primitives between OT and Ibex #1231
                "-ALLOWREDEFINITION",
@@ -119,14 +119,49 @@
                      "-init {xcelium_common_excl_file}",
                      " {eval_cmd} echo {xcelium_cov_refine_files} | sed -E 's/(\\S+)/-load_refinement \\1/g' "]
 
+  cov_unr_dir:     "{scratch_path}/cov_unr"
+
+  // not needed we can reuse the last build snapshot
+  cov_unr_build_opts:[]
+  cov_unr_build_cmd:[]
+
+  cov_unr_run_cmd: "{job_prefix} xrun"
+
+
+  cov_unr_run_opts: [// use xrun in UNR mode
+                     "-unr",
+                     // JasperGold switch (use formal)
+                     "-jg",
+                     // use the same snapshot as used for regression
+                     "-r {tb}",
+                     // pointer to the merged coverage data from the regression
+                     "-covdb {cov_merge_db_dir}",
+                     // what metrics to use
+                     "-jg_coverage {cov_metrics}",
+                     "-64bit",
+                     "-xmlibdirname {build_dir}/xcelium.d",
+                     // overwrite previous results
+                     "-covoverwrite",
+                     "-inst_top {dut_instance}",
+                     // UNR Configurations
+                     "-input {xcelium_unr_cfg_file} "]
+
+
   // pass and fail patterns
   build_fail_patterns: ["\\*E.*$"]
   run_fail_patterns:   ["\\*E.*$"] // Null pointer error
 
   build_modes: [
     {
+      name: xcelium_gui
+      is_sim_mode: 1
+      build_opts: ["-createdebugdb", "-access +c"]
+      run_opts: ["-gui"]
+    }
+    {
       name: xcelium_waves
       is_sim_mode: 1
+      build_opts: ["-access +c"]
     }
     {
       name: xcelium_cov
@@ -137,7 +172,9 @@
                    "-covdut {dut}",
                    // Set the coverage configuration file
                    "-covfile {xcelium_cov_cfg_file}"]
-      run_opts:   [// Coverage database output location.
+      run_opts:   [// Put the coverage model (*.ucm) and the database (*.ucd) together.
+                   "-covmodeldir {cov_db_test_dir}",
+                   // Coverage database output location.
                    "-covworkdir {cov_work_dir}",
                    // Set the scope to the build mode name.
                    "-covscope {build_mode}",

--- a/vendor/lowrisc_ip/dv/tools/sim.tcl
+++ b/vendor/lowrisc_ip/dv/tools/sim.tcl
@@ -17,5 +17,9 @@ if {[info exists ::env(dv_root)]} {
 source "${dv_root}/tools/common.tcl"
 source "${dv_root}/tools/waves.tcl"
 
-run
-quit
+# In GUI mode, let the user take control of running the simulation.
+global gui
+if {$gui == 0} {
+  run
+  quit
+}

--- a/vendor/lowrisc_ip/dv/tools/xcelium/unr.cfg
+++ b/vendor/lowrisc_ip/dv/tools/xcelium/unr.cfg
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+check_unr -setup 
+
+#Setup the clock and reset the design 
+clock -infer
+reset rst_n
+get_reset_info
+
+set_prove_time_limit 5m
+
+check_unr -prove
+check_unr -list -type unreachable
+database -export_unicov
+report -detailed

--- a/vendor/lowrisc_ip/dv/verilator/cpp/dpi_memutil.cc
+++ b/vendor/lowrisc_ip/dv/verilator/cpp/dpi_memutil.cc
@@ -16,24 +16,6 @@
 
 #include "sv_scoped.h"
 
-// DPI Exports
-extern "C" {
-
-/**
- * Write |file| to a memory
- *
- * @param file path to a SystemVerilog $readmemh()-compatible file (VMEM file)
- */
-extern void simutil_memload(const char *file);
-
-/**
- * Write a 32 bit word |val| to memory at index |index|
- *
- * @return 1 if successful, 0 otherwise
- */
-extern int simutil_set_mem(int index, const svBitVecVal *val);
-}
-
 namespace {
 // Convenience class for runtime errors when loading an ELF file
 class ElfError : public std::exception {
@@ -234,73 +216,6 @@ static std::vector<uint8_t> FlattenElfFile(const std::string &filepath) {
   return ret.GetFlat();
 }
 
-// Write a "segment" of data to the given memory area.
-static void WriteSegment(const MemArea &m, uint32_t offset,
-                         const std::vector<uint8_t> &data) {
-  assert(m.width_byte <= 32);
-  assert(m.addr_loc.size == 0 || offset + data.size() <= m.addr_loc.size);
-  assert((offset % m.width_byte) == 0);
-
-  // If this fails to set scope, it will throw an error which should
-  // be caught at this function's callsite.
-  SVScoped scoped(m.location.data());
-
-  // This "mini buffer" is used to transfer each write to SystemVerilog.
-  // `simutil_set_mem` takes a fixed 312 bit vector but it will only use the
-  // bits required for the RAM width. For example for a 32-bit wide RAM only
-  // elements 3 - 0 of `minibuf` will be written to memory. The simulator may
-  // still read bits from minibuf it does not use so we must use a fixed
-  // allocation of the full bit vector size to avoid out of bounds access.
-  uint8_t minibuf[39];
-  memset(minibuf, 0, sizeof minibuf);
-  assert(m.width_byte <= sizeof minibuf);
-
-  uint32_t all_words = (data.size() + m.width_byte - 1) / m.width_byte;
-  uint32_t full_data_words = data.size() / m.width_byte;
-  uint32_t part_data_word_len = data.size() % m.width_byte;
-  bool has_part_data_word = part_data_word_len != 0;
-
-  uint32_t word_offset = offset / m.width_byte;
-
-  // Copy the full data words
-  for (uint32_t i = 0; i < full_data_words; ++i) {
-    uint32_t dst_word = word_offset + i;
-    uint32_t src_byte = i * m.width_byte;
-    memcpy(minibuf, &data[src_byte], m.width_byte);
-    if (!simutil_set_mem(dst_word, (svBitVecVal *)minibuf)) {
-      std::ostringstream oss;
-      oss << "Could not set `" << m.name << "' memory at byte offset 0x"
-          << std::hex << dst_word * m.width_byte << ".";
-      throw std::runtime_error(oss.str());
-    }
-  }
-
-  // Copy any partial data, zeroing minibuf first to ensure that the latter
-  // bytes in the word are zero.
-  if (has_part_data_word) {
-    memset(minibuf, 0, sizeof minibuf);
-    uint32_t dst_word = word_offset + full_data_words;
-    uint32_t src_byte = full_data_words * m.width_byte;
-    memcpy(minibuf, &data[src_byte], part_data_word_len);
-    if (!simutil_set_mem(dst_word, (svBitVecVal *)minibuf)) {
-      std::ostringstream oss;
-      oss << "Could not set `" << m.name << "' memory at byte offset 0x"
-          << std::hex << dst_word * m.width_byte << " (partial data word).";
-      throw std::runtime_error(oss.str());
-    }
-  }
-}
-
-static void WriteElfToMem(const MemArea &m, const std::string &filepath) {
-  WriteSegment(m, 0, FlattenElfFile(filepath));
-}
-
-static void WriteVmemToMem(const MemArea &m, const std::string &filepath) {
-  SVScoped scoped(m.location.data());
-  // TODO: Add error handling.
-  simutil_memload(filepath.data());
-}
-
 // Merge seg0 and seg1, overwriting any overlapping data in seg0 with
 // that from seg1. rng0/rng1 is the base and top address of seg0/seg1,
 // respectively.
@@ -396,66 +311,47 @@ std::vector<uint8_t> StagedMem::GetFlat() const {
   return ret;
 }
 
-bool DpiMemUtil::RegisterMemoryArea(const std::string name,
-                                    const std::string location) {
-  // Default to 32bit width and no address
-  return RegisterMemoryArea(name, location, 32, nullptr);
-}
+void DpiMemUtil::RegisterMemoryArea(const std::string &name, uint32_t base,
+                                    const MemArea *mem_area) {
+  assert(mem_area);
 
-bool DpiMemUtil::RegisterMemoryArea(const std::string name,
-                                    const std::string location,
-                                    size_t width_bit,
-                                    const MemAreaLoc *addr_loc) {
-  assert((width_bit <= 256) &&
-         "TODO: Memory loading only supported up to 256 bits.");
-  assert(width_bit % 8 == 0);
-
-  // First, create and register the memory by name
-  MemArea mem = {.name = name,
-                 .location = location,
-                 .width_byte = (uint32_t)width_bit / 8,
-                 .addr_loc = {.base = 0, .size = 0}};
-  auto ret = name_to_mem_.emplace(name, mem);
-  if (ret.second == false) {
-    std::cerr << "ERROR: Can not register \"" << name << "\" at: \"" << location
-              << "\" (Previously defined at: \"" << ret.first->second.location
-              << "\")" << std::endl;
-    return false;
+  // Check that we don't overflow the address space.
+  uint32_t size = mem_area->GetSizeBytes();
+  uint32_t addr_top = base + (size - 1);
+  if (addr_top < base) {
+    std::ostringstream oss;
+    oss << "Cannot register '" << name << "' at at 0x" << std::hex << base
+        << " because it has size 0x" << size
+        << " and the top would overflow the top of the address space.";
+    throw std::runtime_error(oss.str());
   }
 
-  MemArea *stored_mem_area = &ret.first->second;
-
-  // If we have no address information, there's nothing more to do. However, if
-  // we do have address information, we should add an entry to addr_to_mem_.
-  if (!addr_loc) {
-    return true;
+  size_t new_idx = mem_areas_.size();
+  auto pr = name_to_mem_.emplace(name, new_idx);
+  const MemArea &stored = *mem_areas_[pr.first->second];
+  if (!pr.second) {
+    std::ostringstream oss;
+    oss << "Cannot register '" << name << "' at: '" << mem_area->GetScope()
+        << "' (Previously defined at: '" << stored.GetScope() << "')"
+        << std::endl;
+    throw std::runtime_error(oss.str());
   }
 
-  // Check that the size of the new area is positive, and that we don't overflow
-  // the address space.
-  if (addr_loc->size == 0) {
-    std::cerr << "ERROR: Can not register '" << name
-              << "' because it has zero size.\n";
-    return false;
-  }
-  uint32_t addr_top = addr_loc->base + (addr_loc->size - 1);
-  if (addr_top < addr_loc->base) {
-    std::cerr << "ERROR: Can not register '" << name
-              << "' because it overflows the top of the address space.\n";
-    return false;
-  }
-
-  auto clash = addr_to_mem_.EmplaceDisjoint(addr_loc->base, addr_top,
-                                            std::move(stored_mem_area));
+  auto clash = addr_to_mem_.EmplaceDisjoint(base, addr_top, std::move(new_idx));
   if (clash) {
     assert(*clash);
-    std::cerr << "ERROR: Can not register '" << name
-              << "' because its address range overlaps the existing area `"
-              << (*clash)->name << "'.\n";
-    return false;
+    // Remove the entry we added to name_to_mem_ above
+    name_to_mem_.erase(pr.first);
+
+    std::ostringstream oss;
+    oss << "Cannot register '" << name << "' at 0x" << std::hex << base
+        << " because its address range overlaps an existing area.";
+    throw std::runtime_error(oss.str());
   }
-  stored_mem_area->addr_loc = *addr_loc;
-  return true;
+
+  mem_areas_.push_back(mem_area);
+  base_addrs_.push_back(base);
+  names_.push_back(name);
 }
 
 MemImageType DpiMemUtil::GetMemImageType(const std::string &path,
@@ -466,16 +362,14 @@ MemImageType DpiMemUtil::GetMemImageType(const std::string &path,
 void DpiMemUtil::PrintMemRegions() const {
   std::cout << "Registered memory regions:" << std::endl;
   for (const auto &pr : name_to_mem_) {
-    const MemArea &m = pr.second;
-    std::cout << "\t'" << m.name << "' (" << m.width_byte * 8
-              << "bits) at location: '" << m.location << "'";
-    if (m.addr_loc.size) {
-      uint32_t low = m.addr_loc.base;
-      uint32_t high = m.addr_loc.base + m.addr_loc.size - 1;
-      std::cout << " (LMA range [0x" << std::hex << low << ", 0x" << high
-                << "])" << std::dec;
-    }
-    std::cout << std::endl;
+    const MemArea &mem = *mem_areas_[pr.second];
+    uint32_t base = base_addrs_[pr.second];
+    uint32_t top = base + mem.GetSizeBytes() - 1;
+
+    std::cout << "\t'" << pr.first << "' (" << mem.GetWidth()
+              << "bits) at location: '" << mem.GetScope() << "'"
+              << " (LMA range [0x" << std::hex << base << ", 0x" << top << "])"
+              << std::dec << std::endl;
   }
 }
 
@@ -503,15 +397,15 @@ void DpiMemUtil::LoadFileToNamedMem(bool verbose, const std::string &name,
               << name << "'." << std::endl;
   }
 
-  const MemArea &m = it->second;
+  const MemArea &m = *mem_areas_[it->second];
 
   try {
     switch (type) {
       case kMemImageElf:
-        WriteElfToMem(m, filepath);
+        m.Write(0, FlattenElfFile(filepath));
         break;
       case kMemImageVmem:
-        WriteVmemToMem(m, filepath);
+        m.LoadVmem(filepath);
         break;
       default:
         assert(0);
@@ -519,7 +413,7 @@ void DpiMemUtil::LoadFileToNamedMem(bool verbose, const std::string &name,
   } catch (const SVScoped::Error &err) {
     std::ostringstream oss;
     oss << "No memory found at `" << err.scope_name_
-        << "' (the scope associated with region `" << m.name << "').";
+        << "' (the scope associated with region `" << name << "').";
     throw std::runtime_error(oss.str());
   }
 }
@@ -535,19 +429,23 @@ void DpiMemUtil::LoadElfToMemories(bool verbose, const std::string &filepath) {
     auto mem_area_it = name_to_mem_.find(mem_name);
     assert(mem_area_it != name_to_mem_.end());
 
-    const MemArea &mem_area = mem_area_it->second;
+    const MemArea &mem_area = *mem_areas_[mem_area_it->second];
 
     for (const auto seg_pr : staged_mem.GetSegs()) {
       const AddrRange<uint32_t> &seg_rng = seg_pr.first;
       const std::vector<uint8_t> &seg_data = seg_pr.second;
+
+      assert(seg_rng.lo % mem_area.GetWidthByte() == 0);
+      uint32_t lo_word = seg_rng.lo / mem_area.GetWidthByte();
+
       try {
-        WriteSegment(mem_area, seg_rng.lo, seg_data);
+        mem_area.Write(lo_word, seg_data);
       } catch (const SVScoped::Error &err) {
         std::ostringstream oss;
         oss << "No memory found at `" << err.scope_name_
-            << "' (the scope associated with region `" << mem_area.name
+            << "' (the scope associated with region `" << mem_name
             << "', used by a segment that starts at LMA 0x" << std::hex
-            << mem_area.addr_loc.base + seg_rng.lo << ").";
+            << base_addrs_[mem_area_it->second] + seg_rng.lo << ").";
         throw std::runtime_error(oss.str());
       }
     }
@@ -575,18 +473,22 @@ void DpiMemUtil::StageElf(bool verbose, const std::string &path) {
     if (phdr.p_memsz == 0)
       continue;
 
-    const MemArea &mem_area =
+    size_t mem_area_idx =
         GetRegionForSegment(path, i, phdr.p_paddr, phdr.p_memsz);
 
+    const MemArea &mem_area = *mem_areas_[mem_area_idx];
+    uint32_t mem_area_base = base_addrs_[mem_area_idx];
+    const std::string &name = names_[mem_area_idx];
+
     // Check that the segment is aligned correctly for the memory
-    uint32_t local_base = phdr.p_paddr - mem_area.addr_loc.base;
-    if (local_base % mem_area.width_byte) {
+    uint32_t local_base = phdr.p_paddr - mem_area_base;
+    if (local_base % mem_area.GetWidthByte()) {
       std::ostringstream oss;
       oss << "Segment " << i << " has LMA 0x" << std::hex << phdr.p_paddr
           << ", which starts at offset 0x" << local_base
-          << " in the memory region `" << mem_area.name
+          << " in the memory region `" << name
           << "'. This offset is not aligned to the region's word width of "
-          << std::dec << 8 * mem_area.width_byte << " bits.";
+          << std::dec << mem_area.GetWidth() << " bits.";
       throw ElfError(path, oss.str());
     }
 
@@ -605,12 +507,12 @@ void DpiMemUtil::StageElf(bool verbose, const std::string &path) {
 
     if (verbose) {
       std::cout << "Loading segment " << i << " from ELF file `" << path
-                << "' into memory `" << mem_area.name << "'." << std::endl;
+                << "' into memory `" << name << "'." << std::endl;
     }
 
     // Get the StagedMem object associated with this memory area. If
     // there isn't one, make a new empty one.
-    StagedMem &staged_mem = staging_area_[mem_area.name];
+    StagedMem &staged_mem = staging_area_[name];
 
     const char *seg_data = file_data + phdr.p_offset;
     std::vector<uint8_t> vec(phdr.p_memsz, 0);
@@ -625,9 +527,8 @@ const StagedMem &DpiMemUtil::GetMemoryData(const std::string &mem_name) const {
   return (it == staging_area_.end()) ? empty_ : it->second;
 }
 
-const MemArea &DpiMemUtil::GetRegionForSegment(const std::string &path,
-                                               int seg_idx, uint32_t lma,
-                                               uint32_t mem_sz) const {
+size_t DpiMemUtil::GetRegionForSegment(const std::string &path, int seg_idx,
+                                       uint32_t lma, uint32_t mem_sz) const {
   assert(mem_sz > 0);
 
   auto mem_area_it = addr_to_mem_.find(lma);
@@ -638,9 +539,12 @@ const MemArea &DpiMemUtil::GetRegionForSegment(const std::string &path,
         << ").";
     throw ElfError(path, oss.str());
   }
-  const MemArea *mem_area = mem_area_it->second;
-  assert(mem_area);
-  assert(mem_area->addr_loc.base <= lma);
+  size_t mem_area_idx = mem_area_it->second;
+
+  const MemArea &mem_area = *mem_areas_[mem_area_idx];
+  uint32_t base_addr = base_addrs_[mem_area_idx];
+
+  assert(base_addr <= lma);
 
   uint32_t lma_top = lma + (mem_sz - 1);
   if (lma_top < lma) {
@@ -649,19 +553,19 @@ const MemArea &DpiMemUtil::GetRegionForSegment(const std::string &path,
     throw ElfError(path, oss.str());
   }
 
-  uint32_t local_base = lma - mem_area->addr_loc.base;
-  uint32_t local_top = lma_top - mem_area->addr_loc.base;
+  uint32_t local_base = lma - base_addr;
+  uint32_t local_top = lma_top - base_addr;
 
-  if (mem_area->addr_loc.size <= local_top) {
+  if (mem_area.GetSizeBytes() <= local_top) {
     std::ostringstream oss;
     oss << "Segment " << seg_idx << " has size 0x" << std::hex << mem_sz
         << " bytes. Its LMA of 0x" << lma << " is at offset 0x" << local_base
-        << " in the memory region `" << mem_area->name
+        << " in the memory region `" << names_[mem_area_idx]
         << "', so the segment finishes at offset 0x" << local_top
-        << ", but the memory region is only 0x" << mem_area->addr_loc.size
+        << ", but the memory region is only 0x" << mem_area.GetSizeBytes()
         << " bytes long.";
     throw ElfError(path, oss.str());
   }
 
-  return *mem_area;
+  return mem_area_it->second;
 }

--- a/vendor/lowrisc_ip/dv/verilator/cpp/dpi_memutil.h
+++ b/vendor/lowrisc_ip/dv/verilator/cpp/dpi_memutil.h
@@ -1,35 +1,22 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-#pragma once
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_DPI_MEMUTIL_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_DPI_MEMUTIL_H_
 
 #include <map>
+#include <memory>
 #include <string>
 #include <svdpi.h>
 #include <vector>
 
+#include "mem_area.h"
 #include "ranged_map.h"
 
 enum MemImageType {
   kMemImageUnknown = 0,
   kMemImageElf,
   kMemImageVmem,
-};
-
-// The "load" location of a memory area. base is the lowest address in
-// the area, and should correspond to an ELF file's LMA. size is the
-// length of the area in bytes.
-struct MemAreaLoc {
-  uint32_t base;
-  uint32_t size;
-};
-
-struct MemArea {
-  std::string name;      // Unique identifier
-  std::string location;  // Design scope location
-  uint32_t width_byte;   // Memory width in bytes
-  MemAreaLoc addr_loc;   // Address location. If !size, location is unknown.
 };
 
 // Staged data for a given memory area.
@@ -75,27 +62,23 @@ class DpiMemUtil {
   /**
    * Register a memory as instantiated by generic ram
    *
-   * The |name| must be a unique identifier. The function will return false if
-   * |name| is already used. |location| is the path to the scope of the
-   * instantiated memory, which needs to support the DPI-C interfaces
-   * 'simutil_memload' and 'simutil_set_mem' used for 'vmem' and 'elf' files,
-   * respectively.
+   * The |name| must be a unique identifier. The constructor will
+   * throw a std::runtime_error if |name| is already used.
    *
-   * The |width_bit| argument specifies the with in bits of the target memory
-   * instance (used for packing data). This must be a multiple of 8. If
-   * |addr_loc| is not null, it gives the base and size of the memory for
-   * loading in the address space (corresponding to LMAs in an ELF file).
+   * |base| gives the base address of the memory in a logical address
+   * space that corresponds to LMAs in an ELF file. If this overlaps
+   * with some other registered memory, the constructor throws a
+   * std::runtime_error.
+   *
+   * The |mem_area| argument describes the memory area to be registered and
+   * must not be null. This function does not take ownership of the object,
+   * which must survive at least as long as the DpiMemutil object.
    *
    * Memories must be registered before command arguments are parsed by
    * ParseCommandArgs() in order for them to be known.
    */
-  bool RegisterMemoryArea(const std::string name, const std::string location,
-                          size_t width_bit, const MemAreaLoc *addr_loc);
-
-  /**
-   * Register a memory with default width (32bits)
-   */
-  bool RegisterMemoryArea(const std::string name, const std::string location);
+  void RegisterMemoryArea(const std::string &name, uint32_t base,
+                          const MemArea *mem_area);
 
   /**
    * Guess the type of the file at |path|.
@@ -146,9 +129,15 @@ class DpiMemUtil {
   const StagedMem &GetMemoryData(const std::string &mem_name) const;
 
  private:
-  // Memory area registry
-  std::map<std::string, MemArea> name_to_mem_;
-  RangedMap<uint32_t, MemArea *> addr_to_mem_;
+  // Memory area registry. The maps give indices pointing into the vectors
+  // (which all have the same number of elements). Note that mem_areas_ does
+  // not own the objects that it points to.
+  std::vector<const MemArea *> mem_areas_;
+  std::vector<uint32_t> base_addrs_;
+  std::vector<std::string> names_;
+
+  std::map<std::string, size_t> name_to_mem_;
+  RangedMap<uint32_t, size_t> addr_to_mem_;
 
   // Staging area, loaded by StageElf. The map is keyed by names of memories
   // stored in name_to_mem_. We also ensure that every segment in a StagedMem
@@ -158,9 +147,11 @@ class DpiMemUtil {
   const StagedMem empty_;
 
   /**
-   * Find a region containing for the given segment's addresses.
+   * Find the index of a memory area containing the given segment's addresses.
    * Raises a std::exception if none is found.
    */
-  const MemArea &GetRegionForSegment(const std::string &path, int seg_idx,
-                                     uint32_t lma, uint32_t mem_sz) const;
+  size_t GetRegionForSegment(const std::string &path, int seg_idx, uint32_t lma,
+                             uint32_t mem_sz) const;
 };
+
+#endif  // OPENTITAN_HW_DV_VERILATOR_CPP_DPI_MEMUTIL_H_

--- a/vendor/lowrisc_ip/dv/verilator/cpp/ecc32_mem_area.cc
+++ b/vendor/lowrisc_ip/dv/verilator/cpp/ecc32_mem_area.cc
@@ -1,0 +1,124 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ecc32_mem_area.h"
+
+#include <cassert>
+#include <cstring>
+#include <stdexcept>
+
+Ecc32MemArea::Ecc32MemArea(const std::string &scope, uint32_t size,
+                           uint32_t width_32)
+    : MemArea(scope, size, 4 * width_32) {
+  // Check that multiplying by 4 didn't discard a bit
+  assert(4 * width_32 > width_32);
+
+  // No need to worry about ranges here: we've checked in the base class that
+  // width_byte isn't too big.
+  uint32_t phy_width_bits = 39 * width_32;
+
+  // This is a stronger check than the one in the base class (which
+  // makes sure there's enough space for the un-expanded memory width)
+  assert(phy_width_bits <= SV_MEM_WIDTH_BITS);
+}
+
+void Ecc32MemArea::LoadVmem(const std::string &path) const {
+  throw std::runtime_error(
+      "vmem files are not supported for memories with ECC bits");
+}
+
+void Ecc32MemArea::WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
+                               const std::vector<uint8_t> &data,
+                               size_t start_idx) const {
+  int log_width_32 = width_byte_ / 4;
+  int phy_width_bits = 39 * log_width_32;
+  int phy_width_bytes = (phy_width_bits + 7) / 8;
+
+  // Start by collecting our width_byte_ input bytes into (width_byte_ / 4)
+  // 32-bit groupings and adding check bits. (Eventually, we'll be adding
+  // proper ECC check bits here but, since we're not checking yet, let's
+  // zero-pad for now).
+  //
+  // TODO: Add proper ECC check bits here!
+  struct expanded_t {
+    uint8_t bytes[5];
+  };
+
+  std::vector<expanded_t> expanded(log_width_32);
+  for (int i = 0; i < log_width_32; ++i) {
+    // Store things little-endian, so the "real bits" go in bytes 0 to 3 and
+    // the check bits go in byte 4. Bytes 5 to 7 are zero.
+    expanded_t next;
+    memcpy(next.bytes, &data[start_idx + 4 * i], 4);
+    next.bytes[4] = 0;
+    expanded[i] = next;
+  }
+
+  // Now write to buf, pulling 39 bits from each element of in_64.
+  for (int i = 0; i < phy_width_bytes; ++i) {
+    uint8_t acc = 0;
+    int out_lsb = 0;
+
+    int in_word_idx = (8 * i) / 39;
+    int in_word_lsb = (8 * i) % 39;
+
+    int bits_left = 8;
+    while (bits_left) {
+      int in_byte_idx = in_word_lsb / 8;
+      int in_byte_lsb = in_word_lsb % 8;
+
+      int byte_width = (in_byte_idx == 4) ? 7 : 8;
+      int bits_at_byte = std::min(byte_width - in_byte_lsb, bits_left);
+
+      uint8_t in_data = expanded[in_word_idx].bytes[in_byte_idx] >> in_byte_lsb;
+      uint8_t in_mask = (((uint32_t)1 << bits_at_byte) - 1) & 0xff;
+
+      acc |= (in_data & in_mask) << out_lsb;
+
+      out_lsb += bits_at_byte;
+      if (in_byte_idx == 4) {
+        ++in_word_idx;
+        in_word_lsb = 0;
+      } else {
+        in_word_lsb += bits_at_byte;
+      }
+
+      bits_left -= bits_at_byte;
+    }
+    buf[i] = acc;
+  }
+}
+
+void Ecc32MemArea::ReadBuffer(std::vector<uint8_t> &data,
+                              const uint8_t buf[SV_MEM_WIDTH_BYTES]) const {
+  for (int i = 0; i < width_byte_; ++i) {
+    int in_word = i / 4;
+
+    int in_idx = (7 * in_word + 8 * i) / 8;
+    int in_lsb = (7 * in_word + 8 * i) % 8;
+
+    uint8_t acc = 0;
+
+    int bits_left = 8;
+    int out_lsb = 0;
+
+    while (bits_left) {
+      uint8_t in_data = buf[in_idx] >> in_lsb;
+
+      int bits_at_idx = std::min(8 - in_lsb, bits_left);
+
+      // The mask for the bits to take from in_data.
+      uint8_t in_mask = ((1u << bits_at_idx) - 1) & 0xff;
+
+      acc |= (in_data & in_mask) << out_lsb;
+
+      in_lsb = 0;
+      out_lsb += bits_at_idx;
+      bits_left -= bits_at_idx;
+      ++in_idx;
+    }
+
+    data.push_back(acc);
+  }
+}

--- a/vendor/lowrisc_ip/dv/verilator/cpp/ecc32_mem_area.h
+++ b/vendor/lowrisc_ip/dv/verilator/cpp/ecc32_mem_area.h
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_ECC32_MEM_AREA_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_ECC32_MEM_AREA_H_
+
+#include "mem_area.h"
+
+/**
+ * A memory that implements 32-bit ECC, storing 39 = 32 + 7 bits of physical
+ * data for each 32 bits of logical data.
+ */
+class Ecc32MemArea : public MemArea {
+ public:
+  /**
+   * Constructor
+   *
+   * Create an Ecc32MemArea that will connect to a SystemVerilog memory at
+   * scope. It is size words long. Each memory word is 4 * width_32 bytes wide
+   * in the address space and 39 * width_32 bits wide in the physical memory.
+   */
+  Ecc32MemArea(const std::string &scope, uint32_t size, uint32_t width_32);
+
+  void LoadVmem(const std::string &path) const override;
+
+ private:
+  void WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
+                   const std::vector<uint8_t> &data,
+                   size_t start_idx) const override;
+
+  void ReadBuffer(std::vector<uint8_t> &data,
+                  const uint8_t buf[SV_MEM_WIDTH_BYTES]) const override;
+};
+
+#endif  // OPENTITAN_HW_DV_VERILATOR_CPP_ECC32_MEM_AREA_H_

--- a/vendor/lowrisc_ip/dv/verilator/cpp/mem_area.cc
+++ b/vendor/lowrisc_ip/dv/verilator/cpp/mem_area.cc
@@ -1,0 +1,113 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mem_area.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <sstream>
+
+#include "sv_scoped.h"
+
+// DPI exports, defined in prim_util_memload.svh
+extern "C" {
+void simutil_memload(const char *file);
+int simutil_set_mem(int index, const svBitVecVal *val);
+int simutil_get_mem(int index, svBitVecVal *val);
+}
+
+MemArea::MemArea(const std::string &scope, uint32_t num_words,
+                 uint32_t width_byte)
+    : scope_(scope), num_words_(num_words), width_byte_(width_byte) {
+  assert(0 < num_words);
+  assert(width_byte <= SV_MEM_WIDTH_BYTES);
+}
+
+void MemArea::Write(uint32_t word_offset,
+                    const std::vector<uint8_t> &data) const {
+  // If this fails to set scope, it will throw an error which should
+  // be caught at this function's callsite.
+  SVScoped scoped(scope_);
+
+  // This "mini buffer" is used to transfer each write to SystemVerilog.
+  // `simutil_set_mem` takes a fixed SV_MEM_WIDTH_BITS-bit vector but it will
+  // only use the bits required for the RAM width. As an example, for a 32-bit
+  // wide RAM only elements 3:0 of `minibuf` will be written to memory. Since
+  // the simulator may still read bits from minibuf it does not use, we must
+  // use a fixed allocation of the full bit vector size to avoid an out of
+  // bounds access.
+  uint8_t minibuf[SV_MEM_WIDTH_BYTES];
+  memset(minibuf, 0, sizeof minibuf);
+  assert(width_byte_ <= sizeof minibuf);
+
+  uint32_t data_words = (data.size() + width_byte_ - 1) / width_byte_;
+  assert(word_offset + data_words <= num_words_);
+
+  for (uint32_t i = 0; i < data_words; ++i) {
+    uint32_t dst_word = word_offset + i;
+    WriteBuffer(minibuf, data, i * width_byte_);
+    if (!simutil_set_mem(dst_word, (svBitVecVal *)minibuf)) {
+      std::ostringstream oss;
+      oss << "Could not set memory at byte offset 0x" << std::hex
+          << dst_word * width_byte_ << ".";
+      throw std::runtime_error(oss.str());
+    }
+  }
+}
+
+std::vector<uint8_t> MemArea::Read(uint32_t word_offset,
+                                   uint32_t num_words) const {
+  assert(word_offset + num_words <= num_words_);
+
+  uint32_t num_bytes = width_byte_ * num_words;
+  assert(num_words <= num_bytes);
+
+  SVScoped scoped(scope_);
+
+  // See Write for an explanation for this buffer.
+  uint8_t minibuf[SV_MEM_WIDTH_BYTES];
+  memset(minibuf, 0, sizeof minibuf);
+  assert(width_byte_ <= sizeof minibuf);
+
+  std::vector<uint8_t> ret;
+  ret.reserve(num_bytes);
+
+  for (uint32_t i = 0; i < num_words; ++i) {
+    uint32_t src_word = word_offset + i;
+    if (!simutil_get_mem(src_word, (svBitVecVal *)minibuf)) {
+      std::ostringstream oss;
+      oss << "Could not read memory at byte offset 0x" << std::hex
+          << src_word * width_byte_ << ".";
+      throw std::runtime_error(oss.str());
+    }
+    ReadBuffer(ret, minibuf);
+  }
+
+  return ret;
+}
+
+void MemArea::LoadVmem(const std::string &path) const {
+  SVScoped scoped(scope_.c_str());
+  // TODO: Add error handling.
+  simutil_memload(path.c_str());
+}
+
+void MemArea::WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
+                          const std::vector<uint8_t> &data,
+                          size_t start_idx) const {
+  size_t words_left = data.size() - start_idx;
+  size_t to_copy = std::min(words_left, (size_t)width_byte_);
+  if (to_copy < width_byte_) {
+    memset(buf, 0, SV_MEM_WIDTH_BYTES);
+  }
+  memcpy(buf, &data[start_idx], to_copy);
+}
+
+void MemArea::ReadBuffer(std::vector<uint8_t> &data,
+                         const uint8_t buf[SV_MEM_WIDTH_BYTES]) const {
+  // Append the first width_byte_ bytes of buf to data.
+  std::copy_n(reinterpret_cast<const char *>(buf), width_byte_,
+              std::back_inserter(data));
+}

--- a/vendor/lowrisc_ip/dv/verilator/cpp/mem_area.h
+++ b/vendor/lowrisc_ip/dv/verilator/cpp/mem_area.h
@@ -1,0 +1,116 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_MEM_AREA_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_MEM_AREA_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// This is the maximum width of a memory that's supported by the code in
+// prim_util_memload.svh
+#define SV_MEM_WIDTH_BITS 312
+#define SV_MEM_WIDTH_BYTES ((SV_MEM_WIDTH_BITS + 7) / 8)
+
+/**
+ * A "memory area", representing a memory in the simulated design.
+ */
+class MemArea {
+ public:
+  /** Constructor
+   *
+   * @param scope  The SystemVerilog scope where the instantiated memory can be
+   *               found. This needs to support the DPI-C interfaces \c
+   *               simutil_memload and \c simutil_set_mem (used for vmem and
+   *               ELF files, respectively).
+   *
+   * @param size   The size of the memory in bytes (must be positive and a
+   *               multiple of \p width_byte)
+   *
+   * @param size   The width of each entry in bytes (must be positive)
+   */
+  MemArea(const std::string &scope, uint32_t size, uint32_t width_byte);
+
+  virtual ~MemArea() {}
+
+  /** Write data to this memory area at the given word offset
+   *
+   * This assumes that the result will fit in the memory. If the scope cannot
+   * be set, this throws an SVScoped::Error. If a call to \c simutil_set_mem
+   * fails, this throws a \c std::runtime_error.
+   *
+   * @param word_offset The offset, in words, of the first word that should be
+   *                    written.
+   *
+   * @param data        The data that should be written. If the length is not a
+   *                    multiple of \p word_offset, the last word will be
+   *                    zero-extended.
+   */
+  virtual void Write(uint32_t word_offset,
+                     const std::vector<uint8_t> &data) const;
+
+  /** Read data from this memory area, starting at the given offset.
+   *
+   * This assumes that there are <tt>word_offset + num_words</tt> words in the
+   * memory. Returns a vector with <tt>num_words * width_byte_</tt> elements.
+   *
+   * If the scope cannot be set, this throws an SVScoped::Error. If a call to
+   * simutil_get_mem fails, this throws a std::runtime_error.
+   *
+   * @param word_offset The offset, in words, of the first word that should be
+   *                    written.
+   *
+   * @param num_words   The number of words to read.
+   */
+  virtual std::vector<uint8_t> Read(uint32_t word_offset,
+                                    uint32_t num_words) const;
+
+  /** Use \c simutil_memload to load a vmem file into the memory */
+  virtual void LoadVmem(const std::string &path) const;
+
+  const std::string &GetScope() const { return scope_; }
+  uint32_t GetSizeWords() const { return num_words_; }
+  uint32_t GetSizeBytes() const { return num_words_ * width_byte_; }
+  uint32_t GetWidthByte() const { return width_byte_; }
+  uint32_t GetWidth() const { return 8 * width_byte_; }
+
+ protected:
+  std::string scope_;    ///< Design scope (used for accesses over DPI)
+  uint32_t num_words_;   ///< Size of the memory area in words
+  uint32_t width_byte_;  ///< Size of each word in bytes
+
+  /** Write to buf with the data that should be copied to the physical memory
+   * for a single memory word.
+   *
+   * The default implementation just uses memcpy to copy the data across. Other
+   * implementations might add scrambling, ECC bits or similar. This must write
+   * every bit of buf that will be used by the memory, but needn't clear bits
+   * further up (this is done outside of the loop).
+   *
+   * @param buf       Destination buffer
+   * @param data      A large buffer that contains the data to be written
+   * @param start_idx An offset into \p data for the start of the memory word
+   */
+  virtual void WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
+                           const std::vector<uint8_t> &data,
+                           size_t start_idx) const;
+
+  /** Extract the logical memory contents corresponding to the physical
+   * memory contents in \p buf and append them to \p data.
+   *
+   * The default implementation just uses \c std::copy_n to copy the data
+   * across. Other implementations might undo scrambling, remove ECC bits or
+   * similar.
+   *
+   * @param data The target, onto which the extracted memory contents should be
+   *             appended.
+   *
+   * @param buf  Source buffer (physical memory bits)
+   */
+  virtual void ReadBuffer(std::vector<uint8_t> &data,
+                          const uint8_t buf[SV_MEM_WIDTH_BYTES]) const;
+};
+
+#endif  // OPENTITAN_HW_DV_VERILATOR_CPP_MEM_AREA_H_

--- a/vendor/lowrisc_ip/dv/verilator/cpp/ranged_map.h
+++ b/vendor/lowrisc_ip/dv/verilator/cpp/ranged_map.h
@@ -1,8 +1,8 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-#pragma once
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_RANGED_MAP_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_RANGED_MAP_H_
 
 // Utility class representing disjoint segments of memory
 
@@ -179,3 +179,5 @@ class RangedMap {
  private:
   std::map<rng_t, val_t> map_;
 };
+
+#endif  // OPENTITAN_HW_DV_VERILATOR_CPP_RANGED_MAP_H_

--- a/vendor/lowrisc_ip/dv/verilator/cpp/verilator_memutil.h
+++ b/vendor/lowrisc_ip/dv/verilator/cpp/verilator_memutil.h
@@ -1,11 +1,11 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-#pragma once
+#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_VERILATOR_MEMUTIL_H_
+#define OPENTITAN_HW_DV_VERILATOR_CPP_VERILATOR_MEMUTIL_H_
 
 //
-// A wrapper class that converts a VerilatorMemutil into a SimCtrlExtension
+// A wrapper class that converts a DpiMemutil into a SimCtrlExtension
 //
 
 #include <memory>
@@ -26,17 +26,15 @@ class VerilatorMemUtil : public SimCtrlExtension {
   // Get underlying DpiMemUtil object
   DpiMemUtil *GetUnderlying() { return mem_util_; }
 
-  // Pass-thru functions to underlying object
-  bool RegisterMemoryArea(const std::string name, const std::string location,
-                          size_t width_bit, const MemAreaLoc *addr_loc) {
-    return mem_util_->RegisterMemoryArea(name, location, width_bit, addr_loc);
-  }
-
-  bool RegisterMemoryArea(const std::string name, const std::string location) {
-    return mem_util_->RegisterMemoryArea(name, location);
+  // Pass-thru function to underlying object
+  void RegisterMemoryArea(const std::string &name, uint32_t base,
+                          const MemArea *mem_area) {
+    return mem_util_->RegisterMemoryArea(name, base, mem_area);
   }
 
  private:
   DpiMemUtil *mem_util_;
   std::unique_ptr<DpiMemUtil> allocation_;
 };
+
+#endif  // OPENTITAN_HW_DV_VERILATOR_CPP_VERILATOR_MEMUTIL_H_

--- a/vendor/lowrisc_ip/dv/verilator/memutil_dpi.core
+++ b/vendor/lowrisc_ip/dv/verilator/memutil_dpi.core
@@ -8,9 +8,13 @@ description: "DPI memory utilities"
 filesets:
   files_cpp:
     files:
-      - cpp/ranged_map.h: { is_include_file: true }
       - cpp/dpi_memutil.cc
       - cpp/dpi_memutil.h: { is_include_file: true }
+      - cpp/ecc32_mem_area.cc
+      - cpp/ecc32_mem_area.h: { is_include_file: true }
+      - cpp/mem_area.cc
+      - cpp/mem_area.h: { is_include_file: true }
+      - cpp/ranged_map.h: { is_include_file: true }
       - cpp/sv_scoped.cc
       - cpp/sv_scoped.h: { is_include_file: true }
     file_type: cppSource

--- a/vendor/lowrisc_ip/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_pkg.sv
+++ b/vendor/lowrisc_ip/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_pkg.sv
@@ -39,8 +39,8 @@ package crypto_dpi_prince_pkg;
   );
     for (int i = 0; i < NumRoundsHalf; i++) begin
       ciphertext[i] = c_dpi_prince_encrypt(plaintext,
-                                           key[63:0],
-                                           key[127:64],
+                                           key[127:64], // k0 gets assigned the MSB halve
+                                           key[63:0],   // k1 gets assigned the LSB halve
                                            i+1,
                                            old_key_schedule);
     end
@@ -54,8 +54,8 @@ package crypto_dpi_prince_pkg;
   );
     for (int i = 0; i < NumRoundsHalf; i++) begin
       plaintext[i] = c_dpi_prince_decrypt(ciphertext[i],
-                                          key[63:0],
-                                          key[127:64],
+                                          key[127:64],  // k0 gets assigned the MSB halve
+                                          key[63:0],    // k1 gets assigned the LSB halve
                                           i+1,
                                           old_key_schedule);
     end

--- a/vendor/lowrisc_ip/ip/prim/dv/prim_prince/crypto_dpi_prince/prince_ref.h
+++ b/vendor/lowrisc_ip/ip/prim/dv/prim_prince/crypto_dpi_prince/prince_ref.h
@@ -3,6 +3,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#ifndef OPENTITAN_HW_IP_PRIM_DV_PRIM_PRINCE_CRYPTO_DPI_PRINCE_PRINCE_REF_H_
+#define OPENTITAN_HW_IP_PRIM_DV_PRIM_PRINCE_CRYPTO_DPI_PRINCE_PRINCE_REF_H_
+
 /*! \file prince_ref.h
     \brief Reference implementation of the Prince block cipher, complient to
    C99. 'Reference' here means straightforward, unoptimized, and checked against
@@ -31,9 +34,6 @@
  *    - Modification of `prince_core(...)` to handle the new key schedule and
  *      user-specified number of half-rounds.
  */
-
-#ifndef OPENTITAN_HW_IP_PRIM_DV_PRIM_PRINCE_CRYPTO_DPI_PRINCE_PRINCE_REF_H_
-#define OPENTITAN_HW_IP_PRIM_DV_PRIM_PRINCE_CRYPTO_DPI_PRINCE_PRINCE_REF_H_
 
 #include <stdint.h>
 #include <string.h>

--- a/vendor/lowrisc_ip/ip/prim/lint/prim.vlt
+++ b/vendor/lowrisc_ip/ip/prim/lint/prim.vlt
@@ -4,15 +4,6 @@
 
 `verilator_config
 
-// prim_subreg
-// for RO wd is not used
-lint_off -rule UNUSED -file "*/rtl/prim_subreg.sv" -match "Signal is not used: 'wd'"
-
-// prim_fifo_sync
-// In passthrough mode, clk and reset are not read form within this module
-lint_off -rule UNUSED -file "*/rtl/prim_fifo_sync.sv" -match "*clk_i*"
-lint_off -rule UNUSED -file "*/rtl/prim_fifo_sync.sv" -match "*rst_ni*"
-
 // prim_lfsr
 // lfsr_perm_test is just used for an SVA
 lint_off -rule UNUSED -file "*/rtl/prim_lfsr.sv" -match "*lfsr_perm_test*"

--- a/vendor/lowrisc_ip/ip/prim/lint/prim.waiver
+++ b/vendor/lowrisc_ip/ip/prim/lint/prim.waiver
@@ -4,15 +4,6 @@
 #
 # waiver file for prim
 
-# prim_fifo_sync
-waive -rules {ONE_BIT_MEM_WIDTH} -location {prim_fifo_sync.sv} -msg {Memory 'gen_normal_fifo.storage' has word width which is single bit wide} \
-      -comment "It is permissible that a FIFO has a wordwidth of 1bit"
-
-# prim_fifo_async
-waive -rules {ASSIGN_SIGN} -location {prim_fifo_async.sv} -msg {Signed target 'i' assigned unsigned value 'PTR_WIDTH - 3'} \
-      -comment "Parameter PTR_WIDTH is unsigned, but integer i is signed. This is fine. Changing the integer to unsigned might \
-                cause issues with the for loop never exiting, because an unsigned integer can never become < 0."
-
 # prim_assert
 waive -rules {UNDEF_MACRO_REF} -location {prim_assert.sv} -regexp {Macro definition for 'ASSERT_RPT' includes expansion of undefined macro '__(FILE|LINE)__'} \
       -comment "This is an UVM specific macro inside our assertion shortcuts"
@@ -25,32 +16,6 @@ waive -rules {LINE_LENGTH} -location {prim_assert.sv} -msg {Line length of} \
 waive -rules INTEGER           -location {prim_packer.sv} -msg {'i' of type int used as a non-constant value} \
       -comment "This assigns int i (signed) to a multibit logic variable (unsigned), which is fine"
 
-# primitives: prim_subreg
-waive -rules INPUT_NOT_READ       -location {prim_subreg.sv} -regexp {Input port 'wd' is not read from} \
-      -comment "for RO wd is not used"
-
-# primitives: prim_arbiter_*
-waive -rules PARTIAL_CONST_ASSIGN -location {prim_arbiter_*.sv} -regexp {'mask.0.' is conditionally assigned a constant} \
-      -comment "makes the code more readable"
-waive -rules CONST_FF -location {prim_arbiter_*.sv} -regexp {Flip-flop 'mask.0.' is driven by constant} \
-      -comment "makes the code more readable"
-
-# primitives: prim_sram_arbiter
-waive -rules CONST_OUTPUT -location {prim_sram_arbiter.sv} -regexp {rsp_error.* is driven by constant} \
-      -comment "SRAM protection is not yet implemented"
-
-# primitives: prim_fifos
-
-waive -rules VAR_INDEX_RANGE      -location {prim_fifo_*sync.sv} -regexp {maximum value .* may be too large for 'storage'} \
-      -comment "index is protected by control logic"
-waive -rules EXPLICIT_BITLEN      -location {prim_fifo_*sync.sv} -regexp {Bit length not specified for constant '1'} \
-      -comment "index is protected by control logic"
-waive -rules NOT_READ             -location {prim_fifo_async.sv} -regexp {Signal 'nc_decval_msb' is not read} \
-      -comment "Store temporary values. Not used intentionally"
-
-waive -rules {INPUT_NOT_READ} -location {prim_fifo_sync.sv} -regexp {Input port '(clk_i|rst_ni)' is not read from, instance.*Depth=0\)} \
-      -comment "In passthrough mode, clk and reset are not read form within this module"
-
 # TL-UL fifo
 waive -rules {HIER_BRANCH_NOT_READ} -location {tlul_fifo_sync.sv} -regexp {Connected net '(clk_i|rst_ni)' at prim_fifo_sync.sv:.* is not read from in module 'prim_fifo_sync'} \
       -comment "In passthrough mode, clk and reset are not read form within this module"
@@ -59,11 +24,3 @@ waive -rules {HIER_BRANCH_NOT_READ} -location {tlul_fifo_sync.sv} -regexp {Conne
 #
 #waive -rules NOT_READ -location {prim_ram_*_wrapper*} -regexp {(a|b)_rdata_(q|d)\[38} \
 #      -comment "Syndrome is not going out to the interface"
-
-# prim_arbiter_fixed
-waive -rules {HIER_BRANCH_NOT_READ INPUT_NOT_READ} -location {prim_arbiter_fixed.sv} -regexp {.*'(clk_i|rst_ni)' is not read from in module 'prim_arbiter_fixed'.*} \
-      -comment "clk_ and rst_ni are only used for assertions in this module."
-
-waive -rules {INTEGER} -location {prim_cipher_pkg.sv} -msg {'k' of type int used as a non-constant} \
-      -comment "We need to use the iterator value in the keyschedule function, hence this is ok."
-

--- a/vendor/lowrisc_ip/ip/prim/lint/prim_arbiter.waiver
+++ b/vendor/lowrisc_ip/ip/prim/lint/prim_arbiter.waiver
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_arbiter
+
+waive -rules PARTIAL_CONST_ASSIGN -location {prim_arbiter_*.sv} -regexp {'mask.0.' is conditionally assigned a constant} \
+      -comment "makes the code more readable"
+waive -rules CONST_FF -location {prim_arbiter_*.sv} -regexp {Flip-flop 'mask.0.' is driven by constant} \
+      -comment "makes the code more readable"
+
+waive -rules CONST_OUTPUT -location {prim_sram_arbiter.sv} -regexp {rsp_error.* is driven by constant} \
+      -comment "SRAM protection is not yet implemented"
+
+waive -rules {HIER_BRANCH_NOT_READ INPUT_NOT_READ} -location {prim_arbiter_fixed.sv} -regexp {.*'(clk_i|rst_ni)' is not read from in module 'prim_arbiter_fixed'.*} \
+      -comment "clk_ and rst_ni are only used for assertions in this module."

--- a/vendor/lowrisc_ip/ip/prim/lint/prim_cipher_pkg.waiver
+++ b/vendor/lowrisc_ip/ip/prim/lint/prim_cipher_pkg.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_cipher_pkg
+
+waive -rules {INTEGER} -location {prim_cipher_pkg.sv} -msg {'k' of type int used as a non-constant} \
+      -comment "We need to use the iterator value in the keyschedule function, hence this is ok."

--- a/vendor/lowrisc_ip/ip/prim/lint/prim_fifo.vlt
+++ b/vendor/lowrisc_ip/ip/prim/lint/prim_fifo.vlt
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`verilator_config
+
+// prim_fifo_sync
+// In passthrough mode, clk and reset are not read form within this module
+lint_off -rule UNUSED -file "*/rtl/prim_fifo_sync.sv" -match "*clk_i*"
+lint_off -rule UNUSED -file "*/rtl/prim_fifo_sync.sv" -match "*rst_ni*"

--- a/vendor/lowrisc_ip/ip/prim/lint/prim_fifo.waiver
+++ b/vendor/lowrisc_ip/ip/prim/lint/prim_fifo.waiver
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_fifo
+
+waive -rules {ONE_BIT_MEM_WIDTH} -location {prim_fifo_sync.sv} -msg {Memory 'gen_normal_fifo.storage' has word width which is single bit wide} \
+      -comment "It is permissible that a FIFO has a wordwidth of 1bit"
+
+waive -rules {INPUT_NOT_READ} -location {prim_fifo_sync.sv} -regexp {Input port '(clk_i|rst_ni)' is not read from, instance.*Depth=0\)} \
+      -comment "In passthrough mode, clk and reset are not read form within this module"
+
+
+waive -rules {ASSIGN_SIGN} -location {prim_fifo_async.sv} -msg {Signed target 'i' assigned unsigned value 'PTR_WIDTH - 3'} \
+      -comment "Parameter PTR_WIDTH is unsigned, but integer i is signed. This is fine. Changing the integer to unsigned might \
+                cause issues with the for loop never exiting, because an unsigned integer can never become < 0."
+
+waive -rules NOT_READ             -location {prim_fifo_async.sv} -regexp {Signal 'nc_decval_msb' is not read} \
+      -comment "Store temporary values. Not used intentionally"
+
+
+waive -rules VAR_INDEX_RANGE      -location {prim_fifo_*sync.sv} -regexp {maximum value .* may be too large for 'storage'} \
+      -comment "index is protected by control logic"
+
+waive -rules EXPLICIT_BITLEN      -location {prim_fifo_*sync.sv} -regexp {Bit length not specified for constant '1'} \
+      -comment "index is protected by control logic"

--- a/vendor/lowrisc_ip/ip/prim/lint/prim_subreg.vlt
+++ b/vendor/lowrisc_ip/ip/prim/lint/prim_subreg.vlt
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`verilator_config
+
+// prim_subreg
+// for RO wd is not used
+lint_off -rule UNUSED -file "*/rtl/prim_subreg.sv" -match "Signal is not used: 'wd'"

--- a/vendor/lowrisc_ip/ip/prim/lint/prim_subreg.waiver
+++ b/vendor/lowrisc_ip/ip/prim/lint/prim_subreg.waiver
@@ -1,0 +1,6 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+waive -rules INPUT_NOT_READ       -location {prim_subreg.sv} -regexp {Input port 'wd' is not read from} \
+      -comment "for RO wd is not used"

--- a/vendor/lowrisc_ip/ip/prim/prim.core
+++ b/vendor/lowrisc_ip/ip/prim/prim.core
@@ -18,21 +18,17 @@ filesets:
       - lowrisc:prim:buf
       - lowrisc:prim:flop
       - lowrisc:prim:flop_2sync
-      - lowrisc:prim:cipher_pkg:0.1
+      - lowrisc:prim:arbiter
+      - lowrisc:prim:fifo
+      - lowrisc:prim:alert
+      - lowrisc:prim:subreg
+      - lowrisc:prim:cipher
     files:
       - rtl/prim_clock_gating_sync.sv
-      - rtl/prim_alert_pkg.sv
-      - rtl/prim_alert_receiver.sv
-      - rtl/prim_alert_sender.sv
-      - rtl/prim_arbiter_ppc.sv
-      - rtl/prim_arbiter_tree.sv
-      - rtl/prim_arbiter_fixed.sv
       - rtl/prim_esc_pkg.sv
       - rtl/prim_esc_receiver.sv
       - rtl/prim_esc_sender.sv
       - rtl/prim_sram_arbiter.sv
-      - rtl/prim_fifo_async.sv
-      - rtl/prim_fifo_sync.sv
       - rtl/prim_slicer.sv
       - rtl/prim_sync_reqack.sv
       - rtl/prim_sync_reqack_data.sv
@@ -40,17 +36,10 @@ filesets:
       - rtl/prim_keccak.sv
       - rtl/prim_packer.sv
       - rtl/prim_packer_fifo.sv
-      - rtl/prim_present.sv
-      - rtl/prim_prince.sv
-      - rtl/prim_subst_perm.sv
       - rtl/prim_gate_gen.sv
       - rtl/prim_pulse_sync.sv
       - rtl/prim_filter.sv
       - rtl/prim_filter_ctr.sv
-      - rtl/prim_subreg_arb.sv
-      - rtl/prim_subreg.sv
-      - rtl/prim_subreg_ext.sv
-      - rtl/prim_subreg_shadow.sv
       - rtl/prim_intr_hw.sv
     file_type: systemVerilogSource
 

--- a/vendor/lowrisc_ip/ip/prim/prim_alert.core
+++ b/vendor/lowrisc_ip/ip/prim/prim_alert.core
@@ -1,0 +1,41 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:alert"
+description: "Alert send and receive"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      - lowrisc:prim:diff_decode
+      - lowrisc:prim:buf
+    files:
+      - rtl/prim_alert_pkg.sv
+      - rtl/prim_alert_receiver.sv
+      - rtl/prim_alert_sender.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/vendor/lowrisc_ip/ip/prim/prim_arbiter.core
+++ b/vendor/lowrisc_ip/ip/prim/prim_arbiter.core
@@ -1,0 +1,42 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:arbiter"
+description: "Generic arbiter"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+    files:
+      - rtl/prim_arbiter_ppc.sv
+      - rtl/prim_arbiter_tree.sv
+      - rtl/prim_arbiter_fixed.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_arbiter.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/vendor/lowrisc_ip/ip/prim/prim_cipher.core
+++ b/vendor/lowrisc_ip/ip/prim/prim_cipher.core
@@ -1,0 +1,40 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:cipher"
+description: "Lightweight block ciphers (PRINCE and PRESENT)"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      - lowrisc:prim:cipher_pkg:0.1
+    files:
+      - rtl/prim_subst_perm.sv
+      - rtl/prim_present.sv
+      - rtl/prim_prince.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/vendor/lowrisc_ip/ip/prim/prim_cipher_pkg.core
+++ b/vendor/lowrisc_ip/ip/prim/prim_cipher_pkg.core
@@ -6,12 +6,33 @@ CAPI=2:
 name: "lowrisc:prim:cipher_pkg:0.1"
 description: "PRINCE and PRESENT block cipher package"
 filesets:
-  files_dv:
+  files_rtl:
     files:
       - rtl/prim_cipher_pkg.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_cipher_pkg.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
 targets:
   default:
     filesets:
-      - files_dv
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/vendor/lowrisc_ip/ip/prim/prim_fifo.core
+++ b/vendor/lowrisc_ip/ip/prim/prim_fifo.core
@@ -1,0 +1,45 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:fifo"
+description: "Synchronous and asynchronous fifos"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      - lowrisc:prim:flop_2sync
+    files:
+      - rtl/prim_fifo_async.sv
+      - rtl/prim_fifo_sync.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_fifo.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_fifo.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/vendor/lowrisc_ip/ip/prim/prim_flop_2sync.core
+++ b/vendor/lowrisc_ip/ip/prim/prim_flop_2sync.core
@@ -10,6 +10,9 @@ filesets:
     depend:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
+      # Needed because the generic prim_generic_flop_2sync has a
+      # dependency on prim:flop.
+      - lowrisc:prim:flop
 
   files_verilator_waiver:
     depend:

--- a/vendor/lowrisc_ip/ip/prim/prim_msb_extend.core
+++ b/vendor/lowrisc_ip/ip/prim/prim_msb_extend.core
@@ -1,0 +1,39 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:msb_extend"
+description: "Extend msb"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+    files:
+      - rtl/prim_msb_extend.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/vendor/lowrisc_ip/ip/prim/prim_ram_1p_scr.core
+++ b/vendor/lowrisc_ip/ip/prim/prim_ram_1p_scr.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:util
       - lowrisc:prim:ram_1p_adv
+      - lowrisc:prim:lfsr
       - lowrisc:prim:all
     files:
       - rtl/prim_ram_1p_scr.sv

--- a/vendor/lowrisc_ip/ip/prim/prim_subreg.core
+++ b/vendor/lowrisc_ip/ip/prim/prim_subreg.core
@@ -1,0 +1,44 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:subreg"
+description: "Register slices"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_subreg_arb.sv
+      - rtl/prim_subreg.sv
+      - rtl/prim_subreg_ext.sv
+      - rtl/prim_subreg_shadow.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_subreg.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_subreg.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_edn_req.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_edn_req.sv
@@ -16,7 +16,11 @@
 module prim_edn_req
   import prim_alert_pkg::*;
 #(
-  parameter int OutWidth = 32
+  parameter int OutWidth = 32,
+
+  // Non-functional parameter to switch on the request stability assertion.
+  // Used in submodule `prim_sync_reqack`.
+  parameter bit EnReqStabA = 1
 ) (
   // Design side
   input                       clk_i,
@@ -42,7 +46,8 @@ module prim_edn_req
   prim_sync_reqack_data #(
     .Width(SyncWidth),
     .DataSrc2Dst(1'b0),
-    .DataReg(1'b0)
+    .DataReg(1'b0),
+    .EnReqStabA(EnReqStabA)
   ) u_prim_sync_reqack_data (
     .clk_src_i  ( clk_i                           ),
     .rst_src_ni ( rst_ni                          ),

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_msb_extend.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_msb_extend.sv
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Extend the output with the msb of the input
+
+`include "prim_assert.sv"
+
+module prim_msb_extend # (
+  parameter int InWidth = 2,
+  parameter int OutWidth = 2
+) (
+  input [InWidth-1:0] in_i,
+  output [OutWidth-1:0] out_o
+);
+
+  `ASSERT_INIT(WidthCheck_A, OutWidth >= InWidth)
+
+  localparam int WidthDiff = OutWidth - InWidth;
+
+  if (WidthDiff == 0) begin : gen_feedthru
+    assign out_o = in_i;
+  end else begin : gen_tieoff
+    assign out_o = {{WidthDiff{in_i[InWidth-1]}}, in_i};
+  end
+
+endmodule

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_prince.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_prince.sv
@@ -53,14 +53,14 @@ module prim_prince #(
 
   logic [DataWidth-1:0] k0, k0_prime_d, k1_d, k0_new_d, k0_prime_q, k1_q, k0_new_q;
   always_comb begin : p_key_expansion
-    k0         = key_i[DataWidth-1:0];
+    k0         = key_i[2*DataWidth-1 : DataWidth];
     k0_prime_d = {k0[0], k0[DataWidth-1:2], k0[DataWidth-1] ^ k0[1]};
-    k1_d       = key_i[2*DataWidth-1 : DataWidth];
+    k1_d       = key_i[DataWidth-1:0];
 
     // modify key for decryption
     if (dec_i) begin
       k0          = k0_prime_d;
-      k0_prime_d  = key_i[DataWidth-1:0];
+      k0_prime_d  = key_i[2*DataWidth-1 : DataWidth];
       k1_d       ^= prim_cipher_pkg::PRINCE_ALPHA_CONST[DataWidth-1:0];
     end
   end
@@ -72,7 +72,7 @@ module prim_prince #(
     // Imroved keyschedule proposed by https://eprint.iacr.org/2014/656.pdf
     // In this case we alternate between k1 and k0.
     always_comb begin : p_new_keyschedule_k0_alpha
-      k0_new_d = key_i[DataWidth-1:0];
+      k0_new_d = key_i[2*DataWidth-1 : DataWidth];
       // We need to apply the alpha constant here as well, just as for k1 in decryption mode.
       if (dec_i) begin
         k0_new_d ^= prim_cipher_pkg::PRINCE_ALPHA_CONST[DataWidth-1:0];
@@ -105,8 +105,15 @@ module prim_prince #(
   // datapath //
   //////////////
 
-  // state variable for holding the rounds
-  logic [NumRoundsHalf*2+1:0][DataWidth-1:0] data_state;
+  // State variable for holding the rounds
+  //
+  // The "split_var" hint that we pass to verilator here tells it to schedule the different parts of
+  // data_state separately. This avoids an UNOPTFLAT error where it would otherwise see a dependency
+  // chain
+  //
+  //    data_state -> data_state_round -> data_state_xor -> data_state
+  //
+  logic [NumRoundsHalf*2+1:0][DataWidth-1:0] data_state /* verilator split_var */;
 
   // pre-round XOR
   always_comb begin : p_pre_round_xor

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1p_scr.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -38,7 +38,6 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
   parameter  int NumDiffRounds       = 2,
   // This parameter governs the block-width of additional diffusion layers.
   // For intra-byte diffusion, set this parameter to 8.
-  // Note that DataBitsPerMask must be a multiple of this parameter.
   parameter  int DiffWidth           = DataBitsPerMask,
   // Number of address scrambling rounds. Setting this to 0 disables address scrambling.
   parameter  int NumAddrScrRounds    = 2,
@@ -46,7 +45,11 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
   // If set to 0, the cipher primitive is replicated, and together with a wider nonce input,
   // a unique keystream is generated for the full data width.
   parameter  bit ReplicateKeyStream  = 1'b0,
-
+  // Width of lfsr seed used for random init
+  parameter  int LfsrWidth           = 8,
+  parameter logic [LfsrWidth-1:0][$clog2(LfsrWidth)-1:0] StatePerm = {
+    24'h988eab
+  },
   // Derived parameters
   localparam int AddrWidth           = prim_util_pkg::vbits(Depth),
   // Depending on the data width, we need to instantiate multiple parallel cipher primitives to
@@ -66,6 +69,9 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
   input                             key_valid_i,
   input        [DataKeyWidth-1:0]   key_i,
   input        [NonceWidth-1:0]     nonce_i,
+  input        [LfsrWidth-1:0]      init_seed_i,
+  input                             init_req_i,
+  output logic                      init_ack_o,
 
   // Interface to TL-UL SRAM adapter
   input                             req_i,
@@ -95,7 +101,7 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
 
   // The depth needs to be a power of 2 in case address scrambling is turned on
   `ASSERT_INIT(DepthPow2Check_A, NumAddrScrRounds <= '0 || 2**$clog2(Depth) == Depth)
-  `ASSERT_INIT(DiffWidthAligned_A, (DataBitsPerMask % DiffWidth) == 0)
+  `ASSERT_INIT(DiffWidthMinimum_A, DiffWidth >= 4)
   `ASSERT_INIT(DiffWidthWithParity_A, EnableParity && (DiffWidth == 8) || !EnableParity)
 
   //////////////////////////////
@@ -116,6 +122,77 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
     .out_o(intg_error_o)
   );
 
+  ///////////////////////////
+  // Lfsr for random init  //
+  ///////////////////////////
+
+  logic init_req_q, load_seed;
+  logic [AddrWidth-1:0] addr_cnt_q;
+  logic [LfsrWidth-1:0] lfsr_out;
+  logic init_sel;
+
+  // input muxed addr/data/mask
+  logic [AddrWidth-1:0] addr;
+  logic [Width-1:0] wdata;
+  logic [Width-1:0] wmask;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      init_req_q <= '0;
+    end else begin
+      init_req_q <= init_req_i;
+    end
+  end
+
+  assign load_seed = init_req_i & ~init_req_q;
+
+  prim_lfsr #(
+    .LfsrDw(LfsrWidth),
+    .StateOutDw(LfsrWidth),
+    .StatePermEn(1'b0),
+    .StatePerm(StatePerm)
+  ) u_lfsr (
+    .clk_i,
+    .rst_ni,
+    .lfsr_en_i(init_req_i),
+    .seed_en_i(load_seed),
+    .seed_i(init_seed_i),
+    .entropy_i('0),
+    .state_o(lfsr_out)
+  );
+
+  // TODO: Need to harden these counters long term
+  assign init_ack_o = init_req_q && addr_cnt_q == Depth - 1;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      addr_cnt_q <= '0;
+    end else if (init_ack_o) begin
+      addr_cnt_q <= '0;
+    end else if (init_req_q && addr_cnt_q < Depth - 1) begin
+      addr_cnt_q <= addr_cnt_q + AddrWidth'(1);
+    end
+  end
+
+  // The lfsr width and the width of the data may not be completely aligned
+  localparam int LfsrMult = (Width % LfsrWidth > 0) ? Width / LfsrWidth + 1 :
+                                                      Width / LfsrWidth;
+  localparam int FullRandWidth = LfsrMult * LfsrWidth;
+
+  // The random value may be larger than what is needed
+  logic [FullRandWidth-1:0] rand_val;
+  assign rand_val = {LfsrMult{lfsr_out}};
+
+  if (LfsrMult * LfsrWidth > Width) begin : gen_rand_tieoffs
+    logic unused_rand;
+    assign unused_rand = ^rand_val[FullRandWidth-1:Width];
+  end
+
+  assign init_sel = init_req_q;
+  assign addr = init_sel ? addr_cnt_q : addr_i;
+  assign wdata = init_sel ? rand_val[Width-1:0] : wdata_i;
+  assign wmask = init_sel ? '1 : wmask_i;
+
   /////////////////////////////////////////
   // Pending Write and Address Registers //
   /////////////////////////////////////////
@@ -130,15 +207,15 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
 
   // Read / write strobes
   logic read_en, write_en_d, write_en_q;
-  assign gnt_o = req_i & key_valid_i;
+  assign gnt_o = req_i & key_valid_i & ~init_sel;
 
   assign read_en = gnt_o & ~write_i;
-  assign write_en_d = gnt_o & write_i;
+  assign write_en_d = gnt_o & write_i | init_sel;
 
   logic write_pending_q;
   logic addr_collision_d, addr_collision_q;
   logic [AddrWidth-1:0] waddr_q;
-  assign addr_collision_d = read_en & (write_en_q | write_pending_q) & (addr_i == waddr_q);
+  assign addr_collision_d = read_en & (write_en_q | write_pending_q) & (addr == waddr_q);
 
   // Macro requests and write strobe
   // The macro operation is silenced if an integrity error is seen
@@ -162,7 +239,7 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
 
   // We only select the pending write address in case there is no incoming read transaction.
   logic [AddrWidth-1:0] addr_mux;
-  assign addr_mux = (read_en) ? addr_i : waddr_q;
+  assign addr_mux = (read_en) ? addr : waddr_q;
 
   // This creates a bijective address mapping using a substitution / permutation network.
   logic [AddrWidth-1:0] addr_scr;
@@ -189,7 +266,7 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
       .Decrypt   ( 0                )
     ) u_prim_subst_perm (
       .data_i ( addr_mux       ),
-      // Since the counter mode concatenates {nonce_i[NonceWidth-1-AddrWidth:0], addr_i} to form
+      // Since the counter mode concatenates {nonce_i[NonceWidth-1-AddrWidth:0], addr} to form
       // the IV, the upper AddrWidth bits of the nonce are not used and can be used for address
       // scrambling. In cases where N parallel PRINCE blocks are used due to a data
       // width > 64bit, N*AddrWidth nonce bits are left dangling.
@@ -243,8 +320,8 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
       .rst_ni,
       .valid_i ( gnt_o ),
       // The IV is composed of a nonce and the row address
-      //.data_i  ( {nonce_i[k * (64 - AddrWidth) +: (64 - AddrWidth)], addr_i} ),
-      .data_i  ( {data_scr_nonce[k], addr_i} ),
+      //.data_i  ( {nonce_i[k * (64 - AddrWidth) +: (64 - AddrWidth)], addr} ),
+      .data_i  ( {data_scr_nonce[k], addr} ),
       // All parallel scramblers use the same key
       .key_i,
       // Since we operate in counter mode, this can always be set to encryption mode
@@ -400,12 +477,12 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
       write_en_q          <= write_en_d;
 
       if (read_en) begin
-        raddr_q           <= addr_i;
+        raddr_q           <= addr;
       end
       if (write_en_d) begin
-        waddr_q <= addr_i;
-        wmask_q <= wmask_i;
-        wdata_q <= wdata_i;
+        waddr_q <= addr;
+        wmask_q <= wmask;
+        wdata_q <= wdata;
       end
       if (rw_collision) begin
         wdata_scr_q <= wdata_scr_d;

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_subst_perm.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_subst_perm.sv
@@ -23,7 +23,13 @@ module prim_subst_perm #(
   // datapath //
   //////////////
 
-  logic [NumRounds:0][DataWidth-1:0] data_state;
+  // The "split_var" hint that we pass to verilator here tells it to schedule the different parts of
+  // data_state separately. This avoids an UNOPTFLAT error where it would otherwise see a dependency
+  // chain
+  //
+  //    data_state -> data_state_sbox -> data_state
+  //
+  logic [NumRounds:0][DataWidth-1:0] data_state /* verilator split_var */;
 
   // initialize
   assign data_state[0] = data_i;

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_sync_reqack.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_sync_reqack.sv
@@ -23,7 +23,10 @@
 
 `include "prim_assert.sv"
 
-module prim_sync_reqack (
+module prim_sync_reqack #(
+  // Non-functional parameter to switch on the request stability assertion
+  parameter bit EnReqStabA = 1
+) (
   input  clk_src_i,       // REQ side, SRC domain
   input  rst_src_ni,      // REQ side, SRC domain
   input  clk_dst_i,       // ACK side, DST domain
@@ -164,8 +167,10 @@ module prim_sync_reqack (
     end
   end
 
-  // SRC domain can only de-assert REQ after receiving ACK.
-  `ASSERT(SyncReqAckHoldReq, $fell(src_req_i) |-> $fell(src_ack_o), clk_src_i, !rst_src_ni)
+  if (EnReqStabA) begin : gen_lock_assertion
+    // SRC domain can only de-assert REQ after receiving ACK.
+    `ASSERT(SyncReqAckHoldReq, $fell(src_req_i) |-> $fell(src_ack_o), clk_src_i, !rst_src_ni)
+  end
 
   // DST domain cannot assert ACK without REQ.
   `ASSERT(SyncReqAckAckNeedsReq, dst_ack_i |-> dst_req_o, clk_dst_i, !rst_dst_ni)

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_sync_reqack_data.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_sync_reqack_data.sv
@@ -20,8 +20,9 @@ module prim_sync_reqack_data #(
   parameter int unsigned Width       = 1,
   parameter bit          DataSrc2Dst = 1'b1, // Direction of data flow: 1'b1 = SRC to DST,
                                              //                         1'b0 = DST to SRC
-  parameter bit          DataReg     = 1'b0  // Enable optional register stage for data,
+  parameter bit          DataReg     = 1'b0, // Enable optional register stage for data,
                                              // only usable with DataSrc2Dst == 1'b0.
+  parameter bit EnReqStabA = 1               // Used in submodule `prim_sync_reqack`.
 ) (
   input  clk_src_i,       // REQ side, SRC domain
   input  rst_src_ni,      // REQ side, SRC domain
@@ -40,7 +41,9 @@ module prim_sync_reqack_data #(
   ////////////////////////////////////
   // REQ/ACK synchronizer primitive //
   ////////////////////////////////////
-  prim_sync_reqack u_prim_sync_reqack (
+  prim_sync_reqack #(
+    .EnReqStabA(EnReqStabA)
+  ) u_prim_sync_reqack (
     .clk_src_i,
     .rst_src_ni,
     .clk_dst_i,

--- a/vendor/lowrisc_ip/ip/prim/util/primgen.py
+++ b/vendor/lowrisc_ip/ip/prim/util/primgen.py
@@ -160,6 +160,7 @@ def _parse_module_header(generic_impl_filepath, module_name):
 
 
 def test_parse_parameter_port_list():
+    assert _parse_parameter_port_list("parameter enum_t P") == {'P'}
     assert _parse_parameter_port_list("parameter integer P") == {'P'}
     assert _parse_parameter_port_list("parameter logic [W-1:0] P") == {'P'}
     assert _parse_parameter_port_list("parameter logic [W-1:0] P = '0") == {'P'}
@@ -185,7 +186,7 @@ def _parse_parameter_port_list(parameter_port_list):
     # XXX: Not covering the complete grammar, e.g. `parameter x, y`
     RE_PARAMS = (
         r'parameter\s+'
-        r'(?:[a-zA-Z0-9\]\[:\s\$-]+\s+)?'  # type
+        r'(?:[a-zA-Z0-9_\]\[:\s\$-]+\s+)?'  # type
         r'(?P<name>\w+)'  # name
         r'(?:\s*=\s*[^,;]+)?'  # initial value
     )

--- a/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -32,8 +32,8 @@ module prim_generic_flash #(
   input scan_rst_ni,
   input flash_power_ready_h_i,
   input flash_power_down_h_i,
-  input [TestModeWidth-1:0] flash_test_mode_a_i,
-  input flash_test_voltage_h_i,
+  inout [TestModeWidth-1:0] flash_test_mode_a_io,
+  inout flash_test_voltage_h_io,
   output logic flash_err_o,
   output logic flash_alert_po,
   output logic flash_alert_no,
@@ -111,8 +111,8 @@ module prim_generic_flash #(
   assign unused_scanmode = scanmode_i;
   assign unused_scan_en = scan_en_i;
   assign unused_scan_rst_n = scan_rst_ni;
-  assign unused_flash_test_mode = flash_test_mode_a_i;
-  assign unused_flash_test_voltage = flash_test_voltage_h_i;
+  assign unused_flash_test_mode = flash_test_mode_a_io;
+  assign unused_flash_test_voltage = flash_test_voltage_h_io;
   assign unused_tck = tck_i;
   assign unused_tdi = tdi_i;
   assign unused_tms = tms_i;
@@ -138,7 +138,9 @@ module prim_generic_flash #(
     .SramAw(CfgAddrWidth),
     .SramDw(32),
     .Outstanding(2),
-    .ErrOnWrite(0)
+    .ErrOnWrite(0),
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(1)
   ) u_cfg (
     .clk_i,
     .rst_ni,

--- a/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_generic_ram_1p.sv
+++ b/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_generic_ram_1p.sv
@@ -25,6 +25,9 @@ module prim_generic_ram_1p import prim_ram_1p_pkg::*; #(
   input ram_1p_cfg_t       cfg_i
 );
 
+  // Width must be fully divisible by DataBitsPerMask
+  `ASSERT_INIT(DataBitsPerMaskCheck_A, (Width % DataBitsPerMask) == 0)
+
   logic unused_cfg;
   assign unused_cfg = ^cfg_i;
 

--- a/vendor/lowrisc_ip/lint/tools/ascentlint/parse-lint-report.py
+++ b/vendor/lowrisc_ip/lint/tools/ascentlint/parse-lint-report.py
@@ -40,9 +40,10 @@ def get_results(resdir):
         "lint_infos": []
     }
 
-    log_files = ['lint.log',
-                 'lint-ascentlint/ascentlint.log',
-                 'lint-ascentlint/ascentlint.rpt']
+    log_files = [
+        'ascentlint.log', 'lint-ascentlint/ascentlint.log',
+        'lint-ascentlint/ascentlint.rpt'
+    ]
     log_file_contents = []
     # Open all log files
     for name in log_files:
@@ -85,11 +86,9 @@ def get_results(resdir):
     ])
 
     # Patterns for ascentlint.rpt
-    err_warn_patterns.append([
-        ("lint_errors", r"^E  .*"),
-        ("lint_warnings", r"^W  .*"),
-        ("lint_infos", r"^I  .*")
-    ])
+    err_warn_patterns.append([("lint_errors", r"^E  .*"),
+                              ("lint_warnings", r"^W  .*"),
+                              ("lint_infos", r"^I  .*")])
 
     # Go parse the logs
     for patterns, logs in zip(err_warn_patterns, log_file_contents):
@@ -153,12 +152,12 @@ def main():
     n_errors = len(results["errors"]) + len(results["lint_errors"])
     n_warnings = len(results["warnings"]) + len(results["lint_warnings"])
     if n_errors > 0 or n_warnings > 0:
-        log.info("Found %d lint errors and %d lint warnings", n_errors, n_warnings)
+        log.info("Found %d lint errors and %d lint warnings", n_errors,
+                 n_warnings)
         sys.exit(1)
 
     log.info("Lint logfile parsed succesfully")
     sys.exit(0)
-
 
 
 if __name__ == "__main__":

--- a/vendor/lowrisc_ip/lint/tools/dvsim/common_lint_cfg.hjson
+++ b/vendor/lowrisc_ip/lint/tools/dvsim/common_lint_cfg.hjson
@@ -16,7 +16,8 @@
 
   // Default directory structure for the output
   build_dir:  "{scratch_path}/{build_mode}"
-  build_log:  "{build_dir}/lint.log"
+  build_log:  "{build_dir}/{tool}.log"
+
   // We rely on fusesoc to run lint for us
   build_cmd:  "fusesoc"
   build_opts: ["--cores-root {proj_root}",
@@ -26,6 +27,10 @@
                "--tool={tool}",
                "--build-root={build_dir}",
                "{fusesoc_core}"]
+
+  // Common fail patterns.
+  build_fail_patterns: [// FuseSoC build error
+                        "^ERROR:.*$"]
 
   // these are not needed currently, but have to be defined
   sv_flist_gen_cmd:   ""

--- a/vendor/lowrisc_ip/lint/tools/dvsim/verilator.hjson
+++ b/vendor/lowrisc_ip/lint/tools/dvsim/verilator.hjson
@@ -6,6 +6,6 @@
 
   // Verilator lint-specific results parsing script that is called after running lint
   report_cmd: "{lint_root}/tools/{tool}/parse-lint-report.py "
-  report_opts: ["--logpath={build_dir}/lint.log",
+  report_opts: ["--logpath={build_log}",
                 "--reppath={build_dir}/results.hjson"]
 }

--- a/vendor/lowrisc_ip/lint/tools/veriblelint/parse-lint-report.py
+++ b/vendor/lowrisc_ip/lint/tools/veriblelint/parse-lint-report.py
@@ -41,7 +41,7 @@ def get_results(resdir):
     }
     try:
         # check the report file for lint INFO, WARNING and ERRORs
-        with Path(resdir).joinpath('lint.log').open() as f:
+        with Path(resdir).joinpath('veriblelint.log').open() as f:
             full_file = f.read()
     except IOError as err:
         results["errors"] += ["IOError: %s" % err]
@@ -58,10 +58,8 @@ def get_results(resdir):
         # error if there are no other errors or warnings, since that
         # shows something has come unstuck. (Probably the lint tool
         # spat out a warning that we don't understand)
-        ("fusesoc-error",
-         r"^ERROR: Failed to run .*: Lint failed.*"),
-        ("errors",
-         r"^(?!ERROR: Failed to run .* Lint failed)ERROR: .*"),
+        ("fusesoc-error", r"^ERROR: Failed to run .*: Lint failed.*"),
+        ("errors", r"^(?!ERROR: Failed to run .* Lint failed)ERROR: .*"),
         ("errors", r"^.*Error: .*"),
         ("errors", r"^E .*"),
         ("errors", r"^F .*"),
@@ -136,7 +134,8 @@ def main():
     n_errors = len(results["errors"]) + len(results["lint_errors"])
     n_warnings = len(results["warnings"]) + len(results["lint_warnings"])
     if n_errors > 0 or n_warnings > 0:
-        log.info("Found %d lint errors and %d lint warnings", n_errors, n_warnings)
+        log.info("Found %d lint errors and %d lint warnings", n_errors,
+                 n_warnings)
         sys.exit(1)
 
     log.info("Lint logfile parsed succesfully")

--- a/vendor/lowrisc_ip/lint/tools/verilator/parse-lint-report.py
+++ b/vendor/lowrisc_ip/lint/tools/verilator/parse-lint-report.py
@@ -8,8 +8,8 @@ import argparse
 import logging as log
 import re
 import sys
-from pathlib import Path
 from collections import OrderedDict
+from pathlib import Path
 
 import hjson
 
@@ -45,7 +45,8 @@ def parse_lint_log(str_buffer):
         ("fusesoc-error",
          r"^ERROR: Failed to build .* 'make' exited with an error code"),
         ("errors",
-         r"^(?!ERROR: Failed to build .* 'make' exited with an error code)ERROR: .*"),
+         r"^(?!ERROR: Failed to build .* 'make' exited with an error code)ERROR: .*"
+         ),
         ("errors",
          # This is a redundant Verilator error that we ignore, since we
          # already parse out each individual error.
@@ -111,15 +112,16 @@ def main():
         """)
     parser.add_argument('--logpath',
                         type=str,
-                        default="lint.log",
+                        default="verilator.log",
                         help=('FPV log file path. Defaults to `lint.log` '
                               'under the current script directory.'))
 
-    parser.add_argument('--reppath',
-                        type=str,
-                        default="results.hjson",
-                        help=('Parsed output hjson file path. Defaults to '
-                              '`results.hjson` under the current script directory.'))
+    parser.add_argument(
+        '--reppath',
+        type=str,
+        default="results.hjson",
+        help=('Parsed output hjson file path. Defaults to '
+              '`results.hjson` under the current script directory.'))
 
     args = parser.parse_args()
 
@@ -137,7 +139,8 @@ def main():
     n_errors = len(results["errors"]) + len(results["lint_errors"])
     n_warnings = len(results["warnings"]) + len(results["lint_warnings"])
     if n_errors > 0 or n_warnings > 0:
-        log.info("Found %d lint errors and %d lint warnings", n_errors, n_warnings)
+        log.info("Found %d lint errors and %d lint warnings", n_errors,
+                 n_warnings)
         sys.exit(1)
 
     log.info("Lint logfile parsed succesfully")

--- a/vendor/lowrisc_ip/util/dvsim/CfgFactory.py
+++ b/vendor/lowrisc_ip/util/dvsim/CfgFactory.py
@@ -7,7 +7,7 @@ import sys
 
 from CfgJson import load_hjson
 
-import FpvCfg
+import FormalCfg
 import LintCfg
 import SimCfg
 import SynCfg
@@ -36,7 +36,7 @@ def _load_cfg(path, initial_values):
     classes = [
         LintCfg.LintCfg,
         SynCfg.SynCfg,
-        FpvCfg.FpvCfg,
+        FormalCfg.FormalCfg,
         SimCfg.SimCfg
     ]
     found_cls = None

--- a/vendor/lowrisc_ip/util/dvsim/FlowCfg.py
+++ b/vendor/lowrisc_ip/util/dvsim/FlowCfg.py
@@ -47,6 +47,7 @@ class FlowCfg():
         self.scratch_root = args.scratch_root
         self.branch = args.branch
         self.job_prefix = args.job_prefix
+        self.gui = args.gui
 
         # Options set from hjson cfg.
         self.project = ""
@@ -348,6 +349,12 @@ class FlowCfg():
         '''Public facing API for _create_deploy_objects().
         '''
         self.prune_selected_cfgs()
+
+        # GUI mode is allowed only for one cfg.
+        if self.gui and len(self.cfgs) > 1:
+            log.fatal("In GUI mode, only one cfg can be run.")
+            sys.exit(1)
+
         for item in self.cfgs:
             item._create_deploy_objects()
 
@@ -359,6 +366,11 @@ class FlowCfg():
         deploy = []
         for item in self.cfgs:
             deploy.extend(item.deploy)
+
+        if not deploy:
+            log.fatal("Nothing to run!")
+            sys.exit(1)
+
         return Scheduler(deploy).run()
 
     def _gen_results(self, results):

--- a/vendor/lowrisc_ip/util/dvsim/FormalCfg.py
+++ b/vendor/lowrisc_ip/util/dvsim/FormalCfg.py
@@ -12,18 +12,18 @@ from OneShotCfg import OneShotCfg
 from utils import VERBOSE, subst_wildcards
 
 
-class FpvCfg(OneShotCfg):
-    """Derivative class for FPV purposes.
+class FormalCfg(OneShotCfg):
+    """Derivative class for running formal tools.
     """
 
-    flow = 'fpv'
+    flow = 'formal'
 
     def __init__(self, flow_cfg_file, hjson_data, args, mk_config):
         super().__init__(flow_cfg_file, hjson_data, args, mk_config)
         self.header = ["name", "errors", "warnings", "proven", "cex", "undetermined",
                        "covered", "unreachable", "pass_rate", "cov_rate"]
         self.summary_header = ["name", "pass_rate", "stimuli_cov", "coi_cov", "prove_cov"]
-        self.results_title = self.name.upper() + " FPV Results"
+        self.results_title = self.name.upper() + " Formal Results"
 
     def parse_dict_to_str(self, input_dict, excl_keys = []):
         # This is a helper function to parse dictionary items into a string.
@@ -59,61 +59,61 @@ class FpvCfg(OneShotCfg):
                 output_str += "\n```\n"
         return output_str
 
-    def get_fpv_summary_results(self, result):
+    def get_summary(self, result):
         summary = []
-        fpv_summary = result.get("fpv_summary")
-        if fpv_summary is None:
-            results_str = "No fpv_summary found\n"
+        formal_summary = result.get("summary")
+        if formal_summary is None:
+            results_str = "No summary information found\n"
             summary.append("N/A")
         else:
             colalign = ("center", ) * len(self.header)
             table = [self.header]
             table.append([
                 self.name,
-                str(fpv_summary["errors"]) + " E ",
-                str(fpv_summary["warnings"]) + " W ",
-                str(fpv_summary["proven"]) + " G ",
-                str(fpv_summary["cex"]) + " E ",
-                str(fpv_summary["undetermined"]) + " W ",
-                str(fpv_summary["covered"]) + " G ",
-                str(fpv_summary["unreachable"]) + " E ",
-                fpv_summary["pass_rate"],
-                fpv_summary["cov_rate"]
+                str(formal_summary["errors"]) + " E ",
+                str(formal_summary["warnings"]) + " W ",
+                str(formal_summary["proven"]) + " G ",
+                str(formal_summary["cex"]) + " E ",
+                str(formal_summary["undetermined"]) + " W ",
+                str(formal_summary["covered"]) + " G ",
+                str(formal_summary["unreachable"]) + " E ",
+                formal_summary["pass_rate"],
+                formal_summary["cov_rate"]
             ])
-            summary.append(fpv_summary["pass_rate"])
+            summary.append(formal_summary["pass_rate"])
             if len(table) > 1:
                 results_str = tabulate(table, headers="firstrow", tablefmt="pipe",
                                        colalign=colalign)
             else:
-                results_str = "No content in fpv_summary\n"
+                results_str = "No content in summary\n"
                 summary.append("N/A")
         return results_str, summary
 
-    def get_fpv_coverage_results(self, result):
+    def get_coverage(self, result):
         summary = []
-        fpv_coverage = result.get("fpv_coverage")
-        if fpv_coverage is None:
-            results_str = "No fpv_coverage found\n"
+        formal_coverage = result.get("coverage")
+        if formal_coverage is None:
+            results_str = "No coverage information found\n"
             summary = ["N/A", "N/A", "N/A"]
         else:
             cov_header = ["stimuli", "coi", "proof"]
             cov_colalign = ("center", ) * len(cov_header)
             cov_table = [cov_header]
             cov_table.append([
-                fpv_coverage["stimuli"],
-                fpv_coverage["coi"],
-                fpv_coverage["proof"]
+                formal_coverage["stimuli"],
+                formal_coverage["coi"],
+                formal_coverage["proof"]
             ])
-            summary.append(fpv_coverage["stimuli"])
-            summary.append(fpv_coverage["coi"])
-            summary.append(fpv_coverage["proof"])
+            summary.append(formal_coverage["stimuli"])
+            summary.append(formal_coverage["coi"])
+            summary.append(formal_coverage["proof"])
 
             if len(cov_table) > 1:
                 results_str = tabulate(cov_table, headers="firstrow",
                                        tablefmt="pipe", colalign=cov_colalign)
 
             else:
-                results_str = "No content in fpv_coverage\n"
+                results_str = "No content in formal_coverage\n"
                 summary = ["N/A", "N/A", "N/A"]
         return results_str, summary
 
@@ -122,8 +122,6 @@ class FpvCfg(OneShotCfg):
         # The results_summary will only contain the passing rate and
         # percentages of the stimuli, coi, and proven coverage
         # The email_summary will contain all the information from results_md
-        log.info("Create summary of FPV results")
-
         results_str = "## " + self.results_title + " (Summary)\n\n"
         results_str += "### " + self.timestamp_long + "\n"
         if self.revision:
@@ -153,7 +151,7 @@ class FpvCfg(OneShotCfg):
         error_message = ""
 
         for cfg in self.cfgs:
-            email_result = cfg.result.get("fpv_summary")
+            email_result = cfg.result.get("summary")
             if email_result is not None:
                 email_table.append([
                     cfg.name,
@@ -169,9 +167,9 @@ class FpvCfg(OneShotCfg):
                 ])
             messages = cfg.result.get("messages")
             if messages is not None:
-                # TODO: temp disable printing out "fpv_warnings" in results_summary
-                # Will clean up FPV warnings first, then display "fpv_warnings"
-                error = self.parse_dict_to_str(messages, ["fpv_warnings"])
+                # TODO: temp disable printing out warnings in results_summary
+                # Will clean up formal warnings first, then display warnings
+                error = self.parse_dict_to_str(messages, ["warnings"])
                 if error:
                     error_message += "\n#### " + cfg.name + "\n"
                     error_message += error
@@ -185,7 +183,7 @@ class FpvCfg(OneShotCfg):
 
     def _gen_results(self, results):
         # This function is called after the regression and looks for
-        # results.hjson file with aggregated results from the FPV run.
+        # results.hjson file with aggregated results from the formal logfile.
         # The hjson file is required to follow this format:
         # {
         #   "messages": {
@@ -196,7 +194,7 @@ class FpvCfg(OneShotCfg):
         #      "unreachable" : [],
         #   },
         #
-        #   "fpv_summary": {
+        #   "summary": {
         #      "errors"      : 0
         #      "warnings"    : 2
         #      "proven"      : 20,
@@ -212,8 +210,8 @@ class FpvCfg(OneShotCfg):
         # covered, and unreachable.
         #
         # If coverage was enabled then results.hjson will also have an item that
-        # shows FPV coverage. It will have the following format:
-        #   "fpv_coverage": {
+        # shows formal coverage. It will have the following format:
+        #   "coverage": {
         #      stimuli: "90 %",
         #      coi    : "90 %",
         #      proof  : "80 %"
@@ -223,18 +221,16 @@ class FpvCfg(OneShotCfg):
         if self.revision:
             results_str += "### " + self.revision + "\n"
         results_str += "### Branch: " + self.branch + "\n"
-        results_str += "### FPV Tool: " + self.tool.upper() + "\n"
-        results_str += "### LogFile dir: " + self.scratch_path + "/default\n\n"
-
+        results_str += "### Tool: " + self.tool.upper() + "\n"
         summary = [self.name]  # cfg summary for publish results
 
-        if len(self.build_modes) != 1:
-            mode_names = [mode.name for mode in self.build_modes]
-            log.error("FPV only supports mode 'default', but found these modes: %s", mode_names)
-        else:
-            mode = self.build_modes[0]
-            result_data = Path(subst_wildcards(self.build_dir, {"build_mode": mode.name}) +
-                               '/results.hjson')
+        assert len(self.deploy) == 1
+        mode = self.deploy[0]
+
+        if results[mode] == "P":
+            result_data = Path(subst_wildcards(self.build_dir,
+                                               {"build_mode": mode.name}),
+                               'results.hjson')
             try:
                 with open(result_data, "r") as results_file:
                     self.result = hjson.load(results_file, use_decimal=True)
@@ -246,21 +242,28 @@ class FpvCfg(OneShotCfg):
                     }
                 }
 
-            fpv_result_str, fpv_summary = self.get_fpv_summary_results(self.result)
-            results_str += fpv_result_str
-            summary += fpv_summary
+        results_str += "\n\n## Formal Results\n"
+        formal_result_str, formal_summary = self.get_summary(self.result)
+        results_str += formal_result_str
+        summary += formal_summary
 
-            if self.cov:
-                results_str += "\n\n## Coverage Results\n"
-                results_str += ("### Coverage html file dir: " +
-                                self.scratch_path + "/default/formal-icarus\n\n")
-                cov_result_str, cov_summary = self.get_fpv_coverage_results(self.result)
-                results_str += cov_result_str
-                summary += cov_summary
+        if self.cov:
+            results_str += "\n\n## Coverage Results\n"
+            results_str += ("### Coverage html file dir: " +
+                            self.scratch_path + "/default/formal-icarus\n\n")
+            cov_result_str, cov_summary = self.get_coverage(self.result)
+            results_str += cov_result_str
+            summary += cov_summary
+        else:
+            summary += ["N/A", "N/A", "N/A"]
 
-            messages = self.result.get("messages")
-            if messages is not None:
-                results_str += self.parse_dict_to_str(messages)
+        if results[mode] != "P":
+            results_str += "\n## List of Failures\n" + ''.join(
+                mode.launcher.fail_msg)
+
+        messages = self.result.get("messages")
+        if messages is not None:
+            results_str += self.parse_dict_to_str(messages)
 
         # Write results to the scratch area
         self.results_md = results_str
@@ -269,17 +272,15 @@ class FpvCfg(OneShotCfg):
             f.write(self.results_md)
 
         # Generate result summary
-        if not self.cov:
-            summary += ["N/A", "N/A", "N/A"]
         self.result_summary[self.name] = summary
 
         log.log(VERBOSE, "[results page]: [%s] [%s]", self.name, results_file)
         return self.results_md
 
     def _publish_results(self):
-        '''This does nothing: detailed messages from FPV runs are not published
+        '''This does nothing: detailed messages from the logfile are not published
 
         Our agreement with tool vendors allows us to publish the summary
-        results (as in gen_results_summary), but not anything more detailed.
+        results (as in gen_results_summary).
         '''
         return

--- a/vendor/lowrisc_ip/util/dvsim/LauncherFactory.py
+++ b/vendor/lowrisc_ip/util/dvsim/LauncherFactory.py
@@ -1,0 +1,72 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging as log
+import os
+import sys
+
+from Launcher import Launcher
+from LocalLauncher import LocalLauncher
+from LsfLauncher import LsfLauncher
+from Scheduler import Scheduler
+
+try:
+    from EdaCloudLauncher import EdaCloudLauncher
+    EDACLOUD_LAUNCHER_EXISTS = True
+except ImportError:
+    EDACLOUD_LAUNCHER_EXISTS = False
+
+# The chosen launcher class.
+launcher_cls = None
+
+
+def set_launcher_type(is_local=False):
+    '''Sets the launcher type that will be used to launch the jobs.
+
+    The env variable `DVSIM_LAUNCHER` is used to identify what launcher system
+    to use. This variable is specific to the user's work site. It is meant to
+    be set externally before invoking DVSim. Valid values are [local, lsf,
+    edacloud]. If --local arg is supplied then the local launcher takes
+    precedence.
+    '''
+
+    launcher = os.environ.get("DVSIM_LAUNCHER", "local")
+    if is_local:
+        launcher = "local"
+    Launcher.variant = launcher
+
+    global launcher_cls
+    if launcher == "local":
+        launcher_cls = LocalLauncher
+
+    elif launcher == "lsf":
+        launcher_cls = LsfLauncher
+
+        # The max_parallel setting is not relevant when dispatching with LSF.
+        Scheduler.max_parallel = sys.maxsize
+
+    # These custom launchers are site specific. They may not be committed to
+    # the open source repo.
+    elif launcher == "edacloud" and EDACLOUD_LAUNCHER_EXISTS:
+        launcher_cls = EdaCloudLauncher
+
+        # The max_parallel setting is not relevant when dispatching with
+        # EDACloud.
+        Scheduler.max_parallel = sys.maxsize
+
+    else:
+        log.error("Launcher {} set using DVSIM_LAUNCHER env var does not "
+                  "exist. Using local launcher instead.".format(launcher))
+        launcher_cls = LocalLauncher
+
+
+def get_launcher(deploy):
+    '''Returns an instance of a launcher.
+
+    'deploy' is an instance of the deploy class to with the launcher is paired.
+    '''
+
+    global launcher_cls
+    assert launcher_cls is not None
+    return launcher_cls(deploy)

--- a/vendor/lowrisc_ip/util/dvsim/LsfLauncher.py
+++ b/vendor/lowrisc_ip/util/dvsim/LsfLauncher.py
@@ -1,0 +1,399 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging as log
+import os
+import re
+import subprocess
+import tarfile
+from pathlib import Path
+
+from Launcher import Launcher, LauncherError
+from utils import VERBOSE, clean_odirs
+
+
+class LsfLauncher(Launcher):
+
+    # A hidden directory specific to a cfg, where we put individual 'job'
+    # scripts.
+    jobs_dir = {}
+
+    # All launcher instances available for lookup.
+    jobs = {}
+
+    # When the job completes, we try to read the job script output to determine
+    # the outcome. It may not have been completely written the first time we
+    # read it so we retry on the next poll, no more than 10 times.
+    max_poll_retries = 10
+
+    # TODO: Add support for build/run/cov job specific resource requirements:
+    #       cpu, mem, disk, stack.
+    # TODO: Allow site-specific job resource usage setting using
+    #       `DVSIM_LSF_CFG` environment variable.
+
+    @staticmethod
+    def prepare_workspace(project, repo_top, args):
+        # Since we dispatch to remote machines, a project specific python
+        # virtualenv is exists, needs to be activated when launching the job.
+        Launcher.set_pyvenv(project)
+        if Launcher.pyvenv is None:
+            return
+
+        # If it is already a dir, then nothing to be done.
+        if os.path.isdir(Launcher.pyvenv):
+            return
+
+        # If not, then it needs to be a valid tarball. Extract it in the
+        # scratch area if it does not exist.
+        stem = Path(Launcher.pyvenv).stem
+        if stem.endswith("tar"):
+            stem = stem[:-4]
+        path = Path(args.scratch_root, stem)
+        if not path.is_dir():
+            log.info("[prepare_workspace]: [pyvenv]: Extracting %s",
+                     Launcher.pyvenv)
+            with tarfile.open(Launcher.pyvenv, mode='r') as tar:
+                tar.extractall(args.scratch_root)
+            log.info("[prepare_workspace]: [pyvenv]: Done: %s", path)
+        Launcher.pyvenv = path
+
+    @staticmethod
+    def prepare_workspace_for_cfg(cfg):
+        # Create the job dir.
+        LsfLauncher.jobs_dir[cfg] = Path(cfg.scratch_path, "lsf",
+                                         cfg.timestamp)
+        clean_odirs(odir=LsfLauncher.jobs_dir[cfg], max_odirs=2)
+        os.makedirs(Path(LsfLauncher.jobs_dir[cfg]), exist_ok=True)
+
+    @staticmethod
+    def make_job_script(cfg, job_name):
+        """Creates the job script.
+
+        Once all jobs in the array are launched, the job script can be created.
+        It is a bash script that takes the job index as a single argument.
+        This index is set in the bsub command as '$LSB_JOBINDEX', which bsub
+        sets as the actual index when launching that job in the array. This
+        script is super simple - it is just a giant case statement that
+        switches on the job index to run that specific job. This preferred over
+        creating individual scripts for each job which incurs additional file
+        I/O overhead when the scratch area is on NFS, causing a slowdown.
+
+        Returns the path to the job script.
+        """
+
+        lines = ["#!/usr/bin/env bash\nset -e\n"]
+
+        # Activate the python virtualenv if it exists.
+        if Launcher.pyvenv:
+            lines += ["source {}/bin/activate\n".format(Launcher.pyvenv)]
+
+        lines += ["case $1 in\n"]
+        for job in LsfLauncher.jobs[cfg][job_name]:
+            # Redirect the job's stdout and stderr to its log file.
+            cmd = "{} > {} 2>&1".format(job.deploy.cmd,
+                                        job.deploy.get_log_path())
+            lines += ["  {})\n".format(job.index), "    {};;\n".format(cmd)]
+
+        # Throw error as a sanity check if the job index is invalid.
+        lines += [
+            "  *)\n",
+            "    echo \"ERROR: Illegal job index: $1\" 1>&2; exit 1;;\n",
+            "esac\n"
+        ]
+        if Launcher.pyvenv:
+            lines += ["deactivate\n"]
+
+        job_script = Path(LsfLauncher.jobs_dir[cfg], job_name)
+        try:
+            with open(job_script, "w", encoding='utf-8') as f:
+                f.writelines(lines)
+        except IOError as e:
+            err_msg = "ERROR: Failed to write {}:\n{}".format(job_script, e)
+            LsfLauncher._post_finish_job_array(cfg, job_name, err_msg)
+            raise LauncherError(err_msg)
+
+        log.log(VERBOSE, "[job_script]: %s", job_script)
+        return job_script
+
+    def __init__(self, deploy):
+        super().__init__(deploy)
+
+        # Set the status. Only update after the job is done - i.e. status will
+        # transition from None to P/F/K.
+        self.status = None
+
+        # Maintain the job script output as an instance variable for polling
+        # and cleanup.
+        self.bsub_out = None
+
+        # If we already opened the job script output file (but have not
+        # determined the outcome), then we maintain the file descriptor rather
+        # then reopening it and starting all over again on the next poll.
+        self.bsub_out_fd = None
+        self.bsub_out_err_msg = []
+        self.bsub_out_err_msg_found = False
+
+        # Set the job id.
+        self.job_id = None
+
+        # Polling retry counter..
+        self.num_poll_retries = 0
+
+        # Add self to the list of jobs.
+        cfg_dict = LsfLauncher.jobs.setdefault(deploy.sim_cfg, {})
+        job_name_list = cfg_dict.setdefault(deploy.job_name, [])
+        job_name_list.append(self)
+
+        # Job's index in the array.
+        self.index = len(job_name_list)
+
+    def _do_launch(self):
+        # Add self to the list of jobs.
+        job_name = self.deploy.job_name
+        cfg = self.deploy.sim_cfg
+        job_total = len(LsfLauncher.jobs[cfg][job_name])
+
+        # The actual launching of the bsub command cannot happen until the
+        # Scheduler has dispatched ALL jobs in the array.
+        if self.index < job_total:
+            return
+
+        job_script = self.make_job_script(cfg, job_name)
+
+        # Update the shell's env vars with self.exports. Values in exports must
+        # replace the values in the shell's env vars if the keys match.
+        exports = os.environ.copy()
+        if self.deploy.exports:
+            exports.update(self.deploy.exports)
+
+        # Clear the magic MAKEFLAGS variable from exports if necessary. This
+        # variable is used by recursive Make calls to pass variables from one
+        # level to the next. Here, self.cmd is a call to Make but it's
+        # logically a top-level invocation: we don't want to pollute the flow's
+        # Makefile with Make variables from any wrapper that called dvsim.
+        if 'MAKEFLAGS' in exports:
+            del exports['MAKEFLAGS']
+
+        self._dump_env_vars(exports)
+
+        # TODO: Arbitrarily set the max slot-limit to 100.
+        job_array = "{}[1-{}]".format(job_name, job_total)
+        if job_total > 100:
+            job_array += "%100"
+
+        # TODO: This needs to be moved to a HJson.
+        if self.deploy.sim_cfg.tool == "vcs":
+            job_rusage = "\'rusage[vcssim=1,vcssim_dynamic=1:duration=1]\'"
+
+        elif self.deploy.sim_cfg.tool == "xcelium":
+            job_rusage = "\'rusage[xcelium=1,xcelium_dynamic=1:duration=1]\'"
+
+        else:
+            job_rusage = None
+
+        # Launch the job array.
+        cmd = [
+            "bsub",
+            # TODO: LSF project name could be site specific!
+            "-P",
+            cfg.project,
+            "-J",
+            job_array,
+            "-oo",
+            "{}.%I.out".format(job_script),
+            "-eo",
+            "{}.%I.out".format(job_script)
+        ]
+
+        if job_rusage:
+            cmd += ["-R", job_rusage]
+
+        cmd += ["/usr/bin/bash {} $LSB_JOBINDEX".format(job_script)]
+
+        try:
+            p = subprocess.run(cmd,
+                               check=True,
+                               timeout=60,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE,
+                               env=exports)
+        except subprocess.CalledProcessError as e:
+            # Need to mark all jobs in this range with this fail pattern.
+            err_msg = e.stderr.decode("utf-8").strip()
+            self._post_finish_job_array(cfg, job_name, err_msg)
+            raise LauncherError(err_msg)
+
+        # Extract the job ID.
+        result = p.stdout.decode("utf-8").strip()
+        job_id = result.split('Job <')[1].split('>')[0]
+        if not job_id:
+            self._post_finish_job_array(cfg, job_name, "Job ID not found!")
+            raise LauncherError(err_msg)
+
+        for job in LsfLauncher.jobs[cfg][job_name]:
+            job.bsub_out = Path("{}.{}.out".format(job_script, job.index))
+            job.job_id = "{}[{}]".format(job_id, job.index)
+            job._link_odir("D")
+
+    def poll(self):
+        # It is possible we may have determined the status already.
+        if self.status:
+            return self.status
+
+        if not self.bsub_out_fd:
+            # If job id is not set, the bsub command has not been sent yet.
+            if not self.job_id:
+                return 'D'
+
+            # We redirect the job's output to the log file, so the job script
+            # output remains empty until the point it finishes. This is a very
+            # quick way to check if the job has completed. If nothing has been
+            # written to the job script output yet (or if it is not yet
+            # created), then the job is still running.
+            try:
+                if not self.bsub_out.stat().st_size:
+                    return "D"
+            except FileNotFoundError:
+                return "D"
+
+            # If we got to this point,  we can now open the job script output
+            # file for reading.
+            try:
+                self.bsub_out_fd = open(self.bsub_out, "r")
+            except IOError as e:
+                self._post_finish(
+                    "F",
+                    "ERROR: Failed to open {}\n{}.".format(self.bsub_out, e))
+                return "F"
+
+        # Now that the job has completed, we need to determine its status.
+        #
+        # If the job successfully launched and it failed, the failure message
+        # will appear in its log file (because of the stderr redirection).
+        # But, in some cases, if there is something wrong with the command
+        # itself, bsub might return immediately with an error message, which
+        # will appear in the job script output file. We want to retrieve that
+        # so that we can report the status accurately.
+        #
+        # At this point, we could run bjobs or bhist to determine the status,
+        # but it has been found to be too slow, expecially when running 1000s
+        # of jobs. Plus, we have to read the job script output anyway to look
+        # for those error messages.
+        #
+        # So we just read this file to determine both, the status and extract
+        # the error message, rather than running bjobs or bhist. But there is
+        # one more complication to deal with - if we read the file now, it is
+        # possible that it may not have been fully updated. We will try reading
+        # it anyway. If we are unable to find what we are looking for, then we
+        # will resume reading it again at the next poll. We will do this upto
+        # max_poll_retries times before giving up and flagging an error.
+        #
+        # TODO: Consider using the IBM Plarform LSF Python APIs instead.
+        #       (deferred due to shortage of time / resources).
+        # TODO: Parse job telemetry data for performance insights.
+
+        exit_code = self._get_job_exit_code()
+        if exit_code is not None:
+            self.exit_code = exit_code
+            status, err_msg = self._check_status()
+            # Prioritize error messages from bsub over the job's log file.
+            if self.bsub_out_err_msg:
+                err_msg = self.bsub_out_err_msg
+            self._post_finish(status, err_msg)
+            return status
+
+        else:
+            self.num_poll_retries += 1
+            # Fail the test if we have reached the max polling retries.
+            if self.num_poll_retries == LsfLauncher.max_poll_retries:
+                self._post_finish(
+                    "F", "ERROR: Reached max retries while "
+                    "reading job script output {} to determine"
+                    " the outcome.".format(self.bsub_out))
+                return "F"
+
+        return "D"
+
+    def _get_job_exit_code(self):
+        '''Read the job script output to retrieve the exit code.
+
+        Also read the error message if any, which will appear at the beginning
+        of the log file followed by bsub's standard 'email' format output. It
+        looks something like this:
+
+            <stderr messages>
+            ------------------------------------------------------------
+            Sender: LSF System <...>
+            Subject: ...
+            ...
+
+            Successfully completed.
+            <OR>
+            Exited with exit code 1.
+
+            ...
+
+        The extracted stderr messages are logged to self.fail_msg. The line
+        indicating whether it was successful or it failed with an exit code
+        is used to return the exit code.
+
+        Returns the exit code if found, else None.
+        '''
+
+        # Job script output must have been opened already.
+        assert self.bsub_out_fd
+
+        for line in self.bsub_out_fd:
+            if not self.bsub_out_err_msg_found:
+                m = re.match("^Sender", line)
+                if m:
+                    # Pop the line before the sender line.
+                    self.bsub_out_err_msg = "\n".join(
+                        self.bsub_out_err_msg[:-1])
+                    self.bsub_out_err_msg_found = True
+                else:
+                    self.bsub_out_err_msg.append(line.strip())
+
+            else:
+                m = re.match(r"^Exited with exit code (\d+).\n$", line)
+                if m:
+                    return m.group(1)
+
+                if not self.bsub_out_err_msg:
+                    m = re.match(r"^Successfully completed.\n$", line)
+                    if m:
+                        return 0
+        return None
+
+    def kill(self):
+        if self.job_id:
+            try:
+                subprocess.run(["bkill", "-s", "SIGTERM", self.job_id],
+                               check=True,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+            except subprocess.CalledProcessError as e:
+                log.error("Failed to kill job: {}".format(
+                    e.stderr.decode("utf-8").strip()))
+        else:
+            log.error("Job ID for %s not found", self.deploy.full_name)
+
+        self._post_finish('K', "Job killed!")
+
+    def _post_finish(self, status, err_msg):
+        if self.bsub_out_fd:
+            self.bsub_out_fd.close()
+        self.status = status
+        if self.exit_code is None:
+            self.exit_code = 0 if status == 'P' else 1
+        super()._post_finish(status, err_msg)
+
+    @staticmethod
+    def _post_finish_job_array(cfg, job_name, err_msg):
+        '''On LSF error, mark all jobs in this array as killed.
+
+        err_msg is the error message indicating the cause of failure.'''
+
+        for job in LsfLauncher.jobs[cfg][job_name]:
+            job._post_finish("F", err_msg)

--- a/vendor/lowrisc_ip/util/dvsim/OneShotCfg.py
+++ b/vendor/lowrisc_ip/util/dvsim/OneShotCfg.py
@@ -88,7 +88,8 @@ class OneShotCfg(FlowCfg):
         super()._expand()
 
         # Stuff below only pertains to individual cfg (not primary cfg).
-        if not self.is_primary_cfg:
+        if not self.is_primary_cfg and (not self.select_cfgs or
+                                        self.name in self.select_cfgs):
             # Print scratch_path at the start:
             log.info("[scratch_path]: [%s] [%s]", self.name, self.scratch_path)
 

--- a/vendor/lowrisc_ip/util/dvsim/Scheduler.py
+++ b/vendor/lowrisc_ip/util/dvsim/Scheduler.py
@@ -4,196 +4,87 @@
 
 import logging as log
 import threading
-from collections import OrderedDict
 from signal import SIGINT, signal
 
 from Launcher import LauncherError
+from StatusPrinter import get_status_printer
 from Timer import Timer
 from utils import VERBOSE
 
 
-class TargetScheduler:
-    '''A scheduler for the jobs of a given target'''
-    def __init__(self, name):
-        self.name = name
+# Sum of lenghts of all lists in the given dict.
+def sum_dict_lists(d):
+    '''Given a dict whose key values are lists, return sum of lengths of
+    thoese lists.'''
+    return sum([len(d[k]) for k in d])
 
-        # Sets of items, split up by their current state. The sets are disjoint
-        # and their union equals the keys of self.item_to_status. _queued is a
-        # list so that we dispatch things in order (relevant for things like
-        # tests where we have ordered things cleverly to try to see failures
-        # early)
-        self._queued = []
-        self._running = set()
-        self._passed = set()
-        self._failed = set()
-        self._killed = set()
 
-        # A map from the Deploy objects tracked by this class to their current
-        # status. This status is 'Q', 'D', 'P', 'F' or 'K', corresponding to
-        # membership in the dicts above.
+class Scheduler:
+    '''An object that runs one or more Deploy items'''
+
+    # Max jobs running at one time
+    max_parallel = 16
+
+    def __init__(self, items):
+        self.items = items
+
+        # 'scheduled[target][cfg]' is a list of Deploy objects for the chosen
+        # target and cfg. As items in _scheduled are ready to be run (once
+        # their dependencies pass), they are moved to the _queued list, where
+        # they wait until slots are available for them to be dispatched.
+        # When all items (in all cfgs) of a target are done, it is removed from
+        # this dictionary.
+        self._scheduled = {}
+        self.add_to_scheduled(items)
+
+        # Print status periodically using an external status printer.
+        self.status_printer = get_status_printer()
+        self.status_printer.print_header(
+            msg="Q: queued, D: dispatched, P: passed, F: failed, K: killed, "
+            "T: total")
+
+        # Sets of items, split up by their current state. The sets are
+        # disjoint and their union equals the keys of self.item_to_status.
+        # _queued is a list so that we dispatch things in order (relevant
+        # for things like tests where we have ordered things cleverly to
+        # try to see failures early). They are maintained for each target.
+        self._queued = {}
+        self._running = {}
+        self._passed = {}
+        self._failed = {}
+        self._killed = {}
+        self._total = {}
+        for target in self._scheduled:
+            self._queued[target] = []
+            self._running[target] = set()
+            self._passed[target] = set()
+            self._failed[target] = set()
+            self._killed[target] = set()
+            self._total[target] = sum_dict_lists(self._scheduled[target])
+
+            # Stuff for printing the status.
+            width = len(str(self._total[target]))
+            field_fmt = '{{:0{}d}}'.format(width)
+            self.msg_fmt = 'Q: {0}, D: {0}, P: {0}, F: {0}, K: {0}, T: {0}'.format(
+                field_fmt)
+            msg = self.msg_fmt.format(0, 0, 0, 0, 0, self._total[target])
+            self.status_printer.init_target(target=target, msg=msg)
+
+        # A map from the Deploy objects tracked by this class to their
+        # current status. This status is 'Q', 'D', 'P', 'F' or 'K',
+        # corresponding to membership in the dicts above. This is not
+        # per-target.
         self.item_to_status = {}
 
-    def add_item(self, item):
-        assert item not in self.item_to_status
-        assert item not in self._queued
-        self.item_to_status[item] = 'Q'
-        self._queued.append(item)
+    def run(self):
+        '''Run all scheduled jobs and return the results.
 
-    def _kill_item(self, item):
-        '''Kill a running item'''
-        self._running.remove(item)
-        item.launcher.kill()
-        self._killed.add(item)
-        self.item_to_status[item] = 'K'
-
-    def _poll(self, hms):
-        '''Check for running items that have finished.
-
-        Returns True if something changed.
+        Returns the results (status) of all items dispatched for all
+        targets and cfgs.
         '''
-        to_pass = []
-        to_fail = []
 
-        for item in self._running:
-            status = item.launcher.poll()
-            assert status in ['D', 'P', 'F']
-            if status == 'D':
-                # Still running
-                continue
-            elif status == 'P':
-                log.log(VERBOSE, "[%s]: [%s]: [status] [%s: P]", hms,
-                        item.target, item.full_name)
-                to_pass.append(item)
-            else:
-                log.error("[%s]: [%s]: [status] [%s: F]", hms, item.target,
-                          item.full_name)
-                to_fail.append(item)
+        timer = Timer()
 
-        for item in to_pass:
-            self._running.remove(item)
-            self._passed.add(item)
-            self.item_to_status[item] = 'P'
-        for item in to_fail:
-            self._running.remove(item)
-            self._failed.add(item)
-            self.item_to_status[item] = 'F'
-
-        return to_pass or to_fail
-
-    def _dispatch(self, hms, old_results):
-        '''Dispatch some queued items if possible.
-
-        See run() for the format of old_results.
-        '''
-        num_slots = min(Scheduler.slot_limit,
-                        Scheduler.max_parallel - len(self._running),
-                        len(self._queued))
-        if num_slots <= 0:
-            return
-
-        to_dispatch = []
-
-        while len(to_dispatch) < num_slots and self._queued:
-            next_item = self._queued.pop(0)
-            # Does next_item have any dependencies? Since we dispatch jobs by
-            # target, we can assume that each of those dependencies appears
-            # in old_results.
-            has_failed_dep = False
-            for dep in next_item.dependencies:
-                dep_status = old_results[dep]
-                assert dep_status in ['P', 'F', 'K']
-
-                if next_item.needs_all_dependencies_passing:
-                    if dep_status in ['F', 'K']:
-                        has_failed_dep = True
-                        break
-                else:
-                    # Set has_failed_dep default value to True only if the
-                    # next_item has dependencies, and next_item does not require
-                    # all dependencies to pass
-                    has_failed_dep = True
-                    if dep_status in ['P']:
-                        has_failed_dep = False
-                        break
-
-            # If has_failed_dep then at least one of the dependencies has been
-            # cancelled or has run and failed. Give up on this item too.
-            if has_failed_dep:
-                self._killed.add(next_item)
-                self.item_to_status[next_item] = 'K'
-                continue
-
-            to_dispatch.append(next_item)
-
-        if not to_dispatch:
-            return
-
-        log.log(VERBOSE, "[%s]: [%s]: [dispatch]:\n%s", hms, self.name,
-                ", ".join(item.full_name for item in to_dispatch))
-
-        for item in to_dispatch:
-            self._running.add(item)
-            self.item_to_status[item] = 'D'
-            try:
-                item.launcher.launch()
-            except LauncherError as err:
-                log.error('{}'.format(err))
-                self._kill_item(item)
-
-    def _kill(self):
-        '''Kill any running items and cancel any that are waiting'''
-
-        # Cancel any waiting items. We take a copy of self._queued to avoid
-        # iterating over the set as we modify it.
-        for item in [item for item in self._queued]:
-            self._cancel(item)
-
-        # Kill any running items. Again, take a copy of the set to avoid
-        # modifying it while iterating over it.
-        for item in [item for item in self._running]:
-            self._kill_item(item)
-
-    def _cancel(self, item):
-        '''Cancel an item that is currently queued'''
-        assert item in self._queued
-        self._queued.remove(item)
-        self._killed.add(item)
-        self.item_to_status[item] = 'K'
-
-    def _check_if_done(self, timer, hms, print_status):
-        '''Check whether we are finished.
-
-        If print_status or we've reached a time interval then print current
-        status for those jobs that weren't known to be finished already.
-        '''
-        if timer.check_time():
-            print_status = True
-
-        if print_status:
-            total_cnt = len(self.item_to_status)
-            width = len(str(total_cnt))
-
-            field_fmt = '{{:0{}d}}'.format(width)
-            msg_fmt = ('[Q: {0}, D: {0}, P: {0}, F: {0}, K: {0}, T: {0}]'.
-                       format(field_fmt))
-            msg = msg_fmt.format(len(self._queued), len(self._running),
-                                 len(self._passed), len(self._failed),
-                                 len(self._killed), total_cnt)
-            log.info("[%s]: [%s]: %s", hms, self.name, msg)
-
-        return not (self._queued or self._running)
-
-    def run(self, timer, old_results):
-        '''Run the jobs for this target.
-
-        timer is a Timer that was started at the start of the Runner's run.
-
-        old_results is a dictionary mapping items (from previous targets) to
-        statuses. Every job that appears as a dependency will be in this list
-        (because it ran as part of a previous target).
-
-        Returns the results from this target (in the same format).
-        '''
         # Catch one SIGINT and tell the runner to quit. On a second, die.
         stop_now = threading.Event()
         old_handler = None
@@ -211,19 +102,21 @@ class TargetScheduler:
 
         old_handler = signal(SIGINT, on_sigint)
 
+        # Enqueue all items of the first target.
+        self._enqueue_successors(None)
+
         try:
             while True:
                 if stop_now.is_set():
-                    # We've had an interrupt. Kill any jobs that are running,
-                    # then exit.
+                    # We've had an interrupt. Kill any jobs that are running.
                     self._kill()
-                    exit(1)
 
                 hms = timer.hms()
-                changed = self._poll(hms)
-                self._dispatch(hms, old_results)
-                if self._check_if_done(timer, hms, changed):
-                    break
+                changed = self._poll(hms) or timer.check_time()
+                self._dispatch(hms)
+                if changed:
+                    if self._check_if_done(hms):
+                        break
 
                 # This is essentially sleep(1) to wait a second between each
                 # polling loop. But we do it with a bounded wait on stop_now so
@@ -233,44 +126,363 @@ class TargetScheduler:
         finally:
             signal(SIGINT, old_handler)
 
-        # We got to the end without anything exploding. Return the results for our jobs.
+        # Cleaup the status printer.
+        self.status_printer.exit()
+
+        # We got to the end without anything exploding. Return the results.
         return self.item_to_status
 
+    def add_to_scheduled(self, items):
+        '''Add items to the list of _scheduled.
 
-class Scheduler:
-    '''An object to run one or more Deploy items'''
-
-    # Max jobs running at one time
-    max_parallel = 16
-
-    # Max jobs dispatched in one go.
-    slot_limit = 20
-
-    def __init__(self, items):
-        # An ordered dictionary keyed by target ('build', 'run' or similar).
-        # The value for each target is a TargetScheduler object.
-        self.schedulers = OrderedDict()
+        'items' is a list of Deploy objects.
+        '''
 
         for item in items:
-            # This works like setdefault, but doesn't construct a TargetScheduler
-            # object unnecessarily.
-            tgt_scheduler = self.schedulers.get(item.target)
-            if tgt_scheduler is None:
-                tgt_scheduler = TargetScheduler(item.target)
-                self.schedulers[item.target] = tgt_scheduler
+            target_dict = self._scheduled.setdefault(item.target, {})
+            cfg_list = target_dict.setdefault(item.sim_cfg, [])
+            if item not in cfg_list:
+                cfg_list.append(item)
 
-            tgt_scheduler.add_item(item)
+    def _remove_from_scheduled(self, item):
+        '''Removes the item from _scheduled[target][cfg] list.
 
-    def run(self):
-        '''Run all items
-
-        Returns a map from item to status.
+        When all items in _scheduled[target][cfg] are finally removed, the cfg
+        key is deleted.
         '''
-        timer = Timer()
+        target_dict = self._scheduled[item.target]
+        cfg_list = target_dict.get(item.sim_cfg)
+        if cfg_list is not None:
+            try:
+                cfg_list.remove(item)
+            except ValueError:
+                pass
+            if not cfg_list:
+                del target_dict[item.sim_cfg]
 
-        log.info("[legend]: [Q: queued, D: dispatched, "
-                 "P: passed, F: failed, K: killed, T: total]")
-        results = {}
-        for scheduler in self.schedulers.values():
-            results.update(scheduler.run(timer, results))
-        return results
+    def _get_next_target(self, curr_target):
+        '''Returns the target that succeeds the current one.
+
+        curr_target is the target of the job that just completed (example -
+        build). If it is None, then the first target in _scheduled is returned.
+        '''
+
+        if curr_target is None:
+            return next(iter(self._scheduled))
+
+        assert curr_target in self._scheduled
+        target_iterator = iter(self._scheduled)
+        target = next(target_iterator)
+
+        found = False
+        while not found:
+            if target == curr_target:
+                found = True
+            try:
+                target = next(target_iterator)
+            except StopIteration:
+                return None
+
+        return target
+
+    def _enqueue_successors(self, item=None):
+        '''Move an item's successors from _scheduled to _queued.
+
+        'item' is the recently run job that has completed. If None, then we
+        move all available items in all available cfgs in _scheduled's first
+        target. If 'item' is specified, then we find its successors and move
+        them to _queued.
+        '''
+
+        for next_item in self._get_successors(item):
+            assert next_item not in self.item_to_status
+            assert next_item not in self._queued[next_item.target]
+            self.item_to_status[next_item] = 'Q'
+            self._queued[next_item.target].append(next_item)
+            self._remove_from_scheduled(next_item)
+
+    def _cancel_successors(self, item):
+        '''Cancel an item's successors recursively by moving them from
+        _scheduled or _queued to _killed.'''
+
+        items = self._get_successors(item)
+        while items:
+            next_item = items.pop()
+            self._cancel_item(next_item, cancel_successors=False)
+            items.extend(self._get_successors(next_item))
+
+    def _get_successors(self, item=None):
+        '''Find immediate successors of an item.
+
+        'item' is a job that has completed. We choose the target that follows
+        the 'item''s current target and find the list of successors whose
+        dependency list contains 'item'. If 'item' is None, we pick successors
+        from all cfgs, else we pick successors only from the cfg to which the
+        item belongs.
+
+        Returns the list of item's successors, or an empty list if there are
+        none.
+        '''
+
+        if item is None:
+            target = self._get_next_target(None)
+            cfgs = set(self._scheduled[target])
+        else:
+            target = self._get_next_target(item.target)
+            cfgs = {item.sim_cfg}
+
+        if target is None:
+            return []
+
+        # Find item's successors that can be enqueued. We assume here that
+        # only the immediately succeeding target can be enqueued at this
+        # time.
+        successors = []
+        for cfg in cfgs:
+            for next_item in self._scheduled[target][cfg]:
+                if item is not None:
+                    # Something is terribly wrong if item exists but the
+                    # next_item's dependency list is empty.
+                    assert next_item.dependencies
+                    if item not in next_item.dependencies:
+                        continue
+
+                if self._ok_to_enqueue(next_item):
+                    successors.append(next_item)
+
+        return successors
+
+    def _ok_to_enqueue(self, item):
+        '''Returns true if ALL dependencies of item are complete.'''
+
+        for dep in item.dependencies:
+            # Ignore dependencies that were not scheduled to run.
+            if dep not in self.items:
+                continue
+
+            # Has the dep even been enqueued?
+            if dep not in self.item_to_status:
+                return False
+
+            # Has the dep completed?
+            if self.item_to_status[dep] not in ["P", "F", "K"]:
+                return False
+
+        return True
+
+    def _ok_to_run(self, item):
+        '''Returns true if the required dependencies have passed.
+
+        The item's needs_all_dependencies_passing setting is used to figure
+        out whether we can run this item or not, based on its dependent jobs'
+        statuses.
+        '''
+        # 'item' can run only if its dependencies have passed (their results
+        # should already show up in the item to status map).
+        for dep in item.dependencies:
+            # Ignore dependencies that were not scheduled to run.
+            if dep not in self.items:
+                continue
+
+            dep_status = self.item_to_status[dep]
+            assert dep_status in ['P', 'F', 'K']
+
+            if item.needs_all_dependencies_passing:
+                if dep_status in ['F', 'K']:
+                    return False
+            else:
+                if dep_status in ['P']:
+                    return True
+
+        return item.needs_all_dependencies_passing
+
+    def _poll(self, hms):
+        '''Check for running items that have finished
+
+        Returns True if something changed.
+        '''
+
+        changed = False
+        for target in self._scheduled:
+            to_pass = []
+            to_fail = []
+            for item in self._running[target]:
+                status = item.launcher.poll()
+                assert status in ['D', 'P', 'F']
+                if status == 'D':
+                    # Still running
+                    continue
+                elif status == 'P':
+                    log.log(VERBOSE, "[%s]: [%s]: [status] [%s: P]", hms,
+                            target, item.full_name)
+                    to_pass.append(item)
+                else:
+                    log.error("[%s]: [%s]: [status] [%s: F]", hms, target,
+                              item.full_name)
+                    to_fail.append(item)
+
+            for item in to_pass:
+                self._passed[target].add(item)
+                self._running[target].remove(item)
+                self.item_to_status[item] = 'P'
+                self._enqueue_successors(item)
+
+            for item in to_fail:
+                self._failed[target].add(item)
+                self._running[target].remove(item)
+                self.item_to_status[item] = 'F'
+                # It may be possible that a failed item's successor may not
+                # need all of its dependents to pass (if it has other dependent
+                # jobs). Hence we enqueue all successors rather than canceling
+                # them right here. We leave it to `_dispatch()` to figure out
+                # whether an enqueued item can be run or not.
+                self._enqueue_successors(item)
+
+            changed = changed or to_pass or to_fail
+
+        return changed
+
+    def _dispatch(self, hms):
+        '''Dispatch some queued items if possible.'''
+
+        slots = Scheduler.max_parallel - sum_dict_lists(self._running)
+        if slots <= 0:
+            return
+
+        # Compute how many slots to allocate to each target based on their
+        # weights.
+        sum_weight = 0
+        slots_filled = 0
+        total_weight = sum(self._queued[t][0].weight for t in self._queued
+                           if self._queued[t])
+
+        for target in self._scheduled:
+            if not self._queued[target]:
+                continue
+
+            # N slots are allocated to M targets each with W(m) weights with
+            # the formula:
+            #
+            # N(m) = N * W(m) / T, where,
+            #   T is the sum total of all weights.
+            #
+            # This is however, problematic due to fractions. Even after
+            # rounding off to the nearest digit, slots may not be fully
+            # utilized (one extra left). An alternate approach that avoids this
+            # problem is as follows:
+            #
+            # N(m) = (N * S(W(m)) / T) - F(m), where,
+            #   S(W(m)) is the running sum of weights upto current target m.
+            #   F(m) is the running total of slots filled.
+            #
+            # The computed slots per target is nearly identical to the first
+            # solution, except that it prioritizes the slot allocation to
+            # targets that are earlier in the list such that in the end, all
+            # slots are fully consumed.
+            sum_weight += self._queued[target][0].weight
+            target_slots = round(
+                (slots * sum_weight) / total_weight) - slots_filled
+            if target_slots <= 0:
+                continue
+            slots_filled += target_slots
+
+            to_dispatch = []
+            while self._queued[target] and target_slots > 0:
+                next_item = self._queued[target].pop(0)
+                if not self._ok_to_run(next_item):
+                    self._cancel_item(next_item, cancel_successors=False)
+                    self._enqueue_successors(next_item)
+                    continue
+
+                to_dispatch.append(next_item)
+                target_slots -= 1
+
+            if not to_dispatch:
+                continue
+
+            log.log(VERBOSE, "[%s]: [%s]: [dispatch]:\n%s", hms, target,
+                    ", ".join(item.full_name for item in to_dispatch))
+
+            for item in to_dispatch:
+                self._running[target].add(item)
+                self.item_to_status[item] = 'D'
+                try:
+                    item.launcher.launch()
+                except LauncherError as err:
+                    log.error('{}'.format(err))
+                    self._kill_item(item)
+
+    def _kill(self):
+        '''Kill any running items and cancel any that are waiting'''
+
+        # Cancel any waiting items. We take a copy of self._queued to avoid
+        # iterating over the set as we modify it.
+        for target in self._queued:
+            for item in [item for item in self._queued[target]]:
+                self._cancel_item(item)
+
+        # Kill any running items. Again, take a copy of the set to avoid
+        # modifying it while iterating over it.
+        for target in self._queued:
+            for item in [item for item in self._running[target]]:
+                self._kill_item(item)
+
+    def _check_if_done(self, hms):
+        '''Check if we are done executing all jobs.
+
+        Also, prints the status of currently running jobs.
+        '''
+
+        done = True
+        for target in self._scheduled:
+            done_cnt = sum([
+                len(self._passed[target]),
+                len(self._failed[target]),
+                len(self._killed[target])
+            ])
+            done = done and (done_cnt == self._total[target])
+
+            # Skip if a target has not even begun executing.
+            if not (self._queued[target] or self._running[target] or
+                    done_cnt > 0):
+                continue
+
+            perc = done_cnt / self._total[target] * 100
+
+            msg = self.msg_fmt.format(len(self._queued[target]),
+                                      len(self._running[target]),
+                                      len(self._passed[target]),
+                                      len(self._failed[target]),
+                                      len(self._killed[target]),
+                                      self._total[target])
+            self.status_printer.update_target(target=target,
+                                              msg=msg,
+                                              hms=hms,
+                                              perc=perc)
+        return done
+
+    def _cancel_item(self, item, cancel_successors=True):
+        '''Cancel an item and optionally all of its successors.
+
+        Supplied item may be in _scheduled list or the _queued list. From
+        either, we move it straight to _killed.
+        '''
+
+        self.item_to_status[item] = 'K'
+        self._killed[item.target].add(item)
+        if item in self._queued[item.target]:
+            self._queued[item.target].remove(item)
+        else:
+            self._remove_from_scheduled(item)
+
+        if cancel_successors:
+            self._cancel_successors(item)
+
+    def _kill_item(self, item):
+        '''Kill a running item and cancel all of its successors.'''
+
+        item.launcher.kill()
+        self.item_to_status[item] = 'K'
+        self._killed[item.target].add(item)
+        self._running[item.target].remove(item)
+        self._cancel_successors(item)

--- a/vendor/lowrisc_ip/util/dvsim/StatusPrinter.py
+++ b/vendor/lowrisc_ip/util/dvsim/StatusPrinter.py
@@ -1,0 +1,139 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging as log
+import sys
+
+try:
+    import enlighten
+    ENLIGHTEN_EXISTS = True
+except ImportError:
+    ENLIGHTEN_EXISTS = False
+
+
+class StatusPrinter:
+    '''Abstraction for printing the current target status onto the console.
+
+    Targets are ASIC tool flow steps such as build, run, cov etc. These steps
+    are sequenced by the Scheduler. There may be multiple jobs running in
+    parallel in each target. This class provides a mechanism to peridically
+    print the completion status of each target onto the terminal. Messages
+    printed by this class are rather static in nature - all the necessary
+    computations of how the jobs are progressing need to be handled externally.
+
+    The following are the 'fields' accepted by this class:
+      hms:    Elapsed time in hh:mm:ss.
+      target: The tool flow step.
+      msg:    The completion status message (set externally).
+      perc:   Percentage of completion.
+    '''
+
+    # Print elapsed time in bold.
+    hms_fmt = ''.join(['\033[1m', u'{hms:9s}', '\033[0m'])
+    header_fmt = hms_fmt + u' [{target:^13s}]: [{msg}]'
+    status_fmt = header_fmt + u' {perc:3.0f}%'
+
+    def __init__(self):
+        # Once a target is complete, we no longer need to update it - we can
+        # just skip it. Maintaining this here provides a way to print the status
+        # one last time when it reaches 100%. It is much easier to do that here
+        # than in the Scheduler class.
+        self.target_done = {}
+
+    def print_header(self, msg):
+        '''Initilize / print the header bar.
+
+        The header bar contains an introductory message such as the legend of
+        what Q, D, ... mean.'''
+
+        log.info(self.header_fmt.format(hms="", target="legend", msg=msg))
+
+    def init_target(self, target, msg):
+        '''Initialize the status bar for each target.'''
+
+        self.target_done[target] = False
+
+    def update_target(self, target, hms, msg, perc):
+        '''Periodically update the status bar for each target.'''
+
+        if self.target_done[target]:
+            return
+
+        log.info(
+            self.status_fmt.format(hms=hms, target=target, msg=msg, perc=perc))
+        if perc == 100:
+            self.target_done[target] = True
+
+    def exit(self):
+        '''Do cleanup activities before exitting.'''
+
+        pass
+
+
+class EnlightenStatusPrinter(StatusPrinter):
+    '''Abstraction for printing status using Enlighten.
+
+    Enlighten is a third party progress bar tool. Documentation:
+    https://python-enlighten.readthedocs.io/en/stable/
+
+    Though it offers very fancy progress bar visualization, we stick to a
+    simple status bar 'pinned' to the bottom of the screen for each target
+    that displays statically, a pre-prepared message. We avoid the progress bar
+    visualization since it requires enlighten to perform some computations the
+    Scheduler already does. It also helps keep the overhead to a minimum.
+
+    Enlighten does not work if the output of dvsim is redirected to a file, for
+    example - it needs to be attached to a TTY enabled stream.
+    '''
+    def __init__(self):
+        super().__init__()
+
+        # Initialize the status_bars for header and the targets .
+        self.manager = enlighten.get_manager()
+        self.status_header = None
+        self.status_target = {}
+
+    def print_header(self, msg):
+        self.status_header = self.manager.status_bar(
+            status_format=self.header_fmt,
+            hms="",
+            target="legend",
+            msg=
+            "Q: queued, D: dispatched, P: passed, F: failed, K: killed, T: total"
+        )
+
+    def init_target(self, target, msg):
+        super().init_target(target, msg)
+        self.status_target[target] = self.manager.status_bar(
+            status_format=self.status_fmt,
+            hms="",
+            target=target,
+            msg=msg,
+            perc=0.0)
+
+    def update_target(self, target, hms, msg, perc):
+        if self.target_done[target]:
+            return
+
+        self.status_target[target].update(hms=hms, msg=msg, perc=perc)
+        if perc == 100:
+            self.target_done[target] = True
+
+    def exit(self):
+        self.status_header.close()
+        for target in self.status_target:
+            self.status_target[target].close()
+
+
+def get_status_printer():
+    """Factory method that returns a status printer instance.
+
+    If ENLIGHTEN_EXISTS (enlighten is installed) and stdout is a TTY, then
+    return an instance of EnlightenStatusPrinter, else return an instance of
+    StatusPrinter.
+    """
+    if ENLIGHTEN_EXISTS and sys.stdout.isatty():
+        return EnlightenStatusPrinter()
+    else:
+        return StatusPrinter()

--- a/vendor/lowrisc_ip/util/dvsim/dvsim.py
+++ b/vendor/lowrisc_ip/util/dvsim/dvsim.py
@@ -29,9 +29,10 @@ import sys
 import textwrap
 from pathlib import Path
 
+import Launcher
+import LauncherFactory
 from CfgFactory import make_cfg
 from Deploy import RunTest
-from Launcher import Launcher
 from Scheduler import Scheduler
 from Timer import Timer
 from utils import (TS_FORMAT, TS_FORMAT_LONG, VERBOSE, rm_path,
@@ -312,6 +313,11 @@ def parse_args():
                       help=('Prepend this string when running each tool '
                             'command.'))
 
+    disg.add_argument("--local",
+                      action='store_true',
+                      help=('Force jobs to be dispatched locally onto user\'s '
+                            'machine.'))
+
     disg.add_argument("--remote",
                       action='store_true',
                       help=('Trigger copying of the repo to scratch area.'))
@@ -395,6 +401,11 @@ def parse_args():
                         metavar="MODE",
                         help=('The options for each build_mode in this list '
                               'are applied to all build and run targets.'))
+
+    disg.add_argument("--gui",
+                      action='store_true',
+                      help=('Run the flow in interactive mode instead of the '
+                            'batch mode.'))
 
     rung = parser.add_argument_group('Options for running')
 
@@ -637,7 +648,8 @@ def main():
     # Register the common deploy settings.
     Timer.print_interval = args.print_interval
     Scheduler.max_parallel = args.max_parallel
-    Launcher.max_odirs = args.max_odirs
+    Launcher.Launcher.max_odirs = args.max_odirs
+    LauncherFactory.set_launcher_type(args.local)
 
     # Build infrastructure from hjson file and create the list of items to
     # be deployed.

--- a/vendor/lowrisc_ip/util/dvsim/testplanner/examples/foo_dv_plan.md
+++ b/vendor/lowrisc_ip/util/dvsim/testplanner/examples/foo_dv_plan.md
@@ -4,4 +4,4 @@ title: "FOO DV document"
 
 # testplan
 
-{{< testplan "util/dvsim/testplanner/examples/foo_testplan.hjson" >}}
+{{< incGenFromIpDesc "foo_testplan.hjson" "testplan" >}}

--- a/vendor/lowrisc_ip/util/uvmdvgen/bind.sv.tpl
+++ b/vendor/lowrisc_ip/util/uvmdvgen/bind.sv.tpl
@@ -16,14 +16,11 @@ module ${name}_bind;
 % endif
 % if has_ral:
 
-  import ${name}_reg_pkg::*;
   bind ${name} ${name}_csr_assert_fpv ${name}_csr_assert (
     .clk_i,
     .rst_ni,
     .h2d    (tl_i),
-    .d2h    (tl_o),
-    .reg2hw (reg2hw),
-    .hw2reg (hw2reg)
+    .d2h    (tl_o)
   );
 % endif
 

--- a/vendor/lowrisc_ip/util/uvmdvgen/checklist.md.tpl
+++ b/vendor/lowrisc_ip/util/uvmdvgen/checklist.md.tpl
@@ -7,7 +7,7 @@ NOTE: This is a template checklist document that is required to be copied over t
 directory for a new design that transitions from L0 (Specification) to L1 (Development)
 stage, and updated as needed. Once done, please remove this comment before checking it in.
 -->
-This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [${name.upper()} peripheral.]({{< relref "hw/ip/${name}/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [${name.upper()} peripheral.]({{< relref "." >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 <%text>## Design Checklist</%text>
@@ -16,7 +16,7 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Not Started | [${name.upper()} Design Spec]({{<relref "hw/ip/${name}/doc" >}})
+Documentation | [SPEC_COMPLETE][]              | Not Started | [${name.upper()} Design Spec]({{<relref "." >}})
 Documentation | [CSR_DEFINED][]                | Not Started |
 RTL           | [CLKRST_CONNECTED][]           | Not Started |
 RTL           | [IP_TOP][]                     | Not Started |
@@ -115,8 +115,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [${name.upper()} DV Plan]({{<relref "hw/ip/${name}/doc/dv_plan" >}})
-Documentation | [DV_PLAN_COMPLETED][]                 | Not Started | [${name.upper()} Testplan]({{<relref "hw/ip/${name}/doc/dv_plan/index.md#testplan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [${name.upper()} DV Plan]({{<relref "dv" >}})
+Documentation | [DV_PLAN_COMPLETED][]                 | Not Started | [${name.upper()} Testplan]({{<relref "dv/index.md#testplan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Not Started |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Not Started |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Not Started |

--- a/vendor/lowrisc_ip/util/uvmdvgen/env_cfg.sv.tpl
+++ b/vendor/lowrisc_ip/util/uvmdvgen/env_cfg.sv.tpl
@@ -37,9 +37,9 @@ class ${name}_env_cfg extends dv_base_env_cfg;
     // create ${agent} agent config obj
     m_${agent}_agent_cfg = ${agent}_agent_cfg::type_id::create("m_${agent}_agent_cfg");
 % endfor
-% if is_cip:
+% if has_interrupts:
 
-    // set num_interrupts & num_alerts
+    // set num_interrupts
     begin
       uvm_reg rg = ral.get_reg_by_name("intr_state");
       if (rg != null) begin

--- a/vendor/lowrisc_ip/util/uvmdvgen/index.md.tpl
+++ b/vendor/lowrisc_ip/util/uvmdvgen/index.md.tpl
@@ -123,5 +123,6 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/${name}/dv/${name}_sim_cfg.hjson
 ```
 
 ${'##'} DV plan
-<!-- TODO: uncomment the line below after adding the testplan -->
-{{</* testplan "hw/ip/${name}/data/${name}_testplan.hjson" */>}}
+<!-- TODO: uncomment the line below after adding the testplan.
+Please make sure the testplan is added to `/util/build_docs.py`. -->
+{{</* incGenFromIpDesc "hw/ip/${name}/data/${name}_testplan.hjson" "testplan" */>}

--- a/vendor/lowrisc_ip/util/uvmdvgen/sva.core.tpl
+++ b/vendor/lowrisc_ip/util/uvmdvgen/sva.core.tpl
@@ -25,7 +25,6 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/${name}.hjson
-      depend: lowrisc:ip:${name}
 % endif
 
 targets:


### PR DESCRIPTION
Update code from upstream repository
https://github.com/lowRISC/opentitan to revision
fd9f58c7d21564d67a17c6d0cce3465beeca70a2

Manually fix up users of VerilatorMemutil to match the new API (added
in the "Factor out MemArea as a class" and later commits listed
below).

* [dpi] Make an "ECC32" flavour of MemArea (Rupert Swarbrick)
* [uvmdvgen] Fix has_interrupts in env_cfg (Cindy Chen)
* [dvsim] Keep dependencies list (Srikrishna Iyer)
* [prim_prince] Reverse the k0||k1 mapping to match with the paper
  (Michael Schaffner)
* [dvsim] Fix printing of last 10 lines (Srikrishna Iyer)
* [primgen] Minor fix to enable types with underscores (Michael
  Schaffner)
* [dvsim] Prevent command echo suppression (Srikrishna Iyer)
* [dvsim] Spot fixes for LSF and internal launcher (Srikrishna Iyer)
* [sva] csr assertion dependency update (Cindy Chen)
* [memutil] Change DpiMemUtil so that it no longer owns MemAreas
  (Rupert Swarbrick)
* [memutil] Factor out MemArea as a class (Rupert Swarbrick)
* [prim] Split out PRESENT and PRINCE support from prim:all (Rupert
  Swarbrick)
* [fpv/otp_ctrl] Disable assertions due to lc_esc_en (Cindy Chen)
* [prim_prince] Annotate some arrays to avoid UNOPTFLAT warnings
  (Rupert Swarbrick)
* [top] Hook up latest ast ports and complete a few other integration
  (Timothy Chen)
* Eliminate `#pragma once` in favor of include guards (Chris Frantz)
* [sw,dv] Update headers to pass fix_include_guards.py (Alex Bradbury)
* [xbar/dv] Fix assertion error due to short reset (Weicai Yang)
* [sram] Add memory initialization (Timothy Chen)
* [uvmdvgen] Update links in checklist template (Philipp Wagner)
* [dv/uvmdvgen] Add comment for testplan (Cindy Chen)
* [dv/top_earlgrey] chip csr_aliasing timeout (Cindy Chen)
* [dvsim] Cosmetic updates to launcher methods (Srikrishna Iyer)
* [dv] Update csr_wr to support field write (Weicai Yang)
* [dv/common] Fix regression warnings (Cindy Chen)
* [dv] Get blocks with multiple device interfaces working with chip DV
  (Rupert Swarbrick)
* [doc] Use relative links in Hjson-related shortcodes (Philipp
  Wagner)
* [dvsim] minor enhancement to clean_odir (Srikrishna Iyer)
* [dvsim] Statically display jobs' status (Srikrishna Iyer)
* [dvsim] Do weighted scheduling of jobs (Srikrishna Iyer)
* [dvsim] Schedule jobs by dependency (Srikrishna Iyer)
* [dv] Xcelium UNR typo (Srikrishna Iyer)
* [dvsim] Implement LsfLauncher (Srikrishna Iyer)
* [dv/chip] solve same_csr_outstanding_timeout (Cindy Chen)
* [dv] make dv_base_agent work for high-level agent (Weicai Yang)
* [tools/dv] added UNR flow for xcelium (Rasmus Madsen)
* [prim] Split prim:subreg out of prim:all (Rupert Swarbrick)
* [prim] Split prim_alert_* out of prim:all (Rupert Swarbrick)
* [prim] Split out fifos into a prim_fifo core (Rupert Swarbrick)
* [prim] Split out arbiters into a prim_arbiter core (Rupert
  Swarbrick)
* [prim] Make prim:flop_2sync depend on prim:flop (Rupert Swarbrick)

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>