### PR TITLE
Update google_riscv-dv to google/riscv-dv@59dcd8c

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: 0b625258549e733082c12e5dc749f05aefb07d5a
+    rev: 59dcd8c813484eb6dcca67e7e36089fe772b9cc8
   }
 }

--- a/vendor/google_riscv-dv/.github/workflows/metrics-regress.yml
+++ b/vendor/google_riscv-dv/.github/workflows/metrics-regress.yml
@@ -7,8 +7,8 @@ name: metrics-regress
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+#  pull_request_target:
+#    branches: [ master ]
 
 # If you fork this repository, you must create a new Metrics project for your fork
 # and set the environment variable $METRICS_PROJECT_ID accordingly
@@ -22,5 +22,6 @@ jobs:
           METRICS_CI_TOKEN: ${{ secrets.METRICS_CI_TOKEN }}
           METRICS_REGRESSION_NAME: riscv-dv_regression
           METRICS_PROJECT_ID: ${{ secrets.METRICS_PROJECT_ID }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         shell: bash
 

--- a/vendor/google_riscv-dv/.metrics.json
+++ b/vendor/google_riscv-dv/.metrics.json
@@ -1,15 +1,8 @@
 {
-    "variables": {
-        "DSIM" : "${DSIM_HOME}/bin/dsim",
-        "DSIM_LIB_PATH" : "${DSIM_HOME}/uvm-1.2/src/dpi",
-        "RISCV_GCC" : "${RISCV_TOOLCHAIN}/bin/riscv-none-embed-gcc",
-        "RISCV_OBJCOPY" : "${RISCV_TOOLCHAIN}/bin/riscv-none-embed-objcopy",
-        "OVPSIM_PATH" : "/customer-tools/riscv-ovpsim/bin/Linux64"
-    },
     "builds": {
       "list": [{
         "name": "rv32imc",
-        "image": "ibex-dsim-toolchain:latest",
+        "image": "ibex-toolchain:v2",
         "memory" : "1",  
         "cmd": "python3 run.py --test riscv_arithmetic_basic_test --simulator dsim --output out --verbose --co",
         "wavesCmd": "python3 run.py --test riscv_arithmetic_basic_test --simulator dsim --output out --verbose --co"
@@ -27,8 +20,8 @@
                   "name": "riscv_arithmetic_basic_test",
                   "build": "rv32imc",
                   "iterations": 2,
-                  "cmd": "cd /mux-flow/results; python3 <rootDir>/run.py --test riscv_arithmetic_basic_test --seed <seed> --simulator dsim --iss ovpsim --so --out <rootDir>/out --verbose; <rootDir>/scripts/check-status $?; rm -fr <rootDir>/out/dsim",
-                  "wavesCmd": "python3 <rootDir>/run.py --test riscv_arithmetic_basic_test --seed <seed> --simulator dsim --iss ovpsim --so --out <rootDir>/out --verbose; <rootDir>/scripts/check-status $?; rm -rf out/dsim",
+                  "cmd": "cd /mux-flow/results; python3 <rootDir>/run.py --test riscv_arithmetic_basic_test --seed <seed> --simulator dsim --iss spike --so --out <rootDir>/out --verbose; <rootDir>/scripts/check-status $?; rm -fr <rootDir>/out/dsim",
+                  "wavesCmd": "python3 <rootDir>/run.py --test riscv_arithmetic_basic_test --seed <seed> --simulator dsim --iss spike --so --out <rootDir>/out --verbose; <rootDir>/scripts/check-status $?; rm -rf out/dsim",
                   "logFile": "simulation.log",
                   "metricsFile": "metrics.db",
                   "isPass": "Test passed",

--- a/vendor/google_riscv-dv/pygen/pygen_src/isa/riscv_compressed_instr.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/isa/riscv_compressed_instr.py
@@ -30,55 +30,55 @@ class riscv_compressed_instr(riscv_instr):
 
     @vsc.constraint
     def rvc_csr_c(self):
-        # Registers specified by the three-bit rs1’, rs2’, and rd’
-        with vsc.implies(self.format.inside(vsc.rangelist(riscv_instr_format_t.CIW_FORMAT,
+        # Registers specified by the three-bit rs1, rs2, and rd
+        with vsc.if_then(self.format.inside(vsc.rangelist(riscv_instr_format_t.CIW_FORMAT,
                                                           riscv_instr_format_t.CL_FORMAT,
                                                           riscv_instr_format_t.CS_FORMAT,
                                                           riscv_instr_format_t.CB_FORMAT,
                                                           riscv_instr_format_t.CA_FORMAT))):
-            with vsc.implies(self.has_rs1 == 1):
+            with vsc.if_then(self.has_rs1 == 1):
                 self.rs1.inside(vsc.rangelist(riscv_reg_t.S0, riscv_reg_t.S1, riscv_reg_t.A0,
                                               riscv_reg_t.A1, riscv_reg_t.A2, riscv_reg_t.A3,
                                               riscv_reg_t.A4, riscv_reg_t.A5))
-            with vsc.implies(self.has_rs2 == 1):
+            with vsc.if_then(self.has_rs2 == 1):
                 self.rs2.inside(vsc.rangelist(riscv_reg_t.S0, riscv_reg_t.S1, riscv_reg_t.A0,
                                               riscv_reg_t.A1, riscv_reg_t.A2, riscv_reg_t.A3,
                                               riscv_reg_t.A4, riscv_reg_t.A5))
-            with vsc.implies(self.has_rd == 1):
+            with vsc.if_then(self.has_rd == 1):
                 self.rd.inside(vsc.rangelist(riscv_reg_t.S0, riscv_reg_t.S1, riscv_reg_t.A0,
                                              riscv_reg_t.A1, riscv_reg_t.A2, riscv_reg_t.A3,
                                              riscv_reg_t.A4, riscv_reg_t.A5))
         # _ADDI16SP is only valid when rd == SP
-        with vsc.implies(self.instr_name == riscv_instr_name_t.C_ADDI16SP):
+        with vsc.if_then(self.instr_name == riscv_instr_name_t.C_ADDI16SP):
             self.rd == riscv_reg_t.SP
-        with vsc.implies(self.instr_name.inside(vsc.rangelist(riscv_instr_name_t.C_JR,
+        with vsc.if_then(self.instr_name.inside(vsc.rangelist(riscv_instr_name_t.C_JR,
                                                               riscv_instr_name_t.C_JALR))):
             self.rs1 != riscv_reg_t.ZERO
             self.rs2 == riscv_reg_t.ZERO
 
     @vsc.constraint
     def imm_val_c(self):
-        with vsc.implies(self.imm_type.inside(vsc.rangelist(imm_t.NZIMM, imm_t.NZUIMM))):
+        with vsc.if_then(self.imm_type.inside(vsc.rangelist(imm_t.NZIMM, imm_t.NZUIMM))):
             self.imm[5:0] != 0
-            with vsc.implies(self.instr_name == riscv_instr_name_t.C_LUI):
+            with vsc.if_then(self.instr_name == riscv_instr_name_t.C_LUI):
                 self.imm[31:5] == 0
-            with vsc.implies(self.instr_name.inside(vsc.rangelist(riscv_instr_name_t.C_SRAI,
+            with vsc.if_then(self.instr_name.inside(vsc.rangelist(riscv_instr_name_t.C_SRAI,
                                                                   riscv_instr_name_t.C_SRLI,
                                                                   riscv_instr_name_t.C_SLLI))):
                 self.imm[31:5] == 0
-            with vsc.implies(self.instr_name == riscv_instr_name_t.C_ADDI4SPN):
+            with vsc.if_then(self.instr_name == riscv_instr_name_t.C_ADDI4SPN):
                 self.imm[1:0] == 0
 
     # C_JAL is RV32C only instruction
     @vsc.constraint
     def jal_c(self):
-        with vsc.implies(self.XLEN != 32):
+        with vsc.if_then(self.XLEN != 32):
             self.instr_name != riscv_instr_name_t.C_JAL
 
     # Avoid generating HINT or illegal instruction by default as it's not supported by the compiler
     @vsc.constraint
     def no_hint_illegal_instr_c(self):
-        with vsc.implies(self.instr_name.inside(vsc.rangelist(riscv_instr_name_t.C_ADDI,
+        with vsc.if_then(self.instr_name.inside(vsc.rangelist(riscv_instr_name_t.C_ADDI,
                                                               riscv_instr_name_t.C_ADDIW,
                                                               riscv_instr_name_t.C_LI,
                                                               riscv_instr_name_t.C_LUI,
@@ -90,12 +90,12 @@ class riscv_compressed_instr(riscv_instr):
                                                               riscv_instr_name_t.C_ADD,
                                                               riscv_instr_name_t.C_LWSP))):
             self.rd != riscv_reg_t.ZERO
-        with vsc.implies(self.instr_name == riscv_instr_name_t.C_JR):
+        with vsc.if_then(self.instr_name == riscv_instr_name_t.C_JR):
             self.rs1 != riscv_reg_t.ZERO
-        with vsc.implies(self.instr_name.inside(vsc.rangelist(riscv_instr_name_t.C_ADD,
+        with vsc.if_then(self.instr_name.inside(vsc.rangelist(riscv_instr_name_t.C_ADD,
                                                               riscv_instr_name_t.C_MV))):
             self.rs2 != riscv_reg_t.ZERO
-        with vsc.implies(self.instr_name == riscv_instr_name_t.C_LUI):
+        with vsc.if_then(self.instr_name == riscv_instr_name_t.C_LUI):
             self.rd != riscv_reg_t.SP
 
     def set_imm_len(self):

--- a/vendor/google_riscv-dv/pygen/pygen_src/isa/riscv_instr.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/isa/riscv_instr.py
@@ -98,16 +98,16 @@ class riscv_instr:
 
     @vsc.constraint
     def imm_c(self):
-        with vsc.implies(self.instr_name.inside(vsc.rangelist(riscv_instr_name_t.SLLIW,
+        with vsc.if_then(self.instr_name.inside(vsc.rangelist(riscv_instr_name_t.SLLIW,
                                                               riscv_instr_name_t.SRLIW,
                                                               riscv_instr_name_t.SRAIW))):
             self.imm[11:5] == 0
-        with vsc.implies(self.instr_name.inside(vsc.rangelist(riscv_instr_name_t.SLLI,
+        with vsc.if_then(self.instr_name.inside(vsc.rangelist(riscv_instr_name_t.SLLI,
                                                               riscv_instr_name_t.SRLI,
                                                               riscv_instr_name_t.SRAI))):
-            with vsc.implies(self.XLEN == 32):
+            with vsc.if_then(self.XLEN == 32):
                 self.imm[11:5] == 0
-            with vsc.implies(self.XLEN != 32):
+            with vsc.if_then(self.XLEN != 32):
                 self.imm[11:6] == 0
 
     @classmethod

--- a/vendor/google_riscv-dv/pygen/pygen_src/riscv_data_page_gen.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/riscv_data_page_gen.py
@@ -23,6 +23,7 @@ class riscv_data_page_gen:
     def __init__(self):
         self.data_page_str = []
         self.mem_region_setting = defaultdict(list)
+
     @staticmethod
     def gen_data(idx, pattern, num_of_bytes, data):
         temp_data = 0
@@ -38,8 +39,6 @@ class riscv_data_page_gen:
     def gen_data_page(self, hart_id, pattern, is_kernel=0, amo=0):
         tmp_str = ""
         temp_data = []
-        tmp_data = []
-        page_cnt = 0
         page_size = 0
         self.data_page_str.clear()
         if is_kernel:
@@ -49,30 +48,32 @@ class riscv_data_page_gen:
         else:
             self.mem_region_setting = cfg.mem_region
         for i in range(len(self.mem_region_setting)):
+            logging.info("mem_region_setting {}".format(self.mem_region_setting[i]))
+        for i in range(len(self.mem_region_setting)):
             logging.info("Generate data section: {} size:0x{} xwr:0x{}".format(
-                         self.mem_region_setting[i]["name"],
-                         self.mem_region_setting[i]["size_in_bytes"],
-                         self.mem_region_setting[i]["xwr"]))
+                         self.mem_region_setting[i].name,
+                         self.mem_region_setting[i].size_in_bytes,
+                         self.mem_region_setting[i].xwr))
             if amo:
                 if cfg.use_push_data_section:
                     self.data_page_str.append(".pushsection .{},\"aw\",@progbits;"
-                                              .format(self.mem_region_setting[i]["name"]))
+                                              .format(self.mem_region_setting[i].name))
                 else:
                     self.data_page_str.append(".section .{},\"aw\",@progbits;"
-                                              .format(self.mem_region_setting[i]["name"]))
-                self.data_page_str.append("{}:".format(self.mem_region_setting[i]["name"]))
+                                              .format(self.mem_region_setting[i].name))
+                self.data_page_str.append("{}:".format(self.mem_region_setting[i].name))
             else:
                 if cfg.use_push_data_section:
                     self.data_page_str.append(".pushsection .{},\"aw\",@progbits;"
                                               .format(pkg_ins.hart_prefix(hart_id) +
-                                                      self.mem_region_setting[i]["name"]))
+                                                      self.mem_region_setting[i].name))
                 else:
                     self.data_page_str.append(".section .{},\"aw\",@progbits;"
                                               .format(pkg_ins.hart_prefix(hart_id) +
-                                                      self.mem_region_setting[i]["name"]))
+                                                      self.mem_region_setting[i].name))
                 self.data_page_str.append("{}:".format(pkg_ins.hart_prefix(hart_id) +
-                                                       self.mem_region_setting[i]["name"]))
-            page_size = self.mem_region_setting[i]["size_in_bytes"]
+                                                       self.mem_region_setting[i].name))
+            page_size = self.mem_region_setting[i].size_in_bytes
             for i in range(0, page_size, 32):
                 if page_size - 1 >= 32:
                     temp_data = self.gen_data(idx=i, pattern=pattern,

--- a/vendor/google_riscv-dv/pygen/pygen_src/riscv_illegal_instr.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/riscv_illegal_instr.py
@@ -1,0 +1,368 @@
+
+"""
+Copyright 2020 Google LLC
+Copyright 2020 PerfectVIPs Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+"""
+
+import vsc
+import logging
+from enum import IntEnum, auto
+from importlib import import_module
+from pygen_src.riscv_instr_gen_config import cfg
+from pygen_src.riscv_instr_pkg import riscv_instr_group_t
+rcs = import_module("pygen_src.target." + cfg.argv.target + ".riscv_core_setting")
+
+
+# ---------------------------------------------------------------------------------------------
+# This class is used to generate illegal or HINT instructions.
+# The illegal instruction will be generated in binary format and mixed with other valid instr.
+# The mixed instruction stream will be stored in data section and loaded to instruction pages
+# at run time.
+# ---------------------------------------------------------------------------------------------
+
+
+class illegal_instr_type_e(IntEnum):
+    kIllegalOpcode = 0
+    kIllegalCompressedOpcode = auto()
+    kIllegalFunc3 = auto()
+    kIllegalFunc7 = auto()
+    kReservedCompressedInstr = auto()
+    kHintInstr = auto()
+    kIllegalSystemInstr = auto()
+
+
+class reserved_c_instr_e(IntEnum):
+    kIllegalCompressed = 0
+    kReservedAddispn = auto()
+    kReservedAddiw = auto()
+    kReservedAddi16sp = auto()
+    kReservedLui = auto()
+    kReservedLwsp = auto()
+    kReservedLdsp = auto()
+    kReservedLqsp = auto()
+    kReservedJr = auto()
+    kReservedC0 = auto()
+    kReservedC1 = auto()
+    kReservedC2 = auto()
+
+
+@vsc.randobj
+class riscv_illegal_instr:
+    def __init__(self):
+        self.comment = ""
+        self.exception = vsc.rand_enum_t(illegal_instr_type_e)
+        self.reserved_c = vsc.rand_enum_t(reserved_c_instr_e)
+        self.instr_bin = vsc.rand_bit_t(32)
+        self.opcode = vsc.rand_bit_t(7)
+        self.compressed = vsc.rand_bit_t(1)
+        self.func3 = vsc.rand_bit_t(3)
+        self.func7 = vsc.rand_bit_t(7)
+        self.has_func3 = vsc.rand_bit_t(1)
+        self.has_func7 = vsc.rand_bit_t(1)
+        self.c_op = vsc.rand_bit_t(2)
+        self.c_msb = vsc.rand_bit_t(3)
+        self.csrs = []
+        # Default legal self.opcode for RV32I instructions
+        self.legal_opcode = vsc.list_t(vsc.bit_t(7))
+        self.legal_opcode = [3, 15, 19, 23, 35, 55, 99, 51, 103, 115, 111]
+        # Default legal self.opcode for RV32C instructions
+        self.legal_c00_opcode = vsc.list_t(vsc.bit_t(3))
+        self.legal_c00_opcode = [0, 2, 6]
+        self.legal_c10_opcode = vsc.list_t(vsc.bit_t(3))
+        self.legal_c10_opcode = [0, 2, 4, 6]
+        self.xlen = vsc.uint8_t(0)
+        self.xlen = rcs.XLEN
+        self.temp_1 = vsc.bit_t(6)
+
+    @vsc.constraint
+    def exception_dist_c(self):
+        vsc.dist(self.exception,
+                 [vsc.weight(illegal_instr_type_e.kIllegalOpcode, 3),
+                  vsc.weight(illegal_instr_type_e.kIllegalCompressedOpcode, 1),
+                  vsc.weight(illegal_instr_type_e.kIllegalFunc3, 1),
+                  vsc.weight(illegal_instr_type_e.kIllegalFunc7, 1),
+                  vsc.weight(illegal_instr_type_e.kReservedCompressedInstr, 1),
+                  vsc.weight(illegal_instr_type_e.kHintInstr, 3),
+                  vsc.weight(illegal_instr_type_e.kIllegalSystemInstr, 3)
+                  ])
+
+    @vsc.constraint
+    def instr_bit_assignment_c(self):
+        vsc.solve_order(self.opcode, self.instr_bin)
+        vsc.solve_order(self.func3, self.instr_bin)
+        vsc.solve_order(self.func7, self.instr_bin)
+        vsc.solve_order(self.c_msb, self.instr_bin)
+        # vsc.solve_order(self.c_op, self.instr_bin)
+        with vsc.if_then(self.compressed == 1):
+            self.instr_bin[1:0] == self.c_op
+            self.instr_bin[15:13] == self.c_msb
+        with vsc.else_then():
+            self.instr_bin[6:0] == self.opcode
+            with vsc.if_then(self.has_func7 == 1):
+                self.instr_bin[31:25] == self.func7
+            with vsc.if_then(self.has_func3 == 1):
+                self.instr_bin[14:12] == self.func3
+
+    # Invalid SYSTEM instructions
+    @vsc.constraint
+    def system_instr_c(self):
+        with vsc.if_then(self.exception == illegal_instr_type_e.kIllegalSystemInstr):
+            self.opcode == 115
+            # ECALL/EBREAK/xRET/WFI
+            with vsc.if_then(self.func3 == 0):
+                # Constrain RS1 and RD to be non-zero
+                self.instr_bin[19:15] != 0
+                self.instr_bin[11:7] != 0
+                # Valid SYSTEM instructions considered by this
+                # Constrain the upper 12 bits to be invalid
+                self.instr_bin[31:20].not_inside(vsc.rangelist(0, 1, 2, 258, 770, 1970, 261))
+            with vsc.else_then():
+                # Invalid CSR instructions
+                self.instr_bin[31:20].not_inside(vsc.rangelist(self.csrs))
+                # self.instr_bin[20:31].not_inside(vsc.rangelist(self.custom_csr))
+
+    @vsc.constraint
+    def legal_rv32_c_slli(self):
+        with vsc.if_then((self.c_msb == 0) and (self.c_op == 2) and (self.xlen == 32)):
+            with vsc.if_then(self.exception == illegal_instr_type_e.kReservedCompressedInstr):
+                self.instr_bin[12] == 1
+            with vsc.else_then():
+                self.instr_bin[12] == 0
+
+    @vsc.constraint
+    def exception_type_c(self):
+        with vsc.if_then(self.compressed == 1):
+            self.exception.inside(vsc.rangelist(illegal_instr_type_e.kReservedCompressedInstr,
+                                                illegal_instr_type_e.kIllegalCompressedOpcode,
+                                                illegal_instr_type_e.kHintInstr))
+        with vsc.else_then():
+            self.exception.inside(vsc.rangelist(illegal_instr_type_e.kIllegalOpcode,
+                                                illegal_instr_type_e.kIllegalFunc3,
+                                                illegal_instr_type_e.kIllegalFunc7,
+                                                illegal_instr_type_e.kIllegalSystemInstr))
+        with vsc.if_then(self.has_func7 == 0):
+            self.exception != illegal_instr_type_e.kIllegalFunc7
+        with vsc.if_then(self.has_func3 == 0):
+            self.exception != illegal_instr_type_e.kIllegalFunc3
+
+    @vsc.constraint
+    def compressed_instr_op_c(self):
+        self.c_op != 3
+
+    # Avoid generating illegal func3/func7 errors for self.opcode used by B-extension for now
+    # TODO: add support for generating illegal B-extension instructions
+    @vsc.constraint
+    def b_extension_c(self):
+        if riscv_instr_group_t.RV32B in rcs.supported_isa:
+            with vsc.if_then(self.exception in [illegal_instr_type_e.kIllegalFunc3,
+                                                illegal_instr_type_e.kIllegalFunc7]):
+                self.opcode.inside(vsc.rangelist([51, 19, 59]))
+
+    @vsc.constraint
+    def illegal_compressed_op_c(self):
+        with vsc.if_then(self.exception == illegal_instr_type_e.kIllegalCompressedOpcode):
+            self.c_op != 1
+            with vsc.if_then(self.legal_c00_opcode.size == 8):
+                self.c_op != 0
+            with vsc.else_then():
+                self.c_msb.not_inside(vsc.rangelist(self.legal_c00_opcode))
+            with vsc.if_then(self.legal_c10_opcode.size == 8):
+                self.c_op != 2
+            with vsc.else_then():
+                self.c_msb.not_inside(vsc.rangelist(self.legal_c10_opcode))
+
+    @vsc.constraint
+    def reserved_compressed_instr_c(self):
+        vsc.solve_order(self.exception, self.reserved_c)
+        vsc.solve_order(self.exception, self.opcode)
+        vsc.solve_order(self.reserved_c, self.instr_bin)
+        vsc.solve_order(self.reserved_c, self.c_msb)
+        vsc.solve_order(self.reserved_c, self.c_op)
+        with vsc.if_then(self.xlen == 32):
+            # c.addiw is RV64/RV128 only instruction, the encoding is used for C.JAL for RV32C
+            self.reserved_c != reserved_c_instr_e.kReservedAddiw
+        with vsc.if_then(self.exception == illegal_instr_type_e.kReservedCompressedInstr):
+            with vsc.if_then(self.reserved_c == reserved_c_instr_e.kIllegalCompressed):
+                self.instr_bin[15:0] == 0
+            with vsc.if_then(self.reserved_c == reserved_c_instr_e.kReservedAddispn):
+                ((self.instr_bin[15:0] == 0) and (self.c_op == 0))
+            with vsc.if_then(self.reserved_c == reserved_c_instr_e.kReservedAddiw):
+                ((self.c_msb == 1) and (self.c_op == 1) and
+                 (self.instr_bin[11:7] == 0))
+            with vsc.if_then(self.reserved_c == reserved_c_instr_e.kReservedC0):
+                ((self.instr_bin[15:10] == 39) and
+                 (self.instr_bin[6:5] == 2) and (self.c_op == 1))
+            with vsc.if_then(self.reserved_c == reserved_c_instr_e.kReservedC1):
+                ((self.instr_bin[15:10] == 39) and
+                 (self.instr_bin[6:5] == 3) and (self.c_op == 1))
+            with vsc.if_then(self.reserved_c == reserved_c_instr_e.kReservedC2):
+                ((self.c_msb == 4) and (self.c_op == 0))
+            with vsc.if_then(self.reserved_c == reserved_c_instr_e.kReservedAddi16sp):
+                ((self.c_msb == 3) and (self.c_op == 1) and
+                 (self.instr_bin[11:7] == 2) and
+                 (not self.instr_bin[12]) and (self.instr_bin[6:2] == 0))
+            with vsc.if_then(self.reserved_c == reserved_c_instr_e.kReservedLui):
+                ((self.c_msb == 3) and (self.c_op == 1) and
+                 (not self.instr_bin[12]) and (self.instr_bin[6:2] == 0))
+            with vsc.if_then(self.reserved_c == reserved_c_instr_e.kReservedJr):
+                self.instr_bin == 32770
+            with vsc.if_then(self.reserved_c == reserved_c_instr_e.kReservedLqsp):
+                ((self.c_msb == 1) and (self.c_op == 2) and
+                 (self.instr_bin[11:7] == 0))
+            with vsc.if_then(self.reserved_c == reserved_c_instr_e.kReservedLwsp):
+                ((self.c_msb == 2) and (self.c_op == 2) and
+                 (self.instr_bin[11:7] == 0))
+            with vsc.if_then(self.reserved_c == reserved_c_instr_e.kReservedLdsp):
+                ((self.c_msb == 3) and (self.c_op == 2) and (self.instr_bin[11:7] == 0))
+
+    @vsc.constraint
+    def hint_instr_c(self):
+        with vsc.if_then(self.exception == illegal_instr_type_e.kHintInstr):
+            ((self.c_msb == 0) and (self.c_op == 1) and (self.instr_bin[12] +
+                                                         self.instr_bin[6:2] == 0)) or \
+                ((self.c_msb == 2) and (self.c_op == 1) and (self.instr_bin[11:7] == 0)) or \
+                ((self.c_msb == 4) and (self.c_op == 1) and (self.instr_bin[12:11] == 0) and
+                 (self.instr_bin[6:2] == 0)) or \
+                ((self.c_msb == 4) and (self.c_op == 2) and (self.instr_bin[11:7] == 0) and
+                 (self.instr_bin[6:2] != 0)) or \
+                ((self.c_msb == 3) and (self.c_op == 1) and (self.instr_bin[11:7] == 0) and
+                 (self.instr_bin[12] + self.instr_bin[6:2]) != 0) or \
+                ((self.c_msb == 0) and (self.c_op == 2) and (self.instr_bin[11:7] == 0)) or \
+                ((self.c_msb == 0) and (self.c_op == 2) and (self.instr_bin[11:7] != 0) and
+                 not(self.instr_bin[12]) and (self.instr_bin[6:2] == 0)) or \
+                ((self.c_msb == 4) and (self.c_op == 2) and (self.instr_bin[11:7] == 0) and
+                 self.instr_bin[12] and (self.instr_bin[6:2] != 0))
+
+    @vsc.constraint
+    def illegal_opcode_c(self):
+        vsc.solve_order(self.opcode, self.instr_bin)
+        with vsc.if_then(self.exception == illegal_instr_type_e.kIllegalOpcode):
+            self.opcode.not_inside(vsc.rangelist(self.legal_opcode))
+            self.opcode[1:0] == 3
+        with vsc.else_then():
+            self.opcode.inside(vsc.rangelist(self.legal_opcode))
+
+    # TODO: Enable atomic instruction
+    @vsc.constraint
+    def no_atomic_c(self):
+        with vsc.if_then(self.exception != illegal_instr_type_e.kIllegalOpcode):
+            self.opcode != 47
+
+    @vsc.constraint
+    def illegal_func3_c(self):
+        vsc.solve_order(self.opcode, self.func3)
+        with vsc.if_then(self.compressed == 0):
+            with vsc.if_then(self.exception == illegal_instr_type_e.kIllegalFunc3):
+                with vsc.if_then(self.opcode == 103):
+                    self.func3 != 0
+                with vsc.if_then(self.opcode == 99):
+                    self.func3.inside(vsc.rangelist(2, 3))
+                with vsc.if_then(self.xlen == 32):
+                    with vsc.if_then(self.opcode == 35):
+                        self.func3 >= 3
+                    with vsc.if_then(self.opcode == 3):
+                        self.func3.inside(vsc.rangelist(3, 7))
+                with vsc.else_then():
+                    with vsc.if_then(self.opcode == 35):
+                        self.func3 > 3
+                    with vsc.if_then(self.opcode == 3):
+                        self.func3 == 7
+                with vsc.if_then(self.opcode == 15):
+                    self.func3.not_inside(vsc.rangelist(0, 1))
+                with vsc.if_then(self.opcode == 115):
+                    self.func3 == 4
+                with vsc.if_then(self.opcode == 27):
+                    self.func3.not_inside(vsc.rangelist(0, 1, 5))
+                with vsc.if_then(self.opcode == 59):
+                    self.func3.inside(vsc.rangelist(2, 3))
+                self.opcode.inside(vsc.rangelist(103, 99, 3, 35, 15, 115, 27, 59))
+            with vsc.else_then():
+                with vsc.if_then(self.opcode == 103):
+                    self.func3 == 0
+                with vsc.if_then(self.opcode == 99):
+                    self.func3.inside(vsc.rangelist(2, 3))
+                with vsc.if_then(self.xlen == 32):
+                    with vsc.if_then(self.opcode == 35):
+                        self.func3 < 3
+                    with vsc.if_then(self.opcode == 3):
+                        self.func3.inside(vsc.rangelist(3, 7))
+                with vsc.else_then():
+                    with vsc.if_then(self.opcode == 35):
+                        self.func3 <= 3
+                    with vsc.if_then(self.opcode == 3):
+                        self.func3 != 7
+                with vsc.if_then(self.opcode == 15):
+                    self.func3.inside(vsc.rangelist(0, 1))
+                with vsc.if_then(self.opcode == 115):
+                    self.func3 != 4
+                with vsc.if_then(self.opcode == 27):
+                    self.func3.inside(vsc.rangelist(0, 1, 5))
+                with vsc.if_then(self.opcode == 59):
+                    self.func3.not_inside(vsc.rangelist(2, 3))
+
+    @vsc.constraint
+    def has_func7_c(self):
+        vsc.solve_order(self.opcode, self.func7)
+        with vsc.if_then((self.opcode == 19) and (self.func3 == 1 or self.func3 == 5) or
+                         (self.opcode == 51 or self.opcode == 59)):
+            self.has_func7 == 1
+        with vsc.else_then():
+            self.has_func7 == 0
+
+    @vsc.constraint
+    def has_func3_c(self):
+        vsc.solve_order(self.opcode, self.func7)
+        with vsc.if_then(self.opcode == 55 or self.opcode == 111 or self.opcode == 23):
+            self.has_func3 == 0
+        with vsc.else_then():
+            self.has_func3 == 1
+
+    @vsc.constraint
+    def illegal_func7_c(self):
+        with vsc.if_then(self.compressed == 0):
+            with vsc.if_then(self.exception == illegal_instr_type_e.kIllegalFunc7):
+                self.func7.not_inside(vsc.rangelist(0, 32, 1))
+                with vsc.if_then(self.opcode == 9):  # SLLI, SRLI, SRAI
+                    self.func7[6:1].not_inside(vsc.rangelist(0, 16))
+            with vsc.else_then():
+                self.func7.inside(vsc.rangelist(0, 32, 1))
+
+    def initialize(self):
+        if (riscv_instr_group_t.RV32F in rcs.supported_isa) or \
+                (riscv_instr_group_t.RV32D in rcs.supported_isa):
+            self.legal_opcode.extend(7, 39, 67, 71, 75, 79, 83)
+        if riscv_instr_group_t.RV64I in rcs.supported_isa:
+            self.legal_opcode.append(27)
+        if riscv_instr_group_t.RV32A in rcs.supported_isa:
+            self.legal_opcode.append(47)
+        if (riscv_instr_group_t.RV64I in rcs.supported_isa) or \
+                (riscv_instr_group_t.RV64M in rcs.supported_isa):
+            self.legal_opcode.append(59)
+        if riscv_instr_group_t.RV64I in rcs.supported_isa:
+            self.legal_c00_opcode.extend(3, 7)
+            self.legal_c10_opcode.extend(3, 7)
+        # TODO csr
+
+    def get_bin_str(self):
+        if self.compressed == 1:
+            local_instr_bin = self.instr_bin & 0xffff
+        else:
+            local_instr_bin = hex(self.instr_bin)
+        logging.info("Illegal instruction type: {}, illegal instruction: {}".format(
+            self.exception.name, local_instr_bin))
+        return ("{}".format(local_instr_bin))
+
+    def post_randomize(self):
+        self.comment = self.exception.name
+        if self.exception == illegal_instr_type_e.kReservedCompressedInstr:
+            self.comment += " {}".format(self.reserved_c.name)
+        elif self.exception == illegal_instr_type_e.kIllegalOpcode:
+            self.comment += " {}".format(self.opcode)

--- a/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_gen_config.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_gen_config.py
@@ -12,15 +12,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 """
 
-import argparse
-import logging
 import sys
+import math
+import logging
+import argparse
 import vsc
 from importlib import import_module
 from pygen_src.riscv_instr_pkg import (mtvec_mode_t, f_rounding_mode_t,
                                        riscv_reg_t, privileged_mode_t,
                                        riscv_instr_group_t, data_pattern_t,
-                                       riscv_instr_category_t, satp_mode_t)
+                                       riscv_instr_category_t, satp_mode_t,
+                                       mem_region_t)
 
 
 @vsc.randobj
@@ -81,19 +83,17 @@ class riscv_instr_gen_config:
         # Commenting out for now
         # vector_cfg = riscv_vector_cfg # TODO
         # pmp_cfg = riscv_pmp_cfg  # TODO
-        self.mem_region = {
-            0: {'name': "region_0", 'size_in_bytes': 4096, 'xwr': 8},
-            1: {'name': "region_1", 'size_in_bytes': 4096 * 16, 'xwr': 8}
-        }
-        self.amo_region = {
-            0: {'name': "amo_0", 'size_in_bytes': 64, 'xwr': 8}
-        }
-        self.stack_len = 5000
-        self.s_mem_region = {
-            0: {'name': "s_region_0", 'size_in_bytes': 4096, 'xwr': 8},
-            1: {'name': "s_region_1", 'size_in_bytes': 4096, 'xwr': 8}
-        }
 
+        self.mem_region = vsc.list_t(mem_region_t())
+        self.amo_region = vsc.list_t(mem_region_t())
+        self.s_mem_region = vsc.list_t(mem_region_t())
+        self.mem_region.extend([mem_region_t(name = "region_0", size_in_bytes = 4096, xwr = 8),
+                                mem_region_t(name = "region_1", size_in_bytes = 4096, xwr = 8)])
+        self.amo_region.extend([mem_region_t(name = "amo_0", size_in_bytes = 64, xwr = 8)])
+        self.s_mem_region.extend([mem_region_t(name = "s_region_0", size_in_bytes = 4096, xwr = 8),
+                                  mem_region_t(name = "s_region_1", size_in_bytes = 4096, xwr = 8)])
+
+        self.stack_len = 5000
         self.kernel_stack_len = 4000
         self.kernel_program_instr_cnt = 400
         # list of main implemented CSRs
@@ -112,7 +112,10 @@ class riscv_instr_gen_config:
         self.enable_unaligned_load_store = self.argv.enable_unaligned_load_store
         self.illegal_instr_ratio = self.argv.illegal_instr_ratio
         self.hint_instr_ratio = self.argv.hint_instr_ratio
-        self.num_of_harts = self.argv.num_of_harts
+        if self.argv.num_of_harts is None:
+            self.num_of_harts = rcs.NUM_HARTS
+        else:
+            self.num_of_harts = self.argv.num_of_harts
         self.fix_sp = self.argv.fix_sp
         self.use_push_data_section = self.argv.use_push_data_section
         self.boot_mode_opts = self.argv.boot_mode
@@ -161,6 +164,7 @@ class riscv_instr_gen_config:
         self.enable_debug_single_step = self.argv.enable_debug_single_step
         self.single_step_iterations = 0
         self.set_mstatus_tw = self.argv.set_mstatus_tw
+        self.set_mstatus_mprv = vsc.bit_t(1)
         self.set_mstatus_mprv = self.argv.set_mstatus_mprv
         self.min_stack_len_per_program = 10 * (rcs.XLEN / 8)
         self.max_stack_len_per_program = 16 * (rcs.XLEN / 8)
@@ -180,6 +184,17 @@ class riscv_instr_gen_config:
             self.disable_compressed_instr = 1
         self.setup_instr_distribution()
         self.get_invalid_priv_lvl_csr()
+        # Helpers fields to build the vsc constraints
+        self.supported_interrupt_mode = vsc.list_t(vsc.enum_t(mtvec_mode_t))
+        self.XLEN = vsc.uint32_t()
+        self.SATP_MODE = vsc.enum_t(satp_mode_t)
+        self.init_privil_mode = vsc.enum_t(privileged_mode_t)
+        self.init_privil_mode = self.init_privileged_mode
+        self.supported_interrupt_mode = rcs.supported_interrupt_mode
+        self.XLEN = rcs.XLEN
+        self.SATP_MODE = rcs.SATP_MODE
+        self.tvec_ceil = vsc.uint32_t()
+        self.tvec_ceil = math.ceil(math.log2((self.XLEN * 4) / 8))
 
     @vsc.constraint
     def default_c(self):
@@ -215,11 +230,11 @@ class riscv_instr_gen_config:
 
     @vsc.constraint
     def mtvec_c(self):
-        self.mtvec_mode.inside(vsc.rangelist(mtvec_mode_t.DIRECT, mtvec_mode_t.VECTORED))
+        self.mtvec_mode.inside(vsc.rangelist(self.supported_interrupt_mode))
         with vsc.if_then(self.mtvec_mode == mtvec_mode_t.DIRECT):
             vsc.soft(self.tvec_alignment == 2)
         with vsc.else_then():
-            vsc.soft(self.tvec_alignment == (rcs.XLEN * 4) // 8)
+            vsc.soft(self.tvec_alignment == self.tvec_ceil)
 
     @vsc.constraint
     def floating_point_c(self):
@@ -230,11 +245,11 @@ class riscv_instr_gen_config:
 
     @vsc.constraint
     def mstatus_c(self):
-        if self.set_mstatus_mprv:
+        with vsc.if_then(self.set_mstatus_mprv == 1):
             self.mstatus_mprv == 1
-        else:
+        with vsc.else_then():
             self.mstatus_mprv == 0
-        if rcs.SATP_MODE == satp_mode_t.BARE:
+        with vsc.if_then(self.SATP_MODE == satp_mode_t.BARE):
             self.mstatus_mxr == 0
             self.mstatus_sum == 0
             self.mstatus_tvm == 0
@@ -400,8 +415,6 @@ class riscv_instr_gen_config:
         parse.add_argument('--illegal_instr_ratio',
                            help = 'illegal_instr_ratio', type = int, default = 0)
         parse.add_argument('--hint_instr_ratio', help = 'hint_instr_ratio', type = int, default = 0)
-        # TODO map it with rcs NUM_HARTS. After solving the cyclic issue for core setting.
-        # rcs is out of scope while using in the default value of num_of_harts
         parse.add_argument('--num_of_harts', help = 'num_of_harts',
                            type = int, default = 1)
         parse.add_argument('--enable_unaligned_load_store',
@@ -463,6 +476,7 @@ class riscv_instr_gen_config:
         parse.add_argument('--log_file_name', help='log file name',
                            default="")
         parse.add_argument('--target', help='target', default="rv32imc")
+        parse.add_argument('--gen_test', help='gen_test', default="riscv_instr_base_test")
         parse.add_argument("--enable_visualization", action="store_true", default=False,
                            help="Enabling coverage report visualization for pyflow")
         parse.add_argument('--trace_csv', help='List of csv traces', default="")

--- a/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_pkg.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_pkg.py
@@ -13,15 +13,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 
 import logging
+import vsc
 from enum import Enum, IntEnum, auto
 from bitstring import BitArray
 from importlib import import_module
 
 
+@vsc.randobj
 class mem_region_t:
-    name = 0
-    size_in_bytes = auto()
-    xwr = auto()
+    def __init__(self, name = "", size_in_bytes=0, xwr=0):
+        self.name = name
+        self.size_in_bytes = vsc.uint32_t(i=size_in_bytes)
+        self.xwr = vsc.uint8_t(i=xwr)
 
 
 class satp_mode_t(IntEnum):

--- a/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_stream.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/riscv_instr_stream.py
@@ -186,7 +186,9 @@ class riscv_rand_instr_stream(riscv_instr_stream):
         self.setup_instruction_dist(no_branch, no_load_store)
 
     def randomize_avail_regs(self):
-        if self.avail_regs.size > 0:
+        pass
+        # TODO
+        '''if self.avail_regs.size > 0:
             try:
                 with vsc.randomize_with(self.avail_regs):
                     vsc.unique(self.avail_regs)
@@ -197,7 +199,7 @@ class riscv_rand_instr_stream(riscv_instr_stream):
                                                       self.reserved_rd))
             except Exception:
                 logging.critical("Cannot randomize avail_regs")
-                sys.exit(1)
+                sys.exit(1)'''
 
     def setup_instruction_dist(self, no_branch = 0, no_load_store = 1):
         if cfg.dist_control_mode:

--- a/vendor/google_riscv-dv/pygen/pygen_src/riscv_load_store_instr_lib.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/riscv_load_store_instr_lib.py
@@ -1,0 +1,293 @@
+
+"""
+Copyright 2020 Google LLC
+Copyright 2020 PerfectVIPs Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+"""
+
+import sys
+import random
+import logging
+import vsc
+from enum import IntEnum, auto
+from importlib import import_module
+from pygen_src.riscv_instr_gen_config import cfg
+from pygen_src.isa.riscv_instr import riscv_instr
+from pygen_src.riscv_directed_instr_lib import riscv_mem_access_stream
+from pygen_src.riscv_instr_pkg import riscv_reg_t, riscv_instr_name_t, riscv_instr_group_t
+rcs = import_module("pygen_src.target." + cfg.argv.target + ".riscv_core_setting")
+
+
+class locality_e(IntEnum):
+    NARROW = 0
+    HIGH = auto()
+    MEDIUM = auto()
+    SPARSE = auto()
+
+
+@vsc.randobj
+class riscv_load_store_base_instr_stream(riscv_mem_access_stream):
+    def __init__(self):
+        super().__init__()
+        self.num_load_store = vsc.rand_uint32_t()
+        self.num_mixed_instr = vsc.rand_uint32_t()
+        self.base = vsc.rand_int32_t()
+        self.offset = []
+        self.addr = []
+        self.load_store_instr = []
+        self.data_page_id = vsc.rand_uint32_t()
+        self.rs1_reg = vsc.rand_enum_t(riscv_reg_t)
+        self.locality = vsc.rand_enum_t(locality_e)
+        self.max_load_store_offset = vsc.rand_int32_t()
+        self.use_sp_as_rs1 = vsc.rand_bit_t()
+
+    @vsc.constraint
+    def sp_rnd_order_c(self):
+        vsc.solve_order(self.use_sp_as_rs1, self.rs1_reg)
+
+    @vsc.constraint
+    def sp_c(self):
+        vsc.dist(self.use_sp_as_rs1, [vsc.weight(1, 1), vsc.weight(0, 2)])
+        with vsc.if_then(self.use_sp_as_rs1 == 1):
+            self.rs1_reg == riscv_reg_t.SP
+
+    # TODO Getting pyvsc error -- > rs1 has not been build yet
+    '''@vsc.constraint
+    def rs1_c(self):
+        self.rs1_reg.not_inside(vsc.rangelist(cfg.reserved_regs,
+                                              self.reserved_rd, riscv_reg_t.ZERO))'''
+
+    @vsc.constraint
+    def addr_c(self):
+        # TODO solve_order
+        # vsc.solve_order(self.data_page_id, self.max_load_store_offset)
+        # vsc.solve_order(self.max_load_store_offset, self.base)
+        self.data_page_id < self.max_data_page_id
+        with vsc.foreach(self.data_page, idx = True) as i:
+            with vsc.if_then(i == self.data_page_id):
+                self.max_load_store_offset == self.data_page[i].size_in_bytes
+        self.base in vsc.rangelist(vsc.rng(0, self.max_load_store_offset - 1))
+
+    def randomize_offset(self):
+        addr_ = vsc.rand_int32_t()
+        offset_ = vsc.rand_int32_t()
+        self.offset = [0] * self.num_load_store
+        self.addr = [0] * self.num_load_store
+        for i in range(self.num_load_store):
+            try:
+                if self.locality == locality_e.NARROW:
+                    offset_ = random.randrange(-16, 16)
+                elif self.locality == locality_e.HIGH:
+                    offset_ = random.randrange(-64, 64)
+                elif self.locality == locality_e.MEDIUM:
+                    offset_ = random.randrange(-256, 256)
+                elif self.locality == locality_e.SPARSE:
+                    offset_ = random.randrange(-2048, 2047)
+                var1 = self.base + offset_ - 1
+                var2 = self.base + offset_ + 1
+                addr_ = random.randrange(var1, var2)
+            except Exception:
+                logging.critical("Cannot randomize load/store offset")
+                sys.exit(1)
+            self.offset[i] = offset_
+            self.addr[i] = addr_
+
+    def pre_randomize(self):
+        super().pre_randomize()
+        if(riscv_reg_t.SP in [cfg.reserved_regs, self.reserved_rd]):
+            self.use_sp_as_rs1 = 0
+            with vsc.raw_mode():
+                self.use_sp_as_rs1.rand_mode = False
+            self.sp_rnd_order_c.constraint_mode(False)
+
+    def post_randomize(self):
+        self.randomize_offset()
+        # rs1 cannot be modified by other instructions
+        if not(self.rs1_reg in self.reserved_rd):
+            self.reserved_rd.append(self.rs1_reg)
+        self.gen_load_store_instr()
+        self.add_mixed_instr(self.num_mixed_instr)
+        self.add_rs1_init_la_instr(self.rs1_reg, self.data_page_id, self.base)
+        super().post_randomize()
+
+    # Generate each load/store instruction
+    def gen_load_store_instr(self):
+        allowed_instr = []
+        enable_compressed_load_store = 0
+        self.randomize_avail_regs()
+        if ((self.rs1_reg in [riscv_reg_t.S0, riscv_reg_t.S1, riscv_reg_t.A0, riscv_reg_t.A1,
+                              riscv_reg_t.A2, riscv_reg_t.A3, riscv_reg_t.A4, riscv_reg_t.A5,
+                              riscv_reg_t.SP]) and not(cfg.disable_compressed_instr)):
+            enable_compressed_load_store = 1
+        for i in range(len(self.addr)):
+            # Assign the allowed load/store instructions based on address alignment
+            # This is done separately rather than a constraint to improve the randomization
+            # performance
+            allowed_instr.extend(
+                [riscv_instr_name_t.LB, riscv_instr_name_t.LBU, riscv_instr_name_t.SB])
+            if not cfg.enable_unaligned_load_store:
+                if (self.addr[i] & 1) == 0:
+                    allowed_instr.extend(
+                        [riscv_instr_name_t.LH, riscv_instr_name_t.LHU, riscv_instr_name_t.SH])
+                if self.addr[i] % 4 == 0:
+                    allowed_instr.extend([riscv_instr_name_t.LW, riscv_instr_name_t.SW])
+                    if cfg.enable_floating_point:
+                        allowed_instr.extend([riscv_instr_name_t.FLW,
+                                              riscv_instr_name_t.FSW])
+                    if ((self.offset[i] in range(128)) and (self.offset[i] % 4 == 0) and
+                        (riscv_instr_group_t.RV32C in rcs.supported_isa) and
+                            (enable_compressed_load_store)):
+                        if self.rs1_reg == riscv_reg_t.SP:
+                            logging.info("Add LWSP/SWSP to allowed instr")
+                            allowed_instr.extend(
+                                [riscv_instr_name_t.C_LWSP, riscv_instr_name_t.C_SWSP])
+                        else:
+                            allowed_instr.extend(
+                                [riscv_instr_name_t.C_LW, riscv_instr_name_t.C_SW])
+                            if (cfg.enable_floating_point and
+                                    riscv_instr_group_t.RV32FC in rcs.supported_isa):
+                                allowed_instr.extend(
+                                    [riscv_instr_name_t.C_FLW, riscv_instr_name_t.C_FSW])
+                if (rcs.XLEN >= 64) and (self.addr[i] % 8 == 0):
+                    allowed_instr.extend([riscv_instr_name_t.LWU,
+                                          riscv_instr_name_t.LD,
+                                          riscv_instr_name_t.SD])
+                    if (cfg.enable_floating_point and
+                            (riscv_instr_group_t.RV32D in rcs.supported_isa)):
+                        allowed_instr.extend([riscv_instr_name_t.FLD,
+                                              riscv_instr_name_t.FSD])
+                    if (self.offset[i] in range(256) and (self.offset[i] % 8 == 0) and
+                        (riscv_instr_group_t.RV64C in rcs.supported_isa) and
+                            enable_compressed_load_store):
+                        if self.rs1_reg == riscv_reg_t.SP:
+                            allowed_instr.extend(
+                                [riscv_instr_name_t.C_LDSP, riscv_instr_name_t.C_SDSP])
+                        else:
+                            allowed_instr.extend(
+                                [riscv_instr_name_t.C_LD, riscv_instr_name_t.C_SD])
+                            if (cfg.enable_floating_point and
+                                    (riscv_instr_group_t.RV32DC in rcs.supported_isa)):
+                                allowed_instr.extend(
+                                    [riscv_instr_name_t.C_FLD, riscv_instr_name_t.C_FSD])
+                else:  # unalligned load/store
+                    allowed_instr.extend([riscv_instr_name_t.LW, riscv_instr_name_t.SW,
+                                          riscv_instr_name_t.LH, riscv_instr_name_t.LHU,
+                                          riscv_instr_name_t.SH])
+                    # Compressed load/store still needs to be alligned
+                    if (self.offset[i] in range(128) and (self.offset[i] % 4 == 0) and
+                        (riscv_instr_group_t.RV32C in rcs.supported_isa) and
+                            enable_compressed_load_store):
+                        if self.rs1_reg == riscv_reg_t.SP:
+                            allowed_instr.extend(
+                                [riscv_instr_name_t.C_LWSP, riscv_instr_name_t.C_SWSP])
+                        else:
+                            allowed_instr.extend(
+                                [riscv_instr_name_t.C_LW, riscv_instr_name_t.C_SW])
+                    if rcs.XLEN >= 64:
+                        allowed_instr.extend(
+                            [riscv_instr_name_t.LWU, riscv_instr_name_t.LD, riscv_instr_name_t.SD])
+                        if (self.offset[i] in range(256) and (self.offset[i] % 8 == 0) and
+                            (riscv_instr_group_t.RV64C in rcs.supported_isa) and
+                                enable_compressed_load_store):
+                            if self.rs1_reg == riscv_reg_t.SP:
+                                allowed_instr.extend(
+                                    [riscv_instr_name_t.C_LWSP, riscv_instr_name_t.C_SWSP])
+                            else:
+                                allowed_instr.extend(
+                                    [riscv_instr_name_t.C_LD, riscv_instr_name_t.C_SD])
+            instr = riscv_instr.get_load_store_instr(allowed_instr)
+            instr.has_rs1 = 0
+            instr.has_imm = 0
+            self.randomize_gpr(instr)
+            instr.rs1 = self.rs1_reg
+            instr.imm_str = str(instr.uintToInt(self.offset[i]))
+            instr.process_load_store = 0
+            self.instr_list.append(instr)
+            self.load_store_instr.append(instr)
+
+
+@vsc.randobj
+class riscv_single_load_store_instr_stream(riscv_load_store_base_instr_stream):
+    def __init__(self):
+        super().__init__()
+
+    @vsc.constraint
+    def legal_c(self):
+        self.num_load_store == 1
+        self.num_mixed_instr < 5
+
+
+@vsc.randobj
+class riscv_load_store_stress_instr_stream(riscv_load_store_base_instr_stream):
+    def __init__(self):
+        super().__init__()
+        self.max_instr_cnt = 30
+        self.min_instr_cnt = 10
+
+    @vsc.constraint
+    def legal_c(self):
+        self.num_load_store.inside(vsc.rangelist(vsc.rng(self.min_instr_cnt, self.max_instr_cnt)))
+        self.num_mixed_instr == 0
+
+
+@vsc.randobj
+class riscv_load_store_rand_instr_stream(riscv_load_store_base_instr_stream):
+    def __init__(self):
+        super().__init__()
+
+    @vsc.constraint
+    def legal_c(self):
+        self.num_load_store.inside(vsc.rangelist(vsc.rng(10, 30)))
+        self.num_mixed_instr.inside(vsc.rangelist(vsc.rng(10, 30)))
+
+
+@vsc.randobj
+class riscv_load_store_hazard_instr_stream(riscv_load_store_base_instr_stream):
+    def __init__(self):
+        super().__init__()
+        self.hazard_ratio = vsc.rand_int32_t()
+
+    @vsc.constraint
+    def hazard_ratio_c(self):
+        self.hazard_ratio.inside(vsc.rangelist(vsc.rng(20, 100)))
+
+    @vsc.constraint
+    def legal_c(self):
+        self.num_load_store.inside(vsc.rangelist(vsc.rng(10, 20)))
+        self.num_mixed_instr.inside(vsc.rangelist(vsc.rng(1, 7)))
+
+    def randomize_offset(self):
+        addr_ = vsc.rand_int32_t()
+        offset_ = vsc.rand_int32_t()
+        self.offset = [0] * self.num_load_store
+        self.addr = [0] * self.num_load_store
+        rand_num = random.randrange(0, 100)
+        for i in range(self.num_load_store):
+            if (i > 0) and (rand_num < self.hazard_ratio):
+                self.offset[i] = self.offset[i - 1]
+                self.addr[i] = self.addr[i - 1]
+            else:
+                try:
+                    if self.locality == locality_e.NARROW:
+                        offset_ = random.randrange(-16, 16)
+                    elif self.locality == locality_e.HIGH:
+                        offset_ = random.randrange(-64, 64)
+                    elif self.locality == locality_e.MEDIUM:
+                        offset_ = random.randrange(-256, 256)
+                    elif self.locality == locality_e.SPARSE:
+                        offset_ = random.randrange(-2048, 2047)
+                    var1 = self.base + offset_ - 1
+                    var2 = self.base + offset_ + 1
+                    addr_ = random.randrange(var1, var2)
+                except Exception:
+                    logging.critical("Cannot randomize load/store offset")
+                    sys.exit(1)
+                self.offset[i] = offset_
+                self.addr[i] = addr_

--- a/vendor/google_riscv-dv/pygen/pygen_src/riscv_signature_pkg.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/riscv_signature_pkg.py
@@ -1,0 +1,62 @@
+"""
+Copyright 2020 Google LLC
+Copyright 2020 PerfectVIPs Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+"""
+
+from enum import IntEnum, auto
+
+# Will be the lowest 8 bits of the data word
+
+
+class signature_type_t(IntEnum):
+    '''
+    Information sent to the core relating its current status.
+    Bits [12:8] of the data word will be the core_status_t value
+    corresponding to the current core status.
+    '''
+    CORE_STATUS = 0
+    '''
+    Information sent to the core conveying the uvm simulation result.
+    Bit [8] of the data word will be the test_result_t value.
+    '''
+    TEST_RESULT = auto()
+    '''
+    Sent to the core to indicate a dump of GPRs to testbench.
+    Will be followed by 32 writes of registers x0-x32.
+    '''
+    WRITE_GPR = auto()
+    '''
+    Sent to the core to indicate a write of a CSR's data.
+    Bits [19:8] of the data word will be the CSR address.
+    Will be followed by a second write of the actual data from the CSR.
+    '''
+    WRITE_CSR = auto()
+
+
+class core_status_t(IntEnum):
+    INITIALIZED = 0
+    IN_DEBUG_MODE = auto()
+    IN_MACHINE_MODE = auto()
+    IN_HYPERVISOR_MODE = auto()
+    IN_SUPERVISOR_MODE = auto()
+    IN_USER_MODE = auto()
+    HANDLING_IRQ = auto()
+    FINISHED_IRQ = auto()
+    HANDLING_EXCEPTION = auto()
+    INSTR_FAULT_EXCEPTION = auto()
+    ILLEGAL_INSTR_EXCEPTION = auto()
+    LOAD_FAULT_EXCEPTION = auto()
+    STORE_FAULT_EXCEPTION = auto()
+    EBREAK_EXCEPTION = auto()
+
+
+class test_result_t(IntEnum):
+    TEST_PASS = 0
+    TEST_FAIL = auto()

--- a/vendor/google_riscv-dv/pygen/pygen_src/riscv_utils.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/riscv_utils.py
@@ -20,6 +20,10 @@ from pygen_src.riscv_directed_instr_lib import (riscv_directed_instr_stream,
                                                 riscv_int_numeric_corner_stream,
                                                 riscv_jal_instr, riscv_mem_access_stream)
 from pygen_src.riscv_amo_instr_lib import (riscv_lr_sc_instr_stream, riscv_amo_instr_stream)
+from pygen_src.riscv_load_store_instr_lib import (riscv_load_store_rand_instr_stream,
+                                                  riscv_load_store_hazard_instr_stream,
+                                                  riscv_load_store_stress_instr_stream,
+                                                  riscv_single_load_store_instr_stream)
 
 
 def factory(obj_of):
@@ -29,7 +33,11 @@ def factory(obj_of):
         "riscv_jal_instr": riscv_jal_instr,
         "riscv_mem_access_stream": riscv_mem_access_stream,
         "riscv_lr_sc_instr_stream": riscv_lr_sc_instr_stream,
-        "riscv_amo_instr_stream": riscv_amo_instr_stream
+        "riscv_amo_instr_stream": riscv_amo_instr_stream,
+        "riscv_load_store_rand_instr_stream": riscv_load_store_rand_instr_stream,
+        "riscv_load_store_hazard_instr_stream": riscv_load_store_hazard_instr_stream,
+        "riscv_load_store_stress_instr_stream": riscv_load_store_stress_instr_stream,
+        "riscv_single_load_store_instr_stream": riscv_single_load_store_instr_stream
     }
 
     try:

--- a/vendor/google_riscv-dv/pygen/pygen_src/target/multi_harts/riscvOVPsim.ic
+++ b/vendor/google_riscv-dv/pygen/pygen_src/target/multi_harts/riscvOVPsim.ic
@@ -1,0 +1,22 @@
+# riscOVPsim configuration file converted from YAML
+--variant RV32I
+--override riscvOVPsim/cpu/add_Extensions=MCA
+--override riscvOVPsim/cpu/misa_MXL=1
+--override riscvOVPsim/cpu/misa_MXL_mask=0x0 # 0
+--override riscvOVPsim/cpu/misa_Extensions_mask=0x0 # 0
+--override riscvOVPsim/cpu/unaligned=T
+--override riscvOVPsim/cpu/mtvec_mask=0x0 # 0
+--override riscvOVPsim/cpu/user_version=2.3
+--override riscvOVPsim/cpu/priv_version=1.11
+--override riscvOVPsim/cpu/mvendorid=0
+--override riscvOVPsim/cpu/marchid=0
+--override riscvOVPsim/cpu/mimpid=0
+--override riscvOVPsim/cpu/mhartid=0
+--override riscvOVPsim/cpu/cycle_undefined=F
+--override riscvOVPsim/cpu/instret_undefined=F
+--override riscvOVPsim/cpu/time_undefined=T
+--override riscvOVPsim/cpu/reset_address=0x80000000
+--override riscvOVPsim/cpu/simulateexceptions=T
+--override riscvOVPsim/cpu/defaultsemihost=F
+--override riscvOVPsim/cpu/wfi_is_nop=T
+--exitonsymbol _exit

--- a/vendor/google_riscv-dv/pygen/pygen_src/target/multi_harts/riscv_core_setting.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/target/multi_harts/riscv_core_setting.py
@@ -1,0 +1,83 @@
+"""
+Copyright 2020 Google LLC
+Copyright 2020 PerfectVIPs Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+"""
+from pygen_src.riscv_instr_pkg import (privileged_reg_t, interrupt_cause_t,
+                                       exception_cause_t, satp_mode_t,
+                                       riscv_instr_group_t, privileged_mode_t,
+                                       mtvec_mode_t)
+
+
+
+
+
+XLEN = 32
+
+implemented_csr = [privileged_reg_t.MVENDORID, privileged_reg_t.MARCHID,
+                   privileged_reg_t.MIMPID, privileged_reg_t.MHARTID,
+                   privileged_reg_t.MSTATUS, privileged_reg_t.MISA, privileged_reg_t.MIE,
+                   privileged_reg_t.MTVEC, privileged_reg_t.MCOUNTEREN, privileged_reg_t.MSCRATCH,
+                   privileged_reg_t.MEPC, privileged_reg_t.MCAUSE,
+                   privileged_reg_t.MTVAL, privileged_reg_t.MIP]
+
+SATP_MODE = satp_mode_t.BARE
+
+supported_isa = [riscv_instr_group_t.RV32I, riscv_instr_group_t.RV32M,
+                 riscv_instr_group_t.RV32C, riscv_instr_group_t.RV32A]
+
+supported_privileged_mode = [privileged_mode_t.MACHINE_MODE]
+
+supported_interrupt_mode = [mtvec_mode_t.DIRECT, mtvec_mode_t.VECTORED]
+
+max_interrupt_vector_num = 16
+
+support_debug_mode = 0
+
+NUM_HARTS = 2
+
+support_pmp = 0
+
+unsupported_instr = []
+
+support_umode_trap = 0
+
+support_sfence = 0
+
+support_unaligned_load_store = 1
+
+NUM_FLOAT_GPR = 32
+
+NUM_GPR = 32
+
+NUM_VEC_GPR = 32
+
+VECTOR_EXTENSION_ENABLE = 0
+
+VLEN = 512
+
+ELEN = 32
+
+SELEN = 8
+
+#VELEN = 
+
+MAX_MUL = 8
+
+implemented_interrupt = [interrupt_cause_t.M_SOFTWARE_INTR,
+                         interrupt_cause_t.M_TIMER_INTR,
+                         interrupt_cause_t.M_EXTERNAL_INTR]
+
+implemented_exception = [exception_cause_t.INSTRUCTION_ACCESS_FAULT,
+                         exception_cause_t.ILLEGAL_INSTRUCTION,
+                         exception_cause_t.BREAKPOINT,
+                         exception_cause_t.LOAD_ADDRESS_MISALIGNED,
+                         exception_cause_t.LOAD_ACCESS_FAULT,
+                         exception_cause_t.ECALL_MMODE]

--- a/vendor/google_riscv-dv/pygen/pygen_src/target/rv32i/riscv_core_setting.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/target/rv32i/riscv_core_setting.py
@@ -32,6 +32,8 @@ NUM_HARTS = 1
 
 support_pmp = 0
 
+support_debug_mode = 0
+
 unsupported_instr = []
 
 support_umode_trap = 0
@@ -40,3 +42,5 @@ support_umode_trap = 0
 NUM_FLOAT_GPR = 32
 NUM_GPR = 32
 NUM_VEC_GPR = 32
+
+max_interrupt_vector_num = 16

--- a/vendor/google_riscv-dv/pygen/pygen_src/test/riscv_instr_base_test.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/test/riscv_instr_base_test.py
@@ -12,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import sys
 import logging
+import time
+import multiprocessing
 sys.path.append("pygen/")
 from pygen_src.riscv_instr_pkg import *
 from pygen_src.riscv_instr_gen_config import cfg  # NOQA
@@ -28,19 +30,22 @@ class riscv_instr_base_test:
         self.asm_file_name = cfg.argv.asm_file_name
         self.asm = ""
 
-    def run_phase(self):
-        for _ in range(cfg.num_of_tests):
-            self.randomize_cfg()
-            self.asm = riscv_asm_program_gen()
-            riscv_instr.create_instr_list(cfg)
-            if cfg.asm_test_suffix != "":
-                self.asm_file_name = "{}.{}".format(self.asm_file_name,
-                                                    cfg.asm_test_suffix)
-            test_name = "{}_{}.S".format(self.asm_file_name,
-                                         _ + self.start_idx)
-            self.asm.get_directed_instr_stream()
-            self.asm.gen_program()
-            self.asm.gen_test_file(test_name)
+    def run(self):
+        with multiprocessing.Pool(processes = cfg.num_of_tests) as pool:
+            pool.map(self.run_phase, list(range(cfg.num_of_tests)))
+
+    def run_phase(self, num):
+        self.randomize_cfg()
+        self.asm = riscv_asm_program_gen()
+        riscv_instr.create_instr_list(cfg)
+        if cfg.asm_test_suffix != "":
+            self.asm_file_name = "{}.{}".format(self.asm_file_name,
+                                                cfg.asm_test_suffix)
+        test_name = "{}_{}.S".format(self.asm_file_name,
+                                     num + self.start_idx)
+        self.asm.get_directed_instr_stream()
+        self.asm.gen_program()
+        self.asm.gen_test_file(test_name)
 
     def randomize_cfg(self):
         cfg.randomize()
@@ -48,5 +53,9 @@ class riscv_instr_base_test:
         gen_config_table()
 
 
+start_time = time.time()
 riscv_base_test_ins = riscv_instr_base_test()
-riscv_base_test_ins.run_phase()
+if cfg.argv.gen_test == "riscv_instr_base_test":
+    riscv_base_test_ins.run()
+    end_time = time.time()
+    logging.info("Total execution time: {}s".format(round(end_time - start_time)))

--- a/vendor/google_riscv-dv/pygen/pygen_src/test/riscv_rand_instr_test.py
+++ b/vendor/google_riscv-dv/pygen/pygen_src/test/riscv_rand_instr_test.py
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 
 import sys
+import time
 import logging
 sys.path.append("pygen/")
 from pygen_src.test.riscv_instr_base_test import riscv_instr_base_test
@@ -39,4 +40,8 @@ class riscv_rand_instr_test(riscv_instr_base_test):
         self.asm.add_directed_instr_stream("riscv_mem_region_stress_test", 4)
 
 
+start_time = time.time()
 riscv_rand_test_ins = riscv_rand_instr_test()
+riscv_rand_test_ins.run()
+end_time = time.time()
+logging.info("Total execution time: {}s".format(round(end_time - start_time)))

--- a/vendor/google_riscv-dv/run.py
+++ b/vendor/google_riscv-dv/run.py
@@ -302,7 +302,8 @@ def do_simulate(sim_cmd, simulator, test_list, cwd, sim_opts, seed_gen,
                               (" --log_file_name={}/sim_{}_{}{}.log ".format(
                                   output_dir,
                                   test['test'], i, log_suffix)) + \
-                              (" --target=%s " % (target))
+                              (" --target=%s " % (target)) + \
+                              (" --gen_test=%s " % (test['gen_test']))
                     else:
                         cmd = lsf_cmd + " " + sim_cmd.rstrip() + \
                               (" +UVM_TESTNAME={} ".format(test['gen_test'])) + \

--- a/vendor/google_riscv-dv/scripts/genMetricsList.py
+++ b/vendor/google_riscv-dv/scripts/genMetricsList.py
@@ -20,7 +20,7 @@
 
 import json
 
-runCmdBase = "cd /mux-flow/results; python3 <rootDir>/run.py --test TESTNAME --simulator dsim --iss ovpsim --seed <seed> --so --out <rootDir>/out --verbose; <rootDir>/scripts/check-status $?; rm -fr <rootDir>/out/dsim"
+runCmdBase = "cd /mux-flow/results; python3 <rootDir>/run.py --test TESTNAME --simulator dsim --iss spike --seed <seed> --so --out <rootDir>/out --verbose; <rootDir>/scripts/check-status $?; rm -fr <rootDir>/out/dsim"
 
 ## Based on testlist located in <rootDir>/yaml/base_testlist.yaml
 base_testList = ["riscv_arithmetic_basic_test",

--- a/vendor/google_riscv-dv/src/riscv_illegal_instr.sv
+++ b/vendor/google_riscv-dv/src/riscv_illegal_instr.sv
@@ -96,6 +96,10 @@ class riscv_illegal_instr extends uvm_object;
       kHintInstr               := 3,
       kIllegalSystemInstr      := 3
     };
+    if (!(RV32C inside {supported_isa})) {
+      exception != kHintInstr;
+      compressed == 1'b0;
+    }
   }
 
   constraint instr_bit_assignment_c {

--- a/vendor/google_riscv-dv/test/riscv_instr_cov_test.sv
+++ b/vendor/google_riscv-dv/test/riscv_instr_cov_test.sv
@@ -130,9 +130,9 @@ class riscv_instr_cov_test extends uvm_test;
       if (riscv_instr::instr_template.exists(instr_name)) begin
         riscv_instr instr;
         instr = riscv_instr::get_instr(instr_name);
-        if (instr.group inside {RV32I, RV32M, RV32C, RV64I, RV64M, RV64C,
-                                RV32F, RV64F, RV32D, RV64D,
-                                RV32B, RV64B}) begin
+        if ((instr.group inside {RV32I, RV32M, RV32C, RV64I, RV64M, RV64C,
+                                 RV32F, RV64F, RV32D, RV64D, RV32B, RV64B}) &&
+            (instr.group inside {supported_isa})) begin
           assign_trace_info_to_instr(instr);
           instr.pre_sample();
           instr_cg.sample(instr);

--- a/vendor/google_riscv-dv/yaml/iss.yaml
+++ b/vendor/google_riscv-dv/yaml/iss.yaml
@@ -20,7 +20,7 @@
 - iss: ovpsim
   path_var: OVPSIM_PATH
   cmd: >
-    <path_var>/riscvOVPsim.exe
+    <path_var>/riscvOVPsimPlus.exe
     --controlfile <cfg_path>/riscvOVPsim.ic
     --objfilenoentry <elf>
     --override riscvOVPsim/cpu/simulateexceptions=T

--- a/vendor/google_riscv-dv/yaml/simulator.yaml
+++ b/vendor/google_riscv-dv/yaml/simulator.yaml
@@ -57,7 +57,6 @@
       - "vlog -64
         +incdir+<setting>
         +incdir+<user_extension>
-        -access=rwc
         -f <cwd>/files.f
         -sv
         -mfcu -cuname design_cuname


### PR DESCRIPTION
This updates the vendored riscv-dv, which should fix up the part of https://github.com/lowRISC/ibex/pull/1284 that we don't want to patch locally. Once this is merged, we can rebase that PR and hopefully that will be good to go.

Update code from upstream repository https://github.com/google/riscv-
dv to revision 59dcd8c813484eb6dcca67e7e36089fe772b9cc8

* Update scripts for Metrics CI regression:  bug fixes, change ISS to
  spike in CI regression (Aimee Sutton)
* Add illegal and load store instruction (aneels3)
* Avoid generating hint instruction when RV32C is turned off
  (google/riscv-dv#787) (taoliug)
* Fix illegal opcode issue in the cov_test (google/riscv-dv#786)
  (taoliug)
* [questa] Remove -access=rwc from vlog command line arguments (Rupert
  Swarbrick)
* [ci] temporarily disable CI flow (Udi Jonnalagadda)
* fix issue with rcs for num_of_harts (aneels3)
* fix multi-hart label issue (aneels3)
* add multi_hart test (ishita71)
* Fix minor issues (aneels3)
* Add riscv_signature_pkg (aneels3)
* add gen_signature_handshake (ishita71)
* Add gen_interrupt_vector_table (aneels3)
* Remove the unnecessary lines (Anil Sharma)
* fix issue with riscv_rand_instr_test (aneels3)
* Add multiprocessing code block (aneels3)

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>