### PR TITLE
[rtl] Add SVA to ensure valid_i in compressed decoder is known

### DIFF
--- a/rtl/ibex_compressed_decoder.sv
+++ b/rtl/ibex_compressed_decoder.sv
@@ -282,6 +282,9 @@ module ibex_compressed_decoder (
   // Assertions //
   ////////////////
 
+  // The valid_i signal used to gate below assertions must be known.
+  `ASSERT_KNOWN(IbexInstrValidKnown, valid_i)
+
   // Selectors must be known/valid.
   `ASSERT(IbexInstrLSBsKnown, valid_i |->
       !$isunknown(instr_i[1:0]))


### PR DESCRIPTION
This signal is used to gate several assertions related to unknown/invalid selector signals. We want to be sure to catch any X
values entering the compressed decoder and ultimately ID.

This is related to lowRISC/Ibex#540.