### PR TITLE
[dv] Don't kill regression on sim error

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/ibex_log_to_trace_csv.py
+++ b/dv/uvm/core_ibex/riscv_dv_extension/ibex_log_to_trace_csv.py
@@ -205,7 +205,7 @@ def check_ibex_uvm_log(uvm_log):
         test_result_seen = False
 
         for line in log:
-            if ('UVM_ERROR' in line or 'UVM_FATAL' in line) \
+            if ('UVM_ERROR' in line or 'UVM_FATAL' in line or 'Error' in line) \
                     and not test_result_seen:
                 log_out.append(line)
                 failed = True

--- a/dv/uvm/core_ibex/sim.py
+++ b/dv/uvm/core_ibex/sim.py
@@ -367,7 +367,8 @@ def run_sim_commands(command_list, use_lsf):
         for desc, cmd, dirname in command_list:
             os.makedirs(dirname, exist_ok=True)
             cmds.append(cmd)
-        run_parallel_cmd(cmds, 600, check_return_code=True)
+        run_parallel_cmd(cmds, timeout_s=600, exit_on_error=0,
+                         check_return_code=True)
         return
 
     # We're not in LSF mode, so we'll create the output directories as we go.
@@ -376,7 +377,8 @@ def run_sim_commands(command_list, use_lsf):
     for desc, cmd, dirname in command_list:
         os.makedirs(dirname, exist_ok=True)
         logging.info("Running " + desc)
-        run_cmd(cmd, 600, check_return_code=True)
+        run_cmd(cmd, timeout_s=600, exit_on_error=0,
+                check_return_code=True)
 
 
 def rtl_sim(sim_cmd, test_list, seed_gen, opts,


### PR DESCRIPTION
When the simulator terminates with an error code that is reported as a
test failure and the regression continues. Previously it would kill the
whole regression.