### PR TITLE
[dv] Remove MISA from csr_description.yaml

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/csr_description.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/csr_description.yaml
@@ -39,27 +39,29 @@
 #      - ...
 
 
+# TODO: Enable multiple configurations for CSR test. MISA read value will depend
+# on whether B and M are available. https://github.com/lowRISC/ibex/issues/1333
 # Ibex MISA CSR
-- csr: misa
-  description: >
-    Machine ISA Register
-  address: 0x301
-  privilege_mode: M
-  rv32:
-    - field_name: MXL
-      description: >
-        Encodes native base ISA width
-      type: R
-      reset_val: 1
-      msb: 31
-      lsb: 30
-    - field_name: Extensions
-      description: >
-          Encodes all supported ISA extensions
-      type: R
-      reset_val: 0x101106
-      msb: 25
-      lsb: 0
+#- csr: misa
+#  description: >
+#    Machine ISA Register
+#  address: 0x301
+#  privilege_mode: M
+#  rv32:
+#    - field_name: MXL
+#      description: >
+#        Encodes native base ISA width
+#      type: R
+#      reset_val: 1
+#      msb: 31
+#      lsb: 30
+#    - field_name: Extensions
+#      description: >
+#          Encodes all supported ISA extensions
+#      type: R
+#      reset_val: 0x101106
+#      msb: 25
+#      lsb: 0
 
 # Ibex's implementation of MHARTID is read-only
 # MHARTID


### PR DESCRIPTION
The value of `misa` will change depending on whether M or B are enabled.
The presence and read values of other CSRs may also depend upon the Ibex
configuration. A fix is required to allow riscv_csr_test to deal with
different CSR descriptions for different Ibex configurations. For now
just comment out `misa` from the descriptions file to enable
riscv_csr_test to run on a wider range of configurations.