### PR TITLE
Fix a couple of synthesis bugs

### DIFF
--- a/rtl/ibex_top.sv
+++ b/rtl/ibex_top.sv
@@ -7,6 +7,8 @@
   `define RVFI
 `endif
 
+`include "prim_assert.sv"
+
 /**
  * Top level module of the ibex RISC-V core
  */

--- a/syn/tcl/yosys_run_synth.tcl
+++ b/syn/tcl/yosys_run_synth.tcl
@@ -33,10 +33,10 @@ yosys "chparam -set RegFile $lr_synth_ibex_regfile $lr_synth_top_module"
 yosys "synth $flatten_opt -top $lr_synth_top_module"
 yosys "opt -purge"
 
+yosys "write_verilog $lr_synth_pre_map_out"
+
 # Map latch primitives onto latch cells
 yosys "techmap -map rtl/latch_map.v"
-
-yosys "write_verilog $lr_synth_pre_map_out"
 
 yosys "dfflibmap -liberty $lr_synth_cell_library_path"
 yosys "opt"


### PR DESCRIPTION
1. Missing prim_assert in ibex_top.sv (more of an rtl bug but only found
in running synthesis scripts)
2. Write out the pre-mapped netlist before mapping latches

Relates to #1335

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>