### PR TITLE
Add cast to enum

### DIFF
--- a/dv/uvm/core_ibex/fcov/core_ibex_fcov_if.sv
+++ b/dv/uvm/core_ibex/fcov/core_ibex_fcov_if.sv
@@ -214,7 +214,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; (
     if (!rst_ni) begin
       // First cycle out of reset there is no last stall, use valid bit to deal with this case
       id_stall_type_last_valid <= 1'b0;
-      id_stall_type_last       <= 1'b0;
+      id_stall_type_last       <= IdStallTypeNone;
       instr_unstalled_last     <= 1'b0;
       id_instr_category_last   <= InstrCategoryNone;
     end else begin


### PR DESCRIPTION
Hey!
In this PR I added cast to enum, because we can't assign non-enum to enum LRM 6.19.3

Signed-off-by: Dawid Zimonczyk <dawidz@aldec.com.pl>