### PR TITLE
[rtl] Wire scan_rst_ni through ibex_top_tracing

### DIFF
--- a/doc/02_user/integration.rst
+++ b/doc/02_user/integration.rst
@@ -165,7 +165,7 @@ Interfaces
 |                         |                         |     | test control of reset.                 |
 +-------------------------+-------------------------+-----+----------------------------------------+
 | ``scan_rst_ni``         | 1                       | in  | Test controlled reset.  If DFT not     |
-|                         |                         |     | used, tie off to 0.                    |
+|                         |                         |     | used, tie off to 1.                    |
 +-------------------------+-------------------------+-----+----------------------------------------+
 | ``ram_cfg_i``           | 10                      | in  | RAM configuration inputs, routed to    |
 |                         |                         |     | the icache RAMs                        |

--- a/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
+++ b/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
@@ -132,6 +132,7 @@ module ibex_riscv_compliance (
       .rst_ni         (rst_sys_n         ),
 
       .test_en_i      ('b0               ),
+      .scan_rst_ni    (1'b1              ),
       .ram_cfg_i      ('b0               ),
 
       .hart_id_i      (32'b0             ),

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -78,6 +78,7 @@ module core_ibex_tb_top;
     .rst_ni         (rst_n                ),
 
     .test_en_i      (1'b0                 ),
+    .scan_rst_ni    (1'b1                 ),
     .ram_cfg_i      ('b0                  ),
 
     .hart_id_i      (32'b0                ),

--- a/examples/fpga/artya7/rtl/top_artya7.sv
+++ b/examples/fpga/artya7/rtl/top_artya7.sv
@@ -51,6 +51,7 @@ module top_artya7 (
      .rst_ni                (rst_sys_n),
 
      .test_en_i             ('b0),
+     .scan_rst_ni           (1'b1),
      .ram_cfg_i             ('b0),
 
      .hart_id_i             (32'b0),

--- a/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/examples/simple_system/rtl/ibex_simple_system.sv
@@ -183,6 +183,7 @@ module ibex_simple_system (
       .rst_ni                (rst_sys_n),
 
       .test_en_i             ('b0),
+      .scan_rst_ni           (1'b1),
       .ram_cfg_i             ('b0),
 
       .hart_id_i             (32'b0),

--- a/rtl/ibex_lockstep.sv
+++ b/rtl/ibex_lockstep.sv
@@ -100,9 +100,9 @@ module ibex_lockstep import ibex_pkg::*; #(
   //////////////////////
 
   logic [LockstepOffsetW-1:0] rst_shadow_cnt_d, rst_shadow_cnt_q;
-  logic                       rst_shadow_set_d, rst_shadow_set_q;
   // Internally generated resets cause IMPERFECTSCH warnings
   /* verilator lint_off IMPERFECTSCH */
+  logic                       rst_shadow_set_d, rst_shadow_set_q;
   logic                       rst_shadow_n;
   /* verilator lint_on IMPERFECTSCH */
 

--- a/rtl/ibex_top_tracing.sv
+++ b/rtl/ibex_top_tracing.sv
@@ -32,6 +32,7 @@ module ibex_top_tracing #(
     input  logic                         rst_ni,
 
     input  logic                         test_en_i,     // enable all clock gates for testing
+    input  logic                         scan_rst_ni,
     input  prim_ram_1p_pkg::ram_1p_cfg_t ram_cfg_i,
 
 
@@ -132,7 +133,7 @@ module ibex_top_tracing #(
     .rst_ni,
 
     .test_en_i,
-    .scan_rst_ni('0),
+    .scan_rst_ni,
     .ram_cfg_i,
 
     .hart_id_i,


### PR DESCRIPTION
Better to have the tracing top consistent with the non-tracing top.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>