### PR TITLE
[core_ibex,dv] Allow running RTL simulations in parallel

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -365,7 +365,6 @@ $(OUT-DIR)rtl_sim/.compile.stamp: \
 	$(verb)./sim.py \
 	 --o=$(OUT-DIR) \
 	 --steps=compile \
-	 --ibex_config=$(IBEX_CONFIG) \
 	 ${COMMON_OPTS} \
 	 --simulator="${SIMULATOR}" --simulator_yaml=yaml/rtl_simulation.yaml \
 	 $(cov-arg) $(wave-arg) $(lsf-arg) \
@@ -393,24 +392,28 @@ $(metadata)/rtl_sim.compile.stamp: \
 	cp -r $(OUT-DIR)rtl_sim $(OUT-SEED)
 	@touch $@
 
-# This rule actually runs the simulation. It depends on the copied-in testbench
-# and also on us having already compiled the test programs.
-$(metadata)/rtl_sim.run.stamp: \
+rtl-sim-dirs := $(addprefix $(OUT-SEED)/rtl_sim/,$(tests-and-seeds))
+rtl-sim-logs := $(addsuffix /sim.log,$(rtl-sim-dirs))
+
+$(rtl-sim-logs): \
+  %/sim.log: \
   $(metadata)/rtl_sim.compile.stamp \
-  $(metadata)/instr_gen.compile.stamp $(TESTLIST) \
-  sim.py yaml/rtl_simulation.yaml
-	$(verb)./sim.py \
-	 --o=$(OUT-SEED) \
-	 --steps=sim \
-	 --ibex_config=$(IBEX_CONFIG) \
-	 ${TEST_OPTS} \
-	 --simulator="${SIMULATOR}" --simulator_yaml=yaml/rtl_simulation.yaml \
-	 $(cov-arg) $(wave-arg) $(lsf-arg) \
-	 --sim_opts="+signature_addr=${SIGNATURE_ADDR} ${SIM_OPTS}"
-	@touch $@
+  $(metadata)/instr_gen.compile.stamp \
+  run_rtl.py
+	@echo Running RTL simulation at $@
+	$(verb)mkdir -p $(@D)
+	$(verb)./run_rtl.py \
+	  --simulator $(SIMULATOR) \
+	  --simulator_yaml yaml/rtl_simulation.yaml \
+	  $(cov-arg) $(wave-arg) $(lsf-arg) \
+	  --start-seed $(SEED) \
+      --sim-opts="+signature_addr=${SIGNATURE_ADDR} ${SIM_OPTS}" \
+	  --test-dot-seed $(notdir $*) \
+	  --bin-dir $(OUT-SEED)/instr_gen/asm_test \
+	  --rtl-sim-dir $(OUT-SEED)/rtl_sim
 
 .PHONY: rtl_sim
-rtl_sim: $(metadata)/rtl_sim.run.stamp
+rtl_sim: $(rtl-sim-logs)
 
 ###############################################################################
 # Compare ISS and RTL sim results
@@ -426,12 +429,11 @@ rtl_sim: $(metadata)/rtl_sim.run.stamp
 #
 # with PASSED or FAILED, depending.
 
-rtl-sim-dirs := $(addprefix $(OUT-SEED)/rtl_sim/,$(tests-and-seeds))
 comp-results := $(addsuffix /comparison-result.txt,$(rtl-sim-dirs))
 
 $(comp-results): \
   %/comparison-result.txt: \
-  compare.py $(metadata)/instr_gen.iss.stamp $(metadata)/rtl_sim.run.stamp
+  compare.py $(metadata)/instr_gen.iss.stamp $(rtl-sim-logs)
 	@echo Comparing traces for $*
 	$(verb)./compare.py \
       --iss $(ISS) \
@@ -452,7 +454,7 @@ post_compare: $(OUT-SEED)/regr.log
 # Generate RISCV-DV functional coverage
 # TODO(udi) - add B extension
 .PHONY: riscv_dv_cov
-riscv_dv_fcov: $(metadata)/rtl_sim.run.stamp
+riscv_dv_fcov: $(rtl-sim-logs)
 	$(verb)python3 ${GEN_DIR}/cov.py \
           --core ibex \
           --dir ${OUT-SEED}/rtl_sim \
@@ -466,12 +468,7 @@ riscv_dv_fcov: $(metadata)/rtl_sim.run.stamp
 .PHONY: gen_cov
 gen_cov: riscv_dv_fcov
 	$(verb)rm -rf $(OUT-DIR)rtl_sim/test.vdb
-	$(verb)./sim.py \
-		--steps=cov \
-		${TEST_OPTS} \
-		--simulator="${SIMULATOR}" \
-		$(lsf-arg) \
-		--o="$(OUT-DIR)"
+	$(verb)./sim.py --steps=cov --simulator="${SIMULATOR}" $(lsf-arg) --o="$(OUT-DIR)"
 	@if [ -d "test.vdb" ]; then \
 		mv -f test.vdb $(OUT-DIR)rtl_sim/; \
 	fi

--- a/dv/uvm/core_ibex/compare.py
+++ b/dv/uvm/core_ibex/compare.py
@@ -11,7 +11,9 @@ import argparse
 import os
 import re
 import sys
-from typing import Dict, List, Optional, TextIO, Tuple
+from typing import Dict, Optional, TextIO, Tuple
+
+from test_entry import TestEntry, get_test_entry
 
 _CORE_IBEX = os.path.normpath(os.path.join(os.path.dirname(__file__)))
 _IBEX_ROOT = os.path.normpath(os.path.join(_CORE_IBEX, '../../..'))
@@ -24,7 +26,6 @@ try:
     sys.path = ([os.path.join(_CORE_IBEX, 'riscv_dv_extension'),
                  os.path.join(_RISCV_DV_ROOT, 'scripts')] +
                 sys.path)
-    from lib import process_regression_list  # type: ignore
 
     from spike_log_to_trace_csv import process_spike_sim_log  # type: ignore
     from ovpsim_log_to_trace_csv import process_ovpsim_sim_log  # type: ignore
@@ -35,8 +36,7 @@ try:
 finally:
     sys.path = _OLD_SYS_PATH
 
-_TestEntry = Dict[str, object]
-_TestEntries = List[_TestEntry]
+
 _TestAndSeed = Tuple[str, int]
 _CompareResult = Tuple[bool, Optional[str], Dict[str, str]]
 
@@ -53,18 +53,7 @@ def read_test_dot_seed(arg: str) -> _TestAndSeed:
     return (match.group(1), int(match.group(2), 10))
 
 
-def get_test_entry(testname: str) -> _TestEntry:
-    matched_list = []  # type: _TestEntries
-    testlist = os.path.join(_CORE_IBEX, 'riscv_dv_extension', 'testlist.yaml')
-    process_regression_list(testlist, 'all', 0, matched_list, _RISCV_DV_ROOT)
-
-    for entry in matched_list:
-        if entry['test'] == testname:
-            return entry
-    raise RuntimeError('No matching test entry for {!r}'.format(testname))
-
-
-def compare_test_run(test: _TestEntry,
+def compare_test_run(test: TestEntry,
                      idx: int,
                      seed: int,
                      rtl_log_dir: str,

--- a/dv/uvm/core_ibex/run_rtl.py
+++ b/dv/uvm/core_ibex/run_rtl.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from typing import Tuple
+
+from sim_cmd import get_simulator_cmd
+from test_entry import get_test_entry
+
+_CORE_IBEX = os.path.normpath(os.path.join(os.path.dirname(__file__)))
+
+_TestAndSeed = Tuple[str, int]
+
+
+def read_test_dot_seed(arg: str) -> _TestAndSeed:
+    '''Read a value for --test-dot-seed'''
+
+    match = re.match(r'([^.]+)\.([0-9]+)$', arg)
+    if match is None:
+        raise argparse.ArgumentTypeError('Bad --test-dot-seed ({}): '
+                                         'should be of the form TEST.SEED.'
+                                         .format(arg))
+
+    return (match.group(1), int(match.group(2), 10))
+
+
+def subst_vars(string, var_dict):
+    '''Apply substitutions in var_dict to string
+
+    If var_dict[K] = V, then <K> will be replaced with V in string.'''
+    for key, value in var_dict.items():
+        string = string.replace('<{}>'.format(key), value)
+    return string
+
+
+def get_test_sim_cmd(base_cmd, test, idx, seed, sim_dir, bin_dir, lsf_cmd):
+    '''Generate the command that runs a test iteration in the simulator
+
+    base_cmd is the command to use before any test-specific substitutions. test
+    is a dictionary describing the test (originally read from the testlist YAML
+    file). idx is the test iteration (an integer) and seed is the corresponding
+    seed.
+
+    sim_dir is the directory to which the test results will be written. bin_dir
+    is the directory containing compiled binaries. lsf_cmd (if not None) is a
+    string that runs bsub to submit the task on LSF.
+
+    Returns the command to run.
+
+    '''
+    it_cmd = subst_vars(base_cmd, {'seed': str(seed)})
+    sim_cmd = (it_cmd + ' ' + test['sim_opts'].replace('\n', ' ')
+               if "sim_opts" in test
+               else it_cmd)
+
+    test_name = test['test']
+
+    binary = os.path.join(bin_dir, '{}_{}.bin'.format(test_name, idx))
+
+    # Do final interpolation into the test command for variables that depend on
+    # the test name or iteration number.
+    sim_cmd = subst_vars(sim_cmd,
+                         {
+                             'sim_dir': sim_dir,
+                             'rtl_test': test['rtl_test'],
+                             'binary': binary,
+                             'test_name': test_name,
+                             'iteration': str(idx)
+                         })
+
+    if not os.path.exists(binary):
+        raise RuntimeError('When computing simulation command for running '
+                           'iteration {} of test {}, cannot find the '
+                           'expected binary at {!r}.'
+                           .format(idx, test_name, binary))
+
+    if lsf_cmd is not None:
+        sim_cmd = lsf_cmd + ' ' + sim_cmd
+
+    return sim_cmd
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--simulator', required=True)
+    parser.add_argument("--simulator_yaml", required=True)
+    parser.add_argument("--en_cov", action='store_true')
+    parser.add_argument("--en_wave", action='store_true')
+    parser.add_argument('--start-seed', type=int, required=True)
+    parser.add_argument('--test-dot-seed',
+                        type=read_test_dot_seed,
+                        required=True)
+    parser.add_argument('--lsf-cmd')
+    parser.add_argument('--bin-dir', required=True)
+    parser.add_argument('--rtl-sim-dir', required=True)
+    parser.add_argument('--sim-opts', default='')
+
+    args = parser.parse_args()
+
+    if args.start_seed < 0:
+        raise RuntimeError('Invalid start seed: {}'.format(args.start_seed))
+    testname, seed = args.test_dot_seed
+    if seed < args.start_seed:
+        raise RuntimeError('Start seed is greater than test seed '
+                           f'({args.start_seed} > {seed}).')
+
+    iteration = seed - args.start_seed
+
+    entry = get_test_entry(testname)
+
+    # Look up how to run the simulator in general
+    enables = {
+        'cov_opts': args.en_cov,
+        'wave_opts': args.en_wave
+    }
+    _, base_cmd = get_simulator_cmd(args.simulator,
+                                    args.simulator_yaml, enables)
+
+    # Specialize base_cmd with the right directories and simulator options
+    sim_cmd = subst_vars(base_cmd,
+                         {
+                             'out': args.rtl_sim_dir,
+                             'sim_opts': args.sim_opts,
+                             'cwd': _CORE_IBEX,
+                         })
+
+    # Specialize base_cmd for this specific test
+    test_sim_dir = os.path.join(args.rtl_sim_dir,
+                                '{}.{}'.format(testname, seed))
+    test_cmd = get_test_sim_cmd(sim_cmd, entry, iteration, seed,
+                                test_sim_dir, args.bin_dir, args.lsf_cmd)
+
+    # Run test_cmd (it's a string, so we have to call out to the shell to do
+    # so). Note that we don't capture the success or failure of the subprocess:
+    # if something goes horribly wrong, we assume we won't have a matching
+    # trace.
+    sim_log = os.path.join(test_sim_dir, 'sim.log')
+    with open(sim_log, 'wb') as sim_fd:
+        subprocess.run(test_cmd, shell=True, stdout=sim_fd, stderr=sim_fd)
+
+    # Always return 0 (success), even if the test failed. We've successfully
+    # generated a log either way.
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/dv/uvm/core_ibex/sim_cmd.py
+++ b/dv/uvm/core_ibex/sim_cmd.py
@@ -1,0 +1,116 @@
+import logging
+import os
+import sys
+
+_CORE_IBEX = os.path.normpath(os.path.join(os.path.dirname(__file__)))
+_IBEX_ROOT = os.path.normpath(os.path.join(_CORE_IBEX, '../../..'))
+_RISCV_DV_ROOT = os.path.join(_IBEX_ROOT, 'vendor/google_riscv-dv')
+_OLD_SYS_PATH = sys.path
+
+# Import lib from _DV_SCRIPTS before putting sys.path back as it started.
+try:
+    sys.path = [os.path.join(_RISCV_DV_ROOT, 'scripts')] + sys.path
+    from lib import read_yaml
+finally:
+    sys.path = _OLD_SYS_PATH
+
+
+def subst_opt(string, name, enable, replacement):
+    '''Substitute the <name> option in string
+
+    If enable is False, <name> is replaced by '' in string. If it is True,
+    <name> is replaced by replacement, which should be a string or None. If
+    replacement is None and <name> occurs in string, we throw an error.
+
+    '''
+    needle = '<{}>'.format(name)
+    if not enable:
+        return string.replace(needle, '')
+
+    if replacement is None:
+        if needle in string:
+            raise RuntimeError('No replacement defined for {} '
+                               '(used in string: {!r}).'
+                               .format(needle, string))
+        return string
+
+    return string.replace(needle, replacement)
+
+
+def subst_env_vars(string, env_vars):
+    '''Substitute environment variables in string
+
+    env_vars should be a string with a comma-separated list of environment
+    variables to substitute. For each environment variable, V, in the list, any
+    occurrence of <V> in string will be replaced by the value of the
+    environment variable with that name. If <V> occurs in the string but $V is
+    not set in the environment, an error is raised.
+
+    '''
+    env_vars = env_vars.strip()
+    if not env_vars:
+        return string
+
+    for env_var in env_vars.split(','):
+        env_var = env_var.strip()
+        needle = '<{}>'.format(env_var)
+        if needle in string:
+            value = os.environ.get(env_var)
+            if value is None:
+                raise RuntimeError('Cannot substitute {} in command because '
+                                   'the environment variable ${} is not set.'
+                                   .format(needle, env_var))
+            string = string.replace(needle, value)
+
+    return string
+
+
+def subst_cmd(cmd, enable_dict, opts_dict, env_vars):
+    '''Substitute options and environment variables in cmd
+
+    enable_dict should be a dict mapping names to bools. For each key, N, in
+    enable_dict, if enable_dict[N] is False, then all occurrences of <N> in cmd
+    will be replaced with ''. If enable_dict[N] is True, all occurrences of <N>
+    in cmd will be replaced with opts_dict[N].
+
+    If N is not a key in opts_dict, this is no problem unless cmd contains
+    <N>, in which case we throw a RuntimeError.
+
+    Finally, the environment variables are substituted as described in
+    subst_env_vars and any newlines are stripped out.
+
+    '''
+    for name, enable in enable_dict.items():
+        cmd = subst_opt(cmd, name, enable, opts_dict.get(name))
+
+    return subst_env_vars(cmd, env_vars).replace('\n', ' ')
+
+
+def get_yaml_for_simulator(simulator, yaml_path):
+    '''Read yaml at yaml_path and find entry for simulator'''
+    logging.info("Processing simulator setup file : %s" % yaml_path)
+    for entry in read_yaml(yaml_path):
+        if entry.get('tool') == simulator:
+            return entry
+
+    raise RuntimeError("Cannot find RTL simulator {}".format(simulator))
+
+
+def get_simulator_cmd(simulator, yaml_path, enables):
+    '''Get compile and run commands for the testbench
+
+    simulator is the name of the simulator to use. yaml_path is the path to a
+    yaml file describing various command line options. enables is a dictionary
+    keyed by option names with boolean values: true if the option is enabled.
+
+    Returns (compile_cmds, sim_cmd), which are the simulator commands to
+    compile and run the testbench, respectively. compile_cmd is a list of
+    strings (multiple commands); sim_cmd is a single string.
+
+    '''
+    entry = get_yaml_for_simulator(simulator, yaml_path)
+    env_vars = entry.get('env_var', '')
+
+    return ([subst_cmd(arg, enables, entry['compile'], env_vars)
+             for arg in entry['compile']['cmd']],
+            subst_cmd(entry['sim']['cmd'], enables, entry['sim'], env_vars))

--- a/dv/uvm/core_ibex/test_entry.py
+++ b/dv/uvm/core_ibex/test_entry.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from typing import Dict, List
+
+_CORE_IBEX = os.path.normpath(os.path.join(os.path.dirname(__file__)))
+_IBEX_ROOT = os.path.normpath(os.path.join(_CORE_IBEX, '../../..'))
+_RISCV_DV_ROOT = os.path.join(_IBEX_ROOT, 'vendor/google_riscv-dv')
+_OLD_SYS_PATH = sys.path
+
+# Import riscv_trace_csv and lib from _DV_SCRIPTS before putting sys.path back
+# as it started.
+try:
+    sys.path = ([os.path.join(_CORE_IBEX, 'riscv_dv_extension'),
+                 os.path.join(_RISCV_DV_ROOT, 'scripts')] +
+                sys.path)
+    from lib import process_regression_list  # type: ignore
+finally:
+    sys.path = _OLD_SYS_PATH
+
+
+TestEntry = Dict[str, object]
+TestEntries = List[TestEntry]
+
+
+def get_test_entry(testname: str) -> TestEntry:
+    matched_list = []  # type: TestEntries
+    testlist = os.path.join(_CORE_IBEX, 'riscv_dv_extension', 'testlist.yaml')
+    process_regression_list(testlist, 'all', 0, matched_list, _RISCV_DV_ROOT)
+
+    for entry in matched_list:
+        if entry['test'] == testname:
+            return entry
+    raise RuntimeError('No matching test entry for {!r}'.format(testname))


### PR DESCRIPTION
This is a follow-up to #1372 and exposes the RTL simulation part of the run to Make so that it can run in parallel. I just tried it locally with `time make SEED=1 TEST=riscv_arithmetic_basic_test ITERATIONS=2 VERBOSE=1 -j2` and everything ran nicely.