### PR TITLE
[rtl] Fix typo in MCOUNTEREN

### DIFF
--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -322,7 +322,6 @@ module ibex_cs_registers #(
       // mcounteren: machine counter enable
       CSR_MCOUNTEREN: begin
         csr_rdata_int = '0;
-        illegal_csr   = ~DbgTriggerEn;
       end
 
       CSR_MSCRATCH: csr_rdata_int = mscratch_q;


### PR DESCRIPTION
DbgTriggerEn has no impact on whether this is an illegal csr op.

Fixes #1379

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>