### PR TITLE
Use Yosys bind support for formal tb

### DIFF
--- a/formal/icache/formal_bind.sv
+++ b/formal/icache/formal_bind.sv
@@ -2,12 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// A fragment of SystemVerilog code that is inserted into the ICache. We're using this to emulate
-// missing bind support, so this file should do nothing but instantiate a module.
-//
-// Using a wildcard (.*) for ports allows the testbench to inspect internal signals of the cache.
-
-formal_tb #(
+bind ibex_icache formal_tb #(
   .BranchPredictor (BranchPredictor),
   .ICacheECC       (ICacheECC),
   .BranchCache     (BranchCache),

--- a/formal/icache/ibex_icache_fpv.core
+++ b/formal/icache/ibex_icache_fpv.core
@@ -14,7 +14,7 @@ filesets:
       - lowrisc:util:sv2v
     files:
       - run.sby.j2 : {file_type: sbyConfigTemplate}
-      - formal_tb_frag.svh : {file_type: systemVerilogSource, is_include_file: true}
+      - formal_bind.sv : {file_type: systemVerilogSource}
       - formal_tb.sv : {file_type: systemVerilogSource}
 
 parameters:

--- a/rtl/ibex_icache.sv
+++ b/rtl/ibex_icache.sv
@@ -1064,10 +1064,7 @@ module ibex_icache import ibex_pkg::*; #(
   `ASSERT_KNOWN(TagHitKnown,     lookup_valid_ic1 & tag_hit_ic1)
   `ASSERT_KNOWN(TagInvalidKnown, lookup_valid_ic1 & tag_invalid_ic1)
 
-  // This is only used for the Yosys-based formal flow. Once we have working bind support, we can
-  // get rid of it.
 `ifdef FORMAL
- `ifdef YOSYS
   // Unfortunately, Yosys doesn't support passing unpacked arrays as ports. Explicitly pack up the
   // signals we need.
   logic [NUM_FB-1:0][ADDR_W-1:0] packed_fill_addr_q;
@@ -1076,9 +1073,6 @@ module ibex_icache import ibex_pkg::*; #(
       packed_fill_addr_q[i][ADDR_W-1:0] = fill_addr_q[i];
     end
   end
-
-  `include "formal_tb_frag.svh"
- `endif
 `endif
 
 

--- a/util/ibex_util_sv2v.core
+++ b/util/ibex_util_sv2v.core
@@ -33,6 +33,9 @@ scripts:
       - --define-if=prim:SYNTHESIS
       - -DYOSYS
       - -DFORMAL
+        # Don't try to convert files called FOO_bind.sv. This allows top-level
+        # formal testbenches that work by being bound into the DUT.
+      - --passthru=.*_bind.sv
       - -v
       - files.txt
 


### PR DESCRIPTION
This almost gets rid of all the hacks in the design code.
Unfortunately, there's still one problem (can't pass unpacked arrays
as ports) that we have to work around, but it's *much* nicer!

This can't be merged at the moment, because upstream Yosys doesn't have bind support yet. But it's proof that it works properly :-)