### PR TITLE
[dv/uvm/core_ibex] Fix timeout issue in wfi tests

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -724,7 +724,6 @@ class core_ibex_irq_wfi_test extends core_ibex_directed_test;
 
   virtual task check_stimulus();
     forever begin
-      wait (dut_vif.dut_cb.wfi === 1'b1);
       wait (dut_vif.dut_cb.core_sleep === 1'b1);
       send_irq_stimulus();
     end


### PR DESCRIPTION
The test loops around waiting for the core to sleep then sending
interrupts to wake it. In some cases, the sequence sends an interrupt
that isn't enabled. It never gets back to try again with a new interrupt
since the test is waiting to see wfi first. This change removes that
requirement since it is redundant anyway (have to see wfi to sleep).

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>