### PR TITLE
[dv,core_ibex] Only write sim.log once

### DIFF
--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -48,7 +48,6 @@
         <out>/vcs_simv +vcs+lic+wait <sim_opts> <wave_opts> <cov_opts>
           +ntb_random_seed=<seed> +UVM_TESTNAME=<rtl_test> +bin=<binary>
           +ibex_tracer_file_base=<sim_dir>/trace_core
-          -l <sim_dir>/sim.log
     cov_opts: >
       -cm line+tgl+assert+fsm+branch
       -cm_dir <out>/test.vdb


### PR DESCRIPTION
We're already redirecting stdout to sim.log in run_rtl.py. Specifying
'`-l`' as well meant that VCS opened sim.log in a separate FD.
Suprisingly enough, this mostly worked, but not always! Just write
once :-)

Fixes #1390.