### PR TITLE
[sw] Fix toolchain substitution for file paths.

### DIFF
--- a/examples/sw/led/Makefile
+++ b/examples/sw/led/Makefile
@@ -12,8 +12,8 @@ SRCS = $(PROGRAM).c
 
 CC = riscv32-unknown-elf-gcc
 
-OBJCOPY ?= $(subst gcc,objcopy,$(wordlist 1,1,$(CC)))
-OBJDUMP ?= $(subst gcc,objdump,$(wordlist 1,1,$(CC)))
+OBJCOPY ?= $(patsubst %gcc, %objcopy, $(CC))
+OBJDUMP ?= $(patsubst %gcc, %objdump, $(CC))
 
 LINKER_SCRIPT ?= link.ld
 CRT ?= crt0.S

--- a/examples/sw/simple_system/common/common.mk
+++ b/examples/sw/simple_system/common/common.mk
@@ -21,8 +21,8 @@ ASM_SRCS = $(filter %.S, $(SRCS))
 
 CC = riscv32-unknown-elf-gcc
 
-OBJCOPY ?= $(subst gcc,objcopy,$(wordlist 1,1,$(CC)))
-OBJDUMP ?= $(subst gcc,objdump,$(wordlist 1,1,$(CC)))
+OBJCOPY ?= $(patsubst %gcc, %objcopy, $(CC))
+OBJDUMP ?= $(patsubst %gcc, %objdump, $(CC))
 
 LINKER_SCRIPT ?= $(COMMON_DIR)/link.ld
 CRT ?= $(COMMON_DIR)/crt0.S


### PR DESCRIPTION
This invocation would break:

CC=/opt/lowrisc-toolchain-gcc-rv32imc-20210412-1/bin/riscv32-unknown-elf-gcc make -C examples/sw/led/

because the "-gcc" occurence inside the directory name would also be replaced.

Fix by using pattern substitution.

Signed-off-by: Leon Woestenberg <leon@sidebranch.com>