### PR TITLE
Fix toolchain substitution. Was broken for specific file paths.

### DIFF
--- a/examples/sw/led/Makefile
+++ b/examples/sw/led/Makefile
@@ -12,8 +12,9 @@ SRCS = $(PROGRAM).c
 
 CC = riscv32-unknown-elf-gcc
 
-OBJCOPY ?= $(subst gcc,objcopy,$(wordlist 1,1,$(CC)))
-OBJDUMP ?= $(subst gcc,objdump,$(wordlist 1,1,$(CC)))
+CROSS_COMPILE = $(patsubst %-gcc,%-,$(CC))
+OBJCOPY ?= $(CROSS_COMPILE)objcopy
+OBJDUMP ?= $(CROSS_COMPILE)objdump
 
 LINKER_SCRIPT ?= link.ld
 CRT ?= crt0.S

--- a/examples/sw/simple_system/common/common.mk
+++ b/examples/sw/simple_system/common/common.mk
@@ -21,8 +21,9 @@ ASM_SRCS = $(filter %.S, $(SRCS))
 
 CC = riscv32-unknown-elf-gcc
 
-OBJCOPY ?= $(subst gcc,objcopy,$(wordlist 1,1,$(CC)))
-OBJDUMP ?= $(subst gcc,objdump,$(wordlist 1,1,$(CC)))
+CROSS_COMPILE = $(patsubst %-gcc,%-,$(CC))
+OBJCOPY ?= $(CROSS_COMPILE)objcopy
+OBJDUMP ?= $(CROSS_COMPILE)objdump
 
 LINKER_SCRIPT ?= $(COMMON_DIR)/link.ld
 CRT ?= $(COMMON_DIR)/crt0.S


### PR DESCRIPTION
This invocation would break:

make -C examples/sw/led/ CC=/opt/lowrisc-toolchain-gcc-rv32imc-20210412-1/bin/riscv32-unknown-elf-gcc 

because the "-gcc" occurence inside the directory name would also be replaced.

Fix by using pattern substitution.

Signed-off-by: Leon Woestenberg <leon@sidebranch.com>