### PR TITLE
Updating readme for running ibex with riscv-compliance

### DIFF
--- a/dv/riscv_compliance/README.md
+++ b/dv/riscv_compliance/README.md
@@ -19,13 +19,14 @@ How to run RISC-V Compliance on Ibex
    - Verilator
    - fusesoc
    - srecord (for `srec_cat`)
-   - A RV32 compiler
+   - A RV32 compiler    # Toolchain provided with ibex will work
 
    On Ubuntu/Debian, install the required tools like this:
 
    ```sh
    sudo apt-get install srecord python3-pip
    pip3 install --user -U fusesoc
+   sudo apt install libelf-dev
    ```
 
    We recommend installing Verilator from source as versions from Linux
@@ -50,7 +51,7 @@ How to run RISC-V Compliance on Ibex
    The upstream RISC-V compliance test suite supports Ibex out of the box.
 
    ```
-   git clone https://github.com/riscv/riscv-compliance.git
+   git clone https://github.com/riscv/riscv-arch-test.git
    cd riscv-compliance
    ```
 
@@ -62,7 +63,7 @@ How to run RISC-V Compliance on Ibex
    # give the absolute path to the simulation binary compiled in step 1
    export TARGET_SIM=/path/to/your/Vibex_riscv_compliance
 
-   export RISCV_DEVICE=rv32imc
+   export RISCV_DEVICE=I            # Other targets for compliance can be C & M
    export RISCV_TARGET=ibex
 
    # Note: rv32imc does not include the I and M extension tests


### PR DESCRIPTION
- While running ibex with riscv-compliance a package was necessary in Ubuntu. 
- Also as riscv-compliance repository name has been updated so it is better to update it in README too. I know it redirects you to new repository but I think its better that repository should be updated here too.
- Targets in case of riscv-compliance are I, M, C, Zifencei etc instead of rv32imc.