### PR TITLE
[rtl] Minor lockstep-related updates

### DIFF
--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -120,7 +120,7 @@ module core_ibex_tb_top;
   );
 
   // We should never see any alerts triggered in normal testing
-  `ASSERT(NoAlertsTriggered, clk, !rst_n, !dut_if.alert_minor && !dut_if.alert_major)
+  `ASSERT(NoAlertsTriggered, !dut_if.alert_minor && !dut_if.alert_major, clk, !rst_n)
 
   // Data load/store vif connection
   assign data_mem_vif.reset                   = ~rst_n;

--- a/rtl/ibex_top.sv
+++ b/rtl/ibex_top.sv
@@ -609,28 +609,22 @@ module ibex_top #(
     } = buf_out;
 
     // Manually buffer all input signals.
-    for (genvar k = 0; k < NumBufferBits; k++) begin : gen_buffers
-      prim_buf u_prim_buf (
-        .in_i(buf_in[k]),
-        .out_o(buf_out[k])
-      );
-    end
+    prim_buf #(.Width(NumBufferBits)) u_signals_prim_buf (
+      .in_i(buf_in),
+      .out_o(buf_out)
+    );
 
     logic [TagSizeECC-1:0]  ic_tag_rdata_local [IC_NUM_WAYS];
     logic [LineSizeECC-1:0] ic_data_rdata_local [IC_NUM_WAYS];
     for (genvar k = 0; k < IC_NUM_WAYS; k++) begin : gen_ways
-      for (genvar j = 0; j < TagSizeECC; j++) begin : gen_tag_bufs
-        prim_buf u_prim_buf (
-          .in_i(ic_tag_rdata[k][j]),
-          .out_o(ic_tag_rdata_local[k][j])
-        );
-      end
-      for (genvar j = 0; j < LineSizeECC; j++) begin : gen_data_bufs
-        prim_buf u_prim_buf (
-          .in_i(ic_data_rdata[k][j]),
-          .out_o(ic_data_rdata_local[k][j])
-        );
-      end
+      prim_buf #(.Width(TagSizeECC)) u_tag_prim_buf (
+        .in_i(ic_tag_rdata[k]),
+        .out_o(ic_tag_rdata_local[k])
+      );
+      prim_buf #(.Width(LineSizeECC)) u_data_prim_buf (
+        .in_i(ic_data_rdata[k]),
+        .out_o(ic_data_rdata_local[k])
+      );
     end
 
     logic lockstep_alert_minor_local, lockstep_alert_major_local;


### PR DESCRIPTION
There are two patches here - one is a minor cleanup, the other adds a register slice on the outputs from the lockstep shadow core.

@tjaychen @eunchan The register slice is something we discussed a long time ago when some timing issues showed up in the shadow core. LMK if you think this is worth doing or not.