### PR TITLE
[bitmanip][zba] Add support for Zba (address calculation) extension

### DIFF
--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -462,6 +462,10 @@ module ibex_decoder #(
             {7'b000_0000, 3'b101},
             {7'b010_0000, 3'b101}: illegal_insn = 1'b0;
 
+            // RV32B zba
+            {7'b001_0000, 3'b010}, // sh1add
+            {7'b001_0000, 3'b100}, // sh2add
+            {7'b001_0000, 3'b110}, // sh3add
             // RV32B zbb
             {7'b010_0000, 3'b111}, // andn
             {7'b010_0000, 3'b110}, // orn
@@ -1012,6 +1016,11 @@ module ibex_decoder #(
             {7'b010_0000, 3'b100}: if (RV32B != RV32BNone) alu_operator_o = ALU_XNOR;   // xnor
             {7'b010_0000, 3'b110}: if (RV32B != RV32BNone) alu_operator_o = ALU_ORN;    // orn
             {7'b010_0000, 3'b111}: if (RV32B != RV32BNone) alu_operator_o = ALU_ANDN;   // andn
+
+            // RV32B zba
+            {7'b001_0000, 3'b010}: if (RV32B != RV32BNone) alu_operator_o = ALU_SH1ADD; // sh1add
+            {7'b001_0000, 3'b100}: if (RV32B != RV32BNone) alu_operator_o = ALU_SH2ADD; // sh2add
+            {7'b001_0000, 3'b110}: if (RV32B != RV32BNone) alu_operator_o = ALU_SH3ADD; // sh3add
 
             // RV32B zbs
             {7'b010_0100, 3'b001}: if (RV32B != RV32BNone) alu_operator_o = ALU_SBCLR;  // sbclr

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -101,6 +101,12 @@ package ibex_pkg;
     ALU_SHFL,
     ALU_UNSHFL,
 
+    // Address Calculations
+    // RV32B
+    ALU_SH1ADD,
+    ALU_SH2ADD,
+    ALU_SH3ADD,
+
     // Comparisons
     ALU_LT,
     ALU_LTU,

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -907,6 +907,10 @@ module ibex_tracer (
         // MISC-MEM
         INSN_FENCE:      decode_fence();
         INSN_FENCEI:     decode_mnemonic("fence.i");
+        // RV32B - ZBA
+        INSN_SH1ADD:     decode_r_insn("sh1add");
+        INSN_SH2ADD:     decode_r_insn("sh2add");
+        INSN_SH3ADD:     decode_r_insn("sh3add");
         // RV32B - ZBB
         INSN_SLOI:       decode_i_shift_insn("sloi");
         INSN_SROI:       decode_i_shift_insn("sroi");

--- a/rtl/ibex_tracer_pkg.sv
+++ b/rtl/ibex_tracer_pkg.sv
@@ -71,6 +71,11 @@ package ibex_tracer_pkg;
   parameter logic [31:0] INSN_PMULHU  = { 7'b0000001, 10'h?, 3'b011, 5'h?, {OPCODE_OP} };
 
   // RV32B
+  // ZBA
+  parameter logic [31:0] INSN_SH1ADD = { 7'b0010000, 10'h?, 3'b010, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SH2ADD = { 7'b0010000, 10'h?, 3'b100, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_SH3ADD = { 7'b0010000, 10'h?, 3'b110, 5'h?, {OPCODE_OP} };
+
   // ZBB
   parameter logic [31:0] INSN_SLOI = { 5'b00100        , 12'h?, 3'b001, 5'h?, {OPCODE_OP_IMM} };
   // Only log2(XLEN) bits of the immediate are used. For RV32, this means only the bits in


### PR DESCRIPTION
Add support for the Zba extension added in v0.93 of the bit manipulation
specification (unchanged in v1.0.0). The new instructions added are:

  - sh1add: rd = (rs1 << 1) + rs2
  - sh2add: rd = (rs1 << 2) + rs2
  - sh3add: rd = (rs1 << 3) + rs2

The instructions are single cycle and have been implemented using the
adder in the ALU.

Signed-off-by: Michael Munday <mike.munday@lowrisc.org>