### PR TITLE
[ci] Add GHA workflows to review PRs using Verible

### DIFF
--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -1,0 +1,49 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: pr-lint-review
+
+on:
+  workflow_run:
+    workflows: ["pr-trigger"]
+    types:
+      - completed
+
+jobs:
+  review_triggered:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # this workflow does not run in a PR context
+      # download 'event.json' file from a PR-tiggered workflow
+      # to mock the PR context and make a review
+      - name: 'Download artifact'
+        id: get-artifacts
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "event.json"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/event.json.zip', Buffer.from(download.data));
+      - run: |
+          unzip event.json.zip
+      - name: Run Verible linter action
+        uses: chipsalliance/verible-linter-action@v1.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          suggest_fixes: 'false'
+          config_file: 'vendor/lowrisc_ip/lint/tools/veriblelint/rules.vbl'

--- a/.github/workflows/pr_trigger.yml
+++ b/.github/workflows/pr_trigger.yml
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: pr-trigger
+
+on:
+  pull_request:
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Copy event file
+        run: cp "$GITHUB_EVENT_PATH" ./event.json
+
+      # If this workflow is triggered by a PR from a fork
+      # it won't have sufficient access rights to make a review
+      # so we just save the file needed to do the review
+      # in a context with proper access rights
+      - name: Upload event file as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: event.json
+          path: event.json


### PR DESCRIPTION
This PR adds CI scripts that use [Verible Lint Action](https://github.com/chipsalliance/verible-linter-action)
to automatically review the changes in `.v` and `.sv` files.

You can see an example of how this works here:
https://github.com/antmicro/gha-playground/pull/20

In order to post comments, the action needs a proper token.
Due to restrictions described [in the docs](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token) It's not possible to create comments
in the context of `pull_request` from an external repository.
To tackle this problem we create two workflows:
The first workflow triggered by `pull_request` stores information
about the PR in artifact and triggers the main workflow.
The main workflow runs the Action using a token that allows creating review comments in any PR.

We can also add a configuration file for Verible using the `config_file` input.
Currently the default rule set is used.
These topics are also described in the Readme of the Action.