### PR TITLE
Bump Verible action version

### DIFF
--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -42,7 +42,7 @@ jobs:
       - run: |
           unzip event.json.zip
       - name: Run Verible linter action
-        uses: chipsalliance/verible-linter-action@v1.1
+        uses: chipsalliance/verible-linter-action@v1.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           suggest_fixes: 'false'


### PR DESCRIPTION
We observed problems with the action in this PR: https://github.com/lowRISC/ibex/pull/1434
Then, another issue with errors reported with wrong line numbers appeared here: https://github.com/lowRISC/ibex/pull/1435

It looks like the previous version of the action did not handle git remotes properly and that was the root of the problems observed in both PRs. This is fixed in the new release of the action:
https://github.com/chipsalliance/verible-linter-action/releases

The two PRs were recreated here:
https://github.com/antmicro/gha-playground/pull/90
https://github.com/antmicro/gha-playground/pull/88

I can see that the line-length errors are reported for the expected line numbers.
However, it's expected that line-length error won't be reported for a one line comment, so not getting the error for the long line in the second PR is actually the correct result.
(https://github.com/chipsalliance/verible/blob/master/verilog/analysis/checkers/line_length_rule_test.cc#L85-L110)