### PR TITLE
Set Verible action version to 'main'

### DIFF
--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -42,7 +42,7 @@ jobs:
       - run: |
           unzip event.json.zip
       - name: Run Verible linter action
-        uses: chipsalliance/verible-linter-action@v1.2
+        uses: chipsalliance/verible-linter-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           suggest_fixes: 'false'


### PR DESCRIPTION
Yet again we're solving the problems discussed here:
https://github.com/lowRISC/ibex/pull/1434

Turns out we had updated Verible to a version in which it switched from using `stdout` to `stderr` for printing rule violations, so the output wasn't passed to Reviewdog as expected.
Right now the action uses `stderr`, as it should.

EDIT:
The things above remain true, but we're changing the version to 'main' to make it easier to apply fixes without incrementing the version each time.