### PR TITLE
Remove unused RD in branch insn from tracer

### DIFF
--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -490,7 +490,7 @@ module ibex_tracer (
              rvfi_insn[30:25], rvfi_insn[11:8], 1'b0 });
     branch_target = rvfi_pc_rdata + imm;
 
-    data_accessed = RS1 | RS2 | RD;
+    data_accessed = RS1 | RS2;
     decoded_str = $sformatf("%s\tx%0d,x%0d,%0x",
                             mnemonic, rvfi_rs1_addr, rvfi_rs2_addr, branch_target);
   endfunction


### PR DESCRIPTION
There is an unnecessary use of RD in branch instruction in `ibex_tracer.sv` which is removed. This PR resolves this issue #1441.
https://github.com/lowRISC/ibex/blob/ac8934459b028220ce9fd20683bb018244b59756/rtl/ibex_tracer.sv#L493