### PR TITLE
[syn] Use read_verilog -defer in yosys_run_synth.tcl

### DIFF
--- a/syn/tcl/yosys_run_synth.tcl
+++ b/syn/tcl/yosys_run_synth.tcl
@@ -14,7 +14,7 @@ if { $lr_synth_timing_run } {
   write_sdc_out $lr_synth_sdc_file_in $lr_synth_sdc_file_out
 }
 
-yosys "read_verilog -sv ./rtl/prim_clock_gating.v $lr_synth_out_dir/generated/*.v"
+yosys "read_verilog -defer -sv ./rtl/prim_clock_gating.v $lr_synth_out_dir/generated/*.v"
 
 if { $lr_synth_ibex_branch_target_alu } {
   yosys "chparam -set BranchTargetALU 1 $lr_synth_top_module"


### PR DESCRIPTION
Newer versions of sv2v carry through elaboration system tasks like $fatal. ibex_top_tracing uses $fatal, but isn't actually used in the syn_yosys flow. By using -defer, unused modules like ibex_top_tracing are not elaborated in Yosys.

Fixes https://github.com/lowRISC/ibex/issues/1440.