### PR TITLE
[dv/icache] Add missing window reset call

### DIFF
--- a/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
@@ -188,6 +188,7 @@ class ibex_icache_scoreboard
     invalidate_seed = mem_states.size - 1;
 
     not_invalidating = 1'b0;
+    window_reset();
   endtask
 
   task process_enable(ibex_icache_core_bus_item item);


### PR DESCRIPTION
The cache hit-rate tracking logic needs to be reset on every
invalidation.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>