### PR TITLE
[rtl] Move PMP checking to IF stage output

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ These are configurations on which lowRISC is focusing for performance evaluation
 | Config | "micro" | "small" | "maxperf" | "maxperf-pmp-bmfull" |
 | ------ | ------- | --------| ----------| -------------------- |
 | Features | RV32EC | RV32IMC, 3 cycle mult | RV32IMC, 1 cycle mult, Branch target ALU, Writeback stage | RV32IMCB, 1 cycle mult, Branch target ALU, Writeback stage, 16 PMP regions |
-| Performance (CoreMark/MHz) | 0.904 | 2.47 | 3.13 | 3.05 |
+| Performance (CoreMark/MHz) | 0.904 | 2.47 | 3.13 | 3.13 |
 | Area - Yosys (kGE) | 17.44 | 26.06 | 35.64 | 58.74 |
 | Area - Commercial (estimated kGE) | ~16 | ~24 | ~33 | ~54 |
 | Verification status | Red | Green | Amber | Amber |
@@ -38,7 +38,6 @@ Notes:
 * Performance numbers are based on CoreMark running on the Ibex Simple System [platform](examples/simple_system/README.md).
   Note that different ISAs (use of B and C extensions) give the best results for different configurations.
   See the [Benchmarks README](examples/sw/benchmarks/README.md) for more information.
-  The "maxperf-pmp-bmfull" configuration sets a `SpecBranch` parameter in `ibex_core.sv`; this helps timing but has a small negative performance impact.
 * Yosys synthesis area numbers are based on the Ibex basic synthesis [flow](syn/README.md) using the latch-based register file.
 * Commercial synthesis area numbers are a rough estimate of what might be achievable with a commercial synthesis flow and technology library.
 * For comparison, the original "Zero-riscy" core yields an area of 23.14kGE using our Yosys synthesis flow.

--- a/dv/uvm/core_ibex/fcov/core_ibex_fcov_if.sv
+++ b/dv/uvm/core_ibex/fcov/core_ibex_fcov_if.sv
@@ -9,7 +9,6 @@ interface core_ibex_fcov_if import ibex_pkg::*; (
   input rst_ni,
 
   input priv_lvl_e priv_mode_id,
-  input priv_lvl_e priv_mode_if,
   input priv_lvl_e priv_mode_lsu
 );
   `include "dv_fcov_macros.svh"
@@ -244,9 +243,6 @@ interface core_ibex_fcov_if import ibex_pkg::*; (
     cp_branch_not_taken: coverpoint id_stage_i.fcov_branch_not_taken;
 
     cp_priv_mode_id: coverpoint priv_mode_id {
-      illegal_bins illegal = {PRIV_LVL_H, PRIV_LVL_S};
-    }
-    cp_priv_mode_if: coverpoint priv_mode_if {
       illegal_bins illegal = {PRIV_LVL_H, PRIV_LVL_S};
     }
     cp_priv_mode_lsu: coverpoint priv_mode_lsu {

--- a/dv/uvm/icache/doc/ibex_icache_dv_plan.md
+++ b/dv/uvm/icache/doc/ibex_icache_dv_plan.md
@@ -72,10 +72,10 @@ The memory agent emulates the instruction bus, supplying data to the cache.
 This must be deterministic (in order for the scoreboard to tell whether the cache fetched the right data), but must also be able to change with time (in order to check invalidation works correctly).
 To support this, the memory contents are modelled with a 32-bit seed value.
 
-The architectural state of the instruction bus and memory (contents at each address; PMP ranges; ranges that will cause a memory error) are all derived from this seed.
+The architectural state of the instruction bus and memory (contents at each address; ranges that will cause a memory error) are all derived from this seed.
 The precise functions can be found in [`dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_model.sv`](https://github.com/lowRISC/ibex/blob/master/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_model.sv).
 
-The memory agent is an active slave, responding to instruction fetches from the cache with either a PMP error (on the same cycle as the request) or instruction data (with an in-order request pipeline).
+The memory agent is an active slave, responding to instruction fetches from the cache with instruction data (with an in-order request pipeline).
 
 #### ECC Agent
 

--- a/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
@@ -119,9 +119,7 @@ class ibex_icache_scoreboard
     core_fifo = new("core_fifo", this);
     mem_fifo  = new("mem_fifo",  this);
     seed_fifo = new("seed_fifo", this);
-    mem_model = new("mem_model",
-                    cfg.mem_agent_cfg.disable_pmp_errs,
-                    cfg.mem_agent_cfg.disable_mem_errs);
+    mem_model = new("mem_model", cfg.mem_agent_cfg.disable_mem_errs);
   endfunction
 
   task run_phase(uvm_phase phase);
@@ -441,7 +439,7 @@ class ibex_icache_scoreboard
 
     return is_fetch_compatible_1(seen_insn_data,
                                  seen_err,
-                                 mem_model.is_either_error(seed, addr_lo, mem_err_shift),
+                                 mem_model.is_mem_error(seed, addr_lo, mem_err_shift),
                                  rdata[31:0],
                                  seed,
                                  chatty);
@@ -486,13 +484,13 @@ class ibex_icache_scoreboard
     {seed_hi, mem_err_shift_hi} = mem_state_hi;
 
     // Do the first read (from the low address) and shift right to drop the bits that we don't need.
-    exp_err_lo = mem_model.is_either_error(seed_lo, addr_lo, mem_err_shift_lo);
+    exp_err_lo = mem_model.is_mem_error(seed_lo, addr_lo, mem_err_shift_lo);
     rdata      = mem_model.read_data(seed_lo, addr_lo) >> lo_bits_to_drop;
     exp_data   = rdata[31:0];
 
     // Now do the second read (from the upper address). Shift the result up by lo_bits_to_take,
     // which will discard some top bits. Then extract 32 bits and OR with what we have so far.
-    exp_err_hi = mem_model.is_either_error(seed_hi, addr_hi, mem_err_shift_hi);
+    exp_err_hi = mem_model.is_mem_error(seed_hi, addr_hi, mem_err_shift_hi);
     rdata      = mem_model.read_data(seed_hi, addr_hi) << lo_bits_to_take;
     exp_data   = exp_data | rdata[31:0];
 

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent_cov.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_agent_cov.sv
@@ -51,19 +51,12 @@ class ibex_icache_core_agent_cov extends dv_base_agent_cov #(ibex_icache_core_ag
     coverpoint ready;
   endgroup : cancelled_valid_cg
 
-  // Track the combination of branch_spec and branch. The branch signal implies branch_spec, but the
-  // converse is not true. This covergroup is sampled when branch_spec is high.
-  covergroup branch_spec_cg with function sample (bit branch);
-    coverpoint branch;
-  endgroup : branch_spec_cg
-
   function new(string name, uvm_component parent);
     super.new(name, parent);
     inc_fetch_cg = new();
     branch_dest_cg = new();
     fetch_cg = new();
     cancelled_valid_cg = new();
-    branch_spec_cg = new();
   endfunction : new
 
   // Called on an "incrementing" pair of fetches: two fetches with no branch in between. addr0/addr1

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_if.sv
@@ -9,7 +9,6 @@ interface ibex_icache_core_if (input clk, input rst_n);
 
   // Branch request
   logic         branch;
-  logic         branch_spec;
   logic [31:0]  branch_addr;
 
   // Passing instructions back to the core
@@ -38,7 +37,6 @@ interface ibex_icache_core_if (input clk, input rst_n);
     output req;
 
     output branch;
-    output branch_spec;
     output branch_addr;
 
     output ready;
@@ -53,7 +51,6 @@ interface ibex_icache_core_if (input clk, input rst_n);
   clocking monitor_cb @(posedge clk);
     input  req;
     input  branch;
-    input  branch_spec;
     input  branch_addr;
     input  ready;
     input  valid;
@@ -75,13 +72,11 @@ interface ibex_icache_core_if (input clk, input rst_n);
   // address.
   task automatic branch_to(logic [31:0] addr);
     driver_cb.branch      <= 1'b1;
-    driver_cb.branch_spec <= 1'b1;
     driver_cb.branch_addr <= addr;
 
     @(driver_cb);
 
     driver_cb.branch      <= 1'b0;
-    driver_cb.branch_spec <= 1'b0;
     driver_cb.branch_addr <= 'X;
   endtask
 
@@ -124,7 +119,6 @@ interface ibex_icache_core_if (input clk, input rst_n);
   task automatic reset();
     driver_cb.req         <= 1'b0;
     driver_cb.branch      <= 1'b0;
-    driver_cb.branch_spec <= 1'b0;
     driver_cb.ready       <= 1'b0;
     driver_cb.enable      <= 1'b0;
     driver_cb.invalidate  <= 1'b0;

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_monitor.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_monitor.sv
@@ -123,11 +123,6 @@ class ibex_icache_core_monitor extends dv_base_monitor #(
         if (cfg.en_cov) cov.branch_dest_cg.sample(cfg.vif.branch_addr);
       end
 
-      // If coverage is enabled, spot when the branch spec line is high
-      if (cfg.en_cov && cfg.vif.branch_spec) begin
-        cov.branch_spec_cg.sample(cfg.vif.branch);
-      end
-
       // Spot invalidate signals. These can last for several cycles, but we only care about the
       // first cycle, so we track the last value to spot posedges.
       if (cfg.vif.invalidate && !last_inval) begin

--- a/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_protocol_checker.sv
+++ b/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_protocol_checker.sv
@@ -17,7 +17,6 @@ interface ibex_icache_core_protocol_checker (
    input        req,
 
    input        branch,
-   input        branch_spec,
    input [31:0] branch_addr,
 
    input        ready,
@@ -49,11 +48,6 @@ interface ibex_icache_core_protocol_checker (
   // The branch signal tells the cache to redirect. There's no real requirement on when it can be
   // asserted, but the address must be 16-bit aligned (i.e. the bottom bit must be zero).
   `ASSERT(BranchAddrAligned, branch |-> !branch_addr[0], clk, !rst_n)
-
-  // The 'branch' and 'branch_spec' ports
-  //
-  // The branch_spec signal is used in internal muxing and must be true if branch is true.
-  `ASSERT(BranchImpliesSpec, branch |-> branch_spec, clk, !rst_n)
 
   // The main instruction interface
 

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/README.md
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/README.md
@@ -1,21 +1,18 @@
 # ICache Memory UVM Agent
 
 The ICache memory UVM agent models the instruction memory bus downstream of the ICache.
-This also includes the PMP machinery.
 
 The basic idea is that instruction memory is modelled with a single 32-bit *seed*.
 A simple hash function takes this seed and calculates 32 bits of memory for each (aligned) base address.
-The seed also determines a memory region which should result in PMP errors and another memory region that should result in memory errors.
+The seed also determines a memory region which should result in memory errors.
 
-The agent exposes a slave interface to the core using the usual UVM architecture for a reactive slave, but it looks a little complicated because we need to spot PMP errors immediately (rather than on the next clock edge).
+The agent exposes a slave interface to the core using the usual UVM architecture for a reactive slave.
 The entire dance is as follows:
 
   1. The monitor spots a new request (either because of a posedge on the `req` line or a change in the `addr` line).
   1. It generates an `ibex_icache_mem_req_item` with `is_grant` field false and writes it to the sequencer's request port.
   1. This request gets picked up by the sequence (in `ibex_icache_mem_resp_seq.sv`).
-  1. The sequence checks for a PMP error using its internal memory model and generates a sequence item (of type `ibex_icache_mem_resp_item`) with `is_grant` field false.
-  1. This sequence item is picked up by the driver, which uses it to drive the PMP line appropriately.
-  1. If the PMP response didn't squash the request, it will get granted at some point when the `grant` line goes high. At this point, the monitor will spot the request being granted and create another `ibex_icache_mem_req_item`, writing it to the sequencer's request port. This time, the `is_grant` field is true.
+  1. The request will get granted at some point when the `grant` line goes high. At this point, the monitor will spot the request being granted and create another `ibex_icache_mem_req_item`, writing it to the sequencer's request port. This time, the `is_grant` field is true.
   1. This request in turn gets picked up by the sequence (in `ibex_icache_mem_resp_seq.sv`).
   1. The sequence uses its memory model to decide the data to be fetched and whether the response should have an error. The results get written into a sequence item with `is_grant` field true.
   1. When the driver picks up this sequence item, it adds it to a response queue.

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent_cfg.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent_cfg.sv
@@ -5,7 +5,6 @@
 class ibex_icache_mem_agent_cfg extends dv_base_agent_cfg;
 
   // Knobs
-  bit          disable_pmp_errs = 0;
   bit          disable_mem_errs = 0;
   int unsigned mem_err_shift = 3;
 

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent_cov.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_agent_cov.sv
@@ -10,15 +10,8 @@ class ibex_icache_mem_agent_cov
   // the base class provides the following handles for use:
   // ibex_icache_mem_agent_cfg: cfg
 
-  // Spot the gnt and pmp_err signal being high at the same time (the error should take precedence).
-  // This is sampled when gnt is high and tracks whether pmp_err is high too.
-  covergroup gnt_err_cg with function sample(bit pmp_err);
-    coverpoint pmp_err;
-  endgroup : gnt_err_cg
-
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    gnt_err_cg = new();
   endfunction : new
 
 endclass

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_bus_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_bus_item.sv
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // A transaction item that represents something happening on the memory bus. A 'request' is
-// initiated by the cache and comes with an address. A 'response' comes from the memory system
-// (including possibly the PMP checker). It comes with data and error flags.
+// initiated by the cache and comes with an address. A 'response' comes from the memory system.
+// It comes with data and error flags.
 
 class ibex_icache_mem_bus_item extends uvm_sequence_item;
 

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_driver.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_driver.sv
@@ -4,11 +4,10 @@
 
 // Drive the memory <-> icache interface
 //
-// There are 3 different signals getting driven here:
+// There are 2 different signals getting driven here:
 //
 //    (1) GNT:     This toggles randomly, completely ignoring any other signals.
-//    (2) PMP_ERR: This can be set as a result of taking a bad request.
-//    (3) RDATA:   This gets set with response data some time after granting a request.
+//    (2) RDATA:   This gets set with response data some time after granting a request.
 
 class ibex_icache_mem_driver
   extends dv_base_driver #(.ITEM_T (ibex_icache_mem_resp_item),
@@ -18,7 +17,6 @@ class ibex_icache_mem_driver
   int unsigned max_grant_delay = 10;
 
   mailbox #(ibex_icache_mem_resp_item) rdata_queue;
-  mailbox #(bit [32:0])                req_queue;
 
   `uvm_component_utils(ibex_icache_mem_driver)
   `uvm_component_new
@@ -26,7 +24,6 @@ class ibex_icache_mem_driver
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     rdata_queue   = new("rdata_queue");
-    req_queue     = new("req_queue");
   endfunction
 
   virtual task reset_signals();
@@ -36,7 +33,6 @@ class ibex_icache_mem_driver
     cfg.vif.reset();
 
     // Flush mailboxes of pending requests and responses
-    while (req_queue.try_get(req)) ;
     while (rdata_queue.try_get(resp)) ;
 
   endtask
@@ -46,7 +42,6 @@ class ibex_icache_mem_driver
     fork
       drive_grant();
       take_requests();
-      drive_pmp();
       drive_responses();
       drive_resets();
     join
@@ -81,10 +76,7 @@ class ibex_icache_mem_driver
       `uvm_info(`gfn, $sformatf("rcvd item:\n%0s", req.sprint()), UVM_HIGH)
 
       // Is this a request or a grant?
-      if (!req.is_grant) begin
-        // Push the address onto req_queue (which will be handled by drive_pmp).
-        req_queue.put({req.err, req.address});
-      end else begin
+      if (req.is_grant) begin
         // If a grant, we take a copy and add it to the response queue (handled by drive_responses)
         $cast(rsp, req.clone());
         rsp.set_id_info(req);
@@ -108,50 +100,6 @@ class ibex_icache_mem_driver
       if (!cfg.vif.rst_n) continue;
 
       cfg.vif.send_response(item.err, item.rdata);
-    end
-  endtask
-
-  // Drive the PMP line.
-  //
-  // This task samples from a "PMP" mailbox, which gets a new item from take_requests each time a
-  // new request comes in whose address would be squashed by the PMP.
-  //
-  // Since this isn't synchronised with a clock edge, it's not really possible to avoid glitches and
-  // to only add items when the "right" address has arrived. Instead, this task gets the address
-  // that caused the error. As soon as req is low OR the address on the bus doesn't match, this
-  // driver clears the address and exits. The idea is that if stuff gets out of sync for a delta
-  // cycle or two, drive_pmp can discard items to catch up.
-  task automatic drive_pmp();
-    bit        err;
-    bit [31:0] address;
-    bit [32:0] data;
-
-    forever begin
-      req_queue.get(data);
-      {err, address} = data;
-
-      if (!cfg.vif.rst_n) continue;
-
-      // If err is false, this is a request which shouldn't trigger a PMP error.
-      if (!err) continue;
-
-      // Otherwise, the address is the address that we expect to see on the interface.
-      // If the req line is low, or the address doesn't match, skip this item.
-      if ((!cfg.vif.req) || (cfg.vif.addr != address)) continue;
-
-      // Fork into two processes. The first waits for something else to appear in the queue. The
-      // second drives the line until it thinks the request is finished. The driver is stopped if we
-      // see a new request come in.
-      fork
-        req_queue.peek(data);
-        begin
-          cfg.vif.pmp_err <= 1'b1;
-          // Wait for a reset, an address change or req to de-assert
-          @(negedge cfg.vif.rst_n or negedge cfg.vif.req or cfg.vif.addr);
-        end
-      join_any
-      disable fork;
-      cfg.vif.pmp_err <= 1'b0;
     end
   endtask
 

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_if.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_if.sv
@@ -10,9 +10,6 @@ interface ibex_icache_mem_if (input clk,
   logic        gnt;
   logic [31:0] addr;
 
-  // PMP errors
-  logic        pmp_err;
-
   // Response
   logic        rvalid;
   logic [31:0] rdata;
@@ -24,7 +21,6 @@ interface ibex_icache_mem_if (input clk,
 
     output gnt;
 
-    output pmp_err;
     output rvalid;
     output rdata;
     output err;
@@ -35,8 +31,6 @@ interface ibex_icache_mem_if (input clk,
     input req;
     input gnt;
     input addr;
-
-    input pmp_err;
 
     input rvalid;
     input rdata;
@@ -51,7 +45,6 @@ interface ibex_icache_mem_if (input clk,
   // the DUT).
   task automatic reset();
     driver_cb.rvalid  <= 1'b0;
-    driver_cb.pmp_err <= 1'b0;
     driver_cb.gnt     <= 1'b0;
   endtask
 

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_protocol_checker.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_protocol_checker.sv
@@ -18,17 +18,14 @@ interface ibex_icache_mem_protocol_checker (
   input        gnt,
   input [31:0] addr,
 
-  input        pmp_err,
-
   input        rvalid,
   input [31:0] rdata,
   input        err
 );
 
-  // The req, gnt, pmp_err and rvalid lines should always be known
+  // The req, gnt and rvalid lines should always be known
   `ASSERT_KNOWN(ReqKnown,    req,     clk, !rst_n)
   `ASSERT_KNOWN(GntKnown,    gnt,     clk, !rst_n)
-  `ASSERT_KNOWN(PmpErrKnown, pmp_err, clk, !rst_n)
   `ASSERT_KNOWN(RvalidKnown, rvalid,  clk, !rst_n)
 
   // The addr value should be known when req is asserted
@@ -40,8 +37,8 @@ interface ibex_icache_mem_protocol_checker (
   `ASSERT_KNOWN_IF(RDataKnown, rdata, rvalid & ~err, clk, !rst_n)
 
   // The 'req' signal starts a request and shouldn't drop again until granted. Similarly, requested
-  // address must be stable until the request is granted or cancelled by a PMP error.
-  `ASSERT(ReqUntilGrant, req & ~(gnt | pmp_err) |=> req,           clk, !rst_n)
-  `ASSERT(AddrStable,    req & ~(gnt | pmp_err) |=> $stable(addr), clk, !rst_n)
+  // address must be stable until the request is granted.
+  `ASSERT(ReqUntilGrant, req & ~gnt |=> req,           clk, !rst_n)
+  `ASSERT(AddrStable,    req & ~gnt |=> $stable(addr), clk, !rst_n)
 
 endinterface

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_req_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_req_item.sv
@@ -6,12 +6,11 @@
 // memory.
 //
 // When a request first comes in (via a posedge on the req line), it immediately generates a
-// req_item with is_grant = 0. This is used by the sequence to tell the driver whether to generate a
-// PMP error.
+// req_item with is_grant = 0.
 //
-// Assuming that the request wasn't squashed by a PMP error, it will be granted on some later clock
-// edge. At that point, another req_item is generated with is_grant = 1. This is added to a queue in
-// the driver and will be serviced at some later point.
+// The request will be granted on some later clock edge. At that point, another req_item is
+// generated with is_grant = 1. This is added to a queue in the driver and will be serviced at some
+// later point.
 
 class ibex_icache_mem_req_item extends uvm_sequence_item;
 

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_resp_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_resp_item.sv
@@ -10,14 +10,13 @@ class ibex_icache_mem_resp_item extends uvm_sequence_item;
   int unsigned mid_response_delay = 5;
   int unsigned max_response_delay = 50;
 
-  // True if this is a granted request. Otherwise, this is the first time we've seen an address (and
-  // we might need to drive the PMP line).
+  // True if this is a granted request. Otherwise, this is the first time we've seen an address.
   bit               is_grant;
 
-  // If true, drive either a PMP error (if !is_grant) or respond later with a memory error.
+  // If true, respond with a memory error.
   bit               err;
 
-  // The address of the memory response (only used for requests that trigger a PMP error)
+  // The address of the memory response.
   bit [31:0]        address;
 
   // Only has an effect if is_grant. The number of cycles to wait between reading this from the

--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/seq_lib/ibex_icache_mem_resp_seq.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/seq_lib/ibex_icache_mem_resp_seq.sv
@@ -34,7 +34,7 @@ class ibex_icache_mem_resp_seq extends ibex_icache_mem_base_seq;
 
   task pre_start();
     super.pre_start();
-    mem_model = new("mem_model", cfg.disable_pmp_errs, cfg.disable_mem_errs);
+    mem_model = new("mem_model", cfg.disable_mem_errs);
 
     // Take any pending grants and seed from a previous sequence
     if (prev_sequence) begin
@@ -91,7 +91,7 @@ class ibex_icache_mem_resp_seq extends ibex_icache_mem_base_seq;
     resp_item.is_grant = 1'b0;
     resp_item.address  = req_item.address;
     resp_item.rdata    = 'X;
-    resp_item.err = mem_model.is_pmp_error(cur_seed, req_item.address, cfg.mem_err_shift);
+    resp_item.err = 1'b0;
 
     start_item(resp_item);
     `DV_CHECK_RANDOMIZE_FATAL(resp_item)
@@ -129,7 +129,7 @@ class ibex_icache_mem_resp_seq extends ibex_icache_mem_base_seq;
     // the first time, we can't find it for the second grant.
     pending_grants = pending_grants[N - 1 - i:$];
 
-    // Using the seed that we saw for the request, check the memory model for a (non-PMP) error
+    // Using the seed that we saw for the request, check the memory model for an error
     // at this address. On success, look up the memory data too.
     resp_item.is_grant = 1'b1;
     resp_item.err      = mem_model.is_mem_error(gnt_seed, req_item.address, cfg.mem_err_shift);

--- a/dv/uvm/icache/dv/tb/ic_top.sv
+++ b/dv/uvm/icache/dv/tb/ic_top.sv
@@ -7,7 +7,6 @@ module ic_top import ibex_pkg::*; #(parameter bit ICacheECC = 1'b0) (
     input  logic                           rst_ni,
     input  logic                           req_i,
     input  logic                           branch_i,
-    input  logic                           branch_spec_i,
     input  logic                           branch_mispredict_i,
     input  logic [31:0]                    mispredict_addr_i,
     input  logic [31:0]                    addr_i,
@@ -22,7 +21,6 @@ module ic_top import ibex_pkg::*; #(parameter bit ICacheECC = 1'b0) (
     output logic [31:0]                    instr_addr_o,
     input  logic [BUS_SIZE-1:0]            instr_rdata_i,
     input  logic                           instr_err_i,
-    input  logic                           instr_pmp_err_i,
     input  logic                           instr_rvalid_i,
 
     input  logic                           icache_enable_i,
@@ -59,7 +57,6 @@ module ic_top import ibex_pkg::*; #(parameter bit ICacheECC = 1'b0) (
       .req_i               ( req_i                      ),
 
       .branch_i            ( branch_i                   ),
-      .branch_spec_i       ( branch_spec_i              ),
       .branch_mispredict_i ( branch_mispredict_i        ),
       .mispredict_addr_i   ( mispredict_addr_i          ),
       .addr_i              ( addr_i                     ),
@@ -77,7 +74,6 @@ module ic_top import ibex_pkg::*; #(parameter bit ICacheECC = 1'b0) (
       .instr_rvalid_i      ( instr_rvalid_i             ),
       .instr_rdata_i       ( instr_rdata_i              ),
       .instr_err_i         ( instr_err_i                ),
-      .instr_pmp_err_i     ( instr_pmp_err_i            ),
 
       .ic_tag_req_o        ( ic_tag_req                 ),
       .ic_tag_write_o      ( ic_tag_write               ),

--- a/dv/uvm/icache/dv/tb/tb.sv
+++ b/dv/uvm/icache/dv/tb/tb.sv
@@ -31,7 +31,6 @@ module tb #(parameter bit ICacheECC = 1'b0);
     // Connect icache <-> core interface
     .req_i               (core_if.req),
     .branch_i            (core_if.branch),
-    .branch_spec_i       (core_if.branch_spec),
     .branch_mispredict_i (1'b0),
     .mispredict_addr_i   (32'b0),
     .addr_i              (core_if.branch_addr),
@@ -51,7 +50,6 @@ module tb #(parameter bit ICacheECC = 1'b0);
     .instr_addr_o        (mem_if.addr),
     .instr_rdata_i       (mem_if.rdata),
     .instr_err_i         (mem_if.err),
-    .instr_pmp_err_i     (mem_if.pmp_err),
     .instr_rvalid_i      (mem_if.rvalid)
   );
 

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -47,7 +47,6 @@ module ibex_controller #(
   // to prefetcher
   output logic                  instr_req_o,             // start fetching instructions
   output logic                  pc_set_o,                // jump to address set by pc_mux
-  output logic                  pc_set_spec_o,           // speculative branch
   output ibex_pkg::pc_sel_e     pc_mux_o,                // IF stage fetch address selector
                                                          // (boot, normal, exception...)
   output logic                  nt_branch_mispredict_o,  // Not-taken branch in ID/EX was
@@ -65,8 +64,6 @@ module ibex_controller #(
   // jump/branch signals
   input  logic                  branch_set_i,            // branch set signal (branch definitely
                                                          // taken)
-  input  logic                  branch_set_spec_i,       // speculative branch signal (branch
-                                                         // may be taken)
   input  logic                  branch_not_set_i,        // branch is definitely not taken
   input  logic                  jump_set_i,              // jump taken set signal
 
@@ -384,7 +381,6 @@ module ibex_controller #(
     // helping timing.
     pc_mux_o               = PC_BOOT;
     pc_set_o               = 1'b0;
-    pc_set_spec_o          = 1'b0;
     nt_branch_mispredict_o = 1'b0;
 
     exc_pc_mux_o           = EXC_PC_IRQ;
@@ -413,7 +409,6 @@ module ibex_controller #(
         instr_req_o   = 1'b0;
         pc_mux_o      = PC_BOOT;
         pc_set_o      = 1'b1;
-        pc_set_spec_o = 1'b1;
         ctrl_fsm_ns   = BOOT_SET;
       end
 
@@ -422,7 +417,6 @@ module ibex_controller #(
         instr_req_o   = 1'b1;
         pc_mux_o      = PC_BOOT;
         pc_set_o      = 1'b1;
-        pc_set_spec_o = 1'b1;
 
         ctrl_fsm_ns = FIRST_FETCH;
       end
@@ -526,13 +520,6 @@ module ibex_controller #(
           end
         end
 
-        // pc_set signal excluding branch taken condition
-        if (branch_set_spec_i || jump_set_i) begin
-          // Only speculatively set the PC if the branch predictor hasn't already done the branch
-          // for us
-          pc_set_spec_o = BranchPredictor ? ~instr_bp_taken_i : 1'b1;
-        end
-
         // If entering debug mode or handling an IRQ the core needs to wait until any instruction in
         // ID or WB has finished executing. Stall IF during that time.
         if ((enter_debug_mode || handle_irq) && (stall || id_wb_pending)) begin
@@ -566,7 +553,6 @@ module ibex_controller #(
 
         if (handle_irq) begin
           pc_set_o         = 1'b1;
-          pc_set_spec_o    = 1'b1;
 
           csr_save_if_o    = 1'b1;
           csr_save_cause_o = 1'b1;
@@ -601,7 +587,6 @@ module ibex_controller #(
         // jump to debug exception handler in debug memory
         flush_id         = 1'b1;
         pc_set_o         = 1'b1;
-        pc_set_spec_o    = 1'b1;
 
         csr_save_if_o    = 1'b1;
         debug_csr_save_o = 1'b1;
@@ -632,7 +617,6 @@ module ibex_controller #(
         flush_id      = 1'b1;
         pc_mux_o      = PC_EXC;
         pc_set_o      = 1'b1;
-        pc_set_spec_o = 1'b1;
         exc_pc_mux_o  = EXC_PC_DBD;
 
         // update dcsr and dpc
@@ -666,7 +650,6 @@ module ibex_controller #(
         // exc_req_lsu is high for one clock cycle only (in DECODE)
         if (exc_req_q || store_err_q || load_err_q) begin
           pc_set_o         = 1'b1;
-          pc_set_spec_o    = 1'b1;
           pc_mux_o         = PC_EXC;
           exc_pc_mux_o     = debug_mode_q ? EXC_PC_DBG_EXC : EXC_PC_EXC;
 
@@ -712,7 +695,6 @@ module ibex_controller #(
                  * [Debug Spec v0.13.2, p.42]
                  */
                 pc_set_o         = 1'b0;
-                pc_set_spec_o    = 1'b0;
                 csr_save_id_o    = 1'b0;
                 csr_save_cause_o = 1'b0;
                 ctrl_fsm_ns      = DBG_TAKEN_ID;
@@ -745,7 +727,6 @@ module ibex_controller #(
           if (mret_insn) begin
             pc_mux_o              = PC_ERET;
             pc_set_o              = 1'b1;
-            pc_set_spec_o         = 1'b1;
             csr_restore_mret_id_o = 1'b1;
             if (nmi_mode_q) begin
               nmi_mode_d          = 1'b0; // exit NMI mode
@@ -753,7 +734,6 @@ module ibex_controller #(
           end else if (dret_insn) begin
             pc_mux_o              = PC_DRET;
             pc_set_o              = 1'b1;
-            pc_set_spec_o         = 1'b1;
             debug_mode_d          = 1'b0;
             csr_restore_dret_id_o = 1'b1;
           end else if (wfi_insn) begin
@@ -859,9 +839,6 @@ module ibex_controller #(
   `ASSERT(IbexCtrlStateValid, ctrl_fsm_cs inside {
       RESET, BOOT_SET, WAIT_SLEEP, SLEEP, FIRST_FETCH, DECODE, FLUSH,
       IRQ_TAKEN, DBG_TAKEN_IF, DBG_TAKEN_ID})
-
-  // The speculative branch signal should be set whenever the actual branch signal is set
-  `ASSERT(IbexSpecImpliesSetPC, pc_set_o |-> pc_set_spec_o)
 
   `ifdef INC_ASSERT
     // If something that causes a jump into an exception handler is seen that jump must occur before

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -37,7 +37,6 @@ module ibex_cs_registers #(
 
   // Privilege mode
   output ibex_pkg::priv_lvl_e  priv_mode_id_o,
-  output ibex_pkg::priv_lvl_e  priv_mode_if_o,
   output ibex_pkg::priv_lvl_e  priv_mode_lsu_o,
   output logic                 csr_mstatus_tw_o,
 
@@ -729,8 +728,6 @@ module ibex_cs_registers #(
 
   // Send current priv level to the decoder
   assign priv_mode_id_o = priv_lvl_q;
-  // New instruction fetches need to account for updates to priv_lvl_q this cycle
-  assign priv_mode_if_o = priv_lvl_d;
   // Load/store instructions must factor in MPRV for PMP checking
   assign priv_mode_lsu_o = mstatus_q.mprv ? mstatus_q.mpp : priv_lvl_q;
 

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -40,7 +40,6 @@ module ibex_if_stage import ibex_pkg::*; #(
   input  logic                        instr_rvalid_i,
   input  logic [31:0]                 instr_rdata_i,
   input  logic                        instr_err_i,
-  input  logic                        instr_pmp_err_i,
 
   // ICache RAM IO
   output logic [IC_NUM_WAYS-1:0]      ic_tag_req_o,
@@ -74,11 +73,12 @@ module ibex_if_stage import ibex_pkg::*; #(
   output logic                        dummy_instr_id_o,         // Instruction is a dummy
   output logic [31:0]                 pc_if_o,
   output logic [31:0]                 pc_id_o,
+  input  logic                        pmp_err_if_i,
+  input  logic                        pmp_err_if_plus2_i,
 
   // control signals
   input  logic                        instr_valid_clear_i,      // clear instr valid bit in IF-ID
   input  logic                        pc_set_i,                 // set the PC to a new value
-  input  logic                        pc_set_spec_i,
   input  pc_sel_e                     pc_mux_i,                 // selector for PC multiplexer
   input  logic                        nt_branch_mispredict_i,   // Not-taken branch in ID/EX was
                                                                 // mispredicted (predicted taken)
@@ -118,7 +118,6 @@ module ibex_if_stage import ibex_pkg::*; #(
   // prefetch buffer related signals
   logic              prefetch_busy;
   logic              branch_req;
-  logic              branch_spec;
   logic       [31:0] fetch_addr_n;
   logic              unused_fetch_addr_n0;
 
@@ -129,10 +128,17 @@ module ibex_if_stage import ibex_pkg::*; #(
   logic              fetch_err;
   logic              fetch_err_plus2;
 
+  logic [31:0]       instr_decompressed;
+  logic              illegal_c_insn;
+  logic              instr_is_compressed;
+
   logic              if_instr_valid;
   logic       [31:0] if_instr_rdata;
   logic       [31:0] if_instr_addr;
+  logic              if_instr_bus_err;
+  logic              if_instr_pmp_err;
   logic              if_instr_err;
+  logic              if_instr_err_plus2;
 
   logic       [31:0] exc_pc;
 
@@ -212,7 +218,6 @@ module ibex_if_stage import ibex_pkg::*; #(
         .req_i               ( req_i                      ),
 
         .branch_i            ( branch_req                 ),
-        .branch_spec_i       ( branch_spec                ),
         .branch_mispredict_i ( nt_branch_mispredict_i     ),
         .mispredict_addr_i   ( nt_branch_addr_i           ),
         .addr_i              ( {fetch_addr_n[31:1], 1'b0} ),
@@ -230,7 +235,6 @@ module ibex_if_stage import ibex_pkg::*; #(
         .instr_rvalid_i      ( instr_rvalid_i             ),
         .instr_rdata_i       ( instr_rdata_i              ),
         .instr_err_i         ( instr_err_i                ),
-        .instr_pmp_err_i     ( instr_pmp_err_i            ),
 
         .ic_tag_req_o        ( ic_tag_req_o               ),
         .ic_tag_write_o      ( ic_tag_write_o             ),
@@ -258,7 +262,6 @@ module ibex_if_stage import ibex_pkg::*; #(
         .req_i               ( req_i                      ),
 
         .branch_i            ( branch_req                 ),
-        .branch_spec_i       ( branch_spec                ),
         .branch_mispredict_i ( nt_branch_mispredict_i     ),
         .mispredict_addr_i   ( nt_branch_addr_i           ),
         .addr_i              ( {fetch_addr_n[31:1], 1'b0} ),
@@ -276,7 +279,6 @@ module ibex_if_stage import ibex_pkg::*; #(
         .instr_rvalid_i      ( instr_rvalid_i             ),
         .instr_rdata_i       ( instr_rdata_i              ),
         .instr_err_i         ( instr_err_i                ),
-        .instr_pmp_err_i     ( instr_pmp_err_i            ),
 
         .busy_o              ( prefetch_busy              )
     );
@@ -301,20 +303,28 @@ module ibex_if_stage import ibex_pkg::*; #(
   assign unused_fetch_addr_n0 = fetch_addr_n[0];
 
   assign branch_req  = pc_set_i | predict_branch_taken;
-  assign branch_spec = pc_set_spec_i | predict_branch_taken;
 
   assign pc_if_o     = if_instr_addr;
   assign if_busy_o   = prefetch_busy;
+
+  // PMP errors
+  // An error can come from the instruction address, or the next instruction address for unaligned,
+  // uncompressed instructions.
+  assign if_instr_pmp_err = pmp_err_if_i |
+                            (if_instr_addr[2] & ~instr_is_compressed & pmp_err_if_plus2_i);
+
+  // Combine bus errors and pmp errors
+  assign if_instr_err = if_instr_bus_err | if_instr_pmp_err;
+
+  // Capture the second half of the address for errors on the second part of an instruction
+  assign if_instr_err_plus2 = ((if_instr_addr[2] & ~instr_is_compressed & pmp_err_if_plus2_i) |
+                               fetch_err_plus2) & ~pmp_err_if_i;
 
   // compressed instruction decoding, or more precisely compressed instruction
   // expander
   //
   // since it does not matter where we decompress instructions, we do it here
   // to ease timing closure
-  logic [31:0] instr_decompressed;
-  logic        illegal_c_insn;
-  logic        instr_is_compressed;
-
   ibex_compressed_decoder compressed_decoder_i (
     .clk_i          (clk_i),
     .rst_ni         (rst_ni),
@@ -424,7 +434,7 @@ module ibex_if_stage import ibex_pkg::*; #(
         // To reduce fan-out and help timing from the instr_rdata_id flops they are replicated.
         instr_rdata_alu_id_o     <= instr_out;
         instr_fetch_err_o        <= instr_err_out;
-        instr_fetch_err_plus2_o  <= fetch_err_plus2;
+        instr_fetch_err_plus2_o  <= if_instr_err_plus2;
         instr_rdata_c_id_o       <= if_instr_rdata[15:0];
         instr_is_compressed_id_o <= instr_is_compressed_out;
         illegal_c_insn_id_o      <= illegal_c_instr_out;
@@ -438,7 +448,7 @@ module ibex_if_stage import ibex_pkg::*; #(
         // To reduce fan-out and help timing from the instr_rdata_id flops they are replicated.
         instr_rdata_alu_id_o     <= instr_out;
         instr_fetch_err_o        <= instr_err_out;
-        instr_fetch_err_plus2_o  <= fetch_err_plus2;
+        instr_fetch_err_plus2_o  <= if_instr_err_plus2;
         instr_rdata_c_id_o       <= if_instr_rdata[15:0];
         instr_is_compressed_id_o <= instr_is_compressed_out;
         illegal_c_insn_id_o      <= illegal_c_instr_out;
@@ -455,7 +465,7 @@ module ibex_if_stage import ibex_pkg::*; #(
     // Do not check for sequential increase after a branch, jump, exception, interrupt or debug
     // request, all of which will set branch_req. Also do not check after reset or for dummys.
     assign prev_instr_seq_d = (prev_instr_seq_q | instr_new_id_d) &
-        ~branch_req & ~stall_dummy_instr;
+        ~branch_req & ~if_instr_err & ~stall_dummy_instr;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
@@ -465,8 +475,7 @@ module ibex_if_stage import ibex_pkg::*; #(
       end
     end
 
-    assign prev_instr_addr_incr = pc_id_o + ((instr_is_compressed_id_o && !instr_fetch_err_o) ?
-                                             32'd2 : 32'd4);
+    assign prev_instr_addr_incr = pc_id_o + (instr_is_compressed_id_o ? 32'd2 : 32'd4);
 
     // Check that the address equals the previous address +2/+4
     assign pc_mismatch_alert_o = prev_instr_seq_q & (pc_if_o != prev_instr_addr_incr);
@@ -568,7 +577,7 @@ module ibex_if_stage import ibex_pkg::*; #(
 
     // Don't branch predict on instruction error so only instructions without errors end up in the
     // skid buffer.
-    assign if_instr_err     = ~instr_skid_valid_q & fetch_err;
+    assign if_instr_bus_err = ~instr_skid_valid_q & fetch_err;
     assign instr_bp_taken_d = instr_skid_valid_q ? instr_skid_bp_taken_q : predict_branch_taken;
 
     assign fetch_ready = id_in_ready_i & ~stall_dummy_instr & ~instr_skid_valid_q;
@@ -585,7 +594,7 @@ module ibex_if_stage import ibex_pkg::*; #(
     assign if_instr_valid = fetch_valid;
     assign if_instr_rdata = fetch_rdata;
     assign if_instr_addr  = fetch_addr;
-    assign if_instr_err   = fetch_err;
+    assign if_instr_bus_err = fetch_err;
     assign fetch_ready = id_in_ready_i & ~stall_dummy_instr;
   end
 

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -348,8 +348,9 @@ package ibex_pkg;
   parameter int unsigned PMP_CFG_W            = 8;
 
   // PMP acces type
-  parameter int unsigned PMP_I = 0;
-  parameter int unsigned PMP_D = 1;
+  parameter int unsigned PMP_I  = 0;
+  parameter int unsigned PMP_I2 = 1;
+  parameter int unsigned PMP_D  = 2;
 
   typedef enum logic [1:0] {
     PMP_ACC_EXEC    = 2'b00,

--- a/rtl/ibex_prefetch_buffer.sv
+++ b/rtl/ibex_prefetch_buffer.sv
@@ -18,7 +18,6 @@ module ibex_prefetch_buffer #(
   input  logic        req_i,
 
   input  logic        branch_i,
-  input  logic        branch_spec_i,
   input  logic        branch_mispredict_i,
   input  logic [31:0] mispredict_addr_i,
   input  logic [31:0] addr_i,
@@ -31,14 +30,12 @@ module ibex_prefetch_buffer #(
   output logic        err_o,
   output logic        err_plus2_o,
 
-
   // goes to instruction memory / instruction cache
   output logic        instr_req_o,
   input  logic        instr_gnt_i,
   output logic [31:0] instr_addr_o,
   input  logic [31:0] instr_rdata_i,
   input  logic        instr_err_i,
-  input  logic        instr_pmp_err_i,
   input  logic        instr_rvalid_i,
 
   // Prefetch Buffer Status
@@ -47,14 +44,11 @@ module ibex_prefetch_buffer #(
 
   localparam int unsigned NUM_REQS  = 2;
 
-  logic                branch_suppress;
   logic                valid_new_req, valid_req;
   logic                valid_req_d, valid_req_q;
   logic                discard_req_d, discard_req_q;
-  logic                gnt_or_pmp_err, rvalid_or_pmp_err;
   logic [NUM_REQS-1:0] rdata_outstanding_n, rdata_outstanding_s, rdata_outstanding_q;
   logic [NUM_REQS-1:0] branch_discard_n, branch_discard_s, branch_discard_q;
-  logic [NUM_REQS-1:0] rdata_pmp_err_n, rdata_pmp_err_s, rdata_pmp_err_q;
   logic [NUM_REQS-1:0] rdata_outstanding_rev;
 
   logic [31:0]         stored_addr_d, stored_addr_q;
@@ -62,7 +56,6 @@ module ibex_prefetch_buffer #(
   logic [31:0]         fetch_addr_d, fetch_addr_q;
   logic                fetch_addr_en;
   logic [31:0]         instr_addr, instr_addr_w_aligned;
-  logic                instr_or_pmp_err;
 
   logic                fifo_valid;
   logic [31:0]         fifo_addr;
@@ -85,10 +78,6 @@ module ibex_prefetch_buffer #(
   //////////////////////////////////////////////
   // Fetch fifo - consumes addresses and data //
   //////////////////////////////////////////////
-
-  // Instruction fetch errors are valid on the data phase of a request
-  // PMP errors are generated in the address phase, and registered into a fake data phase
-  assign instr_or_pmp_err = instr_err_i | rdata_pmp_err_q[0];
 
   // A branch will invalidate any previously fetched instructions.
   // Note that the FENCE.I instruction relies on this flushing behaviour on branch. If it is
@@ -118,7 +107,7 @@ module ibex_prefetch_buffer #(
       .in_valid_i            ( fifo_valid        ),
       .in_addr_i             ( fifo_addr         ),
       .in_rdata_i            ( instr_rdata_i     ),
-      .in_err_i              ( instr_or_pmp_err  ),
+      .in_err_i              ( instr_err_i       ),
 
       .out_valid_o           ( valid_raw         ),
       .out_ready_i           ( ready_i           ),
@@ -132,25 +121,14 @@ module ibex_prefetch_buffer #(
   // Requests //
   //////////////
 
-  // Suppress a new request on a not-taken branch (as the external address will be incorrect)
-  assign branch_suppress = branch_spec_i & ~branch_i;
-
   // Make a new request any time there is space in the FIFO, and space in the request queue
-  assign valid_new_req = ~branch_suppress & req_i & (fifo_ready | branch_or_mispredict) &
+  assign valid_new_req = req_i & (fifo_ready | branch_or_mispredict) &
                          ~rdata_outstanding_q[NUM_REQS-1];
 
   assign valid_req = valid_req_q | valid_new_req;
 
-  // If a request address triggers a PMP error, the external bus request is suppressed. We might
-  // therefore never receive a grant for such a request. The grant is faked in this case to make
-  // sure the request proceeds and the error is pushed to the FIFO.
-  assign gnt_or_pmp_err = instr_gnt_i | instr_pmp_err_i;
-
-  // As with the grant, the rvalid must be faked for a PMP error, since the request was suppressed.
-  assign rvalid_or_pmp_err = rdata_outstanding_q[0] & (instr_rvalid_i | rdata_pmp_err_q[0]);
-
   // Hold the request stable for requests that didn't get granted
-  assign valid_req_d = valid_req & ~gnt_or_pmp_err;
+  assign valid_req_d = valid_req & ~instr_gnt_i;
 
   // Record whether an outstanding bus request is cancelled by a branch
   assign discard_req_d = valid_req_q & (branch_or_mispredict | discard_req_q);
@@ -172,7 +150,7 @@ module ibex_prefetch_buffer #(
   // 1. stored_addr_q
 
   // Only update stored_addr_q for new ungranted requests
-  assign stored_addr_en = valid_new_req & ~valid_req_q & ~gnt_or_pmp_err;
+  assign stored_addr_en = valid_new_req & ~valid_req_q & ~instr_gnt_i;
 
   // Store whatever address was issued on the bus
   assign stored_addr_d = instr_addr;
@@ -222,7 +200,7 @@ module ibex_prefetch_buffer #(
 
   // Address mux
   assign instr_addr = valid_req_q         ? stored_addr_q :
-                      branch_spec_i       ? addr_i :
+                      branch_i            ? addr_i :
                       branch_mispredict_i ? mispredict_addr_i :
                                             fetch_addr_q;
 
@@ -237,44 +215,36 @@ module ibex_prefetch_buffer #(
     if (i == 0) begin : g_req0
       // A request becomes outstanding once granted, and is cleared once the rvalid is received.
       // Outstanding requests shift down the queue towards entry 0.
-      assign rdata_outstanding_n[i] = (valid_req & gnt_or_pmp_err) |
+      assign rdata_outstanding_n[i] = (valid_req & instr_gnt_i) |
                                       rdata_outstanding_q[i];
       // If a branch is received at any point while a request is outstanding, it must be tracked
       // to ensure we discard the data once received
-      assign branch_discard_n[i]    = (valid_req & gnt_or_pmp_err & discard_req_d) |
+      assign branch_discard_n[i]    = (valid_req & instr_gnt_i & discard_req_d) |
                                       (branch_or_mispredict & rdata_outstanding_q[i]) |
                                       branch_discard_q[i];
-      // Record whether this request received a PMP error
-      assign rdata_pmp_err_n[i]     = (valid_req & ~rdata_outstanding_q[i] & instr_pmp_err_i) |
-                                      rdata_pmp_err_q[i];
 
     end else begin : g_reqtop
     // Entries > 0 consider the FIFO fill state to calculate their next state (by checking
     // whether the previous entry is valid)
 
-      assign rdata_outstanding_n[i] = (valid_req & gnt_or_pmp_err &
+      assign rdata_outstanding_n[i] = (valid_req & instr_gnt_i &
                                        rdata_outstanding_q[i-1]) |
                                       rdata_outstanding_q[i];
-      assign branch_discard_n[i]    = (valid_req & gnt_or_pmp_err & discard_req_d &
+      assign branch_discard_n[i]    = (valid_req & instr_gnt_i & discard_req_d &
                                        rdata_outstanding_q[i-1]) |
                                       (branch_or_mispredict & rdata_outstanding_q[i]) |
                                       branch_discard_q[i];
-      assign rdata_pmp_err_n[i]     = (valid_req & ~rdata_outstanding_q[i] & instr_pmp_err_i &
-                                       rdata_outstanding_q[i-1]) |
-                                      rdata_pmp_err_q[i];
     end
   end
 
   // Shift the entries down on each instr_rvalid_i
-  assign rdata_outstanding_s = rvalid_or_pmp_err ? {1'b0,rdata_outstanding_n[NUM_REQS-1:1]} :
-                                                   rdata_outstanding_n;
-  assign branch_discard_s    = rvalid_or_pmp_err ? {1'b0,branch_discard_n[NUM_REQS-1:1]} :
-                                                   branch_discard_n;
-  assign rdata_pmp_err_s     = rvalid_or_pmp_err ? {1'b0,rdata_pmp_err_n[NUM_REQS-1:1]} :
-                                                   rdata_pmp_err_n;
+  assign rdata_outstanding_s = instr_rvalid_i ? {1'b0,rdata_outstanding_n[NUM_REQS-1:1]} :
+                                                rdata_outstanding_n;
+  assign branch_discard_s    = instr_rvalid_i ? {1'b0,branch_discard_n[NUM_REQS-1:1]} :
+                                                branch_discard_n;
 
   // Push a new entry to the FIFO once complete (and not cancelled by a branch)
-  assign fifo_valid = rvalid_or_pmp_err & ~branch_discard_q[0];
+  assign fifo_valid = instr_rvalid_i & ~branch_discard_q[0];
 
   assign fifo_addr = branch_i ? addr_i : mispredict_addr_i;
 
@@ -288,13 +258,11 @@ module ibex_prefetch_buffer #(
       discard_req_q        <= 1'b0;
       rdata_outstanding_q  <= 'b0;
       branch_discard_q     <= 'b0;
-      rdata_pmp_err_q      <= 'b0;
     end else begin
       valid_req_q          <= valid_req_d;
       discard_req_q        <= discard_req_d;
       rdata_outstanding_q  <= rdata_outstanding_s;
       branch_discard_q     <= branch_discard_s;
-      rdata_pmp_err_q      <= rdata_pmp_err_s;
     end
   end
 


### PR DESCRIPTION
- Instruction addresses are now checked in the IF stage, after the cache
  and after the prefetch buffer.
- To deal with unaligned instructions, the PMP logic checks the current
  address and the next in parallel.
- The spec_branch timing hack has been removed as it's no longer
  relevant with the PMP logic moved.
- Various updates made to the icache testbench to account for the
  changes.
- Relates to #1471

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>