### PR TITLE
Update google_riscv-dv to google/riscv-dv@6053014

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: ea8dd25140178eed13c3e0f3d3a97a0c07ab44a0
+    rev: 605301400555c235564f9336cc5fc220af7e951c
   }
 }

--- a/vendor/google_riscv-dv/scripts/gen_csr_test.py
+++ b/vendor/google_riscv-dv/scripts/gen_csr_test.py
@@ -214,6 +214,7 @@ def gen_setup(test_file):
     test_file.write(".section .text.init\n")
     test_file.write(".globl _start\n")
     test_file.write(".option norvc\n")
+    test_file.write(".org 0x80\n")
     test_file.write("_start:\n")
 
 

--- a/vendor/google_riscv-dv/src/isa/riscv_zbb_instr.sv
+++ b/vendor/google_riscv-dv/src/isa/riscv_zbb_instr.sv
@@ -31,7 +31,8 @@ class riscv_zbb_instr extends riscv_instr;
       end
 
       I_FORMAT: begin
-        if (instr_name inside { CLZ, CLZW, CTZ, CTZW, CPOP, CPOPW, ORC_B, SEXT_B, SEXT_H, REV8 }) begin
+        if (instr_name inside { CLZ, CLZW, CTZ, CTZW, CPOP, CPOPW, ORC_B, SEXT_B, SEXT_H, REV8 })
+        begin
           has_imm = 1'b0;
         end
       end
@@ -193,14 +194,16 @@ class riscv_zbb_instr extends riscv_instr;
       I_FORMAT: begin
         case (instr_name) inside
           CLZ, CLZW, CPOP, CPOPW, CTZ, CTZW, ORC_B, REV8, SEXT_B, SEXT_H: begin
-            binary = $sformatf("%8h", {get_func7(), get_func5(), rs1, get_func3(), rd, get_opcode()});
+            binary = $sformatf("%8h", {get_func7(), get_func5(), rs1, get_func3(), rd,
+                                       get_opcode()});
           end
           RORIW: begin
             binary = $sformatf("%8h", {get_func7(), imm[5:0], rs1, get_func3(), rd, get_opcode()});
           end
           RORI: begin
             // set bit 0 of funct7 only if rv64 and shamt[MSB] is set
-            binary = $sformatf("%8h", {(get_func7() | (is_rv64() && imm[5])), imm[4:0], rs1, get_func3(), rd, get_opcode()});
+            binary = $sformatf("%8h", {(get_func7() | (is_rv64() && imm[5])), imm[4:0], rs1,
+                                        get_func3(), rd, get_opcode()});
           end
         endcase
       end

--- a/vendor/google_riscv-dv/src/isa/riscv_zbs_instr.sv
+++ b/vendor/google_riscv-dv/src/isa/riscv_zbs_instr.sv
@@ -83,7 +83,8 @@ class riscv_zbs_instr extends riscv_instr;
       I_FORMAT : begin
         case (instr_name) inside
           BCLRI, BEXTI, BINVI, BSETI : begin
-            binary = $sformatf("%8h", {(get_func7() | (is_rv64() && imm[5])), imm[4:0], rs1, get_func3(), rd, get_opcode()});
+            binary = $sformatf("%8h", {(get_func7() | (is_rv64() && imm[5])), imm[4:0], rs1,
+                                        get_func3(), rd, get_opcode()});
           end
         endcase
       end


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv-
dv to revision 605301400555c235564f9336cc5fc220af7e951c

* [style] Break long lines in newly added files (Michael Schaffner)

Signed-off-by: Michael Schaffner <msf@google.com>