### PR TITLE
[bitmanip] Add new OpenTitan config, update documentation on bitmanip support and area numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ These are configurations on which lowRISC is focusing for performance evaluation
 | ------ | ------- | --------| ----------| -------------------- |
 | Features | RV32EC | RV32IMC, 3 cycle mult | RV32IMC, 1 cycle mult, Branch target ALU, Writeback stage | RV32IMCB, 1 cycle mult, Branch target ALU, Writeback stage, 16 PMP regions |
 | Performance (CoreMark/MHz) | 0.904 | 2.47 | 3.13 | 3.13 |
-| Area - Yosys (kGE) | 17.44 | 26.06 | 35.64 | 58.74 |
-| Area - Commercial (estimated kGE) | ~16 | ~24 | ~33 | ~54 |
+| Area - Yosys (kGE) | 16.85 | 26.60 | 32.48 | 66.02 |
+| Area - Commercial (estimated kGE) | ~15 | ~24 | ~30 | ~61 |
 | Verification status | Red | Green | Amber | Amber |
 
 Notes:
@@ -46,8 +46,8 @@ Notes:
   Amber indicates that some verification has been performed, but the configuration is still experimental.
   Red indicates a configuration with minimal/no verification.
   Users must make their own assessment of verification readiness for any tapeout.
-* v0.92 of the RISC-V Bit Manipulation Extension is supported.
-  This is *not ratified* and there may be changes for the v1.0 ratified version.
+* v.1.0.0 of the RISC-V Bit-Manipulation Extension is supported as well as the remaining sub-extensions of draft v.0.93 of the bitmanip spec.
+  The latter are *not ratified* and there may be changes before ratification.
   See [Standards Compliance](https://ibex-core.readthedocs.io/en/latest/01_overview/compliance.html) in the Ibex documentation for more information.
 
 ## Documentation

--- a/doc/01_overview/compliance.rst
+++ b/doc/01_overview/compliance.rst
@@ -8,7 +8,7 @@ It follows these specifications:
 * `RISC-V Instruction Set Manual, Volume II: Privileged Architecture, document version 20190608-Base-Ratified (June 8, 2019) <https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMFDQC-and-Priv-v1.11/riscv-privileged-20190608.pdf>`_.
   Ibex implements the Machine ISA version 1.11.
 * `RISC-V External Debug Support, version 0.13.2 <https://content.riscv.org/wp-content/uploads/2019/03/riscv-debug-release.pdf>`_
-* `RISC-V Bit Manipulation Extension, version 0.92 (draft from November 8, 2019) <https://github.com/riscv/riscv-bitmanip/blob/master/bitmanip-0.92.pdf>`_
+* `RISC-V Bit-Manipulation Extension, version 1.0.0 <https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0-38-g865e7a7.pdf>`_ and `version 0.93 (draft from January 10, 2021) <https://github.com/riscv/riscv-bitmanip/blob/master/bitmanip-0.93.pdf>`_
 * `PMP Enhancements for memory access and execution prevention on Machine mode (Smepmp) version 0.9.3 <https://github.com/riscv/riscv-tee/blob/61455747230a26002d741f64879dd78cc9689323/Smepmp/Smepmp.pdf>`_
 
 Many features in the RISC-V specification are optional, and Ibex can be parametrized to enable or disable some of them.
@@ -35,8 +35,8 @@ In addition, the following instruction set extensions are available.
      - 2.0
      - optional
 
-   * - **B**: Draft Extension for Bit Manipulation Instructions
-     - 0.92 [#B_draft]_
+   * - **B**: Standard Extension for Bit-Manipulation Instructions
+     - 1.0.0 + 0.93 [#B_draft]_
      - optional
 
    * - **Zicsr**: Control and Status Register Instructions
@@ -59,7 +59,9 @@ See :ref:`PMP Enhancements<pmp-enhancements>` for more information on Ibex's exp
 
 .. rubric:: Footnotes
 
-.. [#B_draft] Note that while Ibex fully implements draft version 0.92 of the RISC-V Bit Manipulation Extension, this extension may change before being ratified as a standard by the RISC-V Foundation.
+.. [#B_draft] Ibex fully implements the ratified version 1.0.0 of the RISC-V Bit-Manipulation Extension including the Zba, Zbb, Zbc and Zbs sub-extensions.
+   In addition, Ibex also supports the remaining Zbe, Zbf, Zbp, Zbr and Zbt sub-extensions as defined in draft version 0.93 of the RISC-V Bit-Manipulation Extension.
+   Note that the latter sub-extensions may change before being ratified as a standard by the RISC-V Foundation.
    Ibex will be updated to match future versions of the specification.
    Prior to ratification this may involve backwards incompatible changes.
    Additionally, neither GCC or Clang have committed to maintaining support upstream for unratified versions of the specification.

--- a/doc/01_overview/targets.rst
+++ b/doc/01_overview/targets.rst
@@ -7,7 +7,7 @@ ASIC Synthesis
 ASIC synthesis is supported for Ibex.
 The whole design is completely synchronous and uses positive-edge triggered flip-flops, except for the register file, which can be implemented either with latches or with flip-flops.
 See :ref:`register-file` for more details.
-The core occupies an area of roughly 24 kGE when using the latch-based register file and implementing the RV32IMC ISA, or 16 kGE when implementing the RV32EC ISA.
+The core occupies an area of roughly 24 kGE when using the latch-based register file and implementing the RV32IMC ISA, or 15 kGE when implementing the RV32EC ISA.
 
 
 FPGA Synthesis

--- a/doc/03_reference/instruction_decode_execute.rst
+++ b/doc/03_reference/instruction_decode_execute.rst
@@ -64,44 +64,45 @@ Other blocks use the ALU for the following tasks:
 * It computes memory addresses for loads and stores with a Reg + Imm calculation
 * The LSU uses it to increment addresses when performing two accesses to handle an unaligned access
 
-Bit Manipulation Extension
-  Support for the `RISC-V Bit Manipulation Extension (draft version 0.92 from November 8, 2019) <https://github.com/riscv/riscv-bitmanip/blob/master/bitmanip-0.92.pdf>`_ is optional. [#B_draft]_
+Bit-Manipulation Extension
+  Support for the `RISC-V Bit-Manipulation Extension version 1.0.0 <https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0-38-g865e7a7.pdf>`_ and `draft version 0.93 from January 10, 2021 <https://github.com/riscv/riscv-bitmanip/blob/master/bitmanip-0.93.pdf>`_ is optional. [#B_draft]_
   It can be enabled via the enumerated parameter ``RV32B`` defined in :file:`rtl/ibex_pkg.sv`.
-  By default, this parameter is set to "ibex_pkg::RV32BNone" to disable the bit manipulation extension.
+  By default, this parameter is set to "ibex_pkg::RV32BNone" to disable the bit-manipulation extension.
 
-  There are two versions of the bit manipulation extension available:
-  The balanced implementation comprises a set of sub-extensions aiming for good benefits at a reasonable area overhead.
+  There are three versions of the bit-manipulation extension available:
+  The balanced version comprises a set of sub-extensions aiming for good benefits at a reasonable area overhead.
   It can be selected by setting the ``RV32B`` parameter to "ibex_pkg::RV32BBalanced".
-  The full implementation comprises all 32 bit instructions defined in the extension.
-  This version can be selected by setting the ``RV32B`` parameter to "ibex_pkg::RV32BFull".
-  The following table lists the implemented instructions in each version.
+  The OTEarlGrey version comprises all sub-extensions except for the Zbe.
+  This version can be selected by setting the ``RV32B`` parameter to "ibex_pkg::RV32BOTEarlGrey".
+  The full version comprises all sub-extensions and can be selected by setting the ``RV32B`` parameter to "ibex_pkg::RV32BFull".
+  The following table gives an overview of which sub-extensions are implemented in each version and of which instructions are implemented as multi-cycle instructions.
   Multi-cycle instructions are completed in 2 cycles.
   All remaining instructions complete in a single cycle.
 
-  +---------------------------------+---------------+--------------------------+
-  | Z-Extension                     | Version       | Multi-Cycle Instructions |
-  +=================================+===============+==========================+
-  | Zbb (Base)                      | Balanced/Full | rol, ror[i]              |
-  +---------------------------------+---------------+--------------------------+
-  | Zbs (Single-bit)                | Balanced/Full | None                     |
-  +---------------------------------+---------------+--------------------------+
-  | Zbp (Permutation)               | Full          | None                     |
-  +---------------------------------+---------------+--------------------------+
-  | Zbe (Bit compress/decompress)   | Full          | All                      |
-  +---------------------------------+---------------+--------------------------+
-  | Zbf (Bit-field place)           | Balanced/Full | All                      |
-  +---------------------------------+---------------+--------------------------+
-  | Zbc (Carry-less multiply)       | Full          | None                     |
-  +---------------------------------+---------------+--------------------------+
-  | Zbr (CRC)                       | Full          | All                      |
-  +---------------------------------+---------------+--------------------------+
-  | Zbt (Ternary)                   | Balanced/Full | All                      |
-  +---------------------------------+---------------+--------------------------+
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Bit-Manipulation Sub-Extension | Spec.   | Balanced | OTEarlGrey | Full | Multi-Cycle Instr. |
+  +================================+=========+==========+============+======+====================+
+  | Zba (Address generation)       | v.1.0.0 |    X     |     X      |  X   | None               |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbb (Base)                     | v.1.0.0 |    X     |     X      |  X   | rol, ror[i]        |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbc (Carry-less multiply)      | v.1.0.0 |          |     X      |  X   | None               |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbs (Single-bit)               | v.1.0.0 |    X     |     X      |  X   | None               |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbe (Bit compress/decompress)  | v.0.93  |          |            |  X   | All                |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbf (Bit-field place)          | v.0.93  |    X     |     X      |  X   | All                |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbp (Permutation)              | v.0.93  |          |     X      |  X   | None               |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbr (CRC)                      | v.0.93  |          |     X      |  X   | All                |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbt (Ternary)                  | v.0.93  |    X     |     X      |  X   | All                |
+  +--------------------------------+---------+----------+------------+------+--------------------+
 
-  The implementation of the B-extension comes with an area overhead of 1.8 to 3.0 kGE for the balanced version and 6.0 to 8.7 kGE for the full version.
-  That corresponds to an approximate percentage increase in area of 9 to 14 % and 25 to 30 % for the balanced and full versions respectively.
-  The ranges correspond to synthesis results generated using relaxed and maximum frequency targets respectively.
-  The designs have been synthesized using Synopsys Design Compiler targeting TSMC 65 nm technology.
+  The implementation of the Bit-Manipulation Extension comes with an area overhead of 2.7 kGE for the balanced version, 6.1 kGE for the OTEarlGrey version, and 7.5 kGE for the full version.
+  These numbers were obtained by synthesizing the design with Yosys and relaxed timing constraints.
 
 
 .. _mult-div:
@@ -171,8 +172,9 @@ See :ref:`load-store-unit` for more details.
 
 .. rubric:: Footnotes
 
-.. [#B_draft] Ibex fully implements draft version 0.92 of the RISC-V Bit Manipulation Extension.
-   This extension may change before being ratified as a standard by the RISC-V Foundation.
+.. [#B_draft] Ibex fully implements the ratified version 1.0.0 of the RISC-V Bit-Manipulation Extension including the Zba, Zbb, Zbc and Zbs sub-extensions.
+   In addition, Ibex also supports the remaining Zbe, Zbf, Zbp, Zbr and Zbt sub-extensions as defined in draft version 0.93 of the RISC-V Bit-Manipulation Extension.
+   Note that the latter sub-extensions may change before being ratified as a standard by the RISC-V Foundation.
    Ibex will be updated to match future versions of the specification.
    Prior to ratification this may involve backwards incompatible changes.
    Additionally, neither GCC or Clang have committed to maintaining support upstream for unratified versions of the specification.

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -719,8 +719,6 @@
 # Both an updated compiler and ISS are required to verify the bitmanip v.1.00
 # and draft v.0.93 extensions. For now, disable the bitmanip tests.
 # For details, refer to https://github.com/lowRISC/ibex/issues/1470
-#ISA                 := rv32imcb
-#ISA_ISS             := rv32imc_Zba_Zbb_Zbc_Zbs_Xbitmanip
 #- test: riscv_bitmanip_full_test
 #  desc: >
 #    Random instruction test with supported B extension instructions in full configuration
@@ -738,6 +736,23 @@
 #  rtl_params:
 #    RV32B: "ibex_pkg::RV32BFull"
 #
+#- test: riscv_bitmanip_otearlgrey_test
+#  desc: >
+#    Random instruction test with supported B extension instructions in OTEarlGrey configuration
+#  iterations: 10
+#  gen_test: riscv_rand_instr_test
+#  gen_opts: >
+#    +enable_zba_extension=1
+#    +enable_zbb_extension=1
+#    +enable_zbc_extension=1
+#    +enable_zbs_extension=1
+#    +enable_b_extension=1
+#    +enable_bitmanip_groups=zbf,zbp,zbr,zbt
+#    +disable_cosim=1
+#  rtl_test: core_ibex_base_test
+#  rtl_params:
+#    RV32B: ["ibex_pkg::RV32BFull", "ibex_pkg::RV32BOTEarlGrey"]
+#
 #- test: riscv_bitmanip_balanced_test
 #  desc: >
 #    Random instruction test with supported B extension instructions in balanced configuration
@@ -752,4 +767,4 @@
 #    +disable_cosim=1
 #  rtl_test: core_ibex_base_test
 #  rtl_params:
-#    RV32B: ["ibex_pkg::RV32BFull", "ibex_pkg::RV32BBalanced"]
+#    RV32B: ["ibex_pkg::RV32BFull", "ibex_pkg::RV32BOTEarlGrey", "ibex_pkg::RV32BBalanced"]

--- a/ibex_configs.yaml
+++ b/ibex_configs.yaml
@@ -26,7 +26,7 @@ small:
 opentitan:
   RV32E                    : 0
   RV32M                    : "ibex_pkg::RV32MSingleCycle"
-  RV32B                    : "ibex_pkg::RV32BNone"
+  RV32B                    : "ibex_pkg::RV32BOTEarlGrey"
   RegFile                  : "ibex_pkg::RegFileFF"
   BranchTargetALU          : 1
   WritebackStage           : 1

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -1006,47 +1006,47 @@ module ibex_decoder #(
             // RV32B ALU Operations
             {7'b011_0000, 3'b001}: begin
               if (RV32B != RV32BNone) begin
-                alu_operator_o = ALU_ROL;   // rol
+                alu_operator_o = ALU_ROL;
                 alu_multicycle_o = 1'b1;
               end
             end
             {7'b011_0000, 3'b101}: begin
               if (RV32B != RV32BNone) begin
-                alu_operator_o = ALU_ROR;   // ror
+                alu_operator_o = ALU_ROR;
                 alu_multicycle_o = 1'b1;
               end
             end
 
-            {7'b000_0101, 3'b100}: if (RV32B != RV32BNone) alu_operator_o = ALU_MIN;    // min
-            {7'b000_0101, 3'b110}: if (RV32B != RV32BNone) alu_operator_o = ALU_MAX;    // max
-            {7'b000_0101, 3'b101}: if (RV32B != RV32BNone) alu_operator_o = ALU_MINU;   // minu
-            {7'b000_0101, 3'b111}: if (RV32B != RV32BNone) alu_operator_o = ALU_MAXU;   // maxu
+            {7'b000_0101, 3'b100}: if (RV32B != RV32BNone) alu_operator_o = ALU_MIN;
+            {7'b000_0101, 3'b110}: if (RV32B != RV32BNone) alu_operator_o = ALU_MAX;
+            {7'b000_0101, 3'b101}: if (RV32B != RV32BNone) alu_operator_o = ALU_MINU;
+            {7'b000_0101, 3'b111}: if (RV32B != RV32BNone) alu_operator_o = ALU_MAXU;
 
-            {7'b000_0100, 3'b100}: if (RV32B != RV32BNone) alu_operator_o = ALU_PACK;   // pack
-            {7'b010_0100, 3'b100}: if (RV32B != RV32BNone) alu_operator_o = ALU_PACKU;  // packu
-            {7'b000_0100, 3'b111}: if (RV32B != RV32BNone) alu_operator_o = ALU_PACKH;  // packh
+            {7'b000_0100, 3'b100}: if (RV32B != RV32BNone) alu_operator_o = ALU_PACK;
+            {7'b010_0100, 3'b100}: if (RV32B != RV32BNone) alu_operator_o = ALU_PACKU;
+            {7'b000_0100, 3'b111}: if (RV32B != RV32BNone) alu_operator_o = ALU_PACKH;
 
-            {7'b010_0000, 3'b100}: if (RV32B != RV32BNone) alu_operator_o = ALU_XNOR;   // xnor
-            {7'b010_0000, 3'b110}: if (RV32B != RV32BNone) alu_operator_o = ALU_ORN;    // orn
-            {7'b010_0000, 3'b111}: if (RV32B != RV32BNone) alu_operator_o = ALU_ANDN;   // andn
+            {7'b010_0000, 3'b100}: if (RV32B != RV32BNone) alu_operator_o = ALU_XNOR;
+            {7'b010_0000, 3'b110}: if (RV32B != RV32BNone) alu_operator_o = ALU_ORN;
+            {7'b010_0000, 3'b111}: if (RV32B != RV32BNone) alu_operator_o = ALU_ANDN;
 
             // RV32B zba
-            {7'b001_0000, 3'b010}: if (RV32B != RV32BNone) alu_operator_o = ALU_SH1ADD; // sh1add
-            {7'b001_0000, 3'b100}: if (RV32B != RV32BNone) alu_operator_o = ALU_SH2ADD; // sh2add
-            {7'b001_0000, 3'b110}: if (RV32B != RV32BNone) alu_operator_o = ALU_SH3ADD; // sh3add
+            {7'b001_0000, 3'b010}: if (RV32B != RV32BNone) alu_operator_o = ALU_SH1ADD;
+            {7'b001_0000, 3'b100}: if (RV32B != RV32BNone) alu_operator_o = ALU_SH2ADD;
+            {7'b001_0000, 3'b110}: if (RV32B != RV32BNone) alu_operator_o = ALU_SH3ADD;
 
             // RV32B zbs
-            {7'b010_0100, 3'b001}: if (RV32B != RV32BNone) alu_operator_o = ALU_BCLR;   // bclr
-            {7'b001_0100, 3'b001}: if (RV32B != RV32BNone) alu_operator_o = ALU_BSET;   // bset
-            {7'b011_0100, 3'b001}: if (RV32B != RV32BNone) alu_operator_o = ALU_BINV;   // binv
-            {7'b010_0100, 3'b101}: if (RV32B != RV32BNone) alu_operator_o = ALU_BEXT;   // bext
+            {7'b010_0100, 3'b001}: if (RV32B != RV32BNone) alu_operator_o = ALU_BCLR;
+            {7'b001_0100, 3'b001}: if (RV32B != RV32BNone) alu_operator_o = ALU_BSET;
+            {7'b011_0100, 3'b001}: if (RV32B != RV32BNone) alu_operator_o = ALU_BINV;
+            {7'b010_0100, 3'b101}: if (RV32B != RV32BNone) alu_operator_o = ALU_BEXT;
 
             // RV32B zbf
-            {7'b010_0100, 3'b111}: if (RV32B != RV32BNone) alu_operator_o = ALU_BFP;    // bfp
+            {7'b010_0100, 3'b111}: if (RV32B != RV32BNone) alu_operator_o = ALU_BFP;
 
             // RV32B zbp
-            {7'b011_0100, 3'b101}: if (RV32B != RV32BNone) alu_operator_o = ALU_GREV;    // grev
-            {7'b001_0100, 3'b101}: if (RV32B != RV32BNone) alu_operator_o = ALU_GORC;    // gorc
+            {7'b011_0100, 3'b101}: if (RV32B != RV32BNone) alu_operator_o = ALU_GREV;
+            {7'b001_0100, 3'b101}: if (RV32B != RV32BNone) alu_operator_o = ALU_GORC;
             {7'b000_0100, 3'b001}: begin
               if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) alu_operator_o = ALU_SHFL;
             end
@@ -1083,13 +1083,13 @@ module ibex_decoder #(
             // RV32B zbe
             {7'b010_0100, 3'b110}: begin
               if (RV32B == RV32BFull) begin
-                alu_operator_o = ALU_BDECOMPRESS; // bdecompress
+                alu_operator_o = ALU_BDECOMPRESS;
                 alu_multicycle_o = 1'b1;
               end
             end
             {7'b000_0100, 3'b110}: begin
               if (RV32B == RV32BFull) begin
-                alu_operator_o = ALU_BCOMPRESS;   // bcompress
+                alu_operator_o = ALU_BCOMPRESS;
                 alu_multicycle_o = 1'b1;
               end
             end

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -362,14 +362,18 @@ module ibex_decoder #(
           3'b001: begin
             unique case (instr[31:27])
               5'b0_0000: illegal_insn = (instr[26:25] == 2'b00) ? 1'b0 : 1'b1;        // slli
-              5'b0_0100: illegal_insn = (RV32B == RV32BFull) ? 1'b0 : 1'b1;           // sloi
+              5'b0_0100: begin                                                        // sloi
+                illegal_insn = (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) ? 1'b0 : 1'b1;
+              end
               5'b0_1001,                                                              // bclri
               5'b0_0101,                                                              // bseti
               5'b0_1101: illegal_insn = (RV32B != RV32BNone) ? 1'b0 : 1'b1;           // binvi
-              5'b0_0001: if (instr[26] == 1'b0) begin
-                illegal_insn = (RV32B == RV32BFull) ? 1'b0 : 1'b1;                    // shfl
-              end else begin
-                illegal_insn = 1'b1;
+              5'b0_0001: begin
+                if (instr[26] == 1'b0) begin                                          // shfl
+                  illegal_insn = (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) ? 1'b0 : 1'b1;
+                end else begin
+                  illegal_insn = 1'b1;
+                end
               end
               5'b0_1100: begin
                 unique case(instr[26:20])
@@ -383,8 +387,9 @@ module ibex_decoder #(
                   7'b001_0010,                                                         // crc32.w
                   7'b001_1000,                                                         // crc32c.b
                   7'b001_1001,                                                         // crc32c.h
-                  7'b001_1010: illegal_insn = (RV32B == RV32BFull) ? 1'b0 : 1'b1;      // crc32c.w
-
+                  7'b001_1010: begin                                                   // crc32c.w
+                    illegal_insn = (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) ? 1'b0 : 1'b1;
+                  end
                   default: illegal_insn = 1'b1;
                 endcase
               end
@@ -400,12 +405,14 @@ module ibex_decoder #(
                 5'b0_0000,                                                             // srli
                 5'b0_1000: illegal_insn = (instr[26:25] == 2'b00) ? 1'b0 : 1'b1;       // srai
 
-                5'b0_0100: illegal_insn = (RV32B == RV32BFull) ? 1'b0 : 1'b1;          // sroi
+                5'b0_0100: begin                                                       // sroi
+                  illegal_insn = (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) ? 1'b0 : 1'b1;
+                end
                 5'b0_1100,                                                             // rori
                 5'b0_1001: illegal_insn = (RV32B != RV32BNone) ? 1'b0 : 1'b1;          // bexti
 
                 5'b0_1101: begin
-                  if ((RV32B == RV32BFull)) begin
+                  if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) begin
                     illegal_insn = 1'b0;                                               // grevi
                   end else if (RV32B == RV32BBalanced) begin
                     illegal_insn = (instr[24:20] == 5'b11000) ? 1'b0 : 1'b1;           // rev8
@@ -414,7 +421,7 @@ module ibex_decoder #(
                   end
                 end
                 5'b0_0101: begin
-                  if ((RV32B == RV32BFull)) begin
+                  if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) begin
                     illegal_insn = 1'b0;                                              // gorci
                   end else if (instr[24:20] == 5'b00111) begin
                     illegal_insn = (RV32B == RV32BBalanced) ? 1'b0 : 1'b1;            // orc.b
@@ -423,8 +430,8 @@ module ibex_decoder #(
                   end
                 end
                 5'b0_0001: begin
-                  if (instr[26] == 1'b0) begin
-                    illegal_insn = (RV32B == RV32BFull) ? 1'b0 : 1'b1;                // unshfl
+                  if (instr[26] == 1'b0) begin                                        // unshfl
+                    illegal_insn = (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) ? 1'b0 : 1'b1;
                   end else begin
                     illegal_insn = 1'b1;
                   end
@@ -483,9 +490,6 @@ module ibex_decoder #(
             {7'b010_0100, 3'b101}, // bext
             // RV32B zbf
             {7'b010_0100, 3'b111}: illegal_insn = (RV32B != RV32BNone) ? 1'b0 : 1'b1; // bfp
-            // RV32B zbe
-            {7'b010_0100, 3'b110}, // bdecompress
-            {7'b000_0100, 3'b110}, // bcompress
             // RV32B zbp
             {7'b011_0100, 3'b101}, // grev
             {7'b001_0100, 3'b101}, // gorc
@@ -499,7 +503,12 @@ module ibex_decoder #(
             // RV32B zbc
             {7'b000_0101, 3'b001}, // clmul
             {7'b000_0101, 3'b010}, // clmulr
-            {7'b000_0101, 3'b011}: illegal_insn = (RV32B == RV32BFull) ? 1'b0 : 1'b1; // clmulh
+            {7'b000_0101, 3'b011}: begin // clmulh
+              illegal_insn = (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) ? 1'b0 : 1'b1;
+            end
+            // RV32B zbe
+            {7'b010_0100, 3'b110}, // bdecompress
+            {7'b000_0100, 3'b110}: illegal_insn = (RV32B == RV32BFull) ? 1'b0 : 1'b1; // bcompress
 
             // RV32M instructions
             {7'b000_0001, 3'b000}: begin // mul
@@ -824,7 +833,9 @@ module ibex_decoder #(
               unique case (instr_alu[31:27])
                 5'b0_0000: alu_operator_o = ALU_SLL;    // Shift Left Logical by Immediate
                 // Shift Left Ones by Immediate
-                5'b0_0100: if (RV32B == RV32BFull) alu_operator_o = ALU_SLO;
+                5'b0_0100: begin
+                  if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) alu_operator_o = ALU_SLO;
+                end
                 5'b0_1001: alu_operator_o = ALU_BCLR; // Clear bit specified by immediate
                 5'b0_0101: alu_operator_o = ALU_BSET; // Set bit specified by immediate
                 5'b0_1101: alu_operator_o = ALU_BINV; // Invert bit specified by immediate.
@@ -838,37 +849,37 @@ module ibex_decoder #(
                     7'b000_0100: alu_operator_o = ALU_SEXTB; // sext.b
                     7'b000_0101: alu_operator_o = ALU_SEXTH; // sext.h
                     7'b001_0000: begin
-                      if (RV32B == RV32BFull) begin
+                      if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) begin
                         alu_operator_o = ALU_CRC32_B;  // crc32.b
                         alu_multicycle_o = 1'b1;
                       end
                     end
                     7'b001_0001: begin
-                      if (RV32B == RV32BFull) begin
+                      if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) begin
                         alu_operator_o = ALU_CRC32_H;  // crc32.h
                         alu_multicycle_o = 1'b1;
                       end
                     end
                     7'b001_0010: begin
-                      if (RV32B == RV32BFull) begin
+                      if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) begin
                         alu_operator_o = ALU_CRC32_W;  // crc32.w
                         alu_multicycle_o = 1'b1;
                       end
                     end
                     7'b001_1000: begin
-                      if (RV32B == RV32BFull) begin
+                      if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) begin
                         alu_operator_o = ALU_CRC32C_B; // crc32c.b
                         alu_multicycle_o = 1'b1;
                       end
                     end
                     7'b001_1001: begin
-                      if (RV32B == RV32BFull) begin
+                      if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) begin
                         alu_operator_o = ALU_CRC32C_H; // crc32c.h
                         alu_multicycle_o = 1'b1;
                       end
                     end
                     7'b001_1010: begin
-                      if (RV32B == RV32BFull) begin
+                      if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) begin
                         alu_operator_o = ALU_CRC32C_W; // crc32c.w
                         alu_multicycle_o = 1'b1;
                       end
@@ -899,7 +910,9 @@ module ibex_decoder #(
                   5'b0_0000: alu_operator_o = ALU_SRL;   // Shift Right Logical by Immediate
                   5'b0_1000: alu_operator_o = ALU_SRA;   // Shift Right Arithmetically by Immediate
                   // Shift Right Ones by Immediate
-                  5'b0_0100: if (RV32B == RV32BFull) alu_operator_o = ALU_SRO;
+                  5'b0_0100: begin
+                    if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) alu_operator_o = ALU_SRO;
+                  end
                   5'b0_1001: alu_operator_o = ALU_BEXT;  // Extract bit specified by immediate.
                   5'b0_1100: begin
                     alu_operator_o = ALU_ROR;            // Rotate Right by Immediate
@@ -909,7 +922,7 @@ module ibex_decoder #(
                   5'b0_0101: alu_operator_o = ALU_GORC;  // General Or-combine with Imm Control Val
                   // Unshuffle with Immediate Control Value
                   5'b0_0001: begin
-                    if (RV32B == RV32BFull) begin
+                    if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) begin
                       if (instr_alu[26] == 1'b0) alu_operator_o = ALU_UNSHFL;
                     end
                   end
@@ -1034,18 +1047,38 @@ module ibex_decoder #(
             // RV32B zbp
             {7'b011_0100, 3'b101}: if (RV32B != RV32BNone) alu_operator_o = ALU_GREV;    // grev
             {7'b001_0100, 3'b101}: if (RV32B != RV32BNone) alu_operator_o = ALU_GORC;    // gorc
-            {7'b000_0100, 3'b001}: if (RV32B == RV32BFull) alu_operator_o = ALU_SHFL;    // shfl
-            {7'b000_0100, 3'b101}: if (RV32B == RV32BFull) alu_operator_o = ALU_UNSHFL;  // unshfl
-            {7'b001_0100, 3'b010}: if (RV32B == RV32BFull) alu_operator_o = ALU_XPERM_N; // xperm.n
-            {7'b001_0100, 3'b100}: if (RV32B == RV32BFull) alu_operator_o = ALU_XPERM_B; // xperm.b
-            {7'b001_0100, 3'b110}: if (RV32B == RV32BFull) alu_operator_o = ALU_XPERM_H; // xperm.h
-            {7'b001_0000, 3'b001}: if (RV32B == RV32BFull) alu_operator_o = ALU_SLO;     // slo
-            {7'b001_0000, 3'b101}: if (RV32B == RV32BFull) alu_operator_o = ALU_SRO;     // sro
+            {7'b000_0100, 3'b001}: begin
+              if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) alu_operator_o = ALU_SHFL;
+            end
+            {7'b000_0100, 3'b101}: begin
+              if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) alu_operator_o = ALU_UNSHFL;
+            end
+            {7'b001_0100, 3'b010}: begin
+              if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) alu_operator_o = ALU_XPERM_N;
+            end
+            {7'b001_0100, 3'b100}: begin
+              if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) alu_operator_o = ALU_XPERM_B;
+            end
+            {7'b001_0100, 3'b110}: begin
+              if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) alu_operator_o = ALU_XPERM_H;
+            end
+            {7'b001_0000, 3'b001}: begin
+              if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) alu_operator_o = ALU_SLO;
+            end
+            {7'b001_0000, 3'b101}: begin
+              if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) alu_operator_o = ALU_SRO;
+            end
 
             // RV32B zbc
-            {7'b000_0101, 3'b001}: if (RV32B == RV32BFull) alu_operator_o = ALU_CLMUL;  // clmul
-            {7'b000_0101, 3'b010}: if (RV32B == RV32BFull) alu_operator_o = ALU_CLMULR; // clmulr
-            {7'b000_0101, 3'b011}: if (RV32B == RV32BFull) alu_operator_o = ALU_CLMULH; // clmulh
+            {7'b000_0101, 3'b001}: begin
+              if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) alu_operator_o = ALU_CLMUL;
+            end
+            {7'b000_0101, 3'b010}: begin
+              if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) alu_operator_o = ALU_CLMULR;
+            end
+            {7'b000_0101, 3'b011}: begin
+              if (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) alu_operator_o = ALU_CLMULH;
+            end
 
             // RV32B zbe
             {7'b010_0100, 3'b110}: begin

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -45,9 +45,10 @@ package ibex_pkg;
   } rv32m_e;
 
   typedef enum integer {
-    RV32BNone     = 0,
-    RV32BBalanced = 1,
-    RV32BFull     = 2
+    RV32BNone       = 0,
+    RV32BBalanced   = 1,
+    RV32BOTEarlGrey = 2,
+    RV32BFull       = 3
   } rv32b_e;
 
   /////////////

--- a/syn/syn_yosys.sh
+++ b/syn/syn_yosys.sh
@@ -48,6 +48,7 @@ for file in ../rtl/*.sv; do
     --define=SYNTHESIS \
     ../rtl/*_pkg.sv \
     ../vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1p_pkg.sv \
+    ../vendor/lowrisc_ip/ip/prim/rtl/prim_secded_pkg.sv \
     -I../vendor/lowrisc_ip/ip/prim/rtl \
     -I../vendor/lowrisc_ip/dv/sv/dv_utils \
     $file \


### PR DESCRIPTION
This PR adds a new configuration for OpenTitan that enables all bitmanip sub-extensions except for Zbe. The documentation on the bitmanip support is updated and new area numbers have been gathered.

At the moment, we can't verify the bitmanip implementation in CI as we need to switch the Spike version used in default CI and get an updated toolchain (work in progress). However, I've successfully verified the new configuration locally.
