### PR TITLE
[ci] Add Yosys synthesis flow

### DIFF
--- a/.github/workflows/pr_trigger.yml
+++ b/.github/workflows/pr_trigger.yml
@@ -4,7 +4,10 @@
 name: pr-trigger
 
 on:
-  pull_request:
+  # FIXME: Restore to all PRs
+  push:
+    branches:
+       - master
 
 jobs:
   upload:

--- a/.github/workflows/yosys_synth.yml
+++ b/.github/workflows/yosys_synth.yml
@@ -11,48 +11,47 @@ on:
 
 jobs:
     yosys-uhdm-synthesis:
-    runs-on: ubuntu-latest
-    env:
-      CC: gcc-9
-      CXX: g++-9
-    steps:
-    - name: Install dependencies
-      run: |
-        apt-get update -qq
-        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip
-        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-        update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
-
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        fetch-depth: 1
-
-    - uses: robinraju/release-downloader@v1.3
-      with:
-        repository: "antmicro/yosys-uhdm-plugin-integration"
-        fileName: "yosys-uhdm-integration-*"
-        latest: true
-        tarBall: true
-
-    - name: Extract yosys and UHDM plugin
+      runs-on: ubuntu-latest
+      env:
+        CC: gcc-9
+        CXX: g++-9
       steps:
-          tar -xzf yosys-uhdm-integration-*.tar.gz
-          echo "$GITHUB_WORKSPACE/image" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: |
+          apt-get update -qq
+          apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip
+          update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+          update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - uses: robinraju/release-downloader@v1.3
+        with:
+          repository: "antmicro/yosys-uhdm-plugin-integration"
+          fileName: "yosys-uhdm-integration-*"
+          latest: true
+          tarBall: true
+
+      - name: Extract yosys and UHDM plugin
+        run: |
+            tar -xzf yosys-uhdm-integration-*.tar.gz
+            echo "$GITHUB_WORKSPACE/image" >> $GITHUB_PATH
 
 
-    - name: Get memory file for Ibex
-      steps:
-          # TODO: Build it from source
-          wget https://raw.githubusercontent.com/antmicro/yosys-uhdm-plugin-integration/master/uhdm-tests/ibex/led.vmem
+      - name: Get memory file for Ibex
+        run: |
+            # TODO: Build it from source
+            wget https://raw.githubusercontent.com/antmicro/yosys-uhdm-plugin-integration/master/uhdm-tests/ibex/led.vmem
 
-    - name: Build & Test
-      run: |
-          pip install -r python-requirements.txt
-          fusesoc --cores-root=. run --build --tool=yosys --target=synth lowrisc:ibex:top_artya7_surelog --SRAMInitFile=$GITHUB_WORKSPACE/led.vmem
+      - name: Build & Test
+        run: |
+            pip install -r python-requirements.txt
+            fusesoc --cores-root=. run --build --tool=yosys --target=synth lowrisc:ibex:top_artya7_surelog --SRAMInitFile=$GITHUB_WORKSPACE/led.vmem
 
-    - uses: actions/upload-artifact@v2
-      with:
-        name: lowrisc_ibex_top_artya7_surelog_0.1.edif
-        path: UHDM-integration-tests/build/lowrisc_ibex_top_artya7_surelog_0.1/synth-yosys/lowrisc_ibex_top_artya7_surelog_0.1.edif
-
+      - uses: actions/upload-artifact@v2
+        with:
+          name: lowrisc_ibex_top_artya7_surelog_0.1.edif
+          path: UHDM-integration-tests/build/lowrisc_ibex_top_artya7_surelog_0.1/synth-yosys/lowrisc_ibex_top_artya7_surelog_0.1.edif

--- a/.github/workflows/yosys_synth.yml
+++ b/.github/workflows/yosys_synth.yml
@@ -1,0 +1,58 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: yosys-synthesis
+
+on:
+  push:
+      branches:
+        - master
+  pull_request:
+
+jobs:
+    yosys-uhdm-synthesis:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-9
+      CXX: g++-9
+    steps:
+    - name: Install dependencies
+      run: |
+        apt-get update -qq
+        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+        update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - uses: robinraju/release-downloader@v1.3
+      with:
+        repository: "antmicro/yosys-uhdm-plugin-integration"
+        fileName: "yosys-uhdm-integration-*"
+        latest: true
+        tarBall: true
+
+    - name: Extract yosys and UHDM plugin
+      steps:
+          tar -xzf yosys-uhdm-integration-*.tar.gz
+          echo "$GITHUB_WORKSPACE/image" >> $GITHUB_PATH
+
+
+    - name: Get memory file for Ibex
+      steps:
+          # TODO: Build it from source
+          wget https://raw.githubusercontent.com/antmicro/yosys-uhdm-plugin-integration/master/uhdm-tests/ibex/led.vmem
+
+    - name: Build & Test
+      run: |
+          pip install -r python-requirements.txt
+          fusesoc --cores-root=. run --build --tool=yosys --target=synth lowrisc:ibex:top_artya7_surelog --SRAMInitFile=$GITHUB_WORKSPACE/led.vmem
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: lowrisc_ibex_top_artya7_surelog_0.1.edif
+        path: UHDM-integration-tests/build/lowrisc_ibex_top_artya7_surelog_0.1/synth-yosys/lowrisc_ibex_top_artya7_surelog_0.1.edif
+

--- a/.github/workflows/yosys_synth.yml
+++ b/.github/workflows/yosys_synth.yml
@@ -18,10 +18,10 @@ jobs:
       steps:
       - name: Install dependencies
         run: |
-          apt-get update -qq
-          apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip
-          update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-          update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+          sudo apt-get update -qq
+          sudo apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+          sudo update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/yosys_synth.yml
+++ b/.github/workflows/yosys_synth.yml
@@ -31,20 +31,24 @@ jobs:
       - uses: robinraju/release-downloader@v1.3
         with:
           repository: "antmicro/yosys-uhdm-plugin-integration"
-          fileName: "yosys-uhdm-integration-*"
+          fileName: "*"
           latest: true
           tarBall: true
 
       - name: Extract yosys and UHDM plugin
         run: |
             tar -xzf yosys-uhdm-integration-*.tar.gz
-            echo "$GITHUB_WORKSPACE/image" >> $GITHUB_PATH
-
+            echo "$GITHUB_WORKSPACE/image/bin" >> $GITHUB_PATH
 
       - name: Get memory file for Ibex
         run: |
             # TODO: Build it from source
             wget https://raw.githubusercontent.com/antmicro/yosys-uhdm-plugin-integration/master/uhdm-tests/ibex/led.vmem
+
+      - name: Display environment
+        run: |
+          ls -l
+          echo $PATH
 
       - name: Build & Test
         run: |
@@ -54,4 +58,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: lowrisc_ibex_top_artya7_surelog_0.1.edif
-          path: UHDM-integration-tests/build/lowrisc_ibex_top_artya7_surelog_0.1/synth-yosys/lowrisc_ibex_top_artya7_surelog_0.1.edif
+          path: build/lowrisc_ibex_top_artya7_surelog_0.1/synth-yosys/lowrisc_ibex_top_artya7_surelog_0.1.edif

--- a/examples/fpga/artya7/top_artya7_surelog.core
+++ b/examples/fpga/artya7/top_artya7_surelog.core
@@ -1,0 +1,79 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ibex:top_artya7_surelog:0.1"
+description: "Ibex example toplevel for Arty A7 boards (both, -35 and -100)"
+filesets:
+  files_rtl_artya7:
+    depend:
+      - lowrisc:ibex:ibex_top
+      - lowrisc:ibex:fpga_xilinx_shared
+    files:
+      - rtl/top_artya7.sv
+    file_type: systemVerilogSource
+
+  files_constraints:
+    files:
+      - data/pins_artya7.xdc
+    file_type: xdc
+
+  files_tcl:
+    files:
+      - util/vivado_setup_hooks.tcl : { file_type: tclSource }
+      - util/vivado_hook_write_bitstream_pre.tcl : { file_type: user, copyto: vivado_hook_write_bitstream_pre.tcl }
+
+parameters:
+  # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1
+  # directory. It's best to pass it as absolute path when invoking fusesoc, e.g.
+  # --SRAMInitFile=$PWD/sw/led/led.vmem
+  # XXX: The VMEM file should be added to the sources of the Vivado project to
+  # make the Vivado dependency tracking work. However this requires changes to
+  # fusesoc first.
+  SRAMInitFile:
+    datatype: str
+    description: SRAM initialization file in vmem hex format
+    default: "../../../../../examples/sw/led/led.vmem"
+    paramtype: vlogparam
+
+  # For value definition, please see ip/prim/rtl/prim_pkg.sv
+  PRIM_DEFAULT_IMPL:
+    datatype: str
+    paramtype: vlogdefine
+    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
+
+  FPGAPowerAnalysis:
+    datatype: int
+    paramtype: vlogparam
+    description: Enables custom power analysis scripts for Vivado.
+
+targets:
+  synth:
+    default_tool: vivado
+    filesets:
+      - files_rtl_artya7
+      - files_constraints
+    toplevel: top_artya7
+    parameters:
+      - SRAMInitFile
+      - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
+      - FPGAPowerAnalysis
+    tools:
+      vivado:
+        part: "xc7a100tcsg324-1"  # Default to Arty A7-100
+        synth: "yosys"
+        yosys_synth_options: ['-iopad', '-family xc7', '-run :check', "frontend=surelog"]
+        yosys_read_options: ['-noassert']
+        surelog_options: ['--disable-feature=parametersubstitution', '-DSYNTHESIS']
+      yosys:
+        arch: "xilinx"
+        yosys_synth_options: ['-iopad', '-family xc7', '-run :check', "frontend=surelog"]
+        yosys_read_options: ['-noassert']
+        surelog_options: ['--disable-feature=parametersubstitution', '-DSYNTHESIS']
+      symbiflow:
+        package: "csg324-1"
+        part: "xc7a35t"
+        pnr: "vtr"
+        vendor: "xilinx"
+        yosys_read_options: ['-noassert']
+        surelog_options: ['--disable-feature=parametersubstitution', '-DSYNTHESIS']

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Development version of edalize until all our changes are upstream
-git+https://github.com/lowRISC/edalize.git@ot
+# FIXME: Restore original fork after UHDM support is merged
+git+https://github.com/antmicro/edalize.git@rk/ibex-uhdm-support
 
 # Development version with OT-specific changes
 git+https://github.com/lowRISC/fusesoc.git@ot


### PR DESCRIPTION
Opening a draft PR to get some early input and suggestions.

As proposed in #1481, this PR adds a Github action workflow that synthesizes Ibex via Yosys, using Surelog-UHDM frontend.

It obtains a release from [Antmicro's plugin repository](https://github.com/antmicro/yosys-uhdm-plugin-integration/) and [edalize fork](https://github.com/antmicro/edalize) (until UHDM support is merged in https://github.com/lowRISC/edalize/pull/3).

Each flow generates an EDIF artifact that can be downloaded and processed further locally.