### PR TITLE
Fix memory protocol in FPGA example

### DIFF
--- a/examples/fpga/artya7/rtl/top_artya7.sv
+++ b/examples/fpga/artya7/rtl/top_artya7.sv
@@ -110,15 +110,8 @@ module top_artya7 (
 
 
   // SRAM to Ibex
-  always_ff @(posedge clk_sys or negedge rst_sys_n) begin
-    if (!rst_sys_n) begin
-      instr_gnt    <= '0;
-      data_gnt     <= '0;
-    end else begin
-      instr_gnt    <= instr_req ;
-      data_gnt     <=  data_req ;
-    end
-  end
+  assign instr_gnt = instr_req;
+  assign data_gnt = data_req;
 
   // Connect the LED output to the lower four bits of the most significant
   // byte


### PR DESCRIPTION
The FPGA example does not follow the memory protocol, which causes it to behave incorrectly. This PR fixes that. See the discussion at #1506.