### PR TITLE
[ci] Add missing python3-dev dependency

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -47,6 +47,7 @@ case "$ID-$VERSION_ID" in
         python3-setuptools \
         python3-wheel \
         python3-yaml \
+        python3-dev \
         srecord \
         zlib1g-dev \
         git \


### PR DESCRIPTION
Private CI is broken without this. The public CI runs on azure agents
which already have this installed.