### PR TITLE
Refer to a specific tag for the ibex-cosim version of Spike

### DIFF
--- a/doc/03_reference/cosim.rst
+++ b/doc/03_reference/cosim.rst
@@ -13,7 +13,7 @@ This system supports memory errors, interrupt and debug requests which are obser
 The system uses a generic interface to allow support of multiple ISSes.
 Only VCS is supported as a simulator, though no VCS specific functionality is required so adding support for another simulator should be straight-forward.
 
-To run the co-simulation system the `ibex-cosim branch from the lowRISC fork of Spike <https://github.com/lowRISC/riscv-isa-sim/tree/ibex>`_ is required.
+To run the co-simulation system, a particular version of Spike is required (see the Setup and Usage section, below).
 
 The RISC-V Formal Interface (RVFI) is used to provide information about retired instructions and instructions that produce synchronous traps for checking.
 The RVFI has been extended to provide interrupt and debug information and the value of the ``mcycle`` CSR.
@@ -25,7 +25,8 @@ It is disabled by default in the UVM DV environment currently, however it is int
 Setup and Usage
 ---------------
 
-Clone the `lowRISC fork of Spike <https://github.com/lowRISC/riscv-isa-sim>`_ and checkout the ``ibex_cosim`` branch.
+Clone the `lowRISC fork of Spike <https://github.com/lowRISC/riscv-isa-sim>`_ and check out the ``ibex-cosim-v0.1`` tag.
+Other, later, versions called ``ibex-cosim-v*`` may also work but there's no guarantee of backwards compatibility.
 Follow the Spike build instructions to build and install Spike.
 The build will install multiple header files and libraries, it is recommended a custom install location (using ``--prefix=<path>`` with ``configure``) is used to avoid cluttering system directories.
 The ``--enable-commitlog`` and ``--enable-misaligned`` options must be passed to ``configure``.


### PR DESCRIPTION
We're going to want to make a couple more releases of Spike, cleaving
a bit closer to the upstream repository. Let's be explicit about which
version people should get.