### PR TITLE
[ibex, dv] Added agent configuration for ibex_mem_intf_response_agent

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
@@ -22,6 +22,7 @@ package ibex_mem_intf_agent_pkg;
   `include "ibex_mem_intf_response_driver.sv"
   `include "ibex_mem_intf_response_sequencer.sv"
   `include "ibex_mem_intf_response_seq_lib.sv"
+  `include "ibex_mem_intf_response_agent_cfg.sv"
   `include "ibex_mem_intf_response_agent.sv"
   `include "ibex_mem_intf_request_driver.sv"
   `include "ibex_mem_intf_request_agent.sv"

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent.sv
@@ -10,7 +10,8 @@ class ibex_mem_intf_response_agent extends uvm_agent;
 
   ibex_mem_intf_response_driver     driver;
   ibex_mem_intf_response_sequencer  sequencer;
-  ibex_mem_intf_monitor          monitor;
+  ibex_mem_intf_monitor             monitor;
+  ibex_mem_intf_response_agent_cfg  cfg;
 
   `uvm_component_utils(ibex_mem_intf_response_agent)
   `uvm_component_new
@@ -18,10 +19,13 @@ class ibex_mem_intf_response_agent extends uvm_agent;
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     monitor = ibex_mem_intf_monitor::type_id::create("monitor", this);
+    cfg = ibex_mem_intf_response_agent_cfg::type_id::create("cfg", this);
     if(get_is_active() == UVM_ACTIVE) begin
       driver = ibex_mem_intf_response_driver::type_id::create("driver", this);
       sequencer = ibex_mem_intf_response_sequencer::type_id::create("sequencer", this);
     end
+    if(!uvm_config_db#(virtual ibex_mem_intf)::get(this, "", "vif", cfg.vif))
+      `uvm_fatal("NOVIF",{"virtual interface must be set for: ",get_full_name(),".vif"});
   endfunction : build_phase
 
   function void connect_phase(uvm_phase phase);
@@ -30,6 +34,7 @@ class ibex_mem_intf_response_agent extends uvm_agent;
       driver.seq_item_port.connect(sequencer.seq_item_export);
       monitor.addr_ph_port.connect(sequencer.addr_ph_port.analysis_export);
     end
+    driver.vif = cfg.vif;
   endfunction : connect_phase
 
   function void reset();

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent_cfg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent_cfg.sv
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//------------------------------------------------------------------------------
+// CLASS: ibex_mem_intf_response_agent_cfg
+//------------------------------------------------------------------------------
+
+class ibex_mem_intf_response_agent_cfg extends uvm_object;
+
+  // interface handle used by driver & monitor
+  virtual ibex_mem_intf vif;
+
+  // delay between request and grant
+  int unsigned gnt_delay_min = 0;
+  int unsigned gnt_delay_max = 1000;
+
+  // delay between grant and rvalid
+  int unsigned valid_delay_min = 1;
+  int unsigned valid_delay_max = 1000;
+
+  // Enables/disable all protocol delays.
+  rand bit zero_delays;
+
+  // Knob to enable percentage of zero delay in auto-response sequence.
+  // Default set to 50% for zero delay to be picked
+  int unsigned zero_delay_pct = 50;
+
+  `uvm_object_new
+
+  constraint zero_delays_c {
+    zero_delays dist {1 :/ zero_delay_pct,
+                      0 :/ 100 - zero_delay_pct};
+  }
+
+  `uvm_object_utils_begin(ibex_mem_intf_response_agent_cfg)
+    `uvm_field_int(gnt_delay_min,       UVM_DEFAULT)
+    `uvm_field_int(gnt_delay_max,       UVM_DEFAULT)
+    `uvm_field_int(valid_delay_min,     UVM_DEFAULT)
+    `uvm_field_int(valid_delay_max,     UVM_DEFAULT)
+    `uvm_field_int(zero_delays,         UVM_DEFAULT)
+    `uvm_field_int(zero_delay_pct,      UVM_DEFAULT)
+  `uvm_object_utils_end
+
+endclass

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_driver.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_driver.sv
@@ -8,7 +8,7 @@
 
 class ibex_mem_intf_response_driver extends uvm_driver #(ibex_mem_intf_seq_item);
 
-  protected virtual ibex_mem_intf vif;
+  virtual ibex_mem_intf vif;
 
   int unsigned min_grant_delay = 0;
   int unsigned max_grant_delay = 10;
@@ -21,8 +21,6 @@ class ibex_mem_intf_response_driver extends uvm_driver #(ibex_mem_intf_seq_item)
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     rdata_queue = new();
-    if(!uvm_config_db#(virtual ibex_mem_intf)::get(this, "", "vif", vif))
-      `uvm_fatal("NOVIF",{"virtual interface must be set for: ",get_full_name(),".vif"});
   endfunction: build_phase
 
   virtual task run_phase(uvm_phase phase);


### PR DESCRIPTION
Defining agent configuration for any agent is a standard UVM flow and is
a cleaner flow for defining delay between driving sequence items,
passing virtual interface etc.

Agent configuration has been added to the existing agent to make delay
configuration more flexible in the future.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>