### PR TITLE
[dv] Add X assertions for top-level IO

### DIFF
--- a/rtl/ibex_top.sv
+++ b/rtl/ibex_top.sv
@@ -935,8 +935,41 @@ module ibex_top import ibex_pkg::*; #(
   assign alert_major_bus_o      = lockstep_alert_major_bus;
   assign alert_minor_o          = core_alert_minor | lockstep_alert_minor;
 
+  // X checks for top-level outputs
+  `ASSERT_KNOWN(IbexInstrReqX, instr_req_o)
+  `ASSERT_KNOWN_IF(IbexInstrReqPayloadX, instr_addr_o, instr_req_o)
+
+  `ASSERT_KNOWN(IbexDataReqX, data_req_o)
+  `ASSERT_KNOWN_IF(IbexDataReqPayloadX,
+    {data_we_o, data_be_o, data_addr_o, data_wdata_o, data_wdata_intg_o}, data_req_o)
+
+  `ASSERT_KNOWN(IbexScrambleReqX, scramble_req_o)
+  `ASSERT_KNOWN(IbexDoubleFaultSeenX, double_fault_seen_o)
   `ASSERT_KNOWN(IbexAlertMinorX, alert_minor_o)
   `ASSERT_KNOWN(IbexAlertMajorInternalX, alert_major_internal_o)
   `ASSERT_KNOWN(IbexAlertMajorBusX, alert_major_bus_o)
+  `ASSERT_KNOWN(IbexCoreSleepX, core_sleep_o)
 
+  // X check for top-level inputs
+  `ASSERT_KNOWN(IbexTestEnX, test_en_i)
+  `ASSERT_KNOWN(IbexRamCfgX, ram_cfg_i)
+  `ASSERT_KNOWN(IbexHartIdX, hart_id_i)
+  `ASSERT_KNOWN(IbexBootAddrX, boot_addr_i)
+
+  `ASSERT_KNOWN(IbexInstrGntX, instr_gnt_i)
+  `ASSERT_KNOWN(IbexInstrRValidX, instr_rvalid_i)
+  `ASSERT_KNOWN_IF(IbexInstrRPayloadX,
+    {instr_rdata_i, instr_rdata_intg_i, instr_err_i}, instr_rvalid_i)
+
+  `ASSERT_KNOWN(IbexDataGntX, data_gnt_i)
+  `ASSERT_KNOWN(IbexDataRValidX, data_rvalid_i)
+  `ASSERT_KNOWN_IF(IbexDataRPayloadX, {data_rdata_i, data_rdata_intg_i, data_err_i}, data_rvalid_i)
+
+  `ASSERT_KNOWN(IbexIrqX, {irq_software_i, irq_timer_i, irq_external_i, irq_fast_i, irq_nm_i})
+
+  `ASSERT_KNOWN(IbexScrambleKeyValidX, scramble_key_valid_i)
+  `ASSERT_KNOWN_IF(IbexScramblePayloadX, {scramble_key_i, scramble_nonce_i}, scramble_key_valid_i)
+
+  `ASSERT_KNOWN(IbexDebugReqX, debug_req_i)
+  `ASSERT_KNOWN(IbexFetchEnableX, fetch_enable_i)
 endmodule


### PR DESCRIPTION
Ensure all top-level inputs and outputs are known when they are
expected to be known.

Seems to work fine with some quick tests. I'll do a full regression once this is merged in.