### PR TITLE
[ibex, dv] Makes delays between req, gnt and rvalid configurable

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
@@ -19,10 +19,10 @@ package ibex_mem_intf_agent_pkg;
   typedef uvm_sequencer#(ibex_mem_intf_seq_item) ibex_mem_intf_request_sequencer;
 
   `include "ibex_mem_intf_monitor.sv"
+  `include "ibex_mem_intf_response_agent_cfg.sv"
   `include "ibex_mem_intf_response_driver.sv"
   `include "ibex_mem_intf_response_sequencer.sv"
   `include "ibex_mem_intf_response_seq_lib.sv"
-  `include "ibex_mem_intf_response_agent_cfg.sv"
   `include "ibex_mem_intf_response_agent.sv"
   `include "ibex_mem_intf_request_driver.sv"
   `include "ibex_mem_intf_request_agent.sv"

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent.sv
@@ -34,7 +34,8 @@ class ibex_mem_intf_response_agent extends uvm_agent;
       driver.seq_item_port.connect(sequencer.seq_item_export);
       monitor.addr_ph_port.connect(sequencer.addr_ph_port.analysis_export);
     end
-    driver.vif = cfg.vif;
+    driver.cfg = cfg;
+    sequencer.cfg = cfg;
   endfunction : connect_phase
 
   function void reset();

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent_cfg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent_cfg.sv
@@ -13,11 +13,17 @@ class ibex_mem_intf_response_agent_cfg extends uvm_object;
 
   // delay between request and grant
   int unsigned gnt_delay_min = 0;
-  int unsigned gnt_delay_max = 1000;
+  int unsigned gnt_delay_max = 10;
+  // Pick the weight assigned to choosing medium and long gaps between request and grant
+  int unsigned gnt_pick_medium_speed_weight = 1;
+  int unsigned gnt_pick_slow_speed_weight = 1;
 
   // delay between grant and rvalid
-  int unsigned valid_delay_min = 1;
-  int unsigned valid_delay_max = 1000;
+  int unsigned valid_delay_min = 0;
+  int unsigned valid_delay_max = 20;
+  // Pick the weight assigned to choosing medium and long gaps between grant and rvalid
+  int unsigned valid_pick_medium_speed_weight = 1;
+  int unsigned valid_pick_slow_speed_weight = 1;
 
   // Enables/disable all protocol delays.
   rand bit zero_delays;

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_sequencer.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_sequencer.sv
@@ -10,6 +10,7 @@ class ibex_mem_intf_response_sequencer extends uvm_sequencer #(ibex_mem_intf_seq
 
   // TLM port to peek the address phase from the response monitor
   uvm_tlm_analysis_fifo #(ibex_mem_intf_seq_item) addr_ph_port;
+  ibex_mem_intf_response_agent_cfg cfg;
 
   `uvm_component_utils(ibex_mem_intf_response_sequencer)
 


### PR DESCRIPTION
 
    This commit adds functionalty to the memory response agent to make delays more
    configurable.
    There are two delays
    - Delay between req and gnt
    - Delay between gnt and rvalid
    
    For each of these delays we have three modes:
    * Fully random delay
    * Fixed delay
    * Biased delay. Randomised delays but allow biasing towards 0 delay, to give a mix of runs with back
    to back transfers with no delay and some with delays.
