### PR TITLE
[ibex, dv] Added a sequence to toggle fetch_enable_i pin

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -1400,17 +1400,23 @@ class core_ibex_invalid_csr_test extends core_ibex_directed_test;
 
 endclass
 
-class core_mem_err_test extends core_ibex_directed_test;
-  memory_error_seq memory_error_seq_h;
+class core_ibex_fetch_en_chk_test extends core_ibex_directed_test;
 
-  `uvm_component_utils(core_mem_err_test)
+  `uvm_component_utils(core_ibex_fetch_en_chk_test)
   `uvm_component_new
 
   virtual task send_stimulus();
-    memory_error_seq_h = memory_error_seq::type_id::create("memory_error_seq_h");
-    memory_error_seq_h.vseq.cfg = cfg;
-    memory_error_seq_h.vseq.mem = mem;
-    memory_error_seq_h.start(env.vseqr);
-  endtask: send_stimulus
+    fetch_enable_seq fetch_enable_seq_h;
+    fetch_enable_seq_h = fetch_enable_seq::type_id::create("fetch_enable_seq_h", this);
+    `uvm_info(`gfn, "Running core_ibex_fetch_en_chk_test", UVM_LOW)
+    fork
+      begin
+        vseq.start(env.vseqr);
+      end
+      begin
+        fetch_enable_seq_h.start(env.vseqr);
+      end
+    join_any
+  endtask
 
-endclass: core_mem_err_test
+endclass


### PR DESCRIPTION
Ibex has a top-level `fetch_enable_i` input. When set to on (noting it's a multi-bit signal for
security hardening though only the bottom bit is looked at for non secure ibex) Ibex executes
normally. When set to off Ibex will stop executing. Randomly toggling it should have no functional
effect on Ibex's behaviour.
The fetch enable sequence will randomly toggle the value of `fetch_enable_i` with a configurable
bias between the 'On' value and all other values.