### PR TITLE
Fix port list in top_artya7 example

### DIFF
--- a/examples/fpga/artya7/rtl/top_artya7.sv
+++ b/examples/fpga/artya7/rtl/top_artya7.sv
@@ -82,7 +82,8 @@ module top_artya7 (
 
      .fetch_enable_i        ('b1),
      .alert_minor_o         (),
-     .alert_major_o         (),
+     .alert_major_internal_o(),
+     .alert_major_bus_o     (),
      .core_sleep_o          ()
   );
 


### PR DESCRIPTION
The "alert_major" port was split into "internal" and "bus" parts back
in commit 9943f9a. Update the example to match.

Fixes #1553.