### PR TITLE
[icache, dv] Added scrambling agent to verify scrambling in RAMs

### DIFF
--- a/dv/uvm/icache/dv/env/ibex_icache_env.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_env.sv
@@ -12,6 +12,8 @@ class ibex_icache_env extends dv_base_env #(
 
   ibex_icache_core_agent core_agent;
   ibex_icache_mem_agent  mem_agent;
+  scrambling_key_agent   scrambling_key_agent_h;
+
 
   ibex_icache_ecc_agent  ecc_tag_agents[];
   ibex_icache_ecc_agent  ecc_data_agents[];
@@ -31,6 +33,11 @@ class ibex_icache_env extends dv_base_env #(
 
     mem_agent = ibex_icache_mem_agent::type_id::create("mem_agent", this);
     uvm_config_db#(ibex_icache_mem_agent_cfg)::set(this, "mem_agent*", "cfg", cfg.mem_agent_cfg);
+    scrambling_key_agent_h = scrambling_key_agent::type_id::create("scrambling_key_agent_h", this);
+    uvm_config_db#(scrambling_key_agent_cfg)::set(this, "scrambling_key_agent_h", "cfg",
+                                                  cfg.scrambling_key_cfg);
+    cfg.scrambling_key_cfg.agent_type = push_pull_agent_pkg::PullAgent;
+    cfg.scrambling_key_cfg.if_mode = dv_utils_pkg::Device;
 
     // If ECC is enabled, create ECC agents for the RAMs. We have already created config objects for
     // them (the test called create_ecc_agent_cfgs in its build_phase method), so we just have to

--- a/dv/uvm/icache/dv/env/ibex_icache_env_cfg.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_env_cfg.sv
@@ -11,6 +11,8 @@ class ibex_icache_env_cfg extends dv_base_env_cfg;
   rand ibex_icache_core_agent_cfg   core_agent_cfg;
   rand ibex_icache_mem_agent_cfg    mem_agent_cfg;
 
+  rand scrambling_key_agent_cfg     scrambling_key_cfg;
+
   // Force the clock frequency to 50MHz. The clock frequency doesn't really matter for ICache
   // testing and 50MHz dumped waves are nice to read because clock edges are multiples of 10ns.
   constraint clk_freq_50_c {
@@ -38,8 +40,10 @@ class ibex_icache_env_cfg extends dv_base_env_cfg;
     ral_model_names = {}; // The ICache has no RAL model
     super.initialize(csr_base_addr);
 
-    core_agent_cfg = ibex_icache_core_agent_cfg::type_id::create("core_agent_cfg");
-    mem_agent_cfg  = ibex_icache_mem_agent_cfg::type_id::create ("mem_agent_cfg");
+    core_agent_cfg     = ibex_icache_core_agent_cfg::type_id::create("core_agent_cfg");
+    mem_agent_cfg      = ibex_icache_mem_agent_cfg::type_id::create ("mem_agent_cfg");
+    scrambling_key_cfg = scrambling_key_agent_cfg::type_id::create("scrambling_key_cfg");
+
   endfunction
 
   // Create tag and data ECC agents for each way. If ECC is disabled, this should still be called,

--- a/dv/uvm/icache/dv/env/ibex_icache_env_pkg.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_env_pkg.sv
@@ -10,6 +10,7 @@ package ibex_icache_env_pkg;
   import ibex_icache_core_agent_pkg::*;
   import ibex_icache_mem_agent_pkg::*;
   import ibex_icache_ecc_agent_pkg::*;
+  import push_pull_agent_pkg::*;
   import dv_lib_pkg::*;
 
   // macro includes
@@ -21,6 +22,10 @@ package ibex_icache_env_pkg;
   // types
 
   // functions
+
+  typedef push_pull_agent#(.DeviceDataWidth(194)) scrambling_key_agent;
+  typedef push_pull_agent_cfg#(.DeviceDataWidth(194)) scrambling_key_agent_cfg;
+  typedef virtual push_pull_if#(.DeviceDataWidth(194)) scrambling_key_vif;
 
   // package sources
   `include "ibex_icache_env_cfg.sv"

--- a/dv/uvm/icache/dv/tb/ic_top.sv
+++ b/dv/uvm/icache/dv/tb/ic_top.sv
@@ -126,7 +126,7 @@ module ic_top import ibex_pkg::*; #(
       if (!rst_ni) begin
         scramble_key_q       <= 128'hDDDDDDDDEEEEEEEEAAAAAAAADDDDDDDD;
         scramble_nonce_q     <= 64'hBBBBEEEEEEEEFFFF;
-      end else if (scramble_key_valid_i) begin
+      end else if (scramble_key_valid_i && scramble_req_q) begin
         scramble_key_q       <= scramble_key_i;
         scramble_nonce_q     <= scramble_nonce_i;
       end
@@ -135,7 +135,7 @@ module ic_top import ibex_pkg::*; #(
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
         scramble_key_valid_q <= 1'b1;
-        scramble_req_q       <= '0;
+        scramble_req_q       <= 1'b0;
       end else begin
         scramble_key_valid_q <= scramble_key_valid_d;
         scramble_req_q       <= scramble_req_d;


### PR DESCRIPTION
This commit adds a new scrambling agent to drive scrambling key and valid to the data and tag memory interfaces.