### PR TITLE
[icache, dv] Removed support for single clock cycle PMP error response

### DIFF
--- a/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_req_item.sv
+++ b/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_req_item.sv
@@ -4,21 +4,12 @@
 
 // An item that represents a memory request from the icache and a possible update to the backing
 // memory.
-//
-// When a request first comes in (via a posedge on the req line), it immediately generates a
-// req_item with is_grant = 0.
-//
-// The request will be granted on some later clock edge. At that point, another req_item is
-// generated with is_grant = 1. This is added to a queue in the driver and will be serviced at some
-// later point.
 
 class ibex_icache_mem_req_item extends uvm_sequence_item;
 
-  bit               is_grant;
   logic [31:0]      address;
 
   `uvm_object_utils_begin(ibex_icache_mem_req_item)
-    `uvm_field_int (is_grant, UVM_DEFAULT)
     `uvm_field_int (address,  UVM_DEFAULT | UVM_HEX)
   `uvm_object_utils_end
 


### PR DESCRIPTION
Earlier the design supported single clock cycle error responses from PMP
block whenever a read was done from blocked memory. Now there is at
least one clock cycle delay after the request has been granted for the
error to be asserted. Therefore, this commit removes the support for
single clock cycle PMP error response.