### PR TITLE
Update ISA strings from Xbitmanip to XZb*

### DIFF
--- a/dv/uvm/core_ibex/scripts/scripts_lib.py
+++ b/dv/uvm/core_ibex/scripts/scripts_lib.py
@@ -123,9 +123,11 @@ def get_isas_for_config(cfg: Config) -> Tuple[str, str]:
 
     bitmanip_mapping = {
         'ibex_pkg::RV32BNone': [],
-        'ibex_pkg::RV32BBalanced': ['Zba', 'Zbb', 'Zbs', 'Xbitmanip'],
-        'ibex_pkg::RV32BOTEarlGrey': ['Zba', 'Zbb', 'Zbc', 'Zbs', 'Xbitmanip'],
-        'ibex_pkg::RV32BFull': ['Zba', 'Zbb', 'Zbc', 'Zbs', 'Xbitmanip'],
+        'ibex_pkg::RV32BBalanced': ['Zba', 'Zbb', 'Zbs', 'XZbf', 'XZbt'],
+        'ibex_pkg::RV32BOTEarlGrey': ['Zba', 'Zbb', 'Zbc', 'Zbs',
+                                      'XZbf', 'XZbp', 'XZbr', 'XZbt'],
+        'ibex_pkg::RV32BFull': ['Zba', 'Zbb', 'Zbc', 'Zbs',
+                                'XZbe', 'XZbf', 'XZbp', 'XZbr', 'XZbt']
     }
 
     bitmanip_isa = bitmanip_mapping.get(cfg.rv32b)

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -59,10 +59,6 @@ class core_ibex_base_test extends uvm_test;
 
     // Construct the right ISA string for the cosimulator by looking at top-level testbench
     // parameters.
-    //
-    // Note that the bitmanip extensions from the v0.93 spec (Zbe, Zbf, Zbp, Zbr, Zbt) are all
-    // contained in "Xbitmanip" for Spike at the moment. The specific parts used are listed in
-    // comments below.
     isa = {"rv32", RV32E ? "e" : "i"};
     if (RV32M != RV32MNone) isa = {isa, "m"};
     isa = {isa, "c"};
@@ -70,11 +66,11 @@ class core_ibex_base_test extends uvm_test;
       RV32BNone:
         ;
       RV32BBalanced:
-        isa = {isa, "_Zba_Zbb_Zbs_Xbitmanip"}; // + Zbf, Zbt
+        isa = {isa, "_Zba_Zbb_Zbs_XZbf_XZbt"};
       RV32BOTEarlGrey:
-        isa = {isa, "_Zba_Zbb_Zbc_Zbs_Xbitmanip"}; // + Zbf, Zbp, Zbr, Zbt
+        isa = {isa, "_Zba_Zbb_Zbc_Zbs_XZbf_XZbp_XZbr_XZbt"};
       RV32BFull:
-        isa = {isa, "_Zba_Zbb_Zbc_Zbs_Xbitmanip"}; // + Zbe, Zbf, Zbp, Zbr, Zbt
+        isa = {isa, "_Zba_Zbb_Zbc_Zbs_XZbe_XZbf_XZbp_XZbr_XZbt"};
     endcase
 
     return isa;

--- a/examples/simple_system/ibex_simple_system.cc
+++ b/examples/simple_system/ibex_simple_system.cc
@@ -45,19 +45,20 @@ std::string SimpleSystem::GetIsaString() const {
 
   extensions += "c";
 
-  // See the equivalent get_isa_string() function in core_ibex_base_test.sv for
-  // an explanation of the different ISA strings
   switch (top.ibex_simple_system->RV32B) {
     case 0:  // RV32BNone
       break;
 
     case 1:  // RV32BBalanced
-      extensions += "_Zba_Zbb_Zbs_Xbitmanip";
+      extensions += "_Zba_Zbb_Zbs_XZbf_XZbt";
       break;
 
     case 2:  // RV32BOTEarlGrey
+      extensions += "_Zba_Zbb_Zbc_Zbs_XZbf_XZbp_XZbr_XZbt";
+      break;
+
     case 3:  // RV32BFull
-      extensions += "_Zba_Zbb_Zbc_Zbs_Xbitmanip";
+      extensions += "_Zba_Zbb_Zbc_Zbs_XZbe_XZbf_XZbp_XZbr_XZbt";
       break;
   }
 


### PR DESCRIPTION
This allows us to model stuff more closely. This depends on Spike
version ibex-cosim-v0.2 (which is rebased onto a master branch commit
supporting these more specific ISA strings).
