### PR TITLE
Remove logfile param in Ibex RTL Sim for Xcelium

### DIFF
--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -168,7 +168,6 @@
       xrun -64bit
            -R
            -xmlibdirpath <out>
-           -l <sim_dir>/sim.log
            -licqueue
            -svseed <seed>
            -svrnc rand_struct


### PR DESCRIPTION
Fixes a bug where both Xcelium and Python open the same sim.log file and race to
write the simulation results into it. This change makes Python the sole writer of this
file using the captured stdout/stderr from the subprocess.run call in
run_rtl.py.

This bug was also previously present for VCS but was fixed in 90ff7ca6c.
Goes towards #1571 
