### PR TITLE
[dv,xlm] Save each UCM file in <test_name>.<seed>

### DIFF
--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -186,10 +186,10 @@
            <cov_opts>
            <wave_opts>
     cov_opts: >
-      -covmodeldir <out>/coverage/default/<seed>
+      -covmodeldir <out>/coverage/default/<test_name>.<seed>
       -covworkdir <out>/coverage
       -covscope default
-      -covtest <seed>
+      -covtest <test_name>.<seed>
       +enable_ibex_fcov=1
     wave_opts: >
       -input @"database -open <sim_dir>/waves -shm -default"


### PR DESCRIPTION
This enables to have a coverage report in instances where we have
different types of tests in a single iteration.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>