### PR TITLE
Include the main C++ file only with Verilator

### DIFF
--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -9,7 +9,7 @@ filesets:
     depend:
       - lowrisc:ibex:ibex_simple_system_core
     files:
-      - ibex_simple_system_main.cc
+      - tool_verilator ? (ibex_simple_system_main.cc)
     file_type: cppSource
 
 parameters:


### PR DESCRIPTION
This is necessary for having VCS support with simple system example.
Because in the ibex_simple_system_main.cc we are including some
Verilator exclusive header files.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>