### PR TITLE
[dv,xlm] Pass simulator flag to cov.py in Makefile

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -482,6 +482,7 @@ riscv_dv_fcov: $(rtl-sim-logs)
           --core ibex \
           --dir ${OUT-SEED}/rtl_sim \
           -o ${OUT-SEED}/fcov \
+          --simulator "${SIMULATOR}" \
           --isa rv32imcb \
           --custom_target riscv_dv_extension
 


### PR DESCRIPTION
Enables us to work with only xlm licences when doing the coverage.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>