### PR TITLE
Architectural Coverage Merging/Reporting with XCelium

### DIFF
--- a/dv/uvm/core_ibex/sim.py
+++ b/dv/uvm/core_ibex/sim.py
@@ -136,8 +136,8 @@ def gen_cov(base_dir, simulator, lsf_cmd):
         # Get all needed directories for merge and report stages.
         cov_dirs = {
             'cov_merge_dir': my_env['cov_merge_dir'],
-            'cov_merge_db_dir': my_env['cov_merge_dir'],
-            'cov_merge_report': my_env['cov_merge_dir'],
+            'cov_merge_db_dir': my_env['cov_merge_db_dir'],
+            'cov_report_dir': my_env['cov_report_dir'],
         }
 
         # Create the mentioned directories.

--- a/vendor/google_riscv-dv/yaml/simulator.yaml
+++ b/vendor/google_riscv-dv/yaml/simulator.yaml
@@ -135,11 +135,21 @@
               -uvmhome CDNS-1.2
               -elaborate
               -l <out>/compile.log <cmp_opts>
+              <cov_opts>
               -xmlibdirpath <out>"
+    cov_opts: >
+      -coverage all
+      -covfile <cwd>/../lowrisc_ip/dv/tools/xcelium/cover.ccf
+      -nowarn COVDEF
   sim:
     cmd: >
-      xrun -R -xmlibdirpath <out> <sim_opts> -svseed <seed> -svrnc rand_struct -nokey
-
+      xrun -R -xmlibdirpath <out> <sim_opts> <cov_opts> -svseed <seed> -svrnc rand_struct -nokey
+    cov_opts: >
+          -covmodeldir <out>/riscv-dv/<test_id>.<seed>
+          -covworkdir <out>
+          -covscope riscv-dv
+          -covtest <test_id>.<seed>
+          +enable_ibex_fcov=1
 - tool: pyflow
   sim:
     cmd: >


### PR DESCRIPTION
Enables easily seeing both architectural and microarchitectural
functional coverage reports for regressions of Ibex.

Needs a minor `.tcl` change in order to be fully integrated into our master branch 

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>