### PR TITLE
[ram_2p] Set DataBitsPerMask parameter for prim_ram_2p

### DIFF
--- a/shared/rtl/ram_2p.sv
+++ b/shared/rtl/ram_2p.sv
@@ -68,6 +68,7 @@ module ram_2p #(
   prim_ram_2p #(
     .Width(32),
     .Depth(Depth),
+    .DataBitsPerMask(8),
     .MemInitFile(MemInitFile)
   ) u_ram (
     .clk_a_i   (clk_i),


### PR DESCRIPTION
It turned out that with the default value of 1, Vivado infers a separate 18 Kbit BRAM instance for each bit of the 32-bit word for the FPGA examples. This can be very wasteful in terms of resource utilization especially for smaller configurations.

As our examples don't use ECC or parity and mainly target simualation and FPGA, it's better to use a value of 8 for the DataBitsPerMask parameter. Vivado will then not distribute words across different BRAM instances which results in more efficient FPGA resource utilization.

For a detailed analysis and explanation, please refer to lowRISC/Ibex#1587.