### PR TITLE
Update ibex_controller.sv

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -357,7 +357,7 @@ module ibex_controller #(
 
     // No integrity checking on incoming load data so no internal interrupts
     assign irq_nm_int       = 1'b0;
-    assign irq_nm_int_cause = '0;
+    assign irq_nm_int_cause = NMI_INT_CAUSE_ECC;
     assign irq_nm_int_mtval = '0;
   end
 

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -357,7 +357,7 @@ module ibex_controller #(
 
     // No integrity checking on incoming load data so no internal interrupts
     assign irq_nm_int       = 1'b0;
-    assign irq_nm_int_cause = NMI_INT_CAUSE_ECC;
+    assign irq_nm_int_cause = nmi_int_cause_e'(0);
     assign irq_nm_int_mtval = '0;
   end
 


### PR DESCRIPTION
Vivado gives synthesis error complaining about assignment of irq_nm_int_cause to '0 by saying it is an enum type.

Change the assignment to NMI_INT_CAUSE_ECC, which is defined to 5'b0 in ibex_pkg.sv