### PR TITLE
Xcelium cosim support

### DIFF
--- a/ci/ibex-rtl-ci-steps.yml
+++ b/ci/ibex-rtl-ci-steps.yml
@@ -67,10 +67,6 @@ steps:
       displayName: Run RISC-V Compliance test for Ibex RV32IMC for ${{ config }}
 
     - bash: |
-        # Setup environment to use cosim with Simple System
-        export IBEX_COSIM_ISS_ROOT=/opt/spike-cosim
-        export LD_LIBRARY_PATH=/opt/spike-cosim/lib:$LD_LIBRARY_PATH
-
         # Build simple system with co-simulation
         fusesoc --cores-root=. run --target=sim --setup --build lowrisc:ibex:ibex_simple_system_cosim $IBEX_CONFIG_OPTS
 

--- a/doc/03_reference/cosim.rst
+++ b/doc/03_reference/cosim.rst
@@ -28,13 +28,12 @@ Setup and Usage
 Clone the `lowRISC fork of Spike <https://github.com/lowRISC/riscv-isa-sim>`_ and check out the ``ibex-cosim-v0.2`` tag.
 Other, later, versions called ``ibex-cosim-v*`` may also work but there's no guarantee of backwards compatibility.
 Follow the Spike build instructions to build and install Spike.
-The build will install multiple header files and libraries, it is recommended a custom install location (using ``--prefix=<path>`` with ``configure``) is used to avoid cluttering system directories.
 The ``--enable-commitlog`` and ``--enable-misaligned`` options must be passed to ``configure``.
+We recommend using a custom install location (using ``--prefix=<path>`` with ``configure``) to avoid cluttering system directories.
+Note that, if you do this, you will also need to add an entry to ``PKG_CONFIG_PATH`` so that ``pkg-config`` can tell us how to build against the installed Spike libraries.
 
-Once built, the ``IBEX_COSIM_ISS_ROOT`` environment variable must be set to the Spike root install directory (as given by ``--prefix=<path>`` to ``configure``) in order to build either the UVM DV environment or Simple System with co-simulation support.
-
-To build/run the UVM DV environment with the co-simulator add the ``COSIM=1`` argument to the make command.
-To build Simple System with the co-simulator build the ``lowrisc:ibex:ibex_simple_system_cosim`` core.
+To build/run the UVM DV environment with the co-simulator, add the ``COSIM=1`` argument to the make command.
+To build Simple System with the co-simulator, build the ``lowrisc:ibex:ibex_simple_system_cosim`` core.
 
 Quick Build and Run Instructions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -55,9 +54,6 @@ Build and install the co-simulator
   ../configure --enable-commitlog --enable-misaligned --prefix=/opt/spike-cosim
   sudo make -j8 install
 
-  # Setup IBEX_COSIM_ISS_ROOT so build flow can find the co-simulator
-  export IBEX_COSIM_ISS_ROOT=/opt/spike-cosim
-
 Run the UVM DV regression with co-simulation enabled
 
 .. code-block:: bash
@@ -77,9 +73,6 @@ Build and run Simple System with the co-simulation enabled
   # co-simulator system doesn't produce matching performance counters in spike so
   # any read of those CSRs results in a mismatch and a failure.
   make -C ./examples/sw/benchmarks/coremark SUPPRESS_PCOUNT_DUMP=1
-
-  # Spike's libsoftfloat.so needs to be accessible so add it to LD_LIBRARY_PATH
-  export LD_LIBRARY_PATH=/opt/spike-cosim/lib:$LD_LIBRARY_PATH
 
   # Run coremark binary with co-simulation checking
   build/lowrisc_ibex_ibex_simple_system_cosim_0/sim-verilator/Vibex_simple_system --meminit=ram,examples/sw/benchmarks/coremark/coremark.elf

--- a/doc/03_reference/verification.rst
+++ b/doc/03_reference/verification.rst
@@ -208,9 +208,6 @@ The entirety of this flow is controlled by the Makefile found at
    # Compile and run RTL simulation
    make TEST=xxx compile,rtl_sim
 
-   # Use a different ISS (default is spike)
-   make ... ISS=ovpsim
-
    # Run a full regression with coverage
    make COV=1
 

--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -6,16 +6,6 @@ GEN_DIR             := $(realpath ../../../vendor/google_riscv-dv)
 TOOLCHAIN           := ${RISCV_TOOLCHAIN}
 export IBEX_ROOT    := $(realpath ../../../)
 
-ifeq ($(COSIM),1)
-ifndef IBEX_COSIM_ISS_ROOT
-$(error IBEX_COSIM_ISS_ROOT must be set to the root of a suitable spike build if COSIM=1)
-else
-# Spike builds a libsoftfloat.so shared library that the simulator binary needs.
-# Set LD_LIBRARY_PATH so it can be found.
-export LD_LIBRARY_PATH := $(IBEX_COSIM_ISS_ROOT)/lib/:${LD_LIBRARY_PATH}
-endif
-endif
-
 # Explicitly ask for the bash shell
 SHELL                := bash
 
@@ -400,17 +390,37 @@ cov-arg := $(if $(call equal,$(COV),1),--en_cov,)
 wave-arg := $(if $(call equal,$(WAVES),1),--en_wave,)
 cosim-arg := $(if $(call equal,$(COSIM),1),--en_cosim,)
 
+# Extract LDFLAGS and "LIBS" for the vcs build from pkg-config. VCS expects
+# most things to be supplied with -LDFLAGS arguments, but unfortunately these
+# come before the object files that are being linked. To add libraries
+# themselves, you're supposed to pass them directly (-lfoo). Split things out
+# here to make sense of them.
+SPIKE_PCS      := riscv-riscv riscv-disasm riscv-fdt
+SPIKE_CFLAGS   := $(if $(cosim-arg),$(shell pkg-config --cflags $(SPIKE_PCS) || echo FAIL),)
+SPIKE_ALL_LIBS := $(if $(cosim-arg),$(shell pkg-config --libs $(SPIKE_PCS) || echo FAIL),)
+SPIKE_LIBS     := $(filter -l%,$(SPIKE_ALL_LIBS))
+SPIKE_LDFLAGS  := $(filter-out -l%,$(SPIKE_ALL_LIBS))
+check-spike-pkgconfig := \
+  if [ x'$(SPIKE_CFLAGS)' == xFAIL -o x'$(SPIKE_ALL_LIBS)' == xFAIL ]; then \
+	  echo >&2 "Failed to find Spike pkg-config packages."; \
+      exit 1; \
+  fi
+
 $(OUT-DIR)rtl_sim/.rtl.tb_compile.stamp: \
   $(tb-compile-vars-prereq) $(all-verilog) $(risc-dv-files) \
   sim.py yaml/rtl_simulation.yaml \
   | $(OUT-DIR)rtl_sim
-	$(verb)./sim.py \
-	         --o=$(OUT-DIR) \
-	         --steps=compile \
-	         ${COMMON_OPTS} \
-	         --simulator="${SIMULATOR}" --simulator_yaml=yaml/rtl_simulation.yaml \
-	         $(cov-arg) $(wave-arg) $(cosim-arg) \
-	         --cmp_opts="${COMPILE_OPTS}"
+	$(verb)env \
+	  SPIKE_CFLAGS="$(SPIKE_CFLAGS)" \
+	  SPIKE_LDFLAGS="$(SPIKE_LDFLAGS)" \
+	  SPIKE_LIBS="$(SPIKE_LIBS)" \
+	  ./sim.py \
+	    --o=$(OUT-DIR) \
+	    --steps=compile \
+	    ${COMMON_OPTS} \
+	    --simulator="${SIMULATOR}" --simulator_yaml=yaml/rtl_simulation.yaml \
+	    $(cov-arg) $(wave-arg) $(cosim-arg) \
+	    --cmp_opts="${COMPILE_OPTS}"
 	$(call dump-vars,$(OUT-DIR)rtl_sim/.rtl.tb_compile.vars.mk,comp,$(tb-compile-var-deps))
 	@touch $@
 
@@ -445,15 +455,19 @@ $(rtl-sim-logs): \
   run_rtl.py
 	@echo Running RTL simulation at $@
 	$(verb)mkdir -p $(@D)
-	$(verb)./run_rtl.py \
-	         --simulator $(SIMULATOR) \
-	         --simulator_yaml yaml/rtl_simulation.yaml \
-	         $(cov-arg) $(wave-arg) \
-	         --start-seed $(SEED) \
-	         --sim-opts="+signature_addr=${SIGNATURE_ADDR} ${SIM_OPTS}" \
-	         --test-dot-seed $(notdir $*) \
-	         --bin-dir $(OUT-SEED)/instr_gen/asm_test \
-	         --rtl-sim-dir $(OUT-SEED)/rtl_sim
+	$(verb)env \
+	  SPIKE_CFLAGS="$(SPIKE_CFLAGS)" \
+	  SPIKE_LDFLAGS="$(SPIKE_LDFLAGS)" \
+	  SPIKE_LIBS="$(SPIKE_LIBS)" \
+	  ./run_rtl.py \
+	    --simulator $(SIMULATOR) \
+	    --simulator_yaml yaml/rtl_simulation.yaml \
+	    $(cov-arg) $(wave-arg) \
+	    --start-seed $(SEED) \
+	    --sim-opts="+signature_addr=${SIGNATURE_ADDR} ${SIM_OPTS}" \
+	    --test-dot-seed $(notdir $*) \
+	    --bin-dir $(OUT-SEED)/instr_gen/asm_test \
+	    --rtl-sim-dir $(OUT-SEED)/rtl_sim
 
 .PHONY: rtl_sim_run
 rtl_sim_run: $(rtl-sim-logs)
@@ -520,7 +534,12 @@ riscv_dv_fcov: $(metadata)/.cov.gen_fcov.stamp
 $(metadata)/.cov.merge.stamp: \
 	$(metadata)/.cov.gen_fcov.stamp
 	$(verb)rm -rf $(OUT-DIR)rtl_sim/test.vdb
-	$(verb)./sim.py --steps=cov --simulator="${SIMULATOR}" --o="$(OUT-DIR)"
+	$(verb)env \
+	  SPIKE_CFLAGS="$(SPIKE_CFLAGS)" \
+	  SPIKE_LDFLAGS="$(SPIKE_LDFLAGS)" \
+	  SPIKE_LIBS="$(SPIKE_LIBS)" \
+	  ./sim.py \
+	    --steps=cov --simulator="${SIMULATOR}" --o="$(OUT-DIR)"
 	@if [ -d "test.vdb" ]; then \
 	     mv -f test.vdb $(OUT-DIR)rtl_sim/; \
 	fi

--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -390,30 +390,42 @@ cov-arg := $(if $(call equal,$(COV),1),--en_cov,)
 wave-arg := $(if $(call equal,$(WAVES),1),--en_wave,)
 cosim-arg := $(if $(call equal,$(COSIM),1),--en_cosim,)
 
-# Extract LDFLAGS and "LIBS" for the vcs build from pkg-config. VCS expects
-# most things to be supplied with -LDFLAGS arguments, but unfortunately these
-# come before the object files that are being linked. To add libraries
-# themselves, you're supposed to pass them directly (-lfoo). Split things out
-# here to make sense of them.
-SPIKE_PCS      := riscv-riscv riscv-disasm riscv-fdt
-SPIKE_CFLAGS   := $(if $(cosim-arg),$(shell pkg-config --cflags $(SPIKE_PCS) || echo FAIL),)
-SPIKE_ALL_LIBS := $(if $(cosim-arg),$(shell pkg-config --libs $(SPIKE_PCS) || echo FAIL),)
-SPIKE_LIBS     := $(filter -l%,$(SPIKE_ALL_LIBS))
-SPIKE_LDFLAGS  := $(filter-out -l%,$(SPIKE_ALL_LIBS))
-check-spike-pkgconfig := \
-  if [ x'$(SPIKE_CFLAGS)' == xFAIL -o x'$(SPIKE_ALL_LIBS)' == xFAIL ]; then \
-	  echo >&2 "Failed to find Spike pkg-config packages."; \
-      exit 1; \
-  fi
+# We need to the different simulators to link against the built ISS correctly
+# for cosimulation. This requires some finesse-ing.
+# Extract CFLAGS,LDFLAGS and LIBS from pkg-config. Allow the simulator yaml file
+# to format them appropriately for each simulator.
+# - VCS expects most things to be supplied with -LDFLAGS arguments, but
+# unfortunately these come before the object files that are being linked. To add
+# libraries themselves, you're supposed to pass them directly (-lfoo). Split
+# things out here to make sense of them.
+# - Xcelium expects CFLAGS, includes, and libs to be passed directly to xrun.
+# However, linker flags are to be passed using -Wld. This can be finnicky, so
+# using the alternate -Xlinker style simplifies things.
+SPIKE_PCS          := riscv-riscv riscv-disasm riscv-fdt
+ifeq ($(COSIM),1)
+	_check-spike-pkgconfig := $(shell pkg-config --exists $(SPIKE_PCS); echo $$?)
+  ifeq ($(_check-spike-pkgconfig), 0)
+    SPIKE_CFLAGS_I     := $(shell pkg-config --cflags-only-I $(SPIKE_PCS))
+    SPIKE_CFLAGS_OTHER := $(shell pkg-config --cflags-only-other $(SPIKE_PCS))
+    SPIKE_LIBS_lowerL  := $(shell pkg-config --libs-only-l $(SPIKE_PCS))
+    SPIKE_LIBS_upperL  := $(shell pkg-config --libs-only-L $(SPIKE_PCS))
+    SPIKE_LIBS_OTHER   := $(shell pkg-config --libs-only-other $(SPIKE_PCS))
+    # Formatting
+    SPIKE_LIBS_FMT     := $(shell echo $(SPIKE_LIBS_OTHER) | sed 's_-Wl,__' )
+    # $(info $(SPIKE_LIBS_FMT))
+  else
+    $(error "Failed to find Spike pkg-config packages. Did you set the PKG_CONFIG_PATH correctly?")
+  endif
+endif
 
 $(OUT-DIR)rtl_sim/.rtl.tb_compile.stamp: \
   $(tb-compile-vars-prereq) $(all-verilog) $(risc-dv-files) \
   sim.py yaml/rtl_simulation.yaml \
   | $(OUT-DIR)rtl_sim
 	$(verb)env \
-	  SPIKE_CFLAGS="$(SPIKE_CFLAGS)" \
-	  SPIKE_LDFLAGS="$(SPIKE_LDFLAGS)" \
-	  SPIKE_LIBS="$(SPIKE_LIBS)" \
+	  SPIKE_CFLAGS="$(SPIKE_CFLAGS_I) $(SPIKE_CFLAGS_OTHER)" \
+	  SPIKE_LIBS="$(SPIKE_LIBS_lowerL) $(SPIKE_LIBS_upperL)" \
+	  SPIKE_LDFLAGS="$(SPIKE_LIBS_FMT)" \
 	  ./sim.py \
 	    --o=$(OUT-DIR) \
 	    --steps=compile \
@@ -456,9 +468,9 @@ $(rtl-sim-logs): \
 	@echo Running RTL simulation at $@
 	$(verb)mkdir -p $(@D)
 	$(verb)env \
-	  SPIKE_CFLAGS="$(SPIKE_CFLAGS)" \
-	  SPIKE_LDFLAGS="$(SPIKE_LDFLAGS)" \
-	  SPIKE_LIBS="$(SPIKE_LIBS)" \
+	  SPIKE_CFLAGS="$(SPIKE_CFLAGS_I) $(SPIKE_CFLAGS_OTHER)" \
+	  SPIKE_LIBS="$(SPIKE_LIBS_lowerL) $(SPIKE_LIBS_upperL)" \
+	  SPIKE_LDFLAGS="$(SPIKE_LIBS_FMT)" \
 	  ./run_rtl.py \
 	    --simulator $(SIMULATOR) \
 	    --simulator_yaml yaml/rtl_simulation.yaml \
@@ -535,9 +547,9 @@ $(metadata)/.cov.merge.stamp: \
 	$(metadata)/.cov.gen_fcov.stamp
 	$(verb)rm -rf $(OUT-DIR)rtl_sim/test.vdb
 	$(verb)env \
-	  SPIKE_CFLAGS="$(SPIKE_CFLAGS)" \
-	  SPIKE_LDFLAGS="$(SPIKE_LDFLAGS)" \
-	  SPIKE_LIBS="$(SPIKE_LIBS)" \
+	  SPIKE_CFLAGS="$(SPIKE_CFLAGS_I) $(SPIKE_CFLAGS_OTHER)" \
+	  SPIKE_LIBS="$(SPIKE_LIBS_lowerL) $(SPIKE_LIBS_upperL)" \
+	  SPIKE_LDFLAGS="$(SPIKE_LIBS_FMT)" \
 	  ./sim.py \
 	    --steps=cov --simulator="${SIMULATOR}" --o="$(OUT-DIR)"
 	@if [ -d "test.vdb" ]; then \

--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -467,11 +467,7 @@ $(rtl-sim-logs): \
   run_rtl.py
 	@echo Running RTL simulation at $@
 	$(verb)mkdir -p $(@D)
-	$(verb)env \
-	  SPIKE_CFLAGS="$(SPIKE_CFLAGS_I) $(SPIKE_CFLAGS_OTHER)" \
-	  SPIKE_LIBS="$(SPIKE_LIBS_lowerL) $(SPIKE_LIBS_upperL)" \
-	  SPIKE_LDFLAGS="$(SPIKE_LIBS_FMT)" \
-	  ./run_rtl.py \
+	$(verb)./run_rtl.py \
 	    --simulator $(SIMULATOR) \
 	    --simulator_yaml yaml/rtl_simulation.yaml \
 	    $(cov-arg) $(wave-arg) \
@@ -544,13 +540,9 @@ riscv_dv_fcov: $(metadata)/.cov.gen_fcov.stamp
 #
 # Any coverage databases generated from the riscv_dv_fcov target will be merged as well.
 $(metadata)/.cov.merge.stamp: \
-	$(metadata)/.cov.gen_fcov.stamp
+  $(metadata)/.cov.gen_fcov.stamp
 	$(verb)rm -rf $(OUT-DIR)rtl_sim/test.vdb
-	$(verb)env \
-	  SPIKE_CFLAGS="$(SPIKE_CFLAGS_I) $(SPIKE_CFLAGS_OTHER)" \
-	  SPIKE_LIBS="$(SPIKE_LIBS_lowerL) $(SPIKE_LIBS_upperL)" \
-	  SPIKE_LDFLAGS="$(SPIKE_LIBS_FMT)" \
-	  ./sim.py \
+	$(verb)./sim.py \
 	    --steps=cov --simulator="${SIMULATOR}" --o="$(OUT-DIR)"
 	@if [ -d "test.vdb" ]; then \
 	     mv -f test.vdb $(OUT-DIR)rtl_sim/; \

--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -390,8 +390,8 @@ cov-arg := $(if $(call equal,$(COV),1),--en_cov,)
 wave-arg := $(if $(call equal,$(WAVES),1),--en_wave,)
 cosim-arg := $(if $(call equal,$(COSIM),1),--en_cosim,)
 
-# We need to the different simulators to link against the built ISS correctly
-# for cosimulation. This requires some finesse-ing.
+# We need the different simulators to link against the ISS correctly
+# for cosimulation when building the tb. This requires some finesse-ing.
 # Extract CFLAGS,LDFLAGS and LIBS from pkg-config. Allow the simulator yaml file
 # to format them appropriately for each simulator.
 # - VCS expects most things to be supplied with -LDFLAGS arguments, but

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -105,7 +105,7 @@ class core_ibex_base_test extends uvm_test;
 
     cosim_cfg.isa_string = get_isa_string();
     cosim_cfg.start_pc =    ((32'h`BOOT_ADDR & ~(32'h0000_00FF)) | 8'h80);
-    cosim_cfg.start_mtvec = ((32'h`BOOT_ADDR & ~(32'h0000_00FF)) | 8'h1);
+    cosim_cfg.start_mtvec = ((32'h`BOOT_ADDR & ~(32'h0000_00FF)) | 8'h01);
     // TODO: Turn on when not using icache
     cosim_cfg.probe_imem_for_errs = 1'b0;
     void'($value$plusargs("cosim_log_file=%0s", cosim_log_file));

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -104,8 +104,8 @@ class core_ibex_base_test extends uvm_test;
     cosim_cfg = core_ibex_cosim_cfg::type_id::create("cosim_cfg", this);
 
     cosim_cfg.isa_string = get_isa_string();
-    cosim_cfg.start_pc = {{32'h`BOOT_ADDR}[31:8], 8'h80};
-    cosim_cfg.start_mtvec = {{32'h`BOOT_ADDR}[31:8], 8'h1};
+    cosim_cfg.start_pc =    ((32'h`BOOT_ADDR & ~(32'h0000_00FF)) | 8'h80);
+    cosim_cfg.start_mtvec = ((32'h`BOOT_ADDR & ~(32'h0000_00FF)) | 8'h1);
     // TODO: Turn on when not using icache
     cosim_cfg.probe_imem_for_errs = 1'b0;
     void'($value$plusargs("cosim_log_file=%0s", cosim_log_file));

--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -17,7 +17,7 @@
 # As a result, passing -fno-extended-identifiers tells G++ to pretend that
 # everything is ASCII, preventing strange compilation errors.
 - tool: vcs
-  env_var: IBEX_COSIM_ISS_ROOT,IBEX_ROOT
+  env_var: SPIKE_CFLAGS,SPIKE_LDFLAGS,SPIKE_LIBS,IBEX_ROOT
   compile:
     cmd:
       - "vcs -f ibex_dv.f  -full64
@@ -46,11 +46,10 @@
     cosim_opts: >
       -f ibex_dv_cosim_dpi.f
       +define+INC_IBEX_COSIM
-      -LDFLAGS '-L<IBEX_COSIM_ISS_ROOT>/lib/'
-      -CFLAGS '-I<IBEX_COSIM_ISS_ROOT>/include'
-      -CFLAGS '-I<IBEX_COSIM_ISS_ROOT>/include/softfloat'
+      -LDFLAGS '<SPIKE_LDFLAGS>'
+      -CFLAGS '<SPIKE_CFLAGS>'
       -CFLAGS '-I<IBEX_ROOT>/dv/cosim'
-      -lriscv -lsoftfloat -lfdt -ldl -ldisasm -lstdc++
+      <SPIKE_LIBS> -lstdc++
   sim:
     cmd: >
       env SIM_DIR=<sim_dir>

--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -145,7 +145,7 @@
 
 
 - tool: xlm
-  env_var: dv_root, DUT_TOP
+  env_var: dv_root, DUT_TOP, SPIKE_CFLAGS,SPIKE_LDFLAGS,SPIKE_LIBS,IBEX_ROOT
   compile:
     cmd:
       - "xrun -64bit
@@ -159,14 +159,19 @@
               -elaborate
               -l <out>/compile.log
               -xmlibdirpath <out>
-              <cmp_opts>
-              <cov_opts>
-              <wave_opts>"
+              <cmp_opts> <cov_opts> <wave_opts> <cosim_opts>"
     cov_opts: >
       -coverage all
       -nowarn COVDEF
     wave_opts: >
       -access rwc -linedebug
+    cosim_opts: >
+      -f ibex_dv_cosim_dpi.f
+      +define+INC_IBEX_COSIM
+      <SPIKE_CFLAGS> <SPIKE_LIBS>
+      -Wld,'-Xlinker <SPIKE_LDFLAGS>'
+      -I<IBEX_ROOT>/dv/cosim
+      -lstdc++
   sim:
     cmd: >
       xrun -64bit
@@ -179,6 +184,7 @@
            +UVM_VERBOSITY=UVM_LOW
            +bin=<binary>
            +ibex_tracer_file_base=<sim_dir>/trace_core
+           +cosim_log_file=<sim_dir>/spike_cosim.log
            -nokey
            <sim_opts>
            <cov_opts>

--- a/dv/verilator/simple_system_cosim/ibex_cosim_setup_check.core
+++ b/dv/verilator/simple_system_cosim/ibex_cosim_setup_check.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:tool:ibex_cosim_setup_check:0.1"
-description: "Check $IBEX_COSIM_ISS_ROOT is set"
+description: "Check that Spike is installed properly for cosim"
 
 filesets:
   files_ibex_cosim_setup_check:


### PR DESCRIPTION
This builds on the earlier work in #1575 to get closer to running a cosimulation workflow for core-ibex dv by default.

This PR enables both VCS and Xcelium to run with the cosimualation workflow using COSIM=1 and SIMULATOR=xlm/vcs.
However, the ISS is still setup to run standalone and the output test success critera is based upon the existing comparison mechanisms. Switching over to the cosim workflow by default is left for a later task.

This depends upon using a recent version of spike where pkg-config is supported. 