### PR TITLE
Fix spurious rebuilds from dumped vars

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -226,7 +226,7 @@ FORCE:
 # might print a message to the console explaining why we're rebuilding TGT).
 #
 # Call it as $(call vars-prereq,X,TGT,VS)
-vars-prereq = $(if $(call vars-differ,$(1),$(2),$(3)),FORCE,)
+vars-prereq = $(if $(call vars-differ,$(call strip,$(1)),$(2),$(3)),FORCE,)
 
 ###############################################################################
 # Get a list of tests and seeds


### PR DESCRIPTION
Commit f49f452f2 greatly tidied up the file, which is nice, but also
introduced some whitespace around the first argument to `vars-prereq`.
In Make, this causes chaos!

In particular, we ended up checking whether a variable called
something like "`$(last-   gen  -vars-loaded)`" was defined. It isn't,
but `$(last-gen-vars-loaded)` is.

Call strip in the `vars-prereq` function to get rid of the whitespace at
the "entry point" for all this machinery.