### PR TITLE
Replace dump-vars line for ISS runs

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -367,6 +367,7 @@ $(metadata)/.iss.run.stamp: \
 	  --iterations $(ITERATIONS)           \
 	  --pmp-num-regions $(PMP_REGIONS)     \
 	  --pmp-granularity $(PMP_GRANULARITY)
+	$(call dump-vars,$(metadata)/.iss.vars.mk,iss,$(iss-var-deps))
 	@touch $@
 
 .PHONY: iss_run


### PR DESCRIPTION
I accidentally deleted this in commit 9e0e0cd01.