### PR TITLE
Avoid creating xrun.log files in core_ibex directory

### DIFF
--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -180,6 +180,7 @@
            +UVM_VERBOSITY=UVM_LOW
            +bin=<binary>
            +ibex_tracer_file_base=<sim_dir>/trace_core
+           -l <sim_dir>/xrun.log
            -nokey
            <sim_opts>
            <cov_opts>


### PR DESCRIPTION
This is a bit of an overlap with the existing `sim.log` files that we're
creating (which contain slightly more information), but it turns out
that if you don't say anything then you get an `xrun.log` in the current
working directory.