### PR TITLE
Sim: Simple system: handle unused parameter

### DIFF
--- a/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/examples/simple_system/rtl/ibex_simple_system.sv
@@ -192,7 +192,7 @@ module ibex_simple_system (
       .PMPEnable       ( PMPEnable        ),
       .PMPGranularity  ( PMPGranularity   ),
       .PMPNumRegions   ( PMPNumRegions    ),
-      .MHPMCounterNum  ( 29               ),
+      .MHPMCounterNum  ( MHPMCounterNum   ),
       .MHPMCounterWidth( MHPMCounterWidth ),
       .RV32E           ( RV32E            ),
       .RV32M           ( RV32M            ),


### PR DESCRIPTION
Verilator complains about MHPMCounterNum being not used. Passing it to the instantiated core solves the issue

Signed-off-by: Karol Gugala <kgugala@antmicro.com>