### PR TITLE
Switch to updated Spike version

### DIFF
--- a/doc/03_reference/cosim.rst
+++ b/doc/03_reference/cosim.rst
@@ -25,7 +25,7 @@ It is disabled by default in the UVM DV environment currently, however it is int
 Setup and Usage
 ---------------
 
-Clone the `lowRISC fork of Spike <https://github.com/lowRISC/riscv-isa-sim>`_ and check out the ``ibex-cosim-v0.2`` tag.
+Clone the `lowRISC fork of Spike <https://github.com/lowRISC/riscv-isa-sim>`_ and check out the ``ibex-cosim-v0.3`` tag.
 Other, later, versions called ``ibex-cosim-v*`` may also work but there's no guarantee of backwards compatibility.
 Follow the Spike build instructions to build and install Spike.
 The ``--enable-commitlog`` and ``--enable-misaligned`` options must be passed to ``configure``.

--- a/doc/03_reference/verification.rst
+++ b/doc/03_reference/verification.rst
@@ -101,7 +101,7 @@ In order to run the co-simulation flow, you'll need:
   + Some custom CSRs
   + Custom NMI behavior
 
-  Ibex verification should work with the Spike version that is tagged as ``ibex-cosim-v0.2``.
+  Ibex verification should work with the Spike version that is tagged as ``ibex-cosim-v0.3``.
   Other, later, versions called ``ibex-cosim-v*`` may also work but there's no guarantee of backwards compatibility.
 
   Spike must be built with the ``--enable-commitlog`` and ``--enable-misaligned`` options.

--- a/dv/cosim/spike_cosim.h
+++ b/dv/cosim/spike_cosim.h
@@ -19,6 +19,7 @@
 
 class SpikeCosim : public simif_t, public Cosim {
  private:
+  std::unique_ptr<isa_parser_t> isa_parser;
   std::unique_ptr<processor_t> processor;
   std::unique_ptr<log_file_t> log;
   bus_t bus;


### PR DESCRIPTION
This commit switches to an updated Spike version with support for ePMP.

~I suspect that this PR won't pass CI because the updated Spike version is not yet available on the tool NAS. I just created a new `ibex-cosim-v0.3` tag for that new version.~ ~Related to that I just realized that I probably made mistake when rebasing as I replaced previous call we had to `get_max_xlen()` with `get_xlen()`. I only discovered now that `get_max_xlen()` has been moved to `isa_parser.h` within Spike. I need fix this.~ This is now done.

This is related to #1579.