### PR TITLE
[core_ibex] Disable waves by default

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -29,7 +29,7 @@ export dv_root := $(realpath ../../../vendor/lowrisc_ip/dv)
 export DUT_TOP := dut
 
 # Enable waveform dumping
-WAVES               := 1
+WAVES               := 0
 # Enable coverage dump
 COV                 := 0
 # Enable cosimulation flow


### PR DESCRIPTION
This seems like something you'd want to enable explicitly, to avoid
filling up a disk on a big run.