### PR TITLE
Fix Formatting of IcacheScramble Description

### DIFF
--- a/doc/02_user/integration.rst
+++ b/doc/02_user/integration.rst
@@ -135,7 +135,7 @@ Parameters
 |                              |                     |            | ICache == 1)                                                          |
 +------------------------------+---------------------+------------+-----------------------------------------------------------------------+
 | ``ICacheScramble``           | bit                 | 0          | *EXPERIMENTAL* Enabling this parameter replaces tag and data RAMs of  |
-|                              |                     |            |  ICache with scrambling RAM primitives.                               |
+|                              |                     |            | ICache with scrambling RAM primitives.                                |
 +------------------------------+---------------------+------------+-----------------------------------------------------------------------+
 | ``BranchPrediction``         | bit                 | 0          | *EXPERIMENTAL* Enable Static branch prediction                        |
 +------------------------------+---------------------+------------+-----------------------------------------------------------------------+


### PR DESCRIPTION
Description field for the IcacheScramble instruction rendered incorrectly in the [html version of this page](https://ibex-core.readthedocs.io/en/latest/02_user/integration.html). Fixed the issue in the github rendered version (see rich diff) which will presumable also fix the problem in the HTML version.