### PR TITLE
Fix multi-line string formatting in $sformatf for uvm_fatal macro

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -400,8 +400,8 @@ class core_ibex_debug_intr_basic_test extends core_ibex_base_test;
       end
       begin : ret_timeout
         clk_vif.wait_clks(timeout);
-        `uvm_fatal(`gfn, $sformatf("No %0s detected, or incorrect privilege mode switch in \
-                                    timeout period of %0d cycles", ret, timeout))
+        `uvm_fatal(`gfn, $sformatf({"No %0s detected, or incorrect privilege mode switch in ",
+                                   "timeout period of %0d cycles"}, ret, timeout))
       end
     join_any
     // Will only get here if dret successfully detected within timeout period


### PR DESCRIPTION
Before the change the indentation of the second line would be printed as spaces in the fatal message.