### PR TITLE
Update crash dump to contain mtval

### DIFF
--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -859,10 +859,12 @@ module ibex_core import ibex_pkg::*; #(
   // Crash dump output //
   ///////////////////////
 
+  logic [31:0] crash_dump_mtval;
   assign crash_dump_o.current_pc     = pc_id;
   assign crash_dump_o.next_pc        = pc_if;
   assign crash_dump_o.last_data_addr = lsu_addr_last;
-  assign crash_dump_o.exception_addr = csr_mepc;
+  assign crash_dump_o.exception_pc   = csr_mepc;
+  assign crash_dump_o.exception_addr = crash_dump_mtval;
 
   ///////////////////
   // Alert outputs //
@@ -977,6 +979,7 @@ module ibex_core import ibex_pkg::*; #(
     .csr_mstatus_mie_o(csr_mstatus_mie),
     .csr_mstatus_tw_o (csr_mstatus_tw),
     .csr_mepc_o       (csr_mepc),
+    .csr_mtval_o      (crash_dump_mtval),
 
     // PMP
     .csr_pmp_cfg_o    (csr_pmp_cfg),

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -63,6 +63,7 @@ module ibex_cs_registers #(
   output ibex_pkg::irqs_t      irqs_o,                 // interrupt requests qualified with mie
   output logic                 csr_mstatus_mie_o,
   output logic [31:0]          csr_mepc_o,
+  output logic [31:0]          csr_mtval_o,
 
   // PMP
   output ibex_pkg::pmp_cfg_t     csr_pmp_cfg_o  [PMPNumRegions],
@@ -788,6 +789,7 @@ module ibex_cs_registers #(
   assign csr_mepc_o  = mepc_q;
   assign csr_depc_o  = depc_q;
   assign csr_mtvec_o = mtvec_q;
+  assign csr_mtval_o = mtval_q;
 
   assign csr_mstatus_mie_o   = mstatus_q.mie;
   assign csr_mstatus_tw_o    = mstatus_q.tw;

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -16,6 +16,7 @@ package ibex_pkg;
     logic [31:0] current_pc;
     logic [31:0] next_pc;
     logic [31:0] last_data_addr;
+    logic [31:0] exception_pc;
     logic [31:0] exception_addr;
   } crash_dump_t;
 


### PR DESCRIPTION
- mtval is a bit more useful for double fault situations
  as on the second exception we can still "remember" the
  data address and PC of the first exception.

see https://github.com/lowRISC/ibex/issues/1117