### PR TITLE
Create interrupts/debug/exceptions test

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -357,6 +357,30 @@
   compare_opts:
     compare_final_value_only: 1
 
+- test: riscv_assorted_traps_interrupts_debug_test
+  description: >
+    Send assorted, intermixed stimulus to test trap-handling and recovery
+  iterations: 10
+  gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +require_signature_addr=1
+    +instr_cnt=20000
+    +enable_unaligned_load_store=1
+    +no_wfi=1
+    +enable_misaligned_instr=1
+    +illegal_instr_ratio=5
+    +enable_interrupt=1
+    +enable_timer_irq=1
+    +gen_debug_section=1
+    +randomize_csr=1
+    +no_csr_instr=1
+    +no_directed_instr=1
+    +num_of_sub_program=5
+    +num_debug_sub_program=5
+  rtl_test: core_ibex_assorted_traps_interrupts_debug_test
+  sim_opts: >
+    +require_signature_addr=1
+
 - test: riscv_single_interrupt_test
   description: >
     Random instruction test with complete interrupt handling

--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -1424,3 +1424,64 @@ class core_ibex_fetch_en_chk_test extends core_ibex_directed_test;
   endtask
 
 endclass
+
+// Stimulate a combination of traps/debug requests
+// - exceptions are inserted through the instruction generator cfg (testlist.yaml)
+// - interrupts/debug requests are inserted through testbench stimulus
+class core_ibex_assorted_traps_interrupts_debug_test extends core_ibex_directed_test;
+
+   debug_new_seq debug_new_seq_h;
+   irq_new_seq irq_new_seq_h;
+
+   `uvm_component_utils(core_ibex_assorted_traps_interrupts_debug_test)
+   `uvm_component_new
+
+   virtual task send_stimulus();
+     `DV_CHECK_FATAL(cfg.require_signature_addr, "+require_signature_addr=1 is mandatory for this test.")
+
+     irq_new_seq_h = irq_new_seq::type_id::create("irq_new_seq_h", this);
+     debug_new_seq_h = debug_new_seq::type_id::create("debug_new_seq_h", this);
+
+     irq_new_seq_h.iteration_modes = InfiniteRuns;
+     irq_new_seq_h.stimulus_delay_cycles_min = 500; // Interval between requests
+     irq_new_seq_h.stimulus_delay_cycles_max = 2000;
+     irq_new_seq_h.zero_delay_pct = 10;
+     debug_new_seq_h.iteration_modes = MultipleRuns;
+     debug_new_seq_h.iteration_cnt_max = 10; // Limit this or the test will never end. (end = ecall)
+     debug_new_seq_h.pulse_length_cycles_min = 3000;   // Length of debug request pulse
+     debug_new_seq_h.pulse_length_cycles_max = 5000;
+     debug_new_seq_h.stimulus_delay_cycles_min = 5000; // Interval between requests
+     debug_new_seq_h.stimulus_delay_cycles_max = 8000;
+     debug_new_seq_h.zero_delay_pct = 0;
+
+     `uvm_info(`gfn, "Running test:->core_ibex_assorted_traps_interrupts_debug_test", UVM_LOW)
+     // Fork and never-join the different stimulus generators.
+     // Irq and Debug-Request generators should run independently to each other,
+     // and continue running until the end of the test binary.
+     fork
+       begin
+          // Calls body() in core_ibex_vseq.sv
+          // This starts the memory interface sequences
+          // (It also configures sequences enabled by plusargs, but they're not used here)
+          vseq.start(env.vseqr);
+       end
+       begin
+         // Wait for the hart to initialize
+         wait_for_core_setup();
+         // Wait for a little bit to guarantee that the core has started executing <main>
+         // before starting to generate stimulus for the core.
+         clk_vif.wait_clks(50);
+         // Now start the independent stimulus generators
+         fork
+           begin
+             debug_new_seq_h.start(env.vseqr.irq_seqr);
+           end
+           begin
+             irq_new_seq_h.start(env.vseqr.irq_seqr);
+           end
+         join_none
+       end
+     join_any
+   endtask
+
+endclass


### PR DESCRIPTION
(Ignore first commit, it is #1688 and needs merging before this PR.)

Create a test that uses riscv-dv to create an exception-causing instruction stream, while using the UVM testbench to create external interrupt and debug request stimulus.

The interrupt and debug stimulus are driven as pulses with randomised interval and duration. 
This test would benefit from a way for the interrupts to be de-asserted in response to the ISR's being executed. (See #1570)

Goes towards #1568.