### PR TITLE
[dv] Check privilege after DRET

### DIFF
--- a/dv/uvm/core_ibex/env/core_ibex_dut_probe_if.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_dut_probe_if.sv
@@ -18,6 +18,7 @@ interface core_ibex_dut_probe_if(input logic clk);
   logic                    alert_major_bus;
   logic                    debug_req;
   ibex_pkg::priv_lvl_e     priv_mode;
+  ibex_pkg::ctrl_fsm_e     ctrl_fsm_cs;
 
   clocking dut_cb @(posedge clk);
     output fetch_enable;
@@ -34,6 +35,7 @@ interface core_ibex_dut_probe_if(input logic clk);
     input alert_major_internal;
     input alert_major_bus;
     input priv_mode;
+    input ctrl_fsm_cs;
   endclocking
 
   initial begin

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -191,6 +191,7 @@ module core_ibex_tb_top;
   assign dut_if.mret          = dut.u_ibex_top.u_ibex_core.id_stage_i.controller_i.mret_insn;
   assign dut_if.reset         = ~rst_n;
   assign dut_if.priv_mode     = dut.u_ibex_top.u_ibex_core.priv_mode_id;
+  assign dut_if.ctrl_fsm_cs   = dut.u_ibex_top.u_ibex_core.id_stage_i.controller_i.ctrl_fsm_cs;
   // Instruction monitor connections
   assign instr_monitor_if.reset        = ~rst_n;
   assign instr_monitor_if.valid_id     = dut.u_ibex_top.u_ibex_core.id_stage_i.instr_valid_i;

--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -491,9 +491,13 @@ class core_ibex_directed_test extends core_ibex_debug_intr_basic_test;
   // Illegal instruction checker
   virtual task check_illegal_insn(string exception_msg);
     check_next_core_status(HANDLING_EXCEPTION, "Core did not jump to vectored exception handler", 1000);
-    check_priv_mode(PRIV_LVL_M);
     check_next_core_status(ILLEGAL_INSTR_EXCEPTION, exception_msg, 1000);
     check_mcause(1'b0, ExcCauseIllegalInsn);
+    // Ibex will wait to change the privilege mode until it is allowed to FLUSH. This happens because
+    // we are blocking the current instruction until the instruction from WB stage is ready.
+    wait (dut_vif.dut_cb.ctrl_fsm_cs == FLUSH);
+    clk_vif.wait_clks(2);
+    check_priv_mode(PRIV_LVL_M);
     wait_ret("mret", 1500);
   endtask
 


### PR DESCRIPTION
Timing fix for dret_test and modelling controller behaviour for `FLUSH` transition.

Resolves #1691

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>