### PR TITLE
[lint] Point to correct Verible rules for lint workflow

### DIFF
--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -46,4 +46,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           suggest_fixes: 'false'
-          config_file: 'vendor/lowrisc_ip/lint/tools/veriblelint/rules.vbl'
+          config_file: 'vendor/lowrisc_ip/lint/tools/veriblelint/lowrisc-styleguide.rules.verible_lint'


### PR DESCRIPTION
The file `rules.vbl` existed in previous commits, but was renamed in later vendored in code.