### PR TITLE
[dv] Fix traps in simple system cosim

### DIFF
--- a/dv/verilator/simple_system_cosim/ibex_simple_system_cosim_checker.sv
+++ b/dv/verilator/simple_system_cosim/ibex_simple_system_cosim_checker.sv
@@ -26,7 +26,7 @@ module ibex_simple_system_cosim_checker (
   end
 
   always @(posedge clk_i) begin
-    if (u_top.rvfi_valid & !u_top.rvfi_trap) begin
+    if (u_top.rvfi_valid) begin
       riscv_cosim_set_nmi(cosim_handle, u_top.rvfi_ext_nmi);
       riscv_cosim_set_mip(cosim_handle, u_top.rvfi_ext_mip);
       riscv_cosim_set_debug_req(cosim_handle, u_top.rvfi_ext_debug_req);


### PR DESCRIPTION
Previously any traps seen on RVFI were skipped over. This was old
behaviour. With the latest cosim setup traps must be passed to the
`step` function.

Note the UVM environment does do this correctly so this bug isn't related to the cosim exception issues people have been seeing.