### PR TITLE
[dv] Various coverage hole fixes

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/riscv_core_setting.sv
+++ b/dv/uvm/core_ibex/riscv_dv_extension/riscv_core_setting.sv
@@ -46,7 +46,7 @@ privileged_mode_t supported_privileged_mode[] = {MACHINE_MODE, USER_MODE};
 // Unsupported instructions
 // Avoid generating these instructions in regular regression
 // FENCE.I is intentionally treated as illegal instruction by ibex core
-riscv_instr_name_t unsupported_instr[] = {FENCE_I};
+riscv_instr_name_t unsupported_instr[] = {};
 
 // Specify whether processor supports unaligned loads and stores
 bit support_unaligned_load_store = 1'b1;

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -185,7 +185,7 @@ class core_ibex_base_test extends uvm_test;
   virtual task wait_for_test_done();
     fork
       begin
-        wait (dut_vif.ecall === 1'b1);
+        wait (dut_vif.dut_cb.ecall === 1'b1);
         vseq.stop();
         `uvm_info(`gfn, "ECALL instruction is detected, test done", UVM_LOW)
         fork


### PR DESCRIPTION
First commit fixes how we collect a certain condition in the case of core not having a clock. Second commit enables generating `FENCE.I` instruction in riscv-dv.