### PR TITLE
Riscv csr test fixes

### DIFF
--- a/dv/uvm/core_ibex/compare.py
+++ b/dv/uvm/core_ibex/compare.py
@@ -117,7 +117,7 @@ def compare_test_run(test: TestEntry,
             '[FAILED]: Log processing failed: {}'.format(e)
         return TestRunResult(**kv_data)
 
-    if en_cosim:
+    if en_cosim and not test.get('ignore_cosim_log', False):
         # Process the cosim logfile to check for errors
         kv_data['cosim_trace'] = cosim_trace
         kv_data['cosim_trace_csv'] = cosim_trace + '.csv'

--- a/dv/uvm/core_ibex/riscv_dv_extension/csr_description.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/csr_description.yaml
@@ -286,25 +286,27 @@
       msb: 31
       lsb: 1
 
-# MCAUSE
-- csr: mcause
-  description: >
-    Indicates trap cause
-  address: 0x342
-  privilege_mode: M
-  rv32:
-    - field_name: Interrupt
-      description: >
-        Indicates if trap caused by interrupt
-      type: WARL
-      reset_val: 0
-      msb: 31
-      lsb: 31
-    - field_name: Exception Code
-      type: WLRL
-      reset_val: 0
-      msb: 4
-      lsb: 0
+# TODO: Add support for WARL fields to CSR test generator allowing this CSR to
+# be tested.
+## MCAUSE
+#- csr: mcause
+#  description: >
+#    Indicates trap cause
+#  address: 0x342
+#  privilege_mode: M
+#  rv32:
+#    - field_name: Interrupt
+#      description: >
+#        Indicates if trap caused by interrupt
+#      type: WARL
+#      reset_val: 0
+#      msb: 31
+#      lsb: 31
+#    - field_name: Exception Code
+#      type: WLRL
+#      reset_val: 0
+#      msb: 4
+#      lsb: 0
 
 # MTVAL
 - csr: mtval
@@ -358,6 +360,20 @@
   address: 0x7C0
   privilege_mode: M
   rv32:
+    - field_name: double_fault_seen
+      description: >
+        A synchronous exception was observed when the sync_exc_seen field was set
+      type: RW
+      reset_val: 0
+      msb: 7
+      lsb: 7
+    - field_name: sync_exc_seen
+      description: >
+        A synchronous exception has been observed
+      type: RW
+      reset_val: 0
+      msb: 6
+      lsb: 6
     - field_name: dumm_instr_mask
       description: >
         Mask to control frequency of dummy instruction insertion

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -508,6 +508,7 @@
   sim_opts: >
     +disable_cosim=1
   no_post_compare: true
+  ignore_cosim_log: true
 
 - test: riscv_unaligned_load_store_test
   description: >

--- a/dv/uvm/core_ibex/scripts/run-instr-gen.py
+++ b/dv/uvm/core_ibex/scripts/run-instr-gen.py
@@ -70,6 +70,7 @@ def main() -> int:
                 '--test', testname,
                 '--start_seed', str(seed),
                 '--iterations', '1',
+                '--end_signature_addr', args.end_signature_addr,
                 '--sim_opts', sim_opts_str,
                 '--debug', orig_list])
 


### PR DESCRIPTION
Some issues I came across whilst working on https://github.com/lowRISC/ibex/issues/1663

Commenting out mcause in the CSR description will be temporary but I thought it'd be good to get that test passing.

The `ignore_cosim_log` in the testlist is a bit of a hack (ideally there would be one setting that disables cosim which deal with both the sim option setting and ignore the cosim log) but we will aim to have cosim enabled for all tests so it's a temporary solution for now.