### PR TITLE
[rtl] Deny no-match X access in M-Mode while MML=1

### DIFF
--- a/dv/uvm/core_ibex/fcov/core_ibex_pmp_fcov_if.sv
+++ b/dv/uvm/core_ibex/fcov/core_ibex_pmp_fcov_if.sv
@@ -416,6 +416,8 @@ interface core_ibex_pmp_fcov_if import ibex_pkg::*; #(
     logic pmp_current_priv_req_err;
     assign pmp_current_priv_req_err =
       g_pmp.pmp_i.access_fault_check(csr_pmp_mseccfg.mmwp,
+                                     csr_pmp_mseccfg.mml,
+                                     g_pmp.pmp_i.pmp_req_type_i[PMP_D],
                                      g_pmp.pmp_i.region_match_all[PMP_D],
                                      cs_registers_i.priv_mode_id_o,
                                      current_priv_perm_check);


### PR DESCRIPTION
In ePMP spec, it specifies as:

```
Executing code with Machine mode privileges is only possible from memory
regions with a matching Mmode-only rule or a locked Shared-Region rule
with executable privileges. Executing code from a region without a
matching rule or with a matching S/U-mode-only rule is denied.
```

This change provides that.

Resolves #1736 

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>