### PR TITLE
[dv,cosim] Add memory region to match UVM env

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_cosim_agent/spike_cosim_dpi.cc
+++ b/dv/uvm/core_ibex/common/ibex_cosim_agent/spike_cosim_dpi.cc
@@ -23,6 +23,7 @@ void *spike_cosim_init(const char *isa_string, svBitVecVal *start_pc,
   SpikeCosim *cosim = new SpikeCosim(isa_string, start_pc[0], start_mtvec[0],
                                      log_file_path, false, true);
   cosim->add_memory(0x80000000, 0x80000000);
+  cosim->add_memory(0x00000000, 0x80000000);
   return static_cast<Cosim *>(cosim);
 }
 


### PR DESCRIPTION
This extends our memory range to be between 0 and
0xFFFF_FFFF. This is needed because in the case of
no match between UVM memory model and spike memory
model, we see a mismatch.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>