### PR TITLE
[rtl] Fix scrambling key request on icache inval

### DIFF
--- a/dv/uvm/icache/dv/tb/tb.sv
+++ b/dv/uvm/icache/dv/tb/tb.sv
@@ -91,6 +91,8 @@ module tb #(
       .ic_data_wdata_o     ( ram_if.ic_data_wdata       ),
       .ic_data_rdata_i     ( ram_if.ic_data_rdata_o     ),
       .ic_scr_key_valid_i  ( scramble_key_valid_q       ),
+      // TODO: Hook up to monitor and appropriate checking
+      .ic_scr_key_req_o    (                            ),
 
       // TODO: Probe this and verify functionality
       .ecc_error_o         ( ram_if.ecc_err             )

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -92,6 +92,7 @@ module ibex_core import ibex_pkg::*; #(
   output logic [LineSizeECC-1:0]       ic_data_wdata_o,
   input  logic [LineSizeECC-1:0]       ic_data_rdata_i [IC_NUM_WAYS],
   input  logic                         ic_scr_key_valid_i,
+  output logic                         ic_scr_key_req_o,
 
   // Interrupt inputs
   input  logic                         irq_software_i,
@@ -149,7 +150,6 @@ module ibex_core import ibex_pkg::*; #(
   output logic                         alert_minor_o,
   output logic                         alert_major_internal_o,
   output logic                         alert_major_bus_o,
-  output logic                         icache_inval_o,
   output logic                         core_busy_o
 );
 
@@ -413,6 +413,7 @@ module ibex_core import ibex_pkg::*; #(
     .ic_data_wdata_o   (ic_data_wdata_o),
     .ic_data_rdata_i   (ic_data_rdata_i),
     .ic_scr_key_valid_i(ic_scr_key_valid_i),
+    .ic_scr_key_req_o  (ic_scr_key_req_o),
 
     // outputs to ID stage
     .instr_valid_id_o        (instr_valid_id),
@@ -649,7 +650,6 @@ module ibex_core import ibex_pkg::*; #(
     .instr_id_done_o  (instr_id_done)
   );
 
-  assign icache_inval_o = icache_inval;
   // for RVFI only
   assign unused_illegal_insn_id = illegal_insn_id;
 

--- a/rtl/ibex_icache.sv
+++ b/rtl/ibex_icache.sv
@@ -58,6 +58,7 @@ module ibex_icache import ibex_pkg::*; #(
   output logic [LineSizeECC-1:0]         ic_data_wdata_o,
   input  logic [LineSizeECC-1:0]         ic_data_rdata_i [IC_NUM_WAYS],
   input  logic                           ic_scr_key_valid_i,
+  output logic                           ic_scr_key_req_o,
 
   // Cache status
   input  logic                           icache_enable_i,
@@ -182,11 +183,19 @@ module ibex_icache import ibex_pkg::*; #(
   logic [31:0]                            output_data;
   logic                                   output_err;
   // Invalidations
-  logic                                   start_inval, inval_done;
-  logic                                   inval_lock, inval_req_d, inval_req_q;
-  logic                                   reset_inval_q;
-  logic                                   inval_prog_d, inval_prog_q;
-  logic [IC_INDEX_W-1:0]                  inval_index_d, inval_index_q;
+  typedef enum logic [1:0] {
+    OUT_OF_RESET,
+    AWAIT_SCRAMBLE_KEY,
+    INVAL_CACHE,
+    IDLE
+  } inval_state_e;
+
+  inval_state_e          inval_state_q, inval_state_d;
+  logic                  inval_write_req;
+  logic                  inval_block_cache;
+  logic [IC_INDEX_W-1:0] inval_index_d, inval_index_q;
+  logic                  inval_index_en;
+  logic                  inval_active;
 
   //////////////////////////
   // Instruction prefetch //
@@ -238,28 +247,27 @@ module ibex_icache import ibex_pkg::*; #(
   // Cache write
   assign fill_req_ic0   = (|fill_ram_req);
   assign fill_index_ic0 = fill_ram_req_addr[IC_INDEX_HI:IC_LINE_W];
-  assign fill_tag_ic0   = {(~inval_prog_q & ~ecc_write_req),
+  assign fill_tag_ic0   = {(~inval_write_req & ~ecc_write_req),
                            fill_ram_req_addr[ADDR_W-1:IC_INDEX_HI+1]};
   assign fill_wdata_ic0 = fill_ram_req_data;
 
   // Arbitrated signals - lookups have highest priority
   assign lookup_grant_ic0  = lookup_req_ic0;
-  assign fill_grant_ic0    = fill_req_ic0 & ~lookup_req_ic0 & ~inval_prog_q &
+  assign fill_grant_ic0    = fill_req_ic0 & ~lookup_req_ic0 & ~inval_write_req &
                              ~ecc_write_req;
   // Qualified lookup grant to mask ram signals in IC1 if access was not made
-  assign lookup_actual_ic0 = lookup_grant_ic0 & icache_enable_i & ~inval_prog_q &
-                             ~icache_inval_i & ~inval_lock & ~start_inval;
+  assign lookup_actual_ic0 = lookup_grant_ic0 & icache_enable_i & ~inval_block_cache;
 
   // Tagram
-  assign tag_req_ic0   = lookup_req_ic0 | fill_req_ic0 | inval_prog_q | ecc_write_req;
-  assign tag_index_ic0 = inval_prog_q   ? inval_index_q :
-                         ecc_write_req  ? ecc_write_index :
-                         fill_grant_ic0 ? fill_index_ic0 :
-                                          lookup_index_ic0;
+  assign tag_req_ic0   = lookup_req_ic0 | fill_req_ic0 | inval_write_req | ecc_write_req;
+  assign tag_index_ic0 = inval_write_req ? inval_index_q :
+                         ecc_write_req   ? ecc_write_index :
+                         fill_grant_ic0  ? fill_index_ic0 :
+                                           lookup_index_ic0;
   assign tag_banks_ic0 = ecc_write_req  ? ecc_write_ways :
                          fill_grant_ic0 ? fill_ram_req_way :
                                           {IC_NUM_WAYS{1'b1}};
-  assign tag_write_ic0 = fill_grant_ic0 | inval_prog_q | ecc_write_req;
+  assign tag_write_ic0 = fill_grant_ic0 | inval_write_req | ecc_write_req;
 
   // Dataram
   assign data_req_ic0   = lookup_req_ic0 | fill_req_ic0;
@@ -534,13 +542,11 @@ module ibex_icache import ibex_pkg::*; #(
       end
     end
 
-    assign fill_cache_new = (branch_i | (|cache_cnt_q)) & icache_enable_i &
-                            ~icache_inval_i & ~inval_lock & ~inval_prog_q;
-
+    assign fill_cache_new = (branch_i | (|cache_cnt_q)) & icache_enable_i & ~inval_block_cache;
   end else begin : gen_cache_all
 
     // Cache all missing fetches
-    assign fill_cache_new = icache_enable_i & ~start_inval & ~inval_prog_q;
+    assign fill_cache_new = icache_enable_i & ~inval_block_cache;
   end
 
   //////////////////////////
@@ -603,7 +609,7 @@ module ibex_icache import ibex_pkg::*; #(
     // Any invalidation or disabling of the cache while the buffer is busy will stop allocation
     assign fill_cache_d[fb]    = (fill_alloc[fb] & fill_cache_new) |
                                  (fill_cache_q[fb] & fill_busy_q[fb] &
-                                  icache_enable_i & ~icache_inval_i & ~inval_lock);
+                                  icache_enable_i & ~icache_inval_i);
     // Record whether the request hit in the cache
     assign fill_hit_ic1[fb]    = lookup_valid_ic1 & fill_in_ic1[fb] & tag_hit_ic1 & ~ecc_err_ic1;
     assign fill_hit_d[fb]      = fill_hit_ic1[fb] | (fill_hit_q[fb] & fill_busy_q[fb]);
@@ -1060,39 +1066,82 @@ module ibex_icache import ibex_pkg::*; #(
   // Invalidations //
   ///////////////////
 
+  // Invalidation (writing all entries in the tag RAM with an invalid tag) occurs straight out of
+  // reset and after any invalidation request (signalled via icache_inval_i). An invalidation
+  // request coming whilst another is writing tags causes the invalidation to start again. This
+  // ensures a new scramble key is requested where a previous one is in use.
+  // TODO: Ditch this behaviour for non-secure ibex?
+  always_comb begin
+    inval_state_d     = inval_state_q;
+    inval_index_d     = inval_index_q;
+    inval_index_en    = 1'b0;
+    inval_write_req   = 1'b0;
+    ic_scr_key_req_o  = 1'b0;
 
-  // We need to save the invalidation request inside a register. That way we can wait
-  // until we have a valid scrambling key to do it. Since the key itself is needed for
-  // starting to fill in the RAMs and read from them, ICache also needs to stop operating.
-  assign inval_req_d = (inval_req_q | icache_inval_i) & ~(inval_done & inval_prog_q);
+    // Prevent other cache activity (cache lookups and cache allocations) whilst an invalidation is
+    // in progress. Set to 1 by default as the only time we don't block is when the state machine is
+    // IDLE.
+    inval_block_cache = 1'b1;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      inval_req_q  <= 1'b0;
-    end else begin
-      inval_req_q  <= inval_req_d;
-    end
+    case (inval_state_q)
+      OUT_OF_RESET: begin
+        // Initial state, this initialises the tag RAMs out of reset before the icache can be used
+        inval_state_d = AWAIT_SCRAMBLE_KEY;
+
+        if (~ic_scr_key_valid_i) begin
+          ic_scr_key_req_o = 1'b1;
+        end
+      end
+      AWAIT_SCRAMBLE_KEY: begin
+        // When invalidating a new scrambling key is requested on all invalidation requests. Wait
+        // for that new key to be available before beginning with the actual invalidation (cannot
+        // write to the tag RAM until we have the new scrambling key that will be used). Ignore any
+        // requests in this phase (once a scramble key request has started we cannot request a new
+        // one until the on-going request is done).
+        if (ic_scr_key_valid_i) begin
+          inval_state_d  = INVAL_CACHE;
+          inval_index_d  = '0;
+          inval_index_en = 1'b1;
+        end
+      end
+      INVAL_CACHE: begin
+        // Actually invalidate the cache. Write every entry in the tag RAM with an invalid tag. Once
+        // all are written we're done.
+        inval_write_req = 1'b1;
+        inval_index_d   = (inval_index_q + {{IC_INDEX_W-1{1'b0}},1'b1});
+        inval_index_en  = 1'b1;
+
+        if (icache_inval_i) begin
+          // If a new invalidaiton requests comes in go back to the beginning with a new scramble
+          // key
+          ic_scr_key_req_o = 1'b1;
+          inval_state_d = AWAIT_SCRAMBLE_KEY;
+        end else if (&inval_index_q) begin
+          // When the final index is written we're done
+            inval_state_d = IDLE;
+        end
+      end
+      IDLE: begin
+        // Usual running state
+        if (icache_inval_i) begin
+          ic_scr_key_req_o = 1'b1;
+          inval_state_d = AWAIT_SCRAMBLE_KEY;
+        end else begin
+          // Allow other cache activies whilst in IDLE and no invalidation has been requested
+          inval_block_cache = 1'b0;
+        end
+      end
+      default: ;
+    endcase
   end
 
-  // This will act like a lock mechanism.
-  // Main idea is to lock the invalidation request until we got a valid scrambling key.
-  assign inval_lock = inval_req_d & ~ic_scr_key_valid_i;
-
-  // Invalidate on reset, or when instructed. If an invalidation request is received while a
-  // previous invalidation is ongoing, it does not need to be restarted. Do not start
-  // this process until inval lock is removed meaning the scrambling key is valid.
-  assign start_inval   = ~inval_lock & (~reset_inval_q | inval_req_q) & ~inval_prog_q ;
-  assign inval_prog_d  = ~inval_lock & (start_inval | (inval_prog_q & ~inval_done));
-  assign inval_done    = &inval_index_q;
-  assign inval_index_d = start_inval ? '0 : (inval_index_q + {{IC_INDEX_W-1{1'b0}},1'b1});
+  assign inval_active = inval_state_q != IDLE;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      inval_prog_q  <= 1'b0;
-      reset_inval_q <= 1'b0;
+      inval_state_q <= OUT_OF_RESET;
     end else begin
-      inval_prog_q  <= inval_prog_d;
-      reset_inval_q <= 1'b1;
+      inval_state_q <= inval_state_d;
     end
   end
 
@@ -1100,13 +1149,13 @@ module ibex_icache import ibex_pkg::*; #(
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
         inval_index_q <= '0;
-      end else if (inval_prog_d) begin
+      end else if (inval_index_en) begin
         inval_index_q <= inval_index_d;
       end
     end
   end else begin : g_inval_index_nr
     always_ff @(posedge clk_i) begin
-      if (inval_prog_d) begin
+      if (inval_index_en) begin
         inval_index_q <= inval_index_d;
       end
     end
@@ -1118,7 +1167,7 @@ module ibex_icache import ibex_pkg::*; #(
 
   // Only busy (for WFI purposes) while an invalidation is in-progress, or external requests are
   // outstanding.
-  assign busy_o = inval_req_q | (|(fill_busy_q & ~fill_rvd_done));
+  assign busy_o = inval_active | (|(fill_busy_q & ~fill_rvd_done));
 
   ////////////////
   // Assertions //

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -56,6 +56,7 @@ module ibex_if_stage import ibex_pkg::*; #(
   output logic [LineSizeECC-1:0]      ic_data_wdata_o,
   input  logic [LineSizeECC-1:0]      ic_data_rdata_i [IC_NUM_WAYS],
   input  logic                        ic_scr_key_valid_i,
+  output logic                        ic_scr_key_req_o,
 
   // output of ID stage
   output logic                        instr_valid_id_o,         // instr in IF-ID is valid
@@ -301,6 +302,7 @@ module ibex_if_stage import ibex_pkg::*; #(
         .ic_data_wdata_o     ( ic_data_wdata_o            ),
         .ic_data_rdata_i     ( ic_data_rdata_i            ),
         .ic_scr_key_valid_i  ( ic_scr_key_valid_i         ),
+        .ic_scr_key_req_o    ( ic_scr_key_req_o           ),
 
         .icache_enable_i     ( icache_enable_i            ),
         .icache_inval_i      ( icache_inval_i             ),
@@ -353,6 +355,7 @@ module ibex_if_stage import ibex_pkg::*; #(
     assign ic_data_write_o       = 'b0;
     assign ic_data_addr_o        = 'b0;
     assign ic_data_wdata_o       = 'b0;
+    assign ic_scr_key_req_o      = 'b0;
     assign icache_ecc_error_o    = 'b0;
 
 `ifndef SYNTHESIS

--- a/rtl/ibex_lockstep.sv
+++ b/rtl/ibex_lockstep.sv
@@ -83,6 +83,7 @@ module ibex_lockstep import ibex_pkg::*; #(
   input  logic [LineSizeECC-1:0]       ic_data_wdata_i,
   input  logic [LineSizeECC-1:0]       ic_data_rdata_i [IC_NUM_WAYS],
   input  logic                         ic_scr_key_valid_i,
+  input  logic                         ic_scr_key_req_i,
 
   input  logic                         irq_software_i,
   input  logic                         irq_timer_i,
@@ -99,7 +100,6 @@ module ibex_lockstep import ibex_pkg::*; #(
   output logic                         alert_minor_o,
   output logic                         alert_major_internal_o,
   output logic                         alert_major_bus_o,
-  input  logic                         icache_inval_i,
   input  logic                         core_busy_i,
   input  logic                         test_en_i,
   input  logic                         scan_rst_ni
@@ -259,10 +259,10 @@ module ibex_lockstep import ibex_pkg::*; #(
     logic                        ic_data_write;
     logic [IC_INDEX_W-1:0]       ic_data_addr;
     logic [LineSizeECC-1:0]      ic_data_wdata;
+    logic                        ic_scr_key_req;
     logic                        irq_pending;
     crash_dump_t                 crash_dump;
     logic                        double_fault_seen;
-    logic                        icache_inval;
     logic                        core_busy;
   } delayed_outputs_t;
 
@@ -292,10 +292,10 @@ module ibex_lockstep import ibex_pkg::*; #(
   assign core_outputs_in.ic_data_write       = ic_data_write_i;
   assign core_outputs_in.ic_data_addr        = ic_data_addr_i;
   assign core_outputs_in.ic_data_wdata       = ic_data_wdata_i;
+  assign core_outputs_in.ic_scr_key_req      = ic_scr_key_req_i;
   assign core_outputs_in.irq_pending         = irq_pending_i;
   assign core_outputs_in.crash_dump          = crash_dump_i;
   assign core_outputs_in.double_fault_seen   = double_fault_seen_i;
-  assign core_outputs_in.icache_inval        = icache_inval_i;
   assign core_outputs_in.core_busy           = core_busy_i;
 
   // Delay the outputs
@@ -386,6 +386,7 @@ module ibex_lockstep import ibex_pkg::*; #(
     .ic_data_wdata_o     (shadow_outputs_d.ic_data_wdata),
     .ic_data_rdata_i     (shadow_data_rdata_q[0]),
     .ic_scr_key_valid_i  (shadow_inputs_q[0].ic_scr_key_valid),
+    .ic_scr_key_req_o    (shadow_outputs_d.ic_scr_key_req),
 
     .irq_software_i      (shadow_inputs_q[0].irq_software),
     .irq_timer_i         (shadow_inputs_q[0].irq_timer),
@@ -434,7 +435,6 @@ module ibex_lockstep import ibex_pkg::*; #(
     .alert_minor_o          (shadow_alert_minor),
     .alert_major_internal_o (shadow_alert_major_internal),
     .alert_major_bus_o      (shadow_alert_major_bus),
-    .icache_inval_o         (shadow_outputs_d.icache_inval),
     .core_busy_o            (shadow_outputs_d.core_busy)
   );
 

--- a/rtl/ibex_top.sv
+++ b/rtl/ibex_top.sv
@@ -182,12 +182,12 @@ module ibex_top import ibex_pkg::*; #(
   logic [IC_INDEX_W-1:0]       ic_data_addr;
   logic [LineSizeECC-1:0]      ic_data_wdata;
   logic [LineSizeECC-1:0]      ic_data_rdata [IC_NUM_WAYS];
+  logic                        ic_scr_key_req;
   // Alert signals
   logic                        core_alert_major_internal, core_alert_major_bus, core_alert_minor;
   logic                        lockstep_alert_major_internal, lockstep_alert_major_bus;
   logic                        lockstep_alert_minor;
   // Scramble signals
-  logic                         icache_inval;
   logic [SCRAMBLE_KEY_W-1:0]    scramble_key_q;
   logic [SCRAMBLE_NONCE_W-1:0]  scramble_nonce_q;
   logic                         scramble_key_valid_d, scramble_key_valid_q;
@@ -326,6 +326,7 @@ module ibex_top import ibex_pkg::*; #(
     .ic_data_wdata_o   (ic_data_wdata),
     .ic_data_rdata_i   (ic_data_rdata),
     .ic_scr_key_valid_i(scramble_key_valid_q),
+    .ic_scr_key_req_o  (ic_scr_key_req),
 
     .irq_software_i,
     .irq_timer_i,
@@ -374,7 +375,6 @@ module ibex_top import ibex_pkg::*; #(
     .alert_minor_o         (core_alert_minor),
     .alert_major_internal_o(core_alert_major_internal),
     .alert_major_bus_o     (core_alert_major_bus),
-    .icache_inval_o        (icache_inval),
     .core_busy_o           (core_busy_d)
   );
 
@@ -467,7 +467,7 @@ module ibex_top import ibex_pkg::*; #(
     // Scramble key valid starts with OTP returning new valid key and stays high
     // until we request a new valid key.
     assign scramble_key_valid_d = scramble_req_q ? scramble_key_valid_i :
-                                  icache_inval   ? 1'b0                 :
+                                  ic_scr_key_req ? 1'b0                 :
                                                    scramble_key_valid_q;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -492,14 +492,14 @@ module ibex_top import ibex_pkg::*; #(
 
   // Scramble key request starts with invalidate signal from ICache and stays high
   // until we got a valid key.
-    assign scramble_req_d = scramble_req_q ? ~scramble_key_valid_i : icache_inval;
+    assign scramble_req_d = scramble_req_q ? ~scramble_key_valid_i : ic_scr_key_req;
     assign scramble_req_o = scramble_req_q;
 
   end else begin : gen_noscramble
 
     logic unused_scramble_inputs = scramble_key_valid_i & (|scramble_key_i) & (|RndCnstIbexKey) &
                                    (|scramble_nonce_i) & (|RndCnstIbexNonce) & scramble_req_q &
-                                   icache_inval & scramble_key_valid_d & scramble_req_d;
+                                   ic_scr_key_req & scramble_key_valid_d & scramble_req_d;
 
     assign scramble_req_d       = 1'b0;
     assign scramble_req_q       = 1'b0;
@@ -703,6 +703,7 @@ module ibex_top import ibex_pkg::*; #(
       ic_data_addr,
       ic_data_wdata,
       scramble_key_valid_i,
+      ic_scr_key_req,
       irq_software_i,
       irq_timer_i,
       irq_external_i,
@@ -713,7 +714,6 @@ module ibex_top import ibex_pkg::*; #(
       crash_dump_o,
       double_fault_seen_o,
       fetch_enable_i,
-      icache_inval,
       core_busy_d
     });
 
@@ -757,6 +757,7 @@ module ibex_top import ibex_pkg::*; #(
     logic [IC_INDEX_W-1:0]        ic_data_addr_local;
     logic [LineSizeECC-1:0]       ic_data_wdata_local;
     logic                         scramble_key_valid_local;
+    logic                         ic_scr_key_req_local;
 
     logic                         irq_software_local;
     logic                         irq_timer_local;
@@ -770,7 +771,6 @@ module ibex_top import ibex_pkg::*; #(
     logic                         double_fault_seen_local;
     fetch_enable_t                fetch_enable_local;
 
-    logic                         icache_inval_local;
     logic                         core_busy_local;
 
     assign buf_in = {
@@ -808,6 +808,7 @@ module ibex_top import ibex_pkg::*; #(
       ic_data_addr,
       ic_data_wdata,
       scramble_key_valid_q,
+      ic_scr_key_req,
       irq_software_i,
       irq_timer_i,
       irq_external_i,
@@ -818,7 +819,6 @@ module ibex_top import ibex_pkg::*; #(
       crash_dump_o,
       double_fault_seen_o,
       fetch_enable_i,
-      icache_inval,
       core_busy_d
     };
 
@@ -857,6 +857,7 @@ module ibex_top import ibex_pkg::*; #(
       ic_data_addr_local,
       ic_data_wdata_local,
       scramble_key_valid_local,
+      ic_scr_key_req_local,
       irq_software_local,
       irq_timer_local,
       irq_external_local,
@@ -867,7 +868,6 @@ module ibex_top import ibex_pkg::*; #(
       crash_dump_local,
       double_fault_seen_local,
       fetch_enable_local,
-      icache_inval_local,
       core_busy_local
     } = buf_out;
 
@@ -966,6 +966,7 @@ module ibex_top import ibex_pkg::*; #(
       .ic_data_wdata_i        (ic_data_wdata_local),
       .ic_data_rdata_i        (ic_data_rdata_local),
       .ic_scr_key_valid_i     (scramble_key_valid_local),
+      .ic_scr_key_req_i       (ic_scr_key_req_local),
 
       .irq_software_i         (irq_software_local),
       .irq_timer_i            (irq_timer_local),
@@ -982,7 +983,6 @@ module ibex_top import ibex_pkg::*; #(
       .alert_minor_o          (lockstep_alert_minor_local),
       .alert_major_internal_o (lockstep_alert_major_internal_local),
       .alert_major_bus_o      (lockstep_alert_major_bus_local),
-      .icache_inval_i         (icache_inval_local),
       .core_busy_i            (core_busy_local),
       .test_en_i              (test_en_i),
       .scan_rst_ni            (scan_rst_ni)


### PR DESCRIPTION
Previously on any invalidation request a new scrambling key for icache
was requested. This causes issues if it happens half way through an
ongoing icache invalidation. This fix ensure the scrambling key request
is only sent if we are starting a new invalidation.