### PR TITLE
Change test_done mechanism to use riscvdv handshake, not ecall

### DIFF
--- a/dv/uvm/core_ibex/scripts/run-instr-gen.py
+++ b/dv/uvm/core_ibex/scripts/run-instr-gen.py
@@ -43,6 +43,7 @@ def main() -> int:
     ]
     sim_opts_dict = {
         'uvm_set_inst_override': ','.join(inst_overrides),
+        'require_signature_addr': '1',
         'signature_addr': args.end_signature_addr,
         'pmp_num_regions': str(cfg.pmp_num_regions),
         'pmp_granularity': str(cfg.pmp_granularity),

--- a/dv/uvm/core_ibex/scripts/run-instr-gen.py
+++ b/dv/uvm/core_ibex/scripts/run-instr-gen.py
@@ -41,10 +41,17 @@ def main() -> int:
         'ibex_asm_program_gen',
         'uvm_test_top.asm_gen'
     ]
+
+    # Special-case for riscv_csr_test -> fixup the handshake addr.
+    # Currently use (signature_addr - 0x4) for test_done channel.
+    sig = ((args.end_signature_addr) if ('riscv_csr_test' not in testname)
+           else
+           f'{(int(args.end_signature_addr, 16) - 4):x}')  # (signature_addr - 0x4)
+
     sim_opts_dict = {
         'uvm_set_inst_override': ','.join(inst_overrides),
         'require_signature_addr': '1',
-        'signature_addr': args.end_signature_addr,
+        'signature_addr': sig,
         'pmp_num_regions': str(cfg.pmp_num_regions),
         'pmp_granularity': str(cfg.pmp_granularity),
         'tvec_alignment': '8'
@@ -71,7 +78,7 @@ def main() -> int:
                 '--test', testname,
                 '--start_seed', str(seed),
                 '--iterations', '1',
-                '--end_signature_addr', args.end_signature_addr,
+                '--end_signature_addr', sig,
                 '--sim_opts', sim_opts_str,
                 '--debug', orig_list])
 

--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -8,27 +8,6 @@ class core_ibex_csr_test extends core_ibex_base_test;
   `uvm_component_utils(core_ibex_csr_test)
   `uvm_component_new
 
-  virtual task wait_for_test_done();
-    bit result;
-    fork
-    begin
-      wait_for_mem_txn(cfg.signature_addr, TEST_RESULT);
-      result = signature_data_q.pop_front();
-      if (result == TEST_PASS) begin
-        `uvm_info(`gfn, "CSR test completed successfully!", UVM_LOW)
-      end else if (result == TEST_FAIL) begin
-        `uvm_error(`gfn, "CSR TEST_FAILED!")
-      end else begin
-        `uvm_fatal(`gfn, "CSR test values are not configured properly")
-      end
-    end
-    begin
-      clk_vif.wait_clks(timeout_in_cycles);
-      `uvm_fatal(`gfn, "TEST TIMEOUT!!")
-    end
-    join_any
-  endtask
-
 endclass
 
 // Reset test
@@ -459,7 +438,7 @@ class core_ibex_directed_test extends core_ibex_debug_intr_basic_test;
           fork
             check_stimulus();
           join_none
-          wait (dut_vif.dut_cb.ecall === 1'b1);
+          wait (test_done === 1'b1);
           disable fork;
           if (cur_run_phase.get_objection_count(this) > 1) begin
             cur_run_phase.drop_objection(this);
@@ -1447,7 +1426,7 @@ class core_ibex_assorted_traps_interrupts_debug_test extends core_ibex_directed_
      irq_new_seq_h.stimulus_delay_cycles_max = 2000;
      irq_new_seq_h.zero_delay_pct = 10;
      debug_new_seq_h.iteration_modes = MultipleRuns;
-     debug_new_seq_h.iteration_cnt_max = 10; // Limit this or the test will never end. (end = ecall)
+     debug_new_seq_h.iteration_cnt_max = 10; // Limit this or the test will never end.
      debug_new_seq_h.pulse_length_cycles_min = 3000;   // Length of debug request pulse
      debug_new_seq_h.pulse_length_cycles_max = 5000;
      debug_new_seq_h.stimulus_delay_cycles_min = 5000; // Interval between requests


### PR DESCRIPTION
Use the address (signature_addr - 0x4) for a TEST_PASS handshake.
Create seperate subscriber port for test_done functionality

By creating a new, distinct port and subscribing to all incoming memory items,
the existing wait_for_mem_txn() can be used with minor modifications to be
able to choose the port to wait on as an argument to the task.

Because the wait_for_mem_txn() implementation currently uses get() to pop the
latest item from the item_collected queue, having two different forked processes
that both await on this queue is not possible. The simplest solution is to
create a new, seperate port which also subscribes to the sequence_items
broadcast by the mem_if monitor.

Possible improvements / todo:
- Create a seperate plusarg for this test_done address (don't just assume signature_addr - 0x4 is okay)
- Update documentation
- Consider upstreaming if it proves a good solution.

Closes #1718

Signed-off-by: Harry Callahan <hcallahan@lowrisc.org>