### PR TITLE
[dv] Reduce riscv_pmp_full_random_test iterations

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -740,7 +740,7 @@
     and allow PMP regions to overlap.
     A large number of iterations will be required since this introduces a huge
     state space of configurations.
-  iterations: 100
+  iterations: 5
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000


### PR DESCRIPTION
We're seeing many timeouts in this test. This is causing issues for the
nightly regression. Keep the test in so we're aware of any major issues
with it but with far fewer timeouts to help keep the regression healthy.
We'll revisit the required iterations once we've sorted out the issues
with the test.