### PR TITLE
[dv] Double timeout for an RTL run in regression flow

### DIFF
--- a/dv/uvm/core_ibex/scripts/run_rtl.py
+++ b/dv/uvm/core_ibex/scripts/run_rtl.py
@@ -89,7 +89,7 @@ def _main() -> int:
             # Note that we don't capture the success or failure of the subprocess:
 
             sim_fd.write(f"Running run-rtl command :\n{' '.join(cmd)}\n".encode())
-            run_one(md.verbose, cmd, redirect_stdstreams=sim_fd, timeout_s=900)
+            run_one(md.verbose, cmd, redirect_stdstreams=sim_fd, timeout_s=1800)
 
     # Always return 0 (success), even if the test failed. We've successfully
     # generated a log either way.


### PR DESCRIPTION
This takes it from 15 to 30 minutes

It reduces the total number of timeouts we see. We should still look at fixing up the long running tests but this will give us a healthier regression.

Draft for now whilst we look into impacts on regression run times.