### PR TITLE
[dv] Use lowRISC IP dir from imports instead of re-deriving it

### DIFF
--- a/dv/uvm/core_ibex/scripts/merge_cov.py
+++ b/dv/uvm/core_ibex/scripts/merge_cov.py
@@ -15,7 +15,7 @@ import pathlib3x as pathlib
 from typing import Set
 
 from metadata import RegressionMetadata
-from setup_imports import _IBEX_ROOT
+from setup_imports import _OT_LOWRISC_IP
 from scripts_lib import run_one
 
 
@@ -56,7 +56,7 @@ def merge_cov_vcs(cov_dir: str, verbose: bool, cov_dirs: Set[str]) -> int:
 
 
 def merge_cov_xlm(cov_dir: str, verbose: bool, cov_dirs: Set[str]) -> int:
-    xcelium_scripts = _IBEX_ROOT/'vendor/lowrisc_ip/dv/tools/xcelium'
+    xcelium_scripts = _OT_LOWRISC_IP/'dv/tools/xcelium'
 
     # The merge TCL code uses a glob to find all available scopes and previous
     # runs. In order to actually get the databases we need to go up once so

--- a/dv/uvm/core_ibex/scripts/setup_imports.py
+++ b/dv/uvm/core_ibex/scripts/setup_imports.py
@@ -4,13 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import sys
-import git
 import pathlib3x as pathlib
 
 
 def get_project_root() -> pathlib.Path:
-    """Get the project root directory using git."""
-    return pathlib.Path(git.Repo('.', search_parent_directories=True).working_tree_dir)
+    """Get the project root directory."""
+    return pathlib.Path(__file__).resolve().parents[4]
 
 
 root = get_project_root()

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -14,7 +14,6 @@ junit-xml
 # dataclass  # needed for backports?
 pathlib3x  # Backports some useful features
 typing-utils  # Ditto
-gitpython
 typeguard
 portalocker
 


### PR DESCRIPTION
We'll need this for integrating into OpenTitan DV: https://github.com/lowRISC/opentitan/issues/11794