### PR TITLE
Remove the final cosim flags from core_ibex uvm environment

### DIFF
--- a/dv/uvm/core_ibex/Makefile
+++ b/dv/uvm/core_ibex/Makefile
@@ -23,8 +23,6 @@ SEED                := $(shell echo $$RANDOM)
 WAVES               := 0
 # Enable coverage dump
 COV                 := 0
-# Enable cosimulation flow
-COSIM               := 1
 # RTL simulator (xlm, vcs, questa, dsim, )
 SIMULATOR           := xlm
 # ISS (spike, ovpsim)
@@ -123,7 +121,7 @@ new-metadata-file := $(shell env PYTHONPATH=$(PYTHONPATH) python3 ./scripts/meta
   --dir-metadata $(METADATA-DIR) \
   --dir-out $(OUT-DIR) \
   --args-list "\
-  SEED=$(SEED) WAVES=$(WAVES) COV=$(COV) COSIM=$(COSIM) SIMULATOR=$(SIMULATOR) \
+  SEED=$(SEED) WAVES=$(WAVES) COV=$(COV) SIMULATOR=$(SIMULATOR) \
   ISS=$(ISS) TEST=$(TEST) VERBOSE=$(VERBOSE) ITERATIONS=$(ITERATIONS) \
   SIGNATURE_ADDR=$(SIGNATURE_ADDR) IBEX_CONFIG=$(IBEX_CONFIG)")
 
@@ -171,7 +169,7 @@ instr_gen_compile: $(test-bins)
 
 TB-COMPILE-STAMP = $(METADATA-DIR)/tb.compile.stamp
 rtl_tb_compile: $(METADATA-DIR)/tb.compile.stamp
-rtl-tb-compile-var-deps := SIMULATOR COV WAVES COSIM  # Rebuild if these change
+rtl-tb-compile-var-deps := SIMULATOR COV WAVES # Rebuild if these change
 
 rtl_sim_run: $(rtl-sim-logs)
 

--- a/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_agent_pkg.sv
+++ b/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_agent_pkg.sv
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package ibex_cosim_agent_pkg;
-`ifdef INC_IBEX_COSIM
   import uvm_pkg::*;
   import ibex_mem_intf_agent_pkg::*;
 
@@ -18,5 +17,4 @@ package ibex_cosim_agent_pkg;
   `include "ibex_ifetch_pmp_monitor.sv"
   `include "ibex_cosim_scoreboard.sv"
   `include "ibex_cosim_agent.sv"
-`endif
 endpackage

--- a/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_cfg.sv
+++ b/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_cfg.sv
@@ -10,6 +10,7 @@ class core_ibex_cosim_cfg extends uvm_object;
   string     log_file;
   bit [31:0] pmp_num_regions;
   bit [31:0] pmp_granularity;
+  bit        relax_cosim_check;
 
   `uvm_object_utils_begin(core_ibex_cosim_cfg)
     `uvm_field_string(isa_string, UVM_DEFAULT)

--- a/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_scoreboard.sv
+++ b/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_scoreboard.sv
@@ -136,7 +136,11 @@ class ibex_cosim_scoreboard extends uvm_scoreboard;
                             rvfi_instr.trap)) begin
         // cosim instruction step doesn't match rvfi captured instruction, report a fatal error
         // with the details
-        `uvm_fatal(`gfn, get_cosim_error_str())
+        if (cfg.relax_cosim_check) begin
+          `uvm_info(`gfn, get_cosim_error_str(), UVM_LOW)
+        end else begin
+          `uvm_fatal(`gfn, get_cosim_error_str())
+        end
       end
     end
   endtask: run_cosim_rvfi

--- a/dv/uvm/core_ibex/env/core_ibex_env.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_env.sv
@@ -10,9 +10,7 @@ class core_ibex_env extends uvm_env;
   ibex_mem_intf_response_agent   data_if_response_agent;
   ibex_mem_intf_response_agent   instr_if_response_agent;
   irq_request_agent              irq_agent;
-`ifdef INC_IBEX_COSIM
   ibex_cosim_agent               cosim_agent;
-`endif
   core_ibex_vseqr                vseqr;
   core_ibex_env_cfg              cfg;
   scrambling_key_agent           scrambling_key_agent_h;
@@ -30,15 +28,7 @@ class core_ibex_env extends uvm_env;
     instr_if_response_agent = ibex_mem_intf_response_agent::type_id::
                            create("instr_if_response_agent", this);
     irq_agent = irq_request_agent::type_id::create("irq_agent", this);
-
-`ifdef INC_IBEX_COSIM
-    if (!cfg.disable_cosim) begin
-      cosim_agent = ibex_cosim_agent::type_id::create("cosim_agent", this);
-    end else begin
-      `uvm_info(get_full_name(), "Cosim disabled by plusarg +disable_cosim=1", UVM_LOW)
-      cosim_agent = null;
-    end
-`endif
+    cosim_agent = ibex_cosim_agent::type_id::create("cosim_agent", this);
 
     scrambling_key_agent_h = scrambling_key_agent::type_id::create("scrambling_key_agent_h", this);
     uvm_config_db#(scrambling_key_agent_cfg)::set(this, "scrambling_key_agent_h", "cfg",
@@ -54,15 +44,10 @@ class core_ibex_env extends uvm_env;
     vseqr.data_if_seqr = data_if_response_agent.sequencer;
     vseqr.instr_if_seqr = instr_if_response_agent.sequencer;
     vseqr.irq_seqr = irq_agent.sequencer;
-
-`ifdef INC_IBEX_COSIM
-    if (cosim_agent != null) begin
-      data_if_response_agent.monitor.item_collected_port.connect(
-        cosim_agent.dmem_port);
-      instr_if_response_agent.monitor.item_collected_port.connect(
-        cosim_agent.imem_port);
-    end
-`endif
+    data_if_response_agent.monitor.item_collected_port.connect(
+      cosim_agent.dmem_port);
+    instr_if_response_agent.monitor.item_collected_port.connect(
+      cosim_agent.imem_port);
   endfunction : connect_phase
 
   function void reset();

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -514,6 +514,8 @@
   iterations: 5
   no_iss: 1
   rtl_test: core_ibex_csr_test
+  sim_opts: >
+    +disable_cosim=1
   no_post_compare: true
   ignore_cosim_log: true
 

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -514,8 +514,6 @@
   iterations: 5
   no_iss: 1
   rtl_test: core_ibex_csr_test
-  sim_opts: >
-    +disable_cosim=1
   no_post_compare: true
   ignore_cosim_log: true
 
@@ -904,9 +902,6 @@
   rtl_params:
     PMPEnable: 1
 
-  # Disable cosim for bitmanip tests for now as Ibex implements a different
-  # version of the spec compared to the Spike version used for the cosim.
-
 # Both an updated compiler and ISS are required to verify the bitmanip v.1.00
 # and draft v.0.93 extensions. For now, disable the bitmanip tests.
 # For details, refer to https://github.com/lowRISC/ibex/issues/1470
@@ -922,7 +917,6 @@
     +enable_zbs_extension=1
     +enable_b_extension=1
     +enable_bitmanip_groups=zbe,zbf,zbp,zbr,zbt
-    +disable_cosim=1
   rtl_test: core_ibex_base_test
   rtl_params:
     RV32B: "ibex_pkg::RV32BFull"
@@ -939,7 +933,6 @@
     +enable_zbs_extension=1
     +enable_b_extension=1
     +enable_bitmanip_groups=zbf,zbp,zbr,zbt
-    +disable_cosim=1
   rtl_test: core_ibex_base_test
   rtl_params:
     RV32B: ["ibex_pkg::RV32BFull", "ibex_pkg::RV32BOTEarlGrey"]
@@ -955,7 +948,6 @@
     +enable_zbs_extension=1
     +enable_b_extension=1
     +enable_bitmanip_groups=zbf,zbt
-    +disable_cosim=1
   rtl_test: core_ibex_base_test
   rtl_params:
     RV32B: ["ibex_pkg::RV32BFull", "ibex_pkg::RV32BOTEarlGrey", "ibex_pkg::RV32BBalanced"]

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -6,9 +6,7 @@ class core_ibex_base_test extends uvm_test;
 
   core_ibex_env                                   env;
   core_ibex_env_cfg                               cfg;
-`ifdef INC_IBEX_COSIM
   core_ibex_cosim_cfg                             cosim_cfg;
-`endif
   virtual clk_rst_if                              clk_vif;
   virtual core_ibex_dut_probe_if                  dut_vif;
   virtual core_ibex_instr_monitor_if              instr_vif;
@@ -103,7 +101,6 @@ class core_ibex_base_test extends uvm_test;
     env = core_ibex_env::type_id::create("env", this);
     cfg = core_ibex_env_cfg::type_id::create("cfg", this);
 
-`ifdef INC_IBEX_COSIM
     cosim_cfg = core_ibex_cosim_cfg::type_id::create("cosim_cfg", this);
 
     cosim_cfg.isa_string = get_isa_string();
@@ -126,7 +123,6 @@ class core_ibex_base_test extends uvm_test;
     cosim_cfg.pmp_granularity = pmp_granularity;
 
     uvm_config_db#(core_ibex_cosim_cfg)::set(null, "*cosim_agent*", "cosim_cfg", cosim_cfg);
-`endif
 
     uvm_config_db#(core_ibex_env_cfg)::set(this, "*", "cfg", cfg);
     mem = mem_model_pkg::mem_model#()::type_id::create("mem");
@@ -190,12 +186,8 @@ class core_ibex_base_test extends uvm_test;
       `uvm_fatal(get_full_name(), $sformatf("Cannot open file %0s", bin))
     while ($fread(r8,f_bin)) begin
       `uvm_info(`gfn, $sformatf("Init mem [0x%h] = 0x%0h", addr, r8), UVM_FULL)
-      mem.write(addr, r8);
-`ifdef INC_IBEX_COSIM
-      if (env.cosim_agent != null) begin
-        env.cosim_agent.write_mem_byte(addr, r8);
-      end
-`endif
+      mem.write(addr, r8);                      // Populate RTL memory model
+      env.cosim_agent.write_mem_byte(addr, r8); // Populate ISS memory model
       addr++;
     end
   endfunction

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -121,6 +121,7 @@ class core_ibex_base_test extends uvm_test;
 
     cosim_cfg.pmp_num_regions = pmp_num_regions;
     cosim_cfg.pmp_granularity = pmp_granularity;
+    cosim_cfg.relax_cosim_check = cfg.disable_cosim;
 
     uvm_config_db#(core_ibex_cosim_cfg)::set(null, "*cosim_agent*", "cosim_cfg", cosim_cfg);
 

--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -55,7 +55,6 @@
       -do vcs.tcl
     cosim_opts: >-
       -f <core_ibex>/ibex_dv_cosim_dpi.f
-      +define+INC_IBEX_COSIM
       -LDFLAGS '<ISS_LDFLAGS>'
       -CFLAGS '<ISS_CFLAGS>'
       -CFLAGS '-I<IBEX_ROOT>/dv/cosim'
@@ -254,7 +253,6 @@
       <ISS_LIBS>
       <ISS_CFLAGS>
       -Wld,<ISS_LDFLAGS>
-      +define+INC_IBEX_COSIM
       -lstdc++
   sim:
     cmd:


### PR DESCRIPTION
We are running with cosim by default now, and no longer support COSIM=0. Hence
this option and all downstream conditional paths are no longer required.

~~This also removes the +disable_cosim flag from all tests, as we are working towards all tests running under cosimulation anyway~~. For the bitmanipulation and csr test, any failures are now no-longer due to cosimulation and should be tracked separately. For bitmanipulation, it appears the tests for the `opentitan` configuration are all passing.

`+disable_cosim=1` has it's behaviour changed to de-escelate cosim mismatches from fatal-errors to info messages. This can be useful for debugging, and remains in place as the default for riscv_csr_test as that test has known failures.

Closes #1566 