### PR TITLE
Cpuctrlsts write

### DIFF
--- a/dv/cosim/spike_cosim.h
+++ b/dv/cosim/spike_cosim.h
@@ -69,6 +69,10 @@ class SpikeCosim : public simif_t, public Cosim {
 
   void leave_nmi_mode();
 
+  bool change_cpuctrlsts_sync_exc_seen(bool flag);
+  void set_cpuctrlsts_double_fault_seen();
+  void handle_cpuctrl_exception_entry();
+
   void initial_proc_setup(uint32_t start_pc, uint32_t start_mtvec,
                           uint32_t mhpm_counter_num);
 

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -36,7 +36,7 @@
     +instr_cnt=10000
     +num_of_sub_program=5
     +gen_all_csrs_by_default=1
-    +add_csr_write=MSTATUS,MEPC,MCAUSE,MTVAL
+    +add_csr_write=MSTATUS,MEPC,MCAUSE,MTVAL,0x7c0
     +no_csr_instr=0
   rtl_test: core_ibex_base_test
 

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -1311,7 +1311,7 @@ module ibex_core import ibex_pkg::*; #(
     assign rvfi_trap_id = id_stage_i.controller_i.id_exception_o;
     assign rvfi_trap_wb = id_stage_i.controller_i.exc_req_lsu;
     // WB is instantly done in the tracking pipeline when a trap is progress through the pipeline
-    assign rvfi_wb_done = instr_done_wb | (rvfi_stage_valid[0] & rvfi_stage_trap[0]);
+    assign rvfi_wb_done = rvfi_stage_valid[0] & (instr_done_wb | rvfi_stage_trap[0]);
   end else begin : gen_rvfi_no_wb_stage
     // Without writeback stage first RVFI stage is output stage so simply valid the cycle after
     // instruction leaves ID/EX (and so has retired)


### PR DESCRIPTION
This draft PR gives us the basis of https://github.com/lowRISC/ibex/issues/1654 and https://github.com/lowRISC/ibex/issues/1761. We should look to expand the number of tests we're writing cpuctrlsts so the things it controls get randomly changed under more scenarios.

This also gives us part of: https://github.com/lowRISC/ibex/issues/1760 as it implements the double fault behaviour for cosim.

Also note it's based on https://github.com/lowRISC/ibex/pull/1807 so that needs merging first