### PR TITLE
[dv] Fix timeout issues

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_seq_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_seq_lib.sv
@@ -66,6 +66,10 @@ class core_base_seq #(type REQ = uvm_sequence_item) extends uvm_sequence#(REQ);
     is_started = 1'b0;
   endtask
 
+  virtual task wait_for_stop();
+    wait (seq_finished == 1'b1);
+  endtask
+
 endclass
 
 // Interrupt sequences

--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -439,6 +439,10 @@ class core_ibex_directed_test extends core_ibex_debug_intr_basic_test;
             check_stimulus();
           join_none
           wait (test_done === 1'b1);
+          // disable below can kill processes that are running sequences. As a result they never
+          // stop and the simulation never ends. So wait for all sequences to stop before doing the
+          // disable.
+          vseq.wait_for_stop();
           disable fork;
           if (cur_run_phase.get_objection_count(this) > 1) begin
             cur_run_phase.drop_objection(this);

--- a/dv/uvm/core_ibex/tests/core_ibex_vseq.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_vseq.sv
@@ -98,6 +98,22 @@ class core_ibex_vseq extends uvm_sequence;
     end
   endtask
 
+  virtual task wait_for_stop();
+    if (cfg.enable_irq_single_seq) begin
+      if (irq_raise_single_seq_h.is_started) irq_raise_single_seq_h.wait_for_stop();
+    end
+    if (cfg.enable_irq_multiple_seq) begin
+      if (irq_raise_seq_h.is_started) irq_raise_seq_h.wait_for_stop();
+    end
+    if (cfg.enable_irq_single_seq || cfg.enable_irq_multiple_seq) begin
+      if (irq_drop_seq_h.is_started)   irq_drop_seq_h.wait_for_stop();
+    end
+    if (cfg.enable_debug_seq) begin
+      if (debug_seq_stress_h.is_started) debug_seq_stress_h.wait_for_stop();
+      if (debug_seq_single_h.is_started) debug_seq_single_h.wait_for_stop();
+    end
+  endtask
+
   // Helper tasks to allow the test fine grained control to start sequences through the vseq
   // - necessary for testing directed stimulus scenarios
   virtual task start_debug_stress_seq();


### PR DESCRIPTION
core_ibex_directed_test has a 'disable fork' that was killing processes that were running sequences. Another part of the testbench waits for those sequences to finish. When this 'disable fork' happens too early the sequences are killed before they finish so the testbench never terminated and times out. Instead ensure the sequences have finished before doing the 'disable fork'.