### PR TITLE
[formal] Added missing prim secded package

### DIFF
--- a/formal/riscv-formal/Makefile
+++ b/formal/riscv-formal/Makefile
@@ -51,6 +51,7 @@ SRCS_SV ?=                              \
 
 PKGS ?=                                        \
   $(SRC_DIR)/ibex_pkg.sv                       \
+  $(LOWRISC_IP)/ip/prim/rtl/prim_secded_pkg.sv \
   $(LOWRISC_IP)/ip/prim/rtl/prim_ram_1p_pkg.sv
 
 PRIM_CLOCK ?= $(SYN_DIR)/rtl/prim_clock_gating.v


### PR DESCRIPTION
When doing the command `make -C formal/riscv-formal` without this fix the `sv2v` tool complains with the following error:
```
sv2v --define=RISCV_FORMAL -I../../vendor/lowrisc_ip/ip/prim/rtl -I../../vendor/lowrisc_ip/dv/sv/dv_utils ../../rtl/ibex_pkg.sv ../../vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1p_pkg.sv \
	../../rtl/ibex_top.sv > build/ibex_top.v
sv2v: could not find package "prim_secded_pkg"
CallStack (from HasCallStack):
  error, called at src/Convert/Package.hs:663:42 in main:Convert.Package
make: *** [Makefile:69: build/ibex_top.v] Error 1
```