### PR TITLE
Record test failure due to timeout in regr.log

### DIFF
--- a/dv/uvm/core_ibex/scripts/check_logs.py
+++ b/dv/uvm/core_ibex/scripts/check_logs.py
@@ -31,6 +31,7 @@ def compare_test_run(trr: TestRunResult) -> TestRunResult:
     """
 
     # If the test timed-out, return early to avoid overwriting the failure_mode.
+    # Don't check the logs at all in this case.
     if (trr.failure_mode == Failure_Modes.TIMEOUT):
         trr.passed = False
         return trr
@@ -41,7 +42,7 @@ def compare_test_run(trr: TestRunResult) -> TestRunResult:
         uvm_pass, uvm_log_lines = check_ibex_uvm_log(trr.rtl_log)
     except IOError as e:
         trr.passed = False
-        trr.failure_mode = Failure_Modes.PARSE_ERROR
+        trr.failure_mode = Failure_Modes.FILE_ERROR
         trr.failure_message = f"[FAILED] Could not open simulation log: {e}\n"
         return trr
     if not uvm_pass:
@@ -62,7 +63,7 @@ def compare_test_run(trr: TestRunResult) -> TestRunResult:
         process_ibex_sim_log(trr.rtl_trace, trr.dir_test/'rtl_trace.csv')
     except (OSError, RuntimeError) as e:
         trr.passed = False
-        trr.failure_mode = Failure_Modes.LOG_ERROR
+        trr.failure_mode = Failure_Modes.FILE_ERROR
         trr.failure_message = f"[FAILED]: Log processing failed: {e}"
         return trr
 
@@ -74,7 +75,7 @@ def compare_test_run(trr: TestRunResult) -> TestRunResult:
             raise RuntimeError('Unsupported simulator for cosim')
     except (OSError, RuntimeError) as e:
         trr.passed = False
-        trr.failure_mode = Failure_Modes.LOG_ERROR
+        trr.failure_mode = Failure_Modes.FILE_ERROR
         trr.failure_message = f"[FAILED]: Log processing failed: {e}"
         return trr
 

--- a/dv/uvm/core_ibex/scripts/check_logs.py
+++ b/dv/uvm/core_ibex/scripts/check_logs.py
@@ -14,7 +14,7 @@ import sys
 import pathlib3x as pathlib
 
 from test_entry import read_test_dot_seed
-from test_run_result import TestRunResult
+from test_run_result import TestRunResult, Failure_Modes
 
 from spike_log_to_trace_csv import process_spike_sim_log  # type: ignore
 from ibex_log_to_trace_csv import (process_ibex_sim_log,  # type: ignore
@@ -29,15 +29,23 @@ def compare_test_run(trr: TestRunResult) -> TestRunResult:
 
     Use any log-processing scripts available to check for errors.
     """
+
+    # If the test timed-out, return early to avoid overwriting the failure_mode.
+    if (trr.failure_mode == Failure_Modes.TIMEOUT):
+        trr.passed = False
+        return trr
+
     # Have a look at the UVM log. Report a failure if an issue is seen.
     try:
         logger.debug(f"About to do Log processing: {trr.rtl_log}")
         uvm_pass, uvm_log_lines = check_ibex_uvm_log(trr.rtl_log)
     except IOError as e:
         trr.passed = False
+        trr.failure_mode = Failure_Modes.PARSE_ERROR
         trr.failure_message = f"[FAILED] Could not open simulation log: {e}\n"
         return trr
     if not uvm_pass:
+        trr.failure_mode = Failure_Modes.LOG_ERROR
         trr.failure_message = f"\n[FAILURE]: sim error seen in '{trr.rtl_log.name}'\n"
         if uvm_log_lines:
             trr.failure_message += \
@@ -54,6 +62,7 @@ def compare_test_run(trr: TestRunResult) -> TestRunResult:
         process_ibex_sim_log(trr.rtl_trace, trr.dir_test/'rtl_trace.csv')
     except (OSError, RuntimeError) as e:
         trr.passed = False
+        trr.failure_mode = Failure_Modes.LOG_ERROR
         trr.failure_message = f"[FAILED]: Log processing failed: {e}"
         return trr
 
@@ -65,6 +74,7 @@ def compare_test_run(trr: TestRunResult) -> TestRunResult:
             raise RuntimeError('Unsupported simulator for cosim')
     except (OSError, RuntimeError) as e:
         trr.passed = False
+        trr.failure_mode = Failure_Modes.LOG_ERROR
         trr.failure_message = f"[FAILED]: Log processing failed: {e}"
         return trr
 

--- a/dv/uvm/core_ibex/scripts/collect_results.py
+++ b/dv/uvm/core_ibex/scripts/collect_results.py
@@ -10,7 +10,7 @@ import io
 import pathlib3x as pathlib
 import dataclasses
 from metadata import RegressionMetadata, LockedMetadata
-from test_run_result import TestRunResult
+from test_run_result import TestRunResult, Failure_Modes
 import scripts_lib as ibex_lib
 from typing import List, TextIO
 
@@ -159,10 +159,14 @@ def main() -> int:
         for f in md.tests_pickle_files:
             try:
                 trr = TestRunResult.construct_from_pickle(f)
-                summary_dict[f"{trr.testname}.{trr.seed}"] = ('PASS' if trr.passed else 'FAILED')
+                summary_dict[f"{trr.testname}.{trr.seed}"] = \
+                    ('PASS' if trr.passed else
+                     'FAILED' + (" {T}" if (trr.failure_mode == Failure_Modes.TIMEOUT) else ""))
                 if trr.passed:
                     passing_tests.append(trr)
                 else:
+                    if (trr.failure_mode == Failure_Modes.TIMEOUT):
+                        trr.failure_message = f"[FAILURE] Simulation timed-out [{md.run_rtl_timeout_s}s].\n"
                     failing_tests.append(trr)
             except RuntimeError as e:
                 failing_tests.append(

--- a/dv/uvm/core_ibex/scripts/metadata.py
+++ b/dv/uvm/core_ibex/scripts/metadata.py
@@ -62,6 +62,7 @@ class RegressionMetadata(scripts_lib.testdata_cls):
     tests_and_counts: List[Tuple[str, int]] = field(default_factory=list)
     isa_ibex: Optional[str] = None
     isa_iss: Optional[str] = None
+    run_rtl_timeout_s: int = 1800
 
     # Files that control the regression, specify configurations, tests, etc
     ibex_configs                : pathlib.Path = field(init=False, compare=False, default_factory=pathlib.Path)

--- a/dv/uvm/core_ibex/scripts/test_run_result.py
+++ b/dv/uvm/core_ibex/scripts/test_run_result.py
@@ -20,9 +20,9 @@ class Failure_Modes(Enum):
     """Descriptive enum for the mode in which a test fails"""
 
     NONE = 0
-    TIMEOUT = 1
-    PARSE_ERROR = 2
-    LOG_ERROR = 3
+    TIMEOUT = 1  # The simulation process did not complete within the timeout
+    FILE_ERROR = 2  # There was a problem attempting to open a logfile
+    LOG_ERROR = 3  # The contents of a logfile met a criterion for test failure
 
     def __str__(self):
         """Print enumerated values as e.g. TIMEOUT(1)"""

--- a/dv/uvm/core_ibex/scripts/test_run_result.py
+++ b/dv/uvm/core_ibex/scripts/test_run_result.py
@@ -4,6 +4,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+from enum import Enum
 import pathlib3x as pathlib
 from typing import Optional, List
 import dataclasses
@@ -14,6 +15,18 @@ import scripts_lib
 import logging
 logger = logging.getLogger(__name__)
 
+
+class Failure_Modes(Enum):
+    """Descriptive enum for the mode in which a test fails"""
+
+    NONE = 0
+    TIMEOUT = 1
+    PARSE_ERROR = 2
+    LOG_ERROR = 3
+
+    def __str__(self):
+        """Print enumerated values as e.g. TIMEOUT(1)"""
+        return f'{self.name}({self.value})'
 
 @typechecked
 @dataclasses.dataclass
@@ -26,6 +39,7 @@ class TestRunResult(scripts_lib.testdata_cls):
     """
     passed: Optional[bool] = None                # True if test passed
     # Message describing failure, includes a '[FAILED]: XXXX' line at the end.
+    failure_mode: Optional[Failure_Modes] = None
     failure_message: Optional[str] = None
 
     testdotseed: Optional[str] = None


### PR DESCRIPTION
This commit adds a new field to the trr (test-run-result) structured data
that records the failure_mode of a testcase. If the test failed due to a
timeout, print a small addendum {T} to each log-line in the summary.

eg.

```
23.33% PASS 7 PASSED, 23 FAILED
riscv_debug_basic_test.21259:                     PASS
riscv_debug_basic_test.21260:                     FAILED {T}
riscv_debug_basic_test.21261:                     PASS
riscv_debug_basic_test.21262:                     FAILED {T}
riscv_debug_basic_test.21263:                     FAILED {T}
riscv_debug_instr_test.21259:                     FAILED {T}
riscv_debug_instr_test.21260:                     FAILED {T}
riscv_debug_instr_test.21261:                     FAILED {T}
riscv_debug_instr_test.21262:                     PASS
riscv_debug_instr_test.21263:                     FAILED {T}
riscv_dret_test.21259:                            FAILED
riscv_dret_test.21260:                            FAILED
riscv_dret_test.21261:                            FAILED {T}
```