### PR TITLE
Update SCONTEXT address, add MSCONTEXT csr to match riscv_debug 1.0

### DIFF
--- a/doc/03_reference/cs_registers.rst
+++ b/doc/03_reference/cs_registers.rst
@@ -46,6 +46,8 @@ Ibex implements all the Control and Status Registers (CSRs) listed in the follow
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x3BF  | ``pmpaddr15``      | WARL   | PMP Address Register                          |
 +---------+--------------------+--------+-----------------------------------------------+
+|  0x5A8  | ``scontext``       | WARL   | Supervisor Context Register                   |
++---------+--------------------+--------+-----------------------------------------------+
 |  0x747  | ``mseccfg``        | WARL   | Machine Security Configuration                |
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x757  | ``mseccfgh``       | WARL   | Upper 32 bits of ``mseccfg``                  |
@@ -60,7 +62,7 @@ Ibex implements all the Control and Status Registers (CSRs) listed in the follow
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x7A8  | ``mcontext``       | WARL   | Machine Context Register                      |
 +---------+--------------------+--------+-----------------------------------------------+
-|  0x7AA  | ``scontext``       | WARL   | Supervisor Context Register                   |
+|  0x7AA  | ``mscontext``      | WARL   | Machine Supervisor Context Register           |
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x7B0  | ``dcsr``           | WARL   | Debug Control and Status Register             |
 +---------+--------------------+--------+-----------------------------------------------+

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -523,6 +523,10 @@ module ibex_cs_registers #(
         csr_rdata_int = '0;
         illegal_csr   = ~DbgTriggerEn;
       end
+      CSR_MSCONTEXT: begin
+        csr_rdata_int = '0;
+        illegal_csr   = ~DbgTriggerEn;
+      end
 
       // Custom CSR for controlling CPU features and reporting CPU status
       CSR_CPUCTRLSTS: begin

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -471,6 +471,8 @@ package ibex_pkg;
     CSR_PMPADDR14 = 12'h3BE,
     CSR_PMPADDR15 = 12'h3BF,
 
+    CSR_SCONTEXT  = 12'h5A8,
+
     // ePMP control
     CSR_MSECCFG   = 12'h747,
     CSR_MSECCFGH  = 12'h757,
@@ -481,7 +483,7 @@ package ibex_pkg;
     CSR_TDATA2    = 12'h7A2,
     CSR_TDATA3    = 12'h7A3,
     CSR_MCONTEXT  = 12'h7A8,
-    CSR_SCONTEXT  = 12'h7AA,
+    CSR_MSCONTEXT = 12'h7AA,
 
     // Debug/trace
     CSR_DCSR      = 12'h7b0,


### PR DESCRIPTION
Observing the following spec change:


RISC-V Debug Support Version 1.0.0-STABLE
1.2.1.4 New Features from 0.13 to 1.0
8. Move scontext, renaming original to mscontext, and create hcontext.



MSCONTEXT is a backwards-compatible alias to SCONTEXT. [[1]](https://github.com/riscv/riscv-debug-spec/blob/c40847add0c3e3dcafb6ce568c3979412bb6f341/xml/hwbp_registers.xml#L246)
In Ibex, SCONTEXT is a read-only zero register. Hence MSCONTEXT has the same behaviour.