### PR TITLE
[rtl/dv] Bring back data integrity check on write responses

### DIFF
--- a/doc/03_reference/load_store_unit.rst
+++ b/doc/03_reference/load_store_unit.rst
@@ -61,6 +61,9 @@ The core can optionally generate and verify check bits sent alongside the data f
 Checkbits are generated and checked using an inverted 39/32 Hsaio code (see :file:`vendor/lowrisc_ip/ip/prim/rtl/prim_secded_inv_39_32_enc.sv`).
 An :ref:`internal interrupt<internal-interrupts>` will be generated and a bus major alert signalled if there is a mismatch.
 Where load data has bad checkbits the write to the load's destination register will be suppressed.
+Ibex checks the integrity against the response data for both loads and stores.
+For stores the response data is otherwise ignored so the data can be any value provided the integrity is valid (``data_rdata_intg_i`` must match with ``data_rdata_i``).
+It is recommended for write responses some fixed value is placed on ``data_rdata_i`` and ``data_rdata_intg_i`` by the memory system Ibex is connected to in configurations where integrity is used.
 
 This feature is only used if the core is configured with the SecureIbex parameter set.
 For all other configurations, the integrity signals can be ignored.

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent.sv
@@ -17,6 +17,8 @@ class ibex_mem_intf_response_agent extends uvm_agent;
   `uvm_component_new
 
   virtual function void build_phase(uvm_phase phase);
+    bit secure_ibex;
+
     super.build_phase(phase);
     monitor = ibex_mem_intf_monitor::type_id::create("monitor", this);
     cfg = ibex_mem_intf_response_agent_cfg::type_id::create("cfg", this);
@@ -26,6 +28,12 @@ class ibex_mem_intf_response_agent extends uvm_agent;
     end
     if(!uvm_config_db#(virtual ibex_mem_intf)::get(this, "", "vif", cfg.vif))
       `uvm_fatal("NOVIF",{"virtual interface must be set for: ",get_full_name(),".vif"});
+
+    if (!uvm_config_db#(bit)::get(null, "", "SecureIbex", secure_ibex)) begin
+      secure_ibex = 1'b0;
+    end
+
+    cfg.fixed_data_write_response = secure_ibex;
   endfunction : build_phase
 
   function void connect_phase(uvm_phase phase);

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent_cfg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent_cfg.sv
@@ -11,6 +11,10 @@ class ibex_mem_intf_response_agent_cfg extends uvm_object;
   // interface handle used by driver & monitor
   virtual ibex_mem_intf vif;
 
+  // When set write responses have a fixed 32'hffffffff for rdata and matching correct rintg. When
+  // unset both rdata and rintg fields are x for write responses
+  bit fixed_data_write_response = 1'b0;
+
   // delay between request and grant
   int unsigned gnt_delay_min = 0;
   int unsigned gnt_delay_max = 10;
@@ -40,12 +44,13 @@ class ibex_mem_intf_response_agent_cfg extends uvm_object;
   }
 
   `uvm_object_utils_begin(ibex_mem_intf_response_agent_cfg)
-    `uvm_field_int(gnt_delay_min,       UVM_DEFAULT)
-    `uvm_field_int(gnt_delay_max,       UVM_DEFAULT)
-    `uvm_field_int(valid_delay_min,     UVM_DEFAULT)
-    `uvm_field_int(valid_delay_max,     UVM_DEFAULT)
-    `uvm_field_int(zero_delays,         UVM_DEFAULT)
-    `uvm_field_int(zero_delay_pct,      UVM_DEFAULT)
+    `uvm_field_int(fixed_data_write_response, UVM_DEFAULT)
+    `uvm_field_int(gnt_delay_min,             UVM_DEFAULT)
+    `uvm_field_int(gnt_delay_max,             UVM_DEFAULT)
+    `uvm_field_int(valid_delay_min,           UVM_DEFAULT)
+    `uvm_field_int(valid_delay_max,           UVM_DEFAULT)
+    `uvm_field_int(zero_delays,               UVM_DEFAULT)
+    `uvm_field_int(zero_delay_pct,            UVM_DEFAULT)
   `uvm_object_utils_end
 
 endclass

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_driver.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_driver.sv
@@ -125,9 +125,18 @@ class ibex_mem_intf_response_driver extends uvm_driver #(ibex_mem_intf_seq_item)
           cfg.vif.response_driver_cb.rdata <= tr.data;
           cfg.vif.response_driver_cb.rintg <= tr.intg;
         end else begin
-          // These are only relevant to read responses, so drive to X for a write response
-          cfg.vif.response_driver_cb.rdata <= 'x;
-          cfg.vif.response_driver_cb.rintg <= 'x;
+          // rdata and intg fields aren't relevant to write responses
+          if (cfg.fixed_data_write_response) begin
+            // when fixed_data_write_response is set, set rdata to fixed value with correct matching
+            // rintg field.
+            cfg.vif.response_driver_cb.rdata <= 32'hffffffff;
+            cfg.vif.response_driver_cb.rintg <=
+              prim_secded_pkg::prim_secded_inv_39_32_enc(32'hffffffff)[38:32];
+          end else begin
+            // when fixed_data_write_response is not set, drive the irrelevant fields to x.
+            cfg.vif.response_driver_cb.rdata <= 'x;
+            cfg.vif.response_driver_cb.rintg <= 'x;
+          end
         end
       end
     end

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -58,8 +58,8 @@ module ibex_controller #(
   // LSU
   input  logic [31:0]           lsu_addr_last_i,         // for mtval
   input  logic                  load_err_i,
-  input  logic                  load_intg_err_i,
   input  logic                  store_err_i,
+  input  logic                  mem_resp_intg_err_i,
   output logic                  wb_exception_o,          // Instruction in WB taking an exception
   output logic                  id_exception_o,          // Instruction in ID taking an exception
 
@@ -306,55 +306,55 @@ module ibex_controller #(
   // irq_nm_int_cause.
 
   if (MemECC) begin : g_intg_irq_int
-    logic        load_intg_err_irq_pending_q, load_intg_err_irq_pending_d;
-    logic [31:0] load_intg_err_addr_q, load_intg_err_addr_d;
-    logic        load_intg_err_irq_set, load_intg_err_irq_clear;
+    logic        mem_resp_intg_err_irq_pending_q, mem_resp_intg_err_irq_pending_d;
+    logic [31:0] mem_resp_intg_err_addr_q, mem_resp_intg_err_addr_d;
+    logic        mem_resp_intg_err_irq_set, mem_resp_intg_err_irq_clear;
     logic        entering_nmi;
 
     assign entering_nmi = nmi_mode_d & ~nmi_mode_q;
 
     // Load integerity error internal interrupt
     always_comb begin
-      load_intg_err_addr_d        = load_intg_err_addr_q;
-      load_intg_err_irq_set       = 1'b0;
-      load_intg_err_irq_clear     = 1'b0;
+      mem_resp_intg_err_addr_d        = mem_resp_intg_err_addr_q;
+      mem_resp_intg_err_irq_set       = 1'b0;
+      mem_resp_intg_err_irq_clear     = 1'b0;
 
-      if (load_intg_err_irq_pending_q) begin
+      if (mem_resp_intg_err_irq_pending_q) begin
         // Clear ECC error interrupt when it is handled. External NMI takes a higher priority so
         // don't clear the ECC error interrupt if an external NMI is present.
         if (entering_nmi & !irq_nm_ext_i) begin
-          load_intg_err_irq_clear = 1'b1;
+          mem_resp_intg_err_irq_clear = 1'b1;
         end
-      end else if (load_intg_err_i) begin
+      end else if (mem_resp_intg_err_i) begin
         // When an ECC error is seen set the ECC error interrupt and capture the address that saw
         // the error. If there is already an ecc error IRQ pending ignore any ECC errors coming in.
-        load_intg_err_addr_d        = lsu_addr_last_i;
-        load_intg_err_irq_set       = 1'b1;
+        mem_resp_intg_err_addr_d        = lsu_addr_last_i;
+        mem_resp_intg_err_irq_set       = 1'b1;
       end
     end
 
-    assign load_intg_err_irq_pending_d =
-      (load_intg_err_irq_pending_q & ~load_intg_err_irq_clear) | load_intg_err_irq_set;
+    assign mem_resp_intg_err_irq_pending_d =
+      (mem_resp_intg_err_irq_pending_q & ~mem_resp_intg_err_irq_clear) | mem_resp_intg_err_irq_set;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
-        load_intg_err_irq_pending_q <= 1'b0;
-        load_intg_err_addr_q        <= '0;
+        mem_resp_intg_err_irq_pending_q <= 1'b0;
+        mem_resp_intg_err_addr_q        <= '0;
       end else begin
-        load_intg_err_irq_pending_q <= load_intg_err_irq_pending_d;
-        load_intg_err_addr_q        <= load_intg_err_addr_d;
+        mem_resp_intg_err_irq_pending_q <= mem_resp_intg_err_irq_pending_d;
+        mem_resp_intg_err_addr_q        <= mem_resp_intg_err_addr_d;
       end
     end
 
     // As integrity error is the only internal interrupt implement, set irq_nm_* signals directly
     // within this generate block.
-    assign irq_nm_int = load_intg_err_irq_set | load_intg_err_irq_pending_q;
+    assign irq_nm_int       = mem_resp_intg_err_irq_set | mem_resp_intg_err_irq_pending_q;
     assign irq_nm_int_cause = NMI_INT_CAUSE_ECC;
-    assign irq_nm_int_mtval = load_intg_err_addr_q;
+    assign irq_nm_int_mtval = mem_resp_intg_err_addr_q;
   end else begin : g_no_intg_irq_int
-    logic unused_load_intg_err_i;
+    logic unused_mem_resp_intg_err_i;
 
-    assign unused_load_intg_err_i = load_intg_err_i;
+    assign unused_mem_resp_intg_err_i = mem_resp_intg_err_i;
 
     // No integrity checking on incoming load data so no internal interrupts
     assign irq_nm_int       = 1'b0;

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -204,7 +204,8 @@ module ibex_core import ibex_pkg::*; #(
   logic        instr_intg_err;
   logic        lsu_load_err;
   logic        lsu_store_err;
-  logic        lsu_load_intg_err;
+  logic        lsu_load_resp_intg_err;
+  logic        lsu_store_resp_intg_err;
 
   // LSU signals
   logic        lsu_addr_incr_req;
@@ -594,9 +595,10 @@ module ibex_core import ibex_pkg::*; #(
     .lsu_addr_incr_req_i(lsu_addr_incr_req),
     .lsu_addr_last_i    (lsu_addr_last),
 
-    .lsu_load_err_i     (lsu_load_err),
-    .lsu_load_intg_err_i(lsu_load_intg_err),
-    .lsu_store_err_i    (lsu_store_err),
+    .lsu_load_err_i           (lsu_load_err),
+    .lsu_load_resp_intg_err_i (lsu_load_resp_intg_err),
+    .lsu_store_err_i          (lsu_store_err),
+    .lsu_store_resp_intg_err_i(lsu_store_resp_intg_err),
 
     // Interrupt Signals
     .csr_mstatus_mie_i(csr_mstatus_mie),
@@ -748,9 +750,10 @@ module ibex_core import ibex_pkg::*; #(
     .lsu_resp_valid_o(lsu_resp_valid),
 
     // exception signals
-    .load_err_o     (lsu_load_err),
-    .store_err_o    (lsu_store_err),
-    .load_intg_err_o(lsu_load_intg_err),
+    .load_err_o           (lsu_load_err),
+    .load_resp_intg_err_o (lsu_load_resp_intg_err),
+    .store_err_o          (lsu_store_err),
+    .store_resp_intg_err_o(lsu_store_resp_intg_err),
 
     .busy_o(lsu_busy),
 
@@ -881,7 +884,7 @@ module ibex_core import ibex_pkg::*; #(
   // Major internal alert - core is unrecoverable
   assign alert_major_internal_o = rf_ecc_err_comb | pc_mismatch_alert | csr_shadow_err;
   // Major bus alert
-  assign alert_major_bus_o = lsu_load_intg_err | instr_intg_err;
+  assign alert_major_bus_o = lsu_load_resp_intg_err | lsu_store_resp_intg_err | instr_intg_err;
 
   // Explict INC_ASSERT block to avoid unused signal lint warnings were asserts are not included
   `ifdef INC_ASSERT

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -130,8 +130,9 @@ module ibex_id_stage #(
   output logic                      nmi_mode_o,
 
   input  logic                      lsu_load_err_i,
+  input  logic                      lsu_load_resp_intg_err_i,
   input  logic                      lsu_store_err_i,
-  input  logic                      lsu_load_intg_err_i,
+  input  logic                      lsu_store_resp_intg_err_i,
 
   // Debug Signal
   output logic                      debug_mode_o,
@@ -224,6 +225,8 @@ module ibex_id_stage #(
   logic        stall_wb;
   logic        flush_id;
   logic        multicycle_done;
+
+  logic        mem_resp_intg_err;
 
   // Immediate decoding and sign extension
   logic [31:0] imm_i_type;
@@ -546,6 +549,8 @@ module ibex_id_stage #(
   assign illegal_insn_o = instr_valid_i &
       (illegal_insn_dec | illegal_csr_insn_i | illegal_dret_insn | illegal_umode_insn);
 
+  assign mem_resp_intg_err = lsu_load_resp_intg_err_i | lsu_store_resp_intg_err_i;
+
   ibex_controller #(
     .WritebackStage (WritebackStage),
     .BranchPredictor(BranchPredictor),
@@ -589,12 +594,12 @@ module ibex_id_stage #(
     .exc_cause_o           (exc_cause_o),
 
     // LSU
-    .lsu_addr_last_i(lsu_addr_last_i),
-    .load_err_i     (lsu_load_err_i),
-    .load_intg_err_i(lsu_load_intg_err_i),
-    .store_err_i    (lsu_store_err_i),
-    .wb_exception_o (wb_exception),
-    .id_exception_o (id_exception),
+    .lsu_addr_last_i    (lsu_addr_last_i),
+    .load_err_i         (lsu_load_err_i),
+    .mem_resp_intg_err_i(mem_resp_intg_err),
+    .store_err_i        (lsu_store_err_i),
+    .wb_exception_o     (wb_exception),
+    .id_exception_o     (id_exception),
 
     // jump/branch control
     .branch_set_i     (branch_set),

--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -60,8 +60,9 @@ module ibex_load_store_unit #(
 
   // exception signals
   output logic         load_err_o,
+  output logic         load_resp_intg_err_o,
   output logic         store_err_o,
-  output logic         load_intg_err_o,
+  output logic         store_resp_intg_err_o,
 
   output logic         busy_o,
 
@@ -548,7 +549,8 @@ module ibex_load_store_unit #(
   // The data_intg_err signal is generated combinatorially from the incoming data_rdata_i. Were it
   // to be factored into load_err_o there would be a feedthrough path from data_rdata_i to
   // data_req_o which is undesirable.
-  assign load_intg_err_o = data_intg_err & data_rvalid_i & ~data_we_q;
+  assign load_resp_intg_err_o  = data_intg_err & data_rvalid_i & ~data_we_q;
+  assign store_resp_intg_err_o = data_intg_err & data_rvalid_i & data_we_q;
 
   assign busy_o = (ls_fsm_cs != IDLE);
 


### PR DESCRIPTION
Previously Ibex signaled a major alert on an integrity error (where incoming read data doesn't match its integrity bits) for both read and write responses. This was removed as the data part of a response to a write is ignored.

This brings it back in a more measured way. This provides a little extra fault injection hardening as an attacker glitching the memory bus will generate an alert on both read and write responses.

See https://github.com/lowRISC/opentitan/issues/14611 for some more background on this.