### PR TITLE
[vcs] Fix Ibex DV runs for VCS

### DIFF
--- a/dv/uvm/core_ibex/scripts/run_rtl.py
+++ b/dv/uvm/core_ibex/scripts/run_rtl.py
@@ -80,6 +80,9 @@ def _main() -> int:
     trr.dir_test.mkdir(exist_ok=True, parents=True)
     trr.rtl_cmds   = [format_to_cmd(cmd) for cmd in sim_cmds]
     trr.rtl_stdout = trr.dir_test / 'rtl_sim_stdstreams.log'
+    # Since we cannot pass the logfile to VCS as an argument, we use stdstream log instead
+    if (md.simulator == "vcs"):
+        trr.rtl_log = trr.rtl_stdout
     trr.export(write_yaml=True)
 
     # Write all sim_cmd output into a single logfile

--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -25,7 +25,7 @@
         vcs
           -full64
           -f <core_ibex>/ibex_dv.f
-          -l <tb_dir>/<rtl_log>
+          -l <tb_build_log>
           -sverilog
           -ntb_opts uvm-1.2
           +define+UVM
@@ -71,7 +71,7 @@
             +UVM_VERBOSITY=UVM_LOW
             +bin=<binary>
             +ibex_tracer_file_base=<rtl_trace>
-            +cosim_log_file=<test_dir>/<iss_cosim_trace>
+            +cosim_log_file=<iss_cosim_trace>
             <sim_opts> <wave_opts> <cov_opts>
     cov_opts: >
       -cm line+tgl+assert+fsm+branch
@@ -208,7 +208,7 @@
           -suppress 2583
           -mfcu -cuname design_cuname
           -sv -o design_opt
-          -l <tb_build_logj>
+          -l <tb_build_log>
           -outdir <tb_dir>/qrun.out
   sim:
     cmd:


### PR DESCRIPTION
This commit fixes couple of bugs in how we handle command generation for VCS but we still need to vendor updated riscv-dv repository (with https://github.com/google/riscv-dv/pull/901) to get things running again in VCS. 


Marking this as draft as we wait for riscv-dv changes to get merged.