### PR TITLE
[if,pmp] Check second bit instead of third for instruction alignment

### DIFF
--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -386,13 +386,13 @@ module ibex_if_stage import ibex_pkg::*; #(
   // An error can come from the instruction address, or the next instruction address for unaligned,
   // uncompressed instructions.
   assign if_instr_pmp_err = pmp_err_if_i |
-                            (if_instr_addr[2] & ~instr_is_compressed & pmp_err_if_plus2_i);
+                            (if_instr_addr[1] & ~instr_is_compressed & pmp_err_if_plus2_i);
 
   // Combine bus errors and pmp errors
   assign if_instr_err = if_instr_bus_err | if_instr_pmp_err;
 
   // Capture the second half of the address for errors on the second part of an instruction
-  assign if_instr_err_plus2 = ((if_instr_addr[2] & ~instr_is_compressed & pmp_err_if_plus2_i) |
+  assign if_instr_err_plus2 = ((if_instr_addr[1] & ~instr_is_compressed & pmp_err_if_plus2_i) |
                                fetch_err_plus2) & ~pmp_err_if_i;
 
   // compressed instruction decoding, or more precisely compressed instruction


### PR DESCRIPTION
Ibex was checking the wrong bit when looking at PMP errors and when to count the error it received from instruction fetch +2.

Closes: https://github.com/lowRISC/ibex/issues/1837