### PR TITLE
Fixup some DV tests

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/csr_description.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/csr_description.yaml
@@ -366,56 +366,60 @@
       msb: 1
       lsb: 0
 
-# CPUCTRL
+# TODO: Bit 8 of this CSR is whether the icache scramble key is valid. This
+# could be 0 or 1 depending upon the Ibex config and depending upon the current
+# state of the scramble key. We need a way for the CSR test generator to deal
+# with fields where it cannot predict the value. Until then leave this CSR out.
 #
-- csr: cpuctrl
-  description: >
-    CPU control register (custom)
-  address: 0x7C0
-  privilege_mode: M
-  rv32:
-    - field_name: double_fault_seen
-      description: >
-        A synchronous exception was observed when the sync_exc_seen field was set
-      type: RW
-      reset_val: 0
-      msb: 7
-      lsb: 7
-    - field_name: sync_exc_seen
-      description: >
-        A synchronous exception has been observed
-      type: RW
-      reset_val: 0
-      msb: 6
-      lsb: 6
-    - field_name: dumm_instr_mask
-      description: >
-        Mask to control frequency of dummy instruction insertion
-      type: WARL
-      reset_val: 0
-      msb: 5
-      lsb: 3
-    - field_name: dummy_instr_en
-      description: >
-        Enable or disable dummy instruction insertion
-      type: WARL
-      reset_val: 0
-      msb: 2
-      lsb: 2
-    - field_name: data_ind_timing
-      description: >
-        Enable or disable data-independent timing features
-      type: WARL
-      reset_val: 0
-      msb: 1
-      lsb: 1
-    - field_name: icache_enable
-      description: >
-        Enable or disable the instruction cache
-      type: WARL
-      reset_val: 0
-      msb: 0
-      lsb: 0
+# CPUCTRLSTS
+#- csr: cpuctrlsts
+#  description: >
+#    CPU control register (custom)
+#  address: 0x7C0
+#  privilege_mode: M
+#  rv32:
+#    - field_name: double_fault_seen
+#      description: >
+#        A synchronous exception was observed when the sync_exc_seen field was set
+#      type: RW
+#      reset_val: 0
+#      msb: 7
+#      lsb: 7
+#    - field_name: sync_exc_seen
+#      description: >
+#        A synchronous exception has been observed
+#      type: RW
+#      reset_val: 0
+#      msb: 6
+#      lsb: 6
+#    - field_name: dumm_instr_mask
+#      description: >
+#        Mask to control frequency of dummy instruction insertion
+#      type: WARL
+#      reset_val: 0
+#      msb: 5
+#      lsb: 3
+#    - field_name: dummy_instr_en
+#      description: >
+#        Enable or disable dummy instruction insertion
+#      type: WARL
+#      reset_val: 0
+#      msb: 2
+#      lsb: 2
+#    - field_name: data_ind_timing
+#      description: >
+#        Enable or disable data-independent timing features
+#      type: WARL
+#      reset_val: 0
+#      msb: 1
+#      lsb: 1
+#    - field_name: icache_enable
+#      description: >
+#        Enable or disable the instruction cache
+#      type: WARL
+#      reset_val: 0
+#      msb: 0
+#      lsb: 0
 
 # SECURESEED
 - csr: secureseed

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -553,19 +553,6 @@
   compare_opts:
     compare_final_value_only: 1
 
-- test: riscv_perf_counter_test
-  description: >
-    Dump performance counters at EOT for any analysis
-  iterations: 5
-  gen_test: riscv_rand_instr_test
-  gen_opts: >
-    +require_signature_addr=1
-    +instr_cnt=10000
-    +num_of_sub_program=5
-  rtl_test: core_ibex_perf_test
-  sim_opts: >
-    +require_signature_addr=1
-
 - test: riscv_debug_single_step_test
   description: >
     Randomly assert debug_req_i, and set dcsr.step to make ibex execute one insn then re-enter debug mode


### PR DESCRIPTION
Note that riscv_csr_test is still broken due to https://github.com/lowRISC/ibex/issues/1846 but when that is sorted we should see it pass.