### PR TITLE
Change ibex_mem_intf_response_seq to handle uninit memory differently

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_agent.sv
+++ b/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_agent.sv
@@ -44,4 +44,11 @@ class ibex_cosim_agent extends uvm_agent;
   function void write_mem_byte(bit [31:0] addr, bit [7:0] d);
     riscv_cosim_write_mem_byte(scoreboard.cosim_handle, addr, d);
   endfunction
+
+  function void write_mem_word(bit [31:0] addr, bit [DATA_WIDTH-1:0] d);
+    for (int i = 0; i < DATA_WIDTH / 8; i++) begin
+      write_mem_byte(addr + i, d[7:0]);
+      d = d >> 8;
+    end
+  endfunction
 endclass : ibex_cosim_agent

--- a/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_agent_pkg.sv
+++ b/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_agent_pkg.sv
@@ -4,7 +4,7 @@
 
 package ibex_cosim_agent_pkg;
   import uvm_pkg::*;
-  import ibex_mem_intf_agent_pkg::*;
+  import ibex_mem_intf_pkg::*;
 
   `include "uvm_macros.svh"
 

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
@@ -5,16 +5,11 @@
 package ibex_mem_intf_agent_pkg;
 
   import uvm_pkg::*;
+  import ibex_mem_intf_pkg::*;
   import mem_model_pkg::*;
-
-  parameter int DATA_WIDTH = 32;
-  parameter int ADDR_WIDTH = 32;
-  parameter int INTG_WIDTH = 7;
-
-  typedef enum { READ, WRITE } rw_e;
+  import ibex_cosim_agent_pkg::*;
 
   `include "uvm_macros.svh"
-  `include "ibex_mem_intf_seq_item.sv"
 
   typedef uvm_sequencer#(ibex_mem_intf_seq_item) ibex_mem_intf_request_sequencer;
 

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_pkg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_pkg.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package ibex_mem_intf_pkg;
+
+  import uvm_pkg::*;
+
+  parameter int DATA_WIDTH = 32;
+  parameter int ADDR_WIDTH = 32;
+  parameter int INTG_WIDTH = 7;
+
+  typedef enum { READ, WRITE } rw_e;
+
+  `include "uvm_macros.svh"
+  `include "ibex_mem_intf_seq_item.sv"
+
+endpackage

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent_cfg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent_cfg.sv
@@ -32,7 +32,8 @@ class ibex_mem_intf_response_agent_cfg extends uvm_object;
   // Default set to 50% for zero delay to be picked
   int unsigned zero_delay_pct = 50;
 
-  `uvm_object_new
+  // CONTROL_KNOB : enable/disable to generation of bad integrity upon uninit accesses
+  bit enable_bad_intg_on_uninit_access = 1;
 
   constraint zero_delays_c {
     zero_delays dist {1 :/ zero_delay_pct,
@@ -47,5 +48,10 @@ class ibex_mem_intf_response_agent_cfg extends uvm_object;
     `uvm_field_int(zero_delays,         UVM_DEFAULT)
     `uvm_field_int(zero_delay_pct,      UVM_DEFAULT)
   `uvm_object_utils_end
+
+  function new(string name = "");
+    super.new(name);
+    void'($value$plusargs("enable_bad_intg_on_uninit_access=%0d", enable_bad_intg_on_uninit_access));
+  endfunction
 
 endclass

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_seq_lib.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_seq_lib.sv
@@ -21,8 +21,7 @@ class ibex_mem_intf_response_seq extends uvm_sequence #(ibex_mem_intf_seq_item);
   `uvm_object_new
 
   virtual task body();
-    if(m_mem ==  null)
-      `uvm_fatal(get_full_name(), "Cannot get memory model")
+    if (m_mem == null) `uvm_fatal(get_full_name(), "Cannot get memory model")
     `uvm_info(`gfn, $sformatf("is_dmem_seq: 0x%0x", is_dmem_seq), UVM_LOW)
     forever
     begin
@@ -33,6 +32,8 @@ class ibex_mem_intf_response_seq extends uvm_sequence #(ibex_mem_intf_seq_item);
       bit                  data_was_uninitialized = 1'b0;
 
       p_sequencer.addr_ph_port.get(item);
+      aligned_addr = {item.addr[DATA_WIDTH-1:2], 2'b0};
+
       req = ibex_mem_intf_seq_item::type_id::create("req");
       error_synch = 1'b0;
       if (!req.randomize() with {
@@ -57,48 +58,33 @@ class ibex_mem_intf_response_seq extends uvm_sequence #(ibex_mem_intf_seq_item);
       }) begin
         `uvm_fatal(`gfn, "Cannot randomize response request")
       end
-      enable_error = 1'b0;
       error_synch = 1'b1;
-      aligned_addr = {req.addr[DATA_WIDTH-1:2], 2'b0};
+      enable_error = 1'b0; // Disable after single inserted error.
+
       if (req.error) begin
         `DV_CHECK_STD_RANDOMIZE_FATAL(rand_data)
         req.data = rand_data;
-      end else begin
-        if(req.read_write == READ) begin : READ_block
-          if (is_dmem_seq) begin
-            for (int i = DATA_WIDTH / 8 - 1; i >= 0; i--) begin
-              read_data = read_data << 8;
-              if (req.be[i])
-                read_data[7:0] = m_mem.read_byte(aligned_addr + i);
-            end
-            req.data = read_data;
-          end else begin
-            // Allow fetches from uninitialised IMEM: the core can run ahead of what's actually
-            // initialised and we don't want to kill the simulation. When this happens, we set the
-            // data_was_uninitialized flag and set req.data to zero.
-            req.data = read(.addr(aligned_addr), .not_set(data_was_uninitialized));
-          end
-        end
+      end else if(item.read_write == READ) begin
+        // Get data from memory_model, handle uninit memory accesses.
+        req.data = read(aligned_addr, data_was_uninitialized);
+      end else if(item.read_write == WRITE) begin
+        // Update memory_model
+        write(aligned_addr, item.data);
       end
       // Add integrity bits
       {req.intg, req.data} = prim_secded_pkg::prim_secded_inv_39_32_enc(req.data);
 
       // If data_was_uninitialized is true then we want to force bad integrity bits: invert the
       // correct ones, which we know will break things for the codes we use.
-      if (data_was_uninitialized) req.intg = ~req.intg;
+      if (p_sequencer.cfg.enable_bad_intg_on_uninit_access &&
+          data_was_uninitialized) begin
+        req.intg = ~req.intg;
+      end
 
       `uvm_info(get_full_name(), $sformatf("Response transfer:\n%0s", req.sprint()), UVM_HIGH)
       start_item(req);
       finish_item(req);
-      if(item.read_write == WRITE) begin : WRITE_block
-        bit [DATA_WIDTH-1:0] data;
-        data = req.data;
-        for (int i = 0; i < DATA_WIDTH / 8; i++) begin
-          if (req.be[i])
-            m_mem.write_byte(aligned_addr + i, data[7:0]);
-          data = data >> 8;
-        end
-      end
+
     end
   endtask : body
 
@@ -110,19 +96,62 @@ class ibex_mem_intf_response_seq extends uvm_sequence #(ibex_mem_intf_seq_item);
     return this.error_synch;
   endfunction
 
-  // Read a word of DATA_WIDTH bits at addr.
-  //
-  // Return 0xabababab and write not_set = 1'b1 for addresses where there is no architectural value
-  // (rather than generating an error).
-  protected function logic [DATA_WIDTH-1:0] read(bit [ADDR_WIDTH-1:0] addr, output bit not_set);
-    for (int i = 0; i < DATA_WIDTH / 8; i++) begin
-      if (!m_mem.system_memory.exists(addr + i)) begin
-        not_set = 1'b1;
-        return {DATA_WIDTH/8{8'hab}};
+  // Read a word of DATA_WIDTH bits from addr.
+  // Handle reads fromm uninit memory as follows:
+  // - DMEM : return a random value
+  // - IMEM : return {2{C.unimp}}
+  protected function logic [DATA_WIDTH-1:0] read(bit [ADDR_WIDTH-1:0] addr,
+                                                 output bit did_access_uninit_mem);
+    logic [DATA_WIDTH-1:0] data = '0;
+    bit [7:0] byte_data = '0;
+    bit       byte_is_uninit = 1'b0;
+    for (int i = (DATA_WIDTH / 8) - 1; i >= 0 ; i--) begin
+      data = data << 8;
+      data[7:0] = read_byte(addr + i, byte_is_uninit);
+      if (byte_is_uninit) begin
+        did_access_uninit_mem = 1'b1;
+        // If any byte of the access comes back as uninit, bork the whole access.
+        if (is_dmem_seq) begin
+          // DMEM
+          `DV_CHECK_STD_RANDOMIZE_FATAL(data)
+          // Update mem_model with the randomized data.
+          `uvm_info(`gfn,
+                    $sformatf("Addr is uninit! DMEM seq, returning random data 0x%0h", data),
+                    UVM_MEDIUM)
+          write(addr, data);
+          return data;
+        end else begin
+          // IMEM
+          `uvm_info(`gfn,
+                    $sformatf("Addr is uninit! IMEM seq, returning 0x0000 (c.unimp)"),
+                    UVM_MEDIUM)
+          return {2{16'h0000}}; // 2x C.unimp instructions
+        end
       end
     end
-    not_set = 1'b0;
-    return m_mem.read(addr);
+    return data;
+  endfunction
+
+  // Write a word of DATA_WIDTH bits at addr.
+  protected function void write(bit [ADDR_WIDTH-1:0] addr, bit [DATA_WIDTH-1:0] data);
+    for (int i = 0; i < DATA_WIDTH / 8; i++) begin
+      if (req.be[i])
+        m_mem.write_byte(addr + i, data[7:0]);
+      data = data >> 8;
+    end
+  endfunction
+
+  // Re-implement the read_byte function from mem_model.sv, but without the fatal assertion.
+  function bit [7:0] read_byte(bit [ADDR_WIDTH-1:0] addr, output bit is_byte_uninit);
+    bit [7:0] data = '0;
+    if (!m_mem.addr_exists(addr)) begin
+      `uvm_info(`gfn, $sformatf("Read from uninitialized addr 0x%0h", addr), UVM_MEDIUM)
+      is_byte_uninit = 1'b1;
+    end else begin
+      data = m_mem.system_memory[addr];
+      `uvm_info(`gfn, $sformatf("Read Mem  : Addr[0x%0h], Data[0x%0h]", addr, data), UVM_HIGH)
+    end
+    return data;
   endfunction
 
 endclass : ibex_mem_intf_response_seq

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_seq_lib.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_seq_lib.sv
@@ -10,6 +10,7 @@ class ibex_mem_intf_response_seq extends uvm_sequence #(ibex_mem_intf_seq_item);
 
   ibex_mem_intf_seq_item item;
   mem_model              m_mem;
+  ibex_cosim_agent       cosim_agent;
   bit                    enable_error = 1'b0;
   // Used to ensure that whenever inject_error() is called, the very next transaction will inject an
   // error, and that enable_error will not be flipped back to 0 immediately
@@ -114,11 +115,12 @@ class ibex_mem_intf_response_seq extends uvm_sequence #(ibex_mem_intf_seq_item);
         if (is_dmem_seq) begin
           // DMEM
           `DV_CHECK_STD_RANDOMIZE_FATAL(data)
-          // Update mem_model with the randomized data.
+          // Update mem_model(s) with the randomized data.
           `uvm_info(`gfn,
                     $sformatf("Addr is uninit! DMEM seq, returning random data 0x%0h", data),
                     UVM_MEDIUM)
-          write(addr, data);
+          write(addr, data);                       // Update UVM mem_model
+          cosim_agent.write_mem_word(addr, data);  // Update cosim mem_model
           return data;
         end else begin
           // IMEM

--- a/dv/uvm/core_ibex/ibex_dv.f
+++ b/dv/uvm/core_ibex/ibex_dv.f
@@ -129,13 +129,14 @@ ${LOWRISC_IP_DIR}/dv/sv/mem_model/mem_model_pkg.sv
 ${LOWRISC_IP_DIR}/dv/sv/push_pull_agent/push_pull_if.sv
 ${LOWRISC_IP_DIR}/dv/sv/push_pull_agent/push_pull_agent_pkg.sv
 ${PRJ_DIR}/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf.sv
-${PRJ_DIR}/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
+${PRJ_DIR}/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_pkg.sv
 ${PRJ_DIR}/dv/uvm/core_ibex/common/irq_agent/irq_if.sv
 ${PRJ_DIR}/dv/uvm/core_ibex/common/irq_agent/irq_agent_pkg.sv
 ${PRJ_DIR}/dv/uvm/core_ibex/env/core_ibex_rvfi_if.sv
 ${PRJ_DIR}/dv/uvm/core_ibex/common/ibex_cosim_agent/core_ibex_ifetch_if.sv
 ${PRJ_DIR}/dv/uvm/core_ibex/common/ibex_cosim_agent/core_ibex_ifetch_pmp_if.sv
 ${PRJ_DIR}/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_agent_pkg.sv
+${PRJ_DIR}/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
 ${PRJ_DIR}/dv/uvm/core_ibex/env/core_ibex_instr_monitor_if.sv
 ${PRJ_DIR}/dv/uvm/core_ibex/env/core_ibex_dut_probe_if.sv
 ${PRJ_DIR}/dv/uvm/core_ibex/env/core_ibex_csr_if.sv

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -149,6 +149,10 @@ class core_ibex_base_test extends uvm_test;
     vseq = core_ibex_vseq::type_id::create("vseq");
     vseq.mem = mem;
     vseq.cfg = cfg;
+    // Connect the data memory seq to the cosim agent
+    // This allows the cosim memory to be updated to match when we generate random data in
+    // response to a read from uninit memory.
+    vseq.data_intf_seq.cosim_agent = env.cosim_agent;
   endfunction
 
   virtual function void connect_phase(uvm_phase phase);

--- a/dv/uvm/core_ibex/tests/core_ibex_test_pkg.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_pkg.sv
@@ -9,6 +9,7 @@ package core_ibex_test_pkg;
 
   import uvm_pkg::*;
   import core_ibex_env_pkg::*;
+  import ibex_mem_intf_pkg::*;
   import ibex_mem_intf_agent_pkg::*;
   import irq_agent_pkg::*;
   import riscv_signature_pkg::*;


### PR DESCRIPTION
Reading uninit DMEM returns a random value.
Reading uninit IMEM returns returns `{2{C.unimp}}`.

[~Integrity errors are no-longer generated.~](https://github.com/lowRISC/ibex/pull/1855#discussion_r995967300)
Integrity errors are now generated by default, but this behaviour can be disabled by settings the plusarg `+enable_bad_intg_on_uninit_access=0`



Goes towards #1846 