### PR TITLE
[fcov,pmp] Illegal PMP write coverpoints check dside request error not low

### DIFF
--- a/dv/uvm/core_ibex/fcov/core_ibex_pmp_fcov_if.sv
+++ b/dv/uvm/core_ibex/fcov/core_ibex_pmp_fcov_if.sv
@@ -390,7 +390,7 @@ interface core_ibex_pmp_fcov_if import ibex_pkg::*; #(
                                                     MML_XRM, MML_XRM_XU, MML_RM_RU} &&
              binsof(cp_priv_lvl_dside) intersect {PRIV_LVL_M} &&
              binsof(cp_req_type_dside) intersect {PMP_ACC_WRITE} &&
-             binsof(pmp_dside_req_err) intersect {1});
+             binsof(pmp_dside_req_err) intersect {0});
           illegal_bins illegal_user_allow_write =
             // Ensuring MML is high and we are not in a W allowed configuration in User Mode
             (binsof(cp_region_priv_bits) intersect {MML_NONE, MML_RU, MML_WRM_RU, MML_XU, MML_XRU,
@@ -398,7 +398,7 @@ interface core_ibex_pmp_fcov_if import ibex_pkg::*; #(
                                                     MML_XRM, MML_XRM_XU, MML_RM_RU} &&
              binsof(cp_priv_lvl_dside) intersect {PRIV_LVL_U} &&
              binsof(cp_req_type_dside) intersect {PMP_ACC_WRITE} &&
-             binsof(pmp_dside_req_err) intersect {1});
+             binsof(pmp_dside_req_err) intersect {0});
 
           // Will never see a write access denied when write is allowed
           illegal_bins illegal_deny_write =


### PR DESCRIPTION
Without this check I was getting these errors:
```
xmsim: *SE,EILLCT: (File: ./fcov/core_ibex_pmp_fcov_if.sv, Line: 386):(Time: 16157524 NS + 4) Illegal cross tuple (<MML_XM, PMP_ACC_WRITE, PRIV_LVL_M, 1>) occurred corresponding to illegal cross bin (illegal_machine_allow_write) of cross (core_ibex_tb_top.dut.u_ibex_top.gen_lockstep.u_ibex_lockstep.u_shadow_core.u_pmp_fcov_bind.g_pmp_cgs.g_pmp_region_fcov[4].pmp_region_cg_inst@11387_1.pmp_dside_priv_bits_cross).

xmsim: *SE,EILLCT: (File: ./fcov/core_ibex_pmp_fcov_if.sv, Line: 394):(Time: 11401300 NS + 4) Illegal cross tuple (<MML_XM, PMP_ACC_WRITE, PRIV_LVL_U, 1>) occurred corresponding to illegal cross bin (illegal_user_allow_write) of cross (core_ibex_tb_top.dut.u_ibex_top.gen_lockstep.u_ibex_lockstep.u_shadow_core.u_pmp_fcov_bind.g_pmp_cgs.g_pmp_region_fcov[1].pmp_region_cg_inst@11384_1.pmp_dside_priv_bits_cross).
```