### PR TITLE
Add mechanism for test-specific timeout

### DIFF
--- a/dv/uvm/core_ibex/common/date.c
+++ b/dv/uvm/core_ibex/common/date.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <time.h>
+long int get_unix_timestamp() { return time(NULL); }

--- a/dv/uvm/core_ibex/common/date_dpi.svh
+++ b/dv/uvm/core_ibex/common/date_dpi.svh
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`ifndef DATE_DPI_SVH
+`define DATE_DPI_SVH
+
+import "DPI-C" function longint get_unix_timestamp();
+
+`endif

--- a/dv/uvm/core_ibex/ibex_dv.f
+++ b/dv/uvm/core_ibex/ibex_dv.f
@@ -100,6 +100,8 @@ ${PRJ_DIR}/rtl/ibex_top.sv
 ${PRJ_DIR}/rtl/ibex_top_tracing.sv
 
 // Core DV files
++incdir+${PRJ_DIR}/dv/uvm/core_ibex/common
+${PRJ_DIR}/dv/uvm/core_ibex/common/date.c
 ${PRJ_DIR}/vendor/google_riscv-dv/src/riscv_signature_pkg.sv
 +incdir+${LOWRISC_IP_DIR}/dv/sv/dv_utils
 +incdir+${LOWRISC_IP_DIR}/dv/sv/dv_base_reg

--- a/dv/uvm/core_ibex/scripts/collect_results.py
+++ b/dv/uvm/core_ibex/scripts/collect_results.py
@@ -166,7 +166,7 @@ def main() -> int:
                     passing_tests.append(trr)
                 else:
                     if (trr.failure_mode == Failure_Modes.TIMEOUT):
-                        trr.failure_message = f"[FAILURE] Simulation timed-out [{md.run_rtl_timeout_s}s].\n"
+                        trr.failure_message = f"[FAILURE] Simulation timed-out [{trr.timeout_s}s].\n"
                     failing_tests.append(trr)
             except RuntimeError as e:
                 failing_tests.append(

--- a/dv/uvm/core_ibex/scripts/collect_results.py
+++ b/dv/uvm/core_ibex/scripts/collect_results.py
@@ -165,8 +165,6 @@ def main() -> int:
                 if trr.passed:
                     passing_tests.append(trr)
                 else:
-                    if (trr.failure_mode == Failure_Modes.TIMEOUT):
-                        trr.failure_message = f"[FAILURE] Simulation timed-out [{trr.timeout_s}s].\n"
                     failing_tests.append(trr)
             except RuntimeError as e:
                 failing_tests.append(

--- a/dv/uvm/core_ibex/scripts/run_rtl.py
+++ b/dv/uvm/core_ibex/scripts/run_rtl.py
@@ -78,6 +78,8 @@ def _main() -> int:
         user_subst_options=subst_vars_dict)
     logger.info(sim_cmds)
 
+    trr.timeout_s = (testopts.get('timeout_s') if (testopts.get('timeout_s') is not None) else
+                     md.run_rtl_timeout_s)
     trr.dir_test.mkdir(exist_ok=True, parents=True)
     trr.rtl_cmds   = [format_to_cmd(cmd) for cmd in sim_cmds]
     trr.rtl_stdout = trr.dir_test / 'rtl_sim_stdstreams.log'
@@ -95,7 +97,7 @@ def _main() -> int:
                 sim_fd.write(f"Running run-rtl command :\n{' '.join(cmd)}\n".encode())
                 run_one(md.verbose, cmd,
                         redirect_stdstreams=sim_fd,
-                        timeout_s=md.run_rtl_timeout_s,
+                        timeout_s=trr.timeout_s,
                         reraise=True)  # Allow us to catch timeout exceptions at this level
         except subprocess.TimeoutExpired:
             trr.failure_mode = Failure_Modes.TIMEOUT

--- a/dv/uvm/core_ibex/scripts/test_run_result.py
+++ b/dv/uvm/core_ibex/scripts/test_run_result.py
@@ -41,6 +41,7 @@ class TestRunResult(scripts_lib.testdata_cls):
     # Message describing failure, includes a '[FAILED]: XXXX' line at the end.
     failure_mode: Optional[Failure_Modes] = None
     failure_message: Optional[str] = None
+    timeout_s: Optional[int] = None
 
     testdotseed: Optional[str] = None
     testname: Optional[str] = None        # Name of test


### PR DESCRIPTION
Adding the key 'timeout_s' to the testlist.yaml file for each test now sets the timeout for all iterations of that test. Value in seconds.

Add a wall-clock timeout mechanism within the simulation itself, by using DPI calls to unix 'date' to get the unix timestamp. This allows the test to end gracefully, which ensures all logs and coverage are generated.

e.g.
Set all iterations of the pmp_full_random test to have a 10s timeout.
```
- test: riscv_pmp_full_random_test
  timeout_s: 10
```

This will be very helpful in increasing the number of seeds tested in PMP tests without the inevitable timing-out tests taking up a whole thread for 30 mins (the default timeout for all tests set in metadata.py)

Resolves #1861 