### PR TITLE
Fix bug in passing cosim_agent handle to the data_intf_seq

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -152,10 +152,6 @@ class core_ibex_base_test extends uvm_test;
     vseq = core_ibex_vseq::type_id::create("vseq");
     vseq.mem = mem;
     vseq.cfg = cfg;
-    // Connect the data memory seq to the cosim agent
-    // This allows the cosim memory to be updated to match when we generate random data in
-    // response to a read from uninit memory.
-    vseq.data_intf_seq.cosim_agent = env.cosim_agent;
   endfunction
 
   virtual function void connect_phase(uvm_phase phase);
@@ -165,6 +161,10 @@ class core_ibex_base_test extends uvm_test;
     env.data_if_response_agent.monitor.item_collected_port.connect(
       this.test_done_port.analysis_export);
     env.irq_agent.monitor.irq_port.connect(this.irq_collected_port.analysis_export);
+    // Connect the data memory seq to the cosim agent
+    // This allows the cosim memory to be updated to match when we generate random data in
+    // response to a read from uninit memory.
+    vseq.data_intf_seq.cosim_agent = env.cosim_agent;
   endfunction
 
   virtual task run_phase(uvm_phase phase);


### PR DESCRIPTION
It turns out #1855 could have been tested a little better.

The handle was passed before the cosim object was constructed, so when it came to use the handle it caused a null pointer exception. Moved to the end of the `connect_phase`.