### PR TITLE
[dv] Add test glitching PC of Ibex

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -599,6 +599,13 @@
     compare_final_value_only: 1
     verbose: 1
 
+- test: riscv_pc_intg_test
+  description: >
+    Randomly corrupt the PC of the core once in the middle of program execution
+  iterations: 15
+  gen_test: riscv_rand_instr_test
+  rtl_test: core_ibex_pc_intg_test
+
 - test: riscv_rv32im_instr_test
   description: >
     Random instruction test without compressed instructions

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -160,6 +160,7 @@ module core_ibex_tb_top;
   // We should never see any alerts triggered in normal testing
   `ASSERT(NoAlertsTriggered,
     !dut_if.alert_minor && !dut_if.alert_major_internal && !dut_if.alert_major_bus, clk, !rst_n)
+  `DV_ASSERT_CTRL("tb_no_alerts_triggered", core_ibex_tb_top.NoAlertsTriggered)
 
   // Data load/store vif connection
   assign data_mem_vif.reset = ~rst_n;


### PR DESCRIPTION
This PR addresses #1755 by verifying that a glitch on the PC of Ibex raises an internal major alert in the core.