### PR TITLE
Nested interrupt test fixes

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -901,6 +901,7 @@ class core_ibex_nested_irq_test extends core_ibex_directed_test;
     bit valid_irq;
     bit valid_nested_irq;
     int unsigned initial_irq_delay;
+    vseq.irq_raise_seq_h.max_delay = 5000;
     forever begin
       send_irq_stimulus_start(1'b1, 1'b0, valid_irq);
       if (valid_irq) begin


### PR DESCRIPTION
> After [removing the integrity-errors generated](https://github.com/lowRISC/ibex/pull/1874/files) from uninit memory accesses, the nested_interrupt test was still failing reliably.
> I think I found the reason why this test was accessing uninit memory in the first place, and propose a solution in this PR.
> 
> Note that I am making this PR with changes directly to the vendored RISCV-DV code, with a view to upstream shortly.

Upstream PR merged [here](https://github.com/google/riscv-dv/pull/906), now vendored into Ibex [here](https://github.com/lowRISC/ibex/pull/1880).

> 
> The problem with this test currently is that riscv-dv has routines to push and pop the GPR's to the kernel-stack upon entering and exiting an interrupt handler, storing the pointer to this effective stack-frame in MSCRATCH. However, the code that allows for nested interrupts by setting xSTATUS.xIE inside the ISR also makes use of MSCRATCH to hold a temporary value that stops the program from entering more than one level of nesting. By overwriting our original pointer to the GPR's, we could not restore them when going back to our original program, hence the program state was corrupted and we would access uninit memory.
> 
> These changes fix the problem by storing the pointer to the saved state also on the kernel mode stack, and not in the MSCRATCH csr.
> This PR also raises the value of `vseq.irq_raise_seq_h.max_delay = 5000;`, which allows more instructions to be executed between our applied IRQ stimulus. Locally I see 100% of the riscv_nested_interrupt_test iterations pass within approximately 60s.

Dropped the RISCV-DV changes from this PR, and rebased onto master with those same changes now vendored-in.
Only remaining change in this PR is the change to `vseq.irq_raise_seq_h.max_delay`.