### PR TITLE
[cosim] Fixup ebreak behaviour

### DIFF
--- a/dv/cosim/spike_cosim.h
+++ b/dv/cosim/spike_cosim.h
@@ -62,6 +62,9 @@ class SpikeCosim : public simif_t, public Cosim {
 
   bool pc_is_mret(uint32_t pc);
 
+  bool pc_is_debug_ebreak(uint32_t pc);
+  bool check_debug_ebreak(uint32_t write_reg, uint32_t pc, bool sync_trap);
+
   bool check_gpr_write(const commit_log_reg_t::value_type &reg_change,
                        uint32_t write_reg, uint32_t write_reg_data);
 


### PR DESCRIPTION
When DCSR is set such that ebreak will enter debug mode we were getting cosim mismatches. This was because Ibex produces the ebreak on the RVFI interface and spike effectively skips right over it and executes the first instruction of the debug handler immediately. Traps have similar but not identical behaviour so we need a special case in the step function to handle this.