### PR TITLE
[rtl] Fix id_exception_o signal

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -217,7 +217,7 @@ module ibex_controller #(
   // LSU exception requests
   assign exc_req_lsu = store_err_i | load_err_i;
 
-  assign id_exception_o = exc_req_d;
+  assign id_exception_o = exc_req_d & ~wb_exception_o;
 
   // special requests: special instructions, pipeline flushes, exceptions...
   // All terms in these expressions are qualified by instr_valid_i except exc_req_lsu which can come


### PR DESCRIPTION
Previously it was asserted when an instruction in ID would cause an exception but an earlier instruction in WB also causes an exception which takes priority.

This didn't cause a functional bug as the `id_exception_o` signal was used in a single place ORed with `wb_exception_o`. However it was confusing behaviour and could cause killed instructions to appear on the RVFI causing false cosim mismatches.