### PR TITLE
[rtl] Fix dummy instructions

### DIFF
--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -72,6 +72,7 @@ module ibex_core import ibex_pkg::*; #(
 
   // Register file interface
   output logic                         dummy_instr_id_o,
+  output logic                         dummy_instr_wb_o,
   output logic [4:0]                   rf_raddr_a_o,
   output logic [4:0]                   rf_raddr_b_o,
   output logic [4:0]                   rf_waddr_wb_o,
@@ -303,6 +304,7 @@ module ibex_core import ibex_pkg::*; #(
   logic           rf_write_wb;
   logic           outstanding_load_wb;
   logic           outstanding_store_wb;
+  logic           dummy_instr_wb;
 
   // Interrupts
   logic        nmi_mode;
@@ -789,8 +791,9 @@ module ibex_core import ibex_pkg::*; #(
   );
 
   ibex_wb_stage #(
-    .ResetAll       ( ResetAll       ),
-    .WritebackStage(WritebackStage)
+    .ResetAll         (ResetAll),
+    .WritebackStage   (WritebackStage),
+    .DummyInstructions(DummyInstructions)
   ) wb_stage_i (
     .clk_i                   (clk_i),
     .rst_ni                  (rst_ni),
@@ -814,6 +817,8 @@ module ibex_core import ibex_pkg::*; #(
     .rf_wdata_id_i(rf_wdata_id),
     .rf_we_id_i   (rf_we_id),
 
+    .dummy_instr_id_i(dummy_instr_id),
+
     .rf_wdata_lsu_i(rf_wdata_lsu),
     .rf_we_lsu_i   (rf_we_lsu),
 
@@ -822,6 +827,8 @@ module ibex_core import ibex_pkg::*; #(
     .rf_waddr_wb_o(rf_waddr_wb),
     .rf_wdata_wb_o(rf_wdata_wb),
     .rf_we_wb_o   (rf_we_wb),
+
+    .dummy_instr_wb_o(dummy_instr_wb),
 
     .lsu_resp_valid_i(lsu_resp_valid),
     .lsu_resp_err_i  (lsu_resp_err),
@@ -834,6 +841,7 @@ module ibex_core import ibex_pkg::*; #(
   /////////////////////////////
 
   assign dummy_instr_id_o = dummy_instr_id;
+  assign dummy_instr_wb_o = dummy_instr_wb;
   assign rf_raddr_a_o     = rf_raddr_a;
   assign rf_waddr_wb_o    = rf_waddr_wb;
   assign rf_we_wb_o       = rf_we_wb;

--- a/rtl/ibex_lockstep.sv
+++ b/rtl/ibex_lockstep.sv
@@ -64,6 +64,7 @@ module ibex_lockstep import ibex_pkg::*; #(
   input  logic                         data_err_i,
 
   input  logic                         dummy_instr_id_i,
+  input  logic                         dummy_instr_wb_i,
   input  logic [4:0]                   rf_raddr_a_i,
   input  logic [4:0]                   rf_raddr_b_i,
   input  logic [4:0]                   rf_waddr_wb_i,
@@ -246,6 +247,7 @@ module ibex_lockstep import ibex_pkg::*; #(
     logic [31:0]                 data_addr;
     logic [MemDataWidth-1:0]     data_wdata;
     logic                        dummy_instr_id;
+    logic                        dummy_instr_wb;
     logic [4:0]                  rf_raddr_a;
     logic [4:0]                  rf_raddr_b;
     logic [4:0]                  rf_waddr_wb;
@@ -279,6 +281,7 @@ module ibex_lockstep import ibex_pkg::*; #(
   assign core_outputs_in.data_addr           = data_addr_i;
   assign core_outputs_in.data_wdata          = data_wdata_i;
   assign core_outputs_in.dummy_instr_id      = dummy_instr_id_i;
+  assign core_outputs_in.dummy_instr_wb      = dummy_instr_wb_i;
   assign core_outputs_in.rf_raddr_a          = rf_raddr_a_i;
   assign core_outputs_in.rf_raddr_b          = rf_raddr_b_i;
   assign core_outputs_in.rf_waddr_wb         = rf_waddr_wb_i;
@@ -367,6 +370,7 @@ module ibex_lockstep import ibex_pkg::*; #(
     .data_err_i          (shadow_inputs_q[0].data_err),
 
     .dummy_instr_id_o    (shadow_outputs_d.dummy_instr_id),
+    .dummy_instr_wb_o    (shadow_outputs_d.dummy_instr_wb),
     .rf_raddr_a_o        (shadow_outputs_d.rf_raddr_a),
     .rf_raddr_b_o        (shadow_outputs_d.rf_raddr_b),
     .rf_waddr_wb_o       (shadow_outputs_d.rf_waddr_wb),

--- a/rtl/ibex_register_file_ff.sv
+++ b/rtl/ibex_register_file_ff.sv
@@ -23,6 +23,7 @@ module ibex_register_file_ff #(
 
   input  logic                 test_en_i,
   input  logic                 dummy_instr_id_i,
+  input  logic                 dummy_instr_wb_i,
 
   //Read port R1
   input  logic [4:0]           raddr_a_i,
@@ -108,7 +109,7 @@ module ibex_register_file_ff #(
     logic [DataWidth-1:0] rf_r0_q;
 
     // Write enable for dummy R0 register (waddr_a_i will always be 0 for dummy instructions)
-    assign we_r0_dummy = we_a_i & dummy_instr_id_i;
+    assign we_r0_dummy = we_a_i & dummy_instr_wb_i;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
@@ -122,8 +123,8 @@ module ibex_register_file_ff #(
     assign rf_reg[0] = dummy_instr_id_i ? rf_r0_q : WordZeroVal;
 
   end else begin : g_normal_r0
-    logic unused_dummy_instr_id;
-    assign unused_dummy_instr_id = dummy_instr_id_i;
+    logic unused_dummy_instr;
+    assign unused_dummy_instr = dummy_instr_id_i ^ dummy_instr_wb_i;
 
     // R0 is nil
     assign rf_reg[0] = WordZeroVal;

--- a/rtl/ibex_register_file_fpga.sv
+++ b/rtl/ibex_register_file_fpga.sv
@@ -24,6 +24,7 @@ module ibex_register_file_fpga #(
 
   input  logic                 test_en_i,
   input  logic                 dummy_instr_id_i,
+  input  logic                 dummy_instr_wb_i,
 
   //Read port R1
   input  logic [          4:0] raddr_a_i,
@@ -88,7 +89,7 @@ module ibex_register_file_fpga #(
 
   // Dummy instruction changes not relevant for FPGA implementation
   logic unused_dummy_instr;
-  assign unused_dummy_instr = dummy_instr_id_i;
+  assign unused_dummy_instr = dummy_instr_id_i ^ dummy_instr_wb_i;
   // Test enable signal not used in FPGA implementation
   logic unused_test_en;
   assign unused_test_en = test_en_i;

--- a/rtl/ibex_register_file_latch.sv
+++ b/rtl/ibex_register_file_latch.sv
@@ -24,6 +24,7 @@ module ibex_register_file_latch #(
 
   input  logic                 test_en_i,
   input  logic                 dummy_instr_id_i,
+  input  logic                 dummy_instr_wb_i,
 
   //Read port R1
   input  logic [4:0]           raddr_a_i,
@@ -162,7 +163,7 @@ module ibex_register_file_latch #(
     logic [DataWidth-1:0] mem_r0;
 
     // Write enable for dummy R0 register (waddr_a_i will always be 0 for dummy instructions)
-    assign we_r0_dummy = we_a_i & dummy_instr_id_i;
+    assign we_r0_dummy = we_a_i & dummy_instr_wb_i;
 
     // R0 clock gate
     prim_clock_gating cg_i (
@@ -182,8 +183,8 @@ module ibex_register_file_latch #(
     assign mem[0] = dummy_instr_id_i ? mem_r0 : WordZeroVal;
 
   end else begin : g_normal_r0
-    logic unused_dummy_instr_id;
-    assign unused_dummy_instr_id = dummy_instr_id_i;
+    logic unused_dummy_instr;
+    assign unused_dummy_instr = dummy_instr_id_i ^ dummy_instr_wb_i;
 
     assign mem[0] = WordZeroVal;
   end

--- a/rtl/ibex_top.sv
+++ b/rtl/ibex_top.sv
@@ -159,6 +159,7 @@ module ibex_top import ibex_pkg::*; #(
   logic                        irq_pending;
   // Core <-> Register file signals
   logic                        dummy_instr_id;
+  logic                        dummy_instr_wb;
   logic [4:0]                  rf_raddr_a;
   logic [4:0]                  rf_raddr_b;
   logic [4:0]                  rf_waddr_wb;
@@ -327,6 +328,7 @@ module ibex_top import ibex_pkg::*; #(
     .data_err_i,
 
     .dummy_instr_id_o (dummy_instr_id),
+    .dummy_instr_wb_o (dummy_instr_wb),
     .rf_raddr_a_o     (rf_raddr_a),
     .rf_raddr_b_o     (rf_raddr_b),
     .rf_waddr_wb_o    (rf_waddr_wb),
@@ -418,6 +420,7 @@ module ibex_top import ibex_pkg::*; #(
 
       .test_en_i       (test_en_i),
       .dummy_instr_id_i(dummy_instr_id),
+      .dummy_instr_wb_i(dummy_instr_wb),
 
       .raddr_a_i(rf_raddr_a),
       .rdata_a_o(rf_rdata_a_ecc),
@@ -442,6 +445,7 @@ module ibex_top import ibex_pkg::*; #(
 
       .test_en_i       (test_en_i),
       .dummy_instr_id_i(dummy_instr_id),
+      .dummy_instr_wb_i(dummy_instr_wb),
 
       .raddr_a_i(rf_raddr_a),
       .rdata_a_o(rf_rdata_a_ecc),
@@ -466,6 +470,7 @@ module ibex_top import ibex_pkg::*; #(
 
       .test_en_i       (test_en_i),
       .dummy_instr_id_i(dummy_instr_id),
+      .dummy_instr_wb_i(dummy_instr_wb),
 
       .raddr_a_i(rf_raddr_a),
       .rdata_a_o(rf_rdata_a_ecc),
@@ -708,6 +713,7 @@ module ibex_top import ibex_pkg::*; #(
       data_rdata_core,
       data_err_i,
       dummy_instr_id,
+      dummy_instr_wb,
       rf_raddr_a,
       rf_raddr_b,
       rf_waddr_wb,
@@ -761,6 +767,7 @@ module ibex_top import ibex_pkg::*; #(
     logic                         data_err_local;
 
     logic                         dummy_instr_id_local;
+    logic                         dummy_instr_wb_local;
     logic [4:0]                   rf_raddr_a_local;
     logic [4:0]                   rf_raddr_b_local;
     logic [4:0]                   rf_waddr_wb_local;
@@ -813,6 +820,7 @@ module ibex_top import ibex_pkg::*; #(
       data_rdata_core,
       data_err_i,
       dummy_instr_id,
+      dummy_instr_wb,
       rf_raddr_a,
       rf_raddr_b,
       rf_waddr_wb,
@@ -862,6 +870,7 @@ module ibex_top import ibex_pkg::*; #(
       data_rdata_local,
       data_err_local,
       dummy_instr_id_local,
+      dummy_instr_wb_local,
       rf_raddr_a_local,
       rf_raddr_b_local,
       rf_waddr_wb_local,
@@ -968,6 +977,7 @@ module ibex_top import ibex_pkg::*; #(
       .data_err_i             (data_err_local),
 
       .dummy_instr_id_i       (dummy_instr_id_local),
+      .dummy_instr_wb_i       (dummy_instr_wb_local),
       .rf_raddr_a_i           (rf_raddr_a_local),
       .rf_raddr_b_i           (rf_raddr_b_local),
       .rf_waddr_wb_i          (rf_waddr_wb_local),
@@ -1156,5 +1166,5 @@ module ibex_top import ibex_pkg::*; #(
 
   // Dummy instructions may only write to register 0, which is a special register when dummy
   // instructions are enabled.
-  `ASSERT(WaddrAZeroForDummyInstr, dummy_instr_id && rf_we_wb |-> rf_waddr_wb == '0)
+  `ASSERT(WaddrAZeroForDummyInstr, dummy_instr_wb && rf_we_wb |-> rf_waddr_wb == '0)
 endmodule


### PR DESCRIPTION
Previously there was a single dummy_instr_id_o signal from ibex_core which the register file used to determine if it could write to the zero register (which reads as zero always for real instructions). However a write occurs in the writeback stage so this signal was not asserted correctly.

This adds a dummy_instr_wb_o signal to control the write to zero register. dummy_instr_id_o remains as it's still employed for register reads for dummy instructions.