### PR TITLE
[pmp] Add directed instr streams to increase PMP coverage

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/ibex_directed_instr_lib.sv
+++ b/dv/uvm/core_ibex/riscv_dv_extension/ibex_directed_instr_lib.sv
@@ -61,3 +61,28 @@ class ibex_breakpoint_stream extends riscv_directed_instr_stream;
   endfunction
 
 endclass
+
+// Define a short riscv-dv directed instruction stream to write random values to MSECCFG CSR
+class ibex_rand_mseccfg_stream extends riscv_directed_instr_stream;
+
+  `uvm_object_utils(ibex_rand_mseccfg_stream)
+
+  function new(string name = "");
+    super.new(name);
+  endfunction
+
+  function void post_randomize();
+    riscv_instr          csrrw_instr;
+    // This stream consists of a single instruction
+    initialize_instr_list(1);
+
+    csrrw_instr = riscv_instr::get_instr(CSRRWI);
+    csrrw_instr.atomic = 1'b0;
+    csrrw_instr.csr = MSECCFG;
+    csrrw_instr.rd = '0;
+    // Randomize between 3'b000 and 3'b111 to hit every combination of RLB/MMWP/MML bits.
+    csrrw_instr.imm_str = $sformatf("0x%0x", $urandom_range(7,0));
+    instr_list = {csrrw_instr};
+  endfunction
+
+endclass

--- a/dv/uvm/core_ibex/riscv_dv_extension/ibex_directed_instr_lib.sv
+++ b/dv/uvm/core_ibex/riscv_dv_extension/ibex_directed_instr_lib.sv
@@ -86,3 +86,64 @@ class ibex_rand_mseccfg_stream extends riscv_directed_instr_stream;
   endfunction
 
 endclass
+
+// Define a short riscv-dv directed instruction stream to set a valid NA4 address/config
+class ibex_valid_na4_stream extends riscv_directed_instr_stream;
+
+  `uvm_object_utils(ibex_valid_na4_stream)
+
+  function new(string name = "");
+    super.new(name);
+  endfunction
+
+  function void post_randomize();
+    string               instr_label, gn;
+    riscv_pseudo_instr   la_instr;
+    riscv_instr          addr_csrrw_instr;
+    riscv_instr          srli_instr;
+    riscv_instr          nop_instr;
+    riscv_instr          cfg_csrrw_instr;
+
+    // Inserted stream will consist of five instructions
+    initialize_instr_list(5);
+
+    cfg_csrrw_instr = riscv_instr::get_instr(CSRRSI);
+    cfg_csrrw_instr.atomic = 1'b1;
+    cfg_csrrw_instr.has_label = 1'b0;
+    cfg_csrrw_instr.csr = PMPCFG0;
+    cfg_csrrw_instr.rd = '0;
+    cfg_csrrw_instr.imm_str = $sformatf("%0d", $urandom_range(16,23));
+
+    // Use a label to use it for setting pmpaddr CSR.
+    instr_label = $sformatf("na4_addr_stream_%0x", $urandom());
+
+    nop_instr = riscv_instr::get_instr(NOP);
+    nop_instr.label = instr_label;
+    nop_instr.has_label = 1'b1;
+    nop_instr.atomic = 1'b1;
+
+    // Load the address of the instruction after this whole stream
+    la_instr = riscv_pseudo_instr::type_id::create("la_instr");
+    la_instr.pseudo_instr_name = LA;
+    la_instr.has_label = 1'b0;
+    la_instr.atomic = 1'b1;
+    la_instr.imm_str           = $sformatf("%0s+16", instr_label);
+    la_instr.rd                = cfg.gpr[1];
+
+    srli_instr = riscv_instr::get_instr(SRLI);
+    srli_instr.has_label = 1'b0;
+    srli_instr.atomic = 1'b1;
+    srli_instr.rs1 = cfg.gpr[1];
+    srli_instr.rd = cfg.gpr[1];
+    srli_instr.imm_str = $sformatf("2");
+
+    addr_csrrw_instr = riscv_instr::get_instr(CSRRW);
+    addr_csrrw_instr.has_label = 1'b0;
+    addr_csrrw_instr.atomic = 1'b1;
+    addr_csrrw_instr.csr = PMPADDR0;
+    addr_csrrw_instr.rs1 = cfg.gpr[1];
+    addr_csrrw_instr.rd = '0;
+    instr_list = {cfg_csrrw_instr, nop_instr, la_instr, srli_instr, addr_csrrw_instr};
+  endfunction
+
+endclass

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -786,6 +786,7 @@
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000
+    +set_mstatus_mprv=1
     +pmp_randomize=1
     +pmp_max_offset=00040000
     +pmp_allow_illegal_tor=1

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -794,7 +794,8 @@
     +directed_instr_1=riscv_load_store_hazard_instr_stream,40
     +directed_instr_2=riscv_multi_page_load_store_instr_stream,40
     +directed_instr_3=riscv_load_store_rand_addr_instr_stream,40
-    +directed_instr_4=ibex_rand_mseccfg_stream,10
+    +directed_instr_4=ibex_rand_mseccfg_stream,1
+    +directed_instr_6=ibex_valid_na4_stream,20
   sim_opts: >
     +is_double_fault_detected_fatal=0
     +enable_bad_intg_on_uninit_access=0

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -793,6 +793,7 @@
     +directed_instr_1=riscv_load_store_hazard_instr_stream,40
     +directed_instr_2=riscv_multi_page_load_store_instr_stream,40
     +directed_instr_3=riscv_load_store_rand_addr_instr_stream,40
+    +directed_instr_4=ibex_rand_mseccfg_stream,10
   sim_opts: >
     +is_double_fault_detected_fatal=0
     +enable_bad_intg_on_uninit_access=0


### PR DESCRIPTION
The main idea is to see some writes to `mseccfg` CSR while operating on the `pmp_full_random test` to enhance our stimulus generation and see coverage increases around sticky bit features + some no region match crosses.

Also now we enable randomising `mstatus.mprv` bit in `pmp_full_random_test` with second commit which should improve the coverage on `mprv_effect_cross`

Third commit is about increasing coverage in pmpcfg0 region, enables us to see NA4 region getting configured for instruction channel with randomised execute access.

Note that these changes reduces the pass rate while increasing the coverage.