### PR TITLE
[dv] Small rework to UVM env to fixup reset handling

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_agent.sv
+++ b/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_agent.sv
@@ -67,4 +67,14 @@ class ibex_cosim_agent extends uvm_agent;
     end
   endfunction
 
+  function void reset();
+    scoreboard.rvfi_port.flush();
+    scoreboard.dmem_port.flush();
+    scoreboard.imem_port.flush();
+    scoreboard.ifetch_port.flush();
+    scoreboard.ifetch_pmp_port.flush();
+
+    scoreboard.reset_e.trigger();
+  endfunction : reset
+
 endclass : ibex_cosim_agent

--- a/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_agent.sv
+++ b/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_agent.sv
@@ -51,4 +51,20 @@ class ibex_cosim_agent extends uvm_agent;
       d = d >> 8;
     end
   endfunction
+
+  // Backdoor-load the test binary file into the cosim memory model
+  function void load_binary_to_mem(bit[31:0] base_addr, string bin);
+     bit [7:0]   r8;
+     bit [31:0]  addr = base_addr;
+     int         bin_fd;
+    bin_fd = $fopen(bin,"rb");
+    if (!bin_fd)
+      `uvm_fatal(get_full_name(), $sformatf("Cannot open file %0s", bin))
+    while ($fread(r8,bin_fd)) begin
+      `uvm_info(`gfn, $sformatf("Init mem [0x%h] = 0x%0h", addr, r8), UVM_FULL)
+      write_mem_byte(addr, r8);
+      addr++;
+    end
+  endfunction
+
 endclass : ibex_cosim_agent

--- a/dv/uvm/core_ibex/env/core_ibex_env.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_env.sv
@@ -68,6 +68,7 @@ class core_ibex_env extends uvm_env;
   function void reset();
     data_if_response_agent.reset();
     instr_if_response_agent.reset();
+    cosim_agent.reset();
   endfunction
 
 endclass

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -15,6 +15,7 @@ class core_ibex_base_test extends uvm_test;
   virtual core_ibex_csr_if                        csr_vif;
   mem_model_pkg::mem_model                        mem;
   core_ibex_vseq                                  vseq;
+  string                                          binary;
   bit                                             enable_irq_seq;
   longint                                         timeout_seconds = 1800; // wall-clock seconds
   int unsigned                                    timeout_in_cycles = 100000000;
@@ -173,7 +174,13 @@ class core_ibex_base_test extends uvm_test;
     cur_run_phase = phase;
     dut_vif.dut_cb.fetch_enable <= ibex_pkg::IbexMuBiOff;
     clk_vif.wait_clks(100);
-    load_binary_to_mem();
+
+    void'($value$plusargs("bin=%0s", binary));
+    if (binary == "")
+      `uvm_fatal(get_full_name(), "Please specify test binary by +bin=binary_name")
+    load_binary_to_mems();
+    `uvm_info(get_full_name(), $sformatf("Running test : %0s", binary), UVM_LOW)
+
     dut_vif.dut_cb.fetch_enable <= ibex_pkg::IbexMuBiOn;
     send_stimulus();
     wait_for_test_done();
@@ -198,24 +205,11 @@ class core_ibex_base_test extends uvm_test;
   virtual task check_perf_stats();
   endtask
 
-  function void load_binary_to_mem();
-    string      bin;
-    bit [7:0]   r8;
+  // Backdoor-load the test binary file into the memory models of both the DUT and the cosimulated ISS
+  function void load_binary_to_mems();
     bit [31:0]  addr = 32'h`BOOT_ADDR;
-    int         f_bin;
-    void'($value$plusargs("bin=%0s", bin));
-    if (bin == "")
-      `uvm_fatal(get_full_name(), "Please specify test binary by +bin=binary_name")
-    `uvm_info(get_full_name(), $sformatf("Running test : %0s", bin), UVM_LOW)
-    f_bin = $fopen(bin,"rb");
-    if (!f_bin)
-      `uvm_fatal(get_full_name(), $sformatf("Cannot open file %0s", bin))
-    while ($fread(r8,f_bin)) begin
-      `uvm_info(`gfn, $sformatf("Init mem [0x%h] = 0x%0h", addr, r8), UVM_FULL)
-      mem.write(addr, r8);                      // Populate RTL memory model
-      env.cosim_agent.write_mem_byte(addr, r8); // Populate ISS memory model
-      addr++;
-    end
+    vseq.load_binary_to_mem(addr, binary);            // Populate RTL memory model
+    env.cosim_agent.load_binary_to_mem(addr, binary); // Populate ISS memory model
   endfunction
 
   // Watch for all of the different critera for test pass/failure here

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -179,10 +179,13 @@ class core_ibex_base_test extends uvm_test;
     if (binary == "")
       `uvm_fatal(get_full_name(), "Please specify test binary by +bin=binary_name")
     load_binary_to_mems();
-    `uvm_info(get_full_name(), $sformatf("Running test : %0s", binary), UVM_LOW)
+    `uvm_info(get_full_name(), $sformatf("Running test binary : %0s", binary), UVM_LOW)
 
     dut_vif.dut_cb.fetch_enable <= ibex_pkg::IbexMuBiOn;
-    send_stimulus();
+    fork
+      send_stimulus();
+      handle_reset();
+    join_none
     wait_for_test_done();
     cur_run_phase = null;
     phase.drop_objection(this);
@@ -208,9 +211,44 @@ class core_ibex_base_test extends uvm_test;
   // Backdoor-load the test binary file into the memory models of both the DUT and the cosimulated ISS
   function void load_binary_to_mems();
     bit [31:0]  addr = 32'h`BOOT_ADDR;
-    vseq.load_binary_to_mem(addr, binary);            // Populate RTL memory model
+    load_binary_to_dut_mem(addr, binary);             // Populate RTL memory model
     env.cosim_agent.load_binary_to_mem(addr, binary); // Populate ISS memory model
   endfunction
+
+  // Backdoor-load the test binary file into the DUT memory model
+  function void load_binary_to_dut_mem(bit[31:0] base_addr, string bin);
+     bit [7:0]  r8;
+     bit [31:0] addr = base_addr;
+     int        bin_fd;
+    bin_fd = $fopen(bin,"rb");
+    if (!bin_fd)
+      `uvm_fatal(get_full_name(), $sformatf("Cannot open file %0s", bin))
+    while ($fread(r8, bin_fd)) begin
+      `uvm_info(`gfn, $sformatf("Init mem [0x%h] = 0x%0h", addr, r8), UVM_FULL)
+      mem.write(addr, r8);
+      addr++;
+    end
+  endfunction
+
+  // Monitor the reset line, and sequence the resetting of the testbench environment
+  virtual task handle_reset();
+    forever begin
+      @(posedge dut_vif.reset);
+      `uvm_info(`gfn, "Reset now active", UVM_LOW)
+      // Tear-down testbench components
+      // Flush FIFOs
+      item_collected_port.flush();
+      irq_collected_port.flush();
+
+      @(negedge dut_vif.reset);
+      `uvm_info(`gfn, "Reset now inactive", UVM_LOW)
+      // Build-up testbench components
+
+      // Cosim must be re-initialized before loading the memory
+      env.reset();
+      load_binary_to_mems(); // Backdoor-load, 0-time
+    end
+  endtask : handle_reset
 
   // Watch for all of the different critera for test pass/failure here
   virtual task wait_for_test_done();

--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -36,7 +36,7 @@ class core_ibex_reset_test extends core_ibex_base_test;
           irq_collected_port.flush();
           // Reset testbench state
           env.reset();
-          load_binary_to_mem();
+          load_binary_to_mems();
         end
       join
       // Assert fetch_enable to have the core start executing from boot address

--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -24,22 +24,9 @@ class core_ibex_reset_test extends core_ibex_base_test;
     for (int i = 0; i < num_reset; i = i + 1) begin
       // Mid-test reset is possible in a wide range of times
       clk_vif.wait_clks($urandom_range(0, 50000));
-      fork
-        begin
-          dut_vif.dut_cb.fetch_enable <= ibex_pkg::IbexMuBiOff;
-          clk_vif.apply_reset(.reset_width_clks (100));
-        end
-        begin
-          clk_vif.wait_clks(1);
-          // Flush FIFOs
-          item_collected_port.flush();
-          irq_collected_port.flush();
-          // Reset testbench state
-          env.reset();
-          load_binary_to_mems();
-        end
-      join
-      // Assert fetch_enable to have the core start executing from boot address
+
+      dut_vif.dut_cb.fetch_enable <= ibex_pkg::IbexMuBiOff;
+      clk_vif.apply_reset(.reset_width_clks (100));
       dut_vif.dut_cb.fetch_enable <= ibex_pkg::IbexMuBiOn;
     end
   endtask

--- a/dv/uvm/core_ibex/tests/core_ibex_vseq.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_vseq.sv
@@ -31,6 +31,21 @@ class core_ibex_vseq extends uvm_sequence;
     data_intf_seq.is_dmem_seq = 1'b1;
   endfunction
 
+  // Backdoor-load the test binary file into the DUT memory model
+  function void load_binary_to_mem(bit[31:0] base_addr, string bin);
+    bit [7:0]  r8;
+    bit [31:0] addr = base_addr;
+    int        bin_fd;
+    bin_fd = $fopen(bin,"rb");
+    if (!bin_fd)
+      `uvm_fatal(get_full_name(), $sformatf("Cannot open file %0s", bin))
+    while ($fread(r8, bin_fd)) begin
+      `uvm_info(`gfn, $sformatf("Init mem [0x%h] = 0x%0h", addr, r8), UVM_FULL)
+      mem.write(addr, r8);
+      addr++;
+    end
+  endfunction
+
   // Start the memory-model sequences, which run forever() loops to respond to bus events
   virtual task pre_body();
     instr_intf_seq.m_mem = mem;

--- a/dv/uvm/core_ibex/tests/core_ibex_vseq.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_vseq.sv
@@ -31,21 +31,6 @@ class core_ibex_vseq extends uvm_sequence;
     data_intf_seq.is_dmem_seq = 1'b1;
   endfunction
 
-  // Backdoor-load the test binary file into the DUT memory model
-  function void load_binary_to_mem(bit[31:0] base_addr, string bin);
-    bit [7:0]  r8;
-    bit [31:0] addr = base_addr;
-    int        bin_fd;
-    bin_fd = $fopen(bin,"rb");
-    if (!bin_fd)
-      `uvm_fatal(get_full_name(), $sformatf("Cannot open file %0s", bin))
-    while ($fread(r8, bin_fd)) begin
-      `uvm_info(`gfn, $sformatf("Init mem [0x%h] = 0x%0h", addr, r8), UVM_FULL)
-      mem.write(addr, r8);
-      addr++;
-    end
-  endfunction
-
   // Start the memory-model sequences, which run forever() loops to respond to bus events
   virtual task pre_body();
     instr_intf_seq.m_mem = mem;


### PR DESCRIPTION
Slightly refactor the reset handling to allow a single routine in the base_test to sequence the bring-up of the testbench components after a reset. This ensures a deterministic bring-up of the testbench env, for example, that the cosim agent has it's memory-model reloaded with the test binary after it has been re-initialized (ie. free'd and re-built).

This is by no-means a perfect solution, but a small improvement to get the `riscv_reset_test` working reliably , which applies on-the-fly reset stimulus. A more idiomatic UVM solution could be applied in the future, using e.g. OT for reference.

Closes #1775 