### PR TITLE
Increase iterations for PMP tests to improve coverage

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -709,7 +709,7 @@
     Basic PMP test - all PMP regions will be configured to default setting,
     enabling all forms of accesses, expect that no exception will be thrown.
     Randomize mstatus.mprv.
-  iterations: 10
+  iterations: 50
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000
@@ -720,6 +720,7 @@
   rtl_test: core_ibex_base_test
   rtl_params:
     PMPEnable: 1
+  timeout_s: 300
 
 - test: riscv_pmp_disable_all_regions_test
   desc: >
@@ -727,7 +728,7 @@
     and randomize mstatus.mprv.
     Expect that all appropriate faults are taken, and that the core
     finishes executing successfully.
-  iterations: 20
+  iterations: 50
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000
@@ -753,13 +754,14 @@
   rtl_test: core_ibex_base_test
   rtl_params:
     PMPEnable: 1
+  timeout_s: 300
 
 - test: riscv_pmp_out_of_bounds_test
   desc: >
     Default PMP settings - enable all regions with full permissions.
     Randomize mstatus.mprv and the boot mode.
     Insert streams of memory instructions that access addresses out of PMP boundaries.
-  iterations: 25
+  iterations: 50
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000
@@ -769,13 +771,12 @@
     +directed_instr_0=riscv_load_store_rand_addr_instr_stream,50
     +mseccfg=MML:0,MMWP:0,RLB:0
   rtl_test: core_ibex_base_test
-  sim_opts: >
-    +enable_bad_intg_on_uninit_access=0
   rtl_params:
     PMPEnable: 1
   sim_opts: >
     +is_double_fault_detected_fatal=0
     +enable_bad_intg_on_uninit_access=0
+  timeout_s: 300
 
 - test: riscv_pmp_full_random_test
   desc: >
@@ -783,7 +784,7 @@
     and allow PMP regions to overlap.
     A large number of iterations will be required since this introduces a huge
     state space of configurations.
-  iterations: 20
+  iterations: 600
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000
@@ -808,7 +809,7 @@
     regions are set to execute only in both M and U modes. All other regions
     are set to read/write only. Exceptions when reading/writing code or
     executing data. Randomize mstatus.mprv.
-  iterations: 3
+  iterations: 20
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000
@@ -835,13 +836,14 @@
   rtl_test: core_ibex_base_test
   rtl_params:
     PMPEnable: 1
+  timeout_s: 300
 
 - test: riscv_epmp_mml_execute_only_test
   desc: >
     An enhanced PMP machine mode lockdown test - all PMP regions are set to
     execute only. Exception is expected on any store or load. Randomize
     mstatus.mprv.
-  iterations: 3
+  iterations: 20
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000
@@ -870,13 +872,14 @@
     PMPEnable: 1
   sim_opts: >
     +is_double_fault_detected_fatal=0
+  timeout_s: 300
 
 - test: riscv_epmp_mml_read_only_test
   desc: >
     An enhanced PMP machine mode lockdown test - all PMP regions are set to
     shared read only. Exception is expected right after enabling MML. Randomize
     mstatus.mprv.
-  iterations: 3
+  iterations: 20
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000
@@ -905,6 +908,7 @@
   rtl_test: core_ibex_base_test
   rtl_params:
     PMPEnable: 1
+  timeout_s: 300
 
 - test: riscv_epmp_mmwp_test
   desc: >
@@ -912,7 +916,7 @@
     configured to default setting, enabling all forms of accesses, expect that
     an exception when machine mode access memory not in PMP. Randomize
     mstatus.mprv.
-  iterations: 3
+  iterations: 20
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000
@@ -925,13 +929,14 @@
     PMPEnable: 1
   sim_opts: >
     +is_double_fault_detected_fatal=0
+  timeout_s: 300
 
 - test: riscv_epmp_rlb_test
   desc: >
     An enhanced PMP rule lock bypass - all PMP regions are locked and enable
     all forms of accesses, expect that no exception will be thrown even when
     trying to change locked entries. Randomize mstatus.mprv.
-  iterations: 3
+  iterations: 20
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +instr_cnt=6000
@@ -958,6 +963,7 @@
   rtl_test: core_ibex_base_test
   rtl_params:
     PMPEnable: 1
+  timeout_s: 300
 
 # Both an updated compiler and ISS are required to verify the bitmanip v.1.00
 # and draft v.0.93 extensions. For now, disable the bitmanip tests.


### PR DESCRIPTION
Requires the fixes in #1890 , else the coverage will fail to merge.

With the latest changes in #1886 , we achieve the following coverage on a nightly regression...
```
name                                                CoverGroup Average   CoverGroup Covered   
-----------------------------------------           ------------------------------------------
riscv_instr_pkg                                     72.57%               66.17% (7498/11331)  
push_pull_agent_pkg                                 100.00%              100.00% (3/3)        
core_ibex_fcov_if                                   92.05%               46.68% (1095/2346)   
core_ibex_pmp_fcov_if.g_pmp_cgs_T                   90.00%               80.85% (76/94)       
core_ibex_pmp_fcov_if.g_pmp_cgs_T.g_pmp_region_fcov 92.08%               71.65% (235/328)     

```