### PR TITLE
[dv] Add missing isolation forks

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_monitor.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_monitor.sv
@@ -30,13 +30,15 @@ class ibex_mem_intf_monitor extends uvm_monitor;
   virtual task run_phase(uvm_phase phase);
     wait (vif.monitor_cb.reset === 1'b0);
     forever begin
-      fork : check_mem_intf
-        collect_address_phase();
-        collect_response_phase();
-        wait (vif.monitor_cb.reset === 1'b1);
-      join_any
-      // Will only reach this point when mid-test reset is asserted
-      disable fork;
+      fork begin : isolation_fork
+        fork : check_mem_intf
+          collect_address_phase();
+          collect_response_phase();
+          wait (vif.monitor_cb.reset === 1'b1);
+        join_any
+        // Will only reach this point when mid-test reset is asserted
+        disable fork;
+      end join
       handle_reset();
     end
   endtask : run_phase

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_driver.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_driver.sv
@@ -24,13 +24,15 @@ class ibex_mem_intf_response_driver extends uvm_driver #(ibex_mem_intf_seq_item)
     reset_signals();
     wait (cfg.vif.response_driver_cb.reset === 1'b0);
     forever begin
-      fork : drive_stimulus
-        send_grant();
-        get_and_drive();
-        wait (cfg.vif.response_driver_cb.reset === 1'b1);
-      join_any
-      // Will only be reached after mid-test reset
-      disable fork;
+      fork begin : isolation_fork
+        fork : drive_stimulus
+          send_grant();
+          get_and_drive();
+          wait (cfg.vif.response_driver_cb.reset === 1'b1);
+        join_any
+        // Will only be reached after mid-test reset
+        disable fork;
+      end join
       handle_reset();
     end
   endtask : run_phase

--- a/dv/uvm/core_ibex/common/irq_agent/irq_monitor.sv
+++ b/dv/uvm/core_ibex/common/irq_agent/irq_monitor.sv
@@ -24,12 +24,14 @@ class irq_monitor extends uvm_monitor;
   virtual task run_phase(uvm_phase phase);
     forever begin
       wait (vif.monitor_cb.reset === 1'b0);
-      fork : monitor_irq
-        collect_irq();
-        wait (vif.monitor_cb.reset === 1'b1);
-      join_any
-      // Will only reach here on mid-test reset
-      disable fork;
+      fork begin : isolation_fork
+        fork : monitor_irq
+          collect_irq();
+          wait (vif.monitor_cb.reset === 1'b1);
+        join_any
+        // Will only reach here on mid-test reset
+        disable fork;
+      end join
     end
   endtask : run_phase
 

--- a/dv/uvm/core_ibex/env/core_ibex_scoreboard.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_scoreboard.sv
@@ -89,23 +89,25 @@ class core_ibex_scoreboard extends uvm_scoreboard;
 
   // Helper method which returns if either of the counter thresholds are reached.
   virtual task dfd_wait_for_pass_events();
-    fork
-      begin
-        fault_threshold_total_reached.wait_trigger();
-        `uvm_info(`gfn,
-                  $sformatf({"double_fault detector : reached threshold [%0d] ",
-                             "for total double faults seen."}, cfg.double_fault_threshold_total),
-                  UVM_LOW)
-      end
-      begin
-        fault_threshold_consecutive_reached.wait_trigger();
-        `uvm_info(`gfn,
-                  $sformatf({"double_fault detector : reached threshold [%0d] ",
-                             "for consecutive double faults seen."}, cfg.double_fault_threshold_consecutive),
-                  UVM_LOW)
-      end
-    join_any
-    disable fork;
+    fork begin : isolation_fork
+      fork
+        begin
+          fault_threshold_total_reached.wait_trigger();
+          `uvm_info(`gfn,
+                    $sformatf({"double_fault detector : reached threshold [%0d] ",
+                               "for total double faults seen."}, cfg.double_fault_threshold_total),
+                    UVM_LOW)
+        end
+        begin
+          fault_threshold_consecutive_reached.wait_trigger();
+          `uvm_info(`gfn,
+                    $sformatf({"double_fault detector : reached threshold [%0d] ",
+                               "for consecutive double faults seen."}, cfg.double_fault_threshold_consecutive),
+                    UVM_LOW)
+        end
+      join_any
+      disable fork;
+    end join
   endtask
 
 endclass


### PR DESCRIPTION
The isolation fork ensures the `disable fork` only effects the processes inside the isolation fork. Without it it may terminate other processes that weren't intended to be killed.