### PR TITLE
[xlm] Enable access to signals without dumping waves

### DIFF
--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -241,6 +241,7 @@
         -elaborate
         -l <tb_build_log>
         -xmlibdirpath <tb_dir>
+        -access rw
         <cmp_opts> <cov_opts> <wave_opts> <cosim_opts>
     cov_opts: >
       -coverage all


### PR DESCRIPTION
The `-access rw` option allows Xcelium to access signals in the design (e.g., with `uvm_hdl_read` or `uvm_hdl_force`) without having to dump waves (which substantially increases the run time).  See [1] for the background discussion.

[1]: https://github.com/lowRISC/ibex/pull/1879#issuecomment-1300216022