### PR TITLE
[dv] functional coverpoints for interrupts, exceptions with mstatus.MIE

### DIFF
--- a/dv/uvm/core_ibex/fcov/core_ibex_fcov_if.sv
+++ b/dv/uvm/core_ibex/fcov/core_ibex_fcov_if.sv
@@ -590,6 +590,21 @@ interface core_ibex_fcov_if import ibex_pkg::*; (
         binsof(cp_priv_mode_id) intersect {PRIV_LVL_U};
     }
 
+    priv_mode_irq_cross: cross cp_priv_mode_id, cp_interrupt_taken, cs_registers_i.mstatus_q.mie {
+      // No interrupt would be taken in M-mode when its mstatus.MIE = 0
+      illegal_bins mmode_mstatus_mie =
+        binsof(cs_registers_i.mstatus_q.mie) intersect {1'b0} &&
+        binsof(cp_priv_mode_id) intersect {PRIV_LVL_M};
+    }
+
+    priv_mode_exception_cross: cross cp_priv_mode_id, cp_ls_pmp_exception, cp_ls_error_exception {
+      illegal_bins pmp_and_error_exeption_both_or_none =
+        (binsof(cp_ls_pmp_exception) intersect {1'b1} &&
+         binsof(cp_ls_error_exception) intersect {1'b1}) ||
+        (binsof(cp_ls_pmp_exception) intersect {1'b0} &&
+         binsof(cp_ls_error_exception) intersect {1'b0});
+    }
+
     stall_cross: cross cp_id_instr_category, cp_stall_type_id {
       illegal_bins illegal =
         // Only Div, Mul, Branch and Jump instructions can see an instruction stall

--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -678,7 +678,10 @@ class core_ibex_debug_intr_basic_test extends core_ibex_base_test;
     wait_for_csr_write(CSR_MSTATUS, 5000);
     mstatus = signature_data;
     `DV_CHECK_EQ_FATAL(mstatus[12:11], select_mode(), "Incorrect mstatus.mpp")
-    `DV_CHECK_EQ_FATAL(mstatus[7], 1'b1, "mstatus.mpie was not set to 1'b1 after entering handler")
+    // mstatus.MPIE must be 1 when trap from M mode otherwise not necessarily be 1
+    // as lower priv modes could trap when mstatus.MPIE is 0
+    `DV_CHECK_EQ_FATAL(mstatus[7] | ~&mstatus[12:11], 1'b1,
+        "mstatus.mpie was not set to 1'b1 after entering handler")
     `DV_CHECK_EQ_FATAL(mstatus[3], 1'b0, "mstatus.mie was not set to 1'b0 after entering handler")
     // check mcause against the interrupt id
     check_mcause(1'b1, irq_id);

--- a/ibex_top.core
+++ b/ibex_top.core
@@ -131,7 +131,7 @@ parameters:
     datatype: int
     default: 0
     paramtype: vlogparam
-    description: "Granularity of NAPOT range, 0 = 4 byte, 1 = byte, 2 = 16 byte, 3 = 32 byte etc"
+    description: "Granularity of NAPOT range, 0 = 4 byte, 1 = 8 byte, 2 = 16 byte, 3 = 32 byte etc"
 
   PMPNumRegions:
     datatype: int


### PR DESCRIPTION
**Modifications:**

- Added functional coverpoints for interrupts and exceptions crossed with mstatus.MIE
- Fixed the check for MPIE on entering handler after taking an interrupt - when taking an interrupt from lower mode, mstatus.MIE is not necessarily to be 1 and hence MPIE is not supposed to be 1 on entering handler
- a minor typo fix in description of granularity

Issue: https://github.com/lowRISC/ibex/issues/1825