### PR TITLE
[dv] fixed uvm check for mstatus.MPIE when interrupt is nmi

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -679,8 +679,8 @@ class core_ibex_debug_intr_basic_test extends core_ibex_base_test;
     mstatus = signature_data;
     `DV_CHECK_EQ_FATAL(mstatus[12:11], select_mode(), "Incorrect mstatus.mpp")
     // mstatus.MPIE must be 1 when trap from M mode otherwise not necessarily be 1
-    // as lower priv modes could trap when mstatus.MPIE is 0
-    `DV_CHECK_EQ_FATAL(mstatus[7] | ~&mstatus[12:11], 1'b1,
+    // as lower priv modes could trap when mstatus.MPIE is 0, or even nmi interrupt
+    `DV_CHECK_EQ_FATAL(mstatus[7] | ~&mstatus[12:11] | (irq_id == ExcCauseIrqNm.lower_cause), 1'b1,
         "mstatus.mpie was not set to 1'b1 after entering handler")
     `DV_CHECK_EQ_FATAL(mstatus[3], 1'b0, "mstatus.mie was not set to 1'b0 after entering handler")
     // check mcause against the interrupt id


### PR DESCRIPTION
When interrupt taken is nmi, then MPIE might not necessarily be 1, so modifying the condition with the check when cause code is nmi, this check would be ignored.

A test in CI pipeline was failing due to this, now its passed.