### PR TITLE
Update google_riscv-dv to google/riscv-dv@d7c50c1

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: be9c75fe6911504c0e6e9b89dc2a7766e367c500
+    rev: d7c50c1eb9abe85bd6673878fe2e98489cf5f07e
   }
 }

--- a/vendor/google_riscv-dv/src/isa/riscv_compressed_instr.sv
+++ b/vendor/google_riscv-dv/src/isa/riscv_compressed_instr.sv
@@ -314,7 +314,7 @@ class riscv_compressed_instr extends riscv_instr;
       C_EBREAK:
         binary = $sformatf("%4h", {get_func3(), 1'b1, 10'b0, get_c_opcode()});
       C_JALR:
-        binary = $sformatf("%4h", {get_func3(), 1'b1, 10'b0, get_c_opcode()});
+        binary = $sformatf("%4h", {get_func3(), 1'b1, rs1, 5'b0, get_c_opcode()});
       C_ADD:
         binary = $sformatf("%4h", {get_func3(), 1'b1, rd, rs2, get_c_opcode()});
       C_SDSP:

--- a/vendor/google_riscv-dv/src/isa/riscv_zbb_instr.sv
+++ b/vendor/google_riscv-dv/src/isa/riscv_zbb_instr.sv
@@ -238,4 +238,17 @@ class riscv_zbb_instr extends riscv_instr;
            });
   endfunction : is_supported
 
+  virtual function void update_src_regs(string operands[$]);
+    // All ZBB I_FORMAT instructions other than RORI use the immediate to specify the operation,
+    // rather than being an explicit operand. Handle this case here, otherwise use the normal
+    // `update_src_regs`
+    if ((format == I_FORMAT) && (instr_name != RORI)) begin
+      `DV_CHECK_FATAL(operands.size() == 2, instr_name)
+      rs1 = get_gpr(operands[1]);
+      rs1_value = get_gpr_state(operands[1]);
+    end else begin
+      super.update_src_regs(operands);
+    end
+  endfunction : update_src_regs
+
 endclass : riscv_zbb_instr

--- a/vendor/google_riscv-dv/test/riscv_instr_cov_test.sv
+++ b/vendor/google_riscv-dv/test/riscv_instr_cov_test.sv
@@ -137,7 +137,9 @@ class riscv_instr_cov_test extends uvm_test;
         riscv_instr instr;
         instr = riscv_instr::get_instr(instr_name);
         if ((instr.group inside {RV32I, RV32M, RV32C, RV64I, RV64M, RV64C,
-                                 RV32F, RV64F, RV32D, RV64D, RV32B, RV64B}) &&
+                                 RV32F, RV64F, RV32D, RV64D, RV32B, RV64B,
+                                 RV32ZBA, RV32ZBB, RV32ZBC, RV32ZBS,
+                                 RV64ZBA, RV64ZBB, RV64ZBC, RV64ZBS}) &&
             (instr.group inside {supported_isa})) begin
           assign_trace_info_to_instr(instr);
           instr.pre_sample();


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv- dv to revision d7c50c1eb9abe85bd6673878fe2e98489cf5f07e

* Fix `update_src_regs` for ZBB (Greg Chadwick)
* Sample bitmanip instruction coverage (Greg Chadwick)
* Fix for issue google/riscv-dv#826, illegal rs1 in C_JALR (Henrik Fegran)

Signed-off-by: Greg Chadwick <gac@lowrisc.org>