### PR TITLE
[dv] Add instruction stream to toggle Ibex specific features

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -138,6 +138,9 @@
     +no_fence=1
     +num_of_sub_program=0
     +randomize_csr=1
+    +directed_instr_0=ibex_rand_cpuctrlsts_stream,4
+    +toggle_dit=1
+    +toggle_dummy_instr=1
   rtl_test: core_ibex_debug_intr_basic_test
   sim_opts: >
     +require_signature_addr=1
@@ -435,6 +438,9 @@
     +enable_interrupt=1
     +enable_timer_irq=1
     +randomize_csr=1
+    +directed_instr_0=ibex_rand_cpuctrlsts_stream,4
+    +toggle_dit=1
+    +toggle_dummy_instr=1
   rtl_test: core_ibex_debug_intr_basic_test
   sim_opts: >
     +require_signature_addr=1


### PR DESCRIPTION
It randomly writes to fields of cpuctrlsts to enable and disable data independent timing, dummy instruction insertion and the icache. This is used in riscv_debug_basic_test and riscv_single_interrupt_test to see interrupts and debug requests when dummy instruction insertion and data independent timing is enabled.