### PR TITLE
Update google_riscv-dv to google/riscv-dv@68ab823

### DIFF
--- a/vendor/google_riscv-dv.lock.hjson
+++ b/vendor/google_riscv-dv.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/google/riscv-dv
-    rev: d7c50c1eb9abe85bd6673878fe2e98489cf5f07e
+    rev: 68ab8230c52ec66b393c04394aef4d6082ee53b4
   }
 }

--- a/vendor/google_riscv-dv/src/riscv_privileged_common_seq.sv
+++ b/vendor/google_riscv-dv/src/riscv_privileged_common_seq.sv
@@ -20,6 +20,7 @@ class riscv_privileged_common_seq extends uvm_sequence;
   riscv_instr_gen_config  cfg;
   int                     hart;
   riscv_privil_reg        mstatus;
+  rand bit                mstatus_mie;
   riscv_privil_reg        mie;
   riscv_privil_reg        sstatus;
   riscv_privil_reg        sie;
@@ -88,7 +89,12 @@ class riscv_privileged_common_seq extends uvm_sequence;
     mstatus.set_field("MPP", mode);
     mstatus.set_field("SPP", 0);
     // Enable interrupt
-    mstatus.set_field("MPIE", cfg.enable_interrupt);
+    // Only machine mode requires mstatus.MIE to be 1 for enabling interrupt
+    if (mode == MACHINE_MODE) begin
+      mstatus.set_field("MPIE", cfg.enable_interrupt);
+    end else begin
+      mstatus.set_field("MPIE", cfg.enable_interrupt & mstatus_mie);
+    end
     // MIE is set when returning with mret, avoids trapping before returning
     mstatus.set_field("MIE", 0);
     mstatus.set_field("SPIE", cfg.enable_interrupt);


### PR DESCRIPTION
Update code from upstream repository https://github.com/google/riscv- dv to revision 68ab8230c52ec66b393c04394aef4d6082ee53b4

* [pmp] Ensure MML PMP configurations don't dominate. (Greg Chadwick)
* [pmp] Add option to constrain addresses to stay in 32-bit space (Greg Chadwick)
* randomizing mstatus.MIE when priv mode is lower than machine (Saad Khalid)

Signed-off-by: Greg Chadwick <gac@lowrisc.org>