### PR TITLE
[python-requirements] Pin setuptools version to < 66.0.0

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -69,7 +69,7 @@ case "$ID-$VERSION_ID" in
     # an older version of a package must be used for a certain Python version.
     # If that information is not read, pip installs the latest version, which
     # then fails to run.
-    $SUDO_CMD pip3 install -U pip setuptools
+    $SUDO_CMD pip3 install -U pip "setuptools<66.0.0"
 
     $SUDO_CMD pip3 install -r python-requirements.txt
 


### PR DESCRIPTION
Starting with setuptools version 66.0.0, legacy package version names such as 0.23ubuntu1 are no longer supported. Since some of our Python dependencies use this format, we pin the setuptools version to the last version before this change. This unblocks CI and gives us time to upgrade/rebase our dependencies.
