### PR TITLE
run directed tests along with random when given TEST=all

### DIFF
--- a/dv/uvm/core_ibex/scripts/metadata.py
+++ b/dv/uvm/core_ibex/scripts/metadata.py
@@ -315,7 +315,7 @@ class RegressionMetadata(scripts_lib.testdata_cls):
         matched_list: ibex_cmd._TestEntries = []
         for entry in m.get('tests'):
             select_test = any(x in self.test.split(',')
-                              for x in ['all_directed', entry.get('test')])
+                              for x in ['all_directed', 'all', entry.get('test')])
             if select_test:
                 entry.update({'iterations': (self.iterations or entry['iterations'])})
                 if entry['iterations'] > 0:


### PR DESCRIPTION
When TEST=all, only riscv-dv random tests are running.

@hcallahan-lowrisc is this okay to run all tests (random and directed) with TEST=all? It would be useful for collecting overall coverage.