### PR TITLE
Directed test for PMP.LXWR transitions when mseccfg.mml is 1

### DIFF
--- a/dv/uvm/core_ibex/directed_tests/custom_macros.h
+++ b/dv/uvm/core_ibex/directed_tests/custom_macros.h
@@ -1,0 +1,117 @@
+#Copyright lowRISC contributors.
+#Licensed under the Apache License, Version 2.0, see LICENSE for details.
+#SPDX - License - Identifier : Apache - 2.0
+
+############################################################################## #
+
+#Reset PMP CSRs
+#define RESET_PMP     \
+  csrw pmpcfg0, x0;   \
+  csrw pmpcfg1, x0;   \
+  csrw pmpcfg2, x0;   \
+  csrw pmpcfg3, x0;   \
+  csrw pmpaddr0, x0;  \
+  csrw pmpaddr1, x0;  \
+  csrw pmpaddr2, x0;  \
+  csrw pmpaddr3, x0;  \
+  csrw pmpaddr4, x0;  \
+  csrw pmpaddr5, x0;  \
+  csrw pmpaddr6, x0;  \
+  csrw pmpaddr7, x0;  \
+  csrw pmpaddr8, x0;  \
+  csrw pmpaddr9, x0;  \
+  csrw pmpaddr10, x0; \
+  csrw pmpaddr11, x0; \
+  csrw pmpaddr12, x0; \
+  csrw pmpaddr13, x0; \
+  csrw pmpaddr14, x0; \
+  csrw pmpaddr15, x0; \
+  csrw CSR_MSECCFG, x0;
+
+#Calculate NAPOT addr by applying mask
+#define SET_NAPOT_ADDR(addr, gran) \
+  li t0, gran >> 3;                \
+  not t2, t0;                      \
+  la t1, addr;                     \
+  srli t1, t1, 2;                  \
+  and t1, t1, t2;                  \
+  addi t0, t0, -1;                 \
+  or t1, t1, t0;
+
+#Set pmp configuration CSR depending upon region
+#define SET_PMP_CFG(pmp_cfg, pmp_region) \
+  li t0, (8 * pmp_region) & 0x1f;        \
+  li t1, pmp_region;                     \
+  li t2, 3;                              \
+  bgt t1, t2, 1f;                        \
+  li t1, pmp_cfg;                        \
+  sll t1, t1, t0;                        \
+  csrw pmpcfg0, t1;                      \
+  j 4f;                                  \
+  1 : li t2, 7;                          \
+  bgt t1, t2, 2f;                        \
+  li t1, pmp_cfg;                        \
+  sll t1, t1, t0;                        \
+  csrw pmpcfg1, t1;                      \
+  2 : li t2, 11;                         \
+  bgt t1, t2, 3f;                        \
+  li t1, pmp_cfg;                        \
+  sll t1, t1, t0;                        \
+  csrw pmpcfg2, t1;                      \
+  3 : li t2, 15;                         \
+  bgt t1, t2, 4f;                        \
+  li t1, pmp_cfg;                        \
+  sll t1, t1, t0;                        \
+  csrw pmpcfg3, t1;                      \
+  4:
+
+#define SET_PMP_NAPOT(addr, gran, pmp_cfg, pmp_region) \
+  SET_NAPOT_ADDR(addr, gran);                          \
+  csrw pmpaddr##pmp_region, t1;                        \
+  SET_PMP_CFG(pmp_cfg, pmp_region);
+
+#define SET_PMP_TOR(addr_high, addr_low, pmp_cfg, pmp_region_high, \
+                    pmp_region_low)                                \
+  la t0, addr_low;                                                 \
+  srli t0, t0, 2;                                                  \
+  csrw pmpaddr##pmp_region_low, t0;                                \
+  la t0, addr_high;                                                \
+  srli t0, t0, 2;                                                  \
+  csrw pmpaddr##pmp_region_high, t0;                               \
+  SET_PMP_CFG(pmp_cfg, pmp_region_high);
+
+#define SET_PMP_TOR_ADDR_FROM_REG(addr_high, addr_low, pmp_cfg,    \
+                                  pmp_region_high, pmp_region_low) \
+  srli t0, addr_low, 2;                                            \
+  csrw pmpaddr##pmp_region_low, t0;                                \
+  srli t0, addr_high, 2;                                           \
+  csrw pmpaddr##pmp_region_high, t0;                               \
+  SET_PMP_CFG(pmp_cfg, pmp_region_high);
+
+#define SKIP_PC       \
+  csrr t0, mepc;      \
+  lb t1, 0(t0);       \
+  li t2, 0x3;         \
+  and t1, t1, t2;     \
+  bne t1, t2, 1f;     \
+  addi t0, t0, 2;     \
+  1 : addi t0, t0, 2; \
+  csrw mepc, t0;
+
+#Accesses at start, mid and end of PMP range
+#define RW_ACCESSES(pmp_addr, gran) \
+  la s0, pmp_addr;                  \
+  lw s1, 0(s0);                     \
+  sw s1, 0(s0);                     \
+  li s1, gran / 2;                  \
+  add s2, s0, s1;                   \
+  lw s1, 0(s2);                     \
+  sw s1, 0(s2);                     \
+  li s1, gran - 4;                  \
+  add s2, s0, s1;                   \
+  lw s1, 0(s2);                     \
+  sw s1, 0(s2);
+
+#define SET_MSECCFG(val) \
+  li t1, val;            \
+  csrs CSR_MSECCFG, t1;

--- a/dv/uvm/core_ibex/directed_tests/directed_testlist.yaml
+++ b/dv/uvm/core_ibex/directed_tests/directed_testlist.yaml
@@ -60,7 +60,7 @@
   test_srcs: empty/empty.S
   config: riscv-tests
 
-- test: pmp_mseccfg_test_rlb1_l0_0
+- test: pmp_mseccfg_test_rlb1_l0_0_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -72,7 +72,7 @@
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DPMP_REGION=4 -DRLB -DSET_PMP_L=0 -DSET_PMP_L_PREV=0
 
-- test: pmp_mseccfg_test_rlb1_l0_1
+- test: pmp_mseccfg_test_rlb1_l0_1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -84,7 +84,7 @@
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DPMP_REGION=4 -DRLB -DSET_PMP_L=1 -DSET_PMP_L_PREV=0
 
-- test: pmp_mseccfg_test_rlb1_l1_0
+- test: pmp_mseccfg_test_rlb1_l1_0_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -96,7 +96,7 @@
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DPMP_REGION=4 -DRLB -DSET_PMP_L=0 -DSET_PMP_L_PREV=1
 
-- test: pmp_mseccfg_test_rlb1_l1_1
+- test: pmp_mseccfg_test_rlb1_l1_1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -108,7 +108,7 @@
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DPMP_REGION=4 -DRLB -DSET_PMP_L=1 -DSET_PMP_L_PREV=1
 
-- test: pmp_mseccfg_test_rlb0_l0_0
+- test: pmp_mseccfg_test_rlb0_l0_0_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -120,7 +120,7 @@
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DPMP_REGION=4 -DSET_PMP_L=0 -DSET_PMP_L_PREV=0
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -132,7 +132,7 @@
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -144,7 +144,7 @@
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -156,7 +156,7 @@
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_W1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_x1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_x1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -168,7 +168,7 @@
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_X1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -180,7 +180,7 @@
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_W1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_x1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_x1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -192,7 +192,7 @@
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_X1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1_x1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1_x1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -204,7 +204,7 @@
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_W1_X1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1_x1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1_x1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -215,6 +215,162 @@
             -I../../../vendor/riscv-test-env/p/
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_W1_X1
+
+- test: pmp_mseccfg_test_rlb1_l0_0_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=0 -DSET_PMP_L_PREV=0 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb1_l0_1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb1_l1_0_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=0 -DSET_PMP_L_PREV=1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb1_l1_1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=1 -DSET_PMP_L_PREV=1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_0_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DSET_PMP_L=0 -DSET_PMP_L_PREV=0 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_W1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_x1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_X1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_W1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_x1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_X1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1_x1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_W1_X1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1_x1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_W1_X1 -DU_MODE
 
 - test: access_pmp_overlap
   desc: >

--- a/dv/uvm/core_ibex/directed_tests/directed_testlist.yaml
+++ b/dv/uvm/core_ibex/directed_tests/directed_testlist.yaml
@@ -60,6 +60,162 @@
   test_srcs: empty/empty.S
   config: riscv-tests
 
+- test: pmp_mseccfg_test_rlb1_l0_0
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=0 -DSET_PMP_L_PREV=0
+
+- test: pmp_mseccfg_test_rlb1_l0_1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=1 -DSET_PMP_L_PREV=0
+
+- test: pmp_mseccfg_test_rlb1_l1_0
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=0 -DSET_PMP_L_PREV=1
+
+- test: pmp_mseccfg_test_rlb1_l1_1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=1 -DSET_PMP_L_PREV=1
+
+- test: pmp_mseccfg_test_rlb0_l0_0
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DSET_PMP_L=0 -DSET_PMP_L_PREV=0
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_W1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_x1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_X1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_W1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_x1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_X1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1_x1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_W1_X1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1_x1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_W1_X1
+
 - test: access_pmp_overlap
   desc: >
     PMP access basic test

--- a/dv/uvm/core_ibex/directed_tests/empty/empty.S
+++ b/dv/uvm/core_ibex/directed_tests/empty/empty.S
@@ -1,3 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+###############################################################################
+# Description:
+#   Empty test to check the sanity of directed test flow. It can be used as a
+# sample test.
+
 #include "riscv_test.h"
 #include "test_macros.h"
 

--- a/dv/uvm/core_ibex/directed_tests/gen_testlist.py
+++ b/dv/uvm/core_ibex/directed_tests/gen_testlist.py
@@ -80,6 +80,162 @@ def add_configs_and_handwritten_directed_tests():
   test_srcs: empty/empty.S
   config: riscv-tests
 
+- test: pmp_mseccfg_test_rlb1_l0_0
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=0 -DSET_PMP_L_PREV=0
+
+- test: pmp_mseccfg_test_rlb1_l0_1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=1 -DSET_PMP_L_PREV=0
+
+- test: pmp_mseccfg_test_rlb1_l1_0
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=0 -DSET_PMP_L_PREV=1
+
+- test: pmp_mseccfg_test_rlb1_l1_1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=1 -DSET_PMP_L_PREV=1
+
+- test: pmp_mseccfg_test_rlb0_l0_0
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DSET_PMP_L=0 -DSET_PMP_L_PREV=0
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_W1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_x1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_X1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_W1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_x1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_X1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1_x1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_W1_X1
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1_x1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_W1_X1
+
 - test: access_pmp_overlap
   desc: >
     PMP access basic test

--- a/dv/uvm/core_ibex/directed_tests/gen_testlist.py
+++ b/dv/uvm/core_ibex/directed_tests/gen_testlist.py
@@ -80,7 +80,7 @@ def add_configs_and_handwritten_directed_tests():
   test_srcs: empty/empty.S
   config: riscv-tests
 
-- test: pmp_mseccfg_test_rlb1_l0_0
+- test: pmp_mseccfg_test_rlb1_l0_0_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -92,7 +92,7 @@ def add_configs_and_handwritten_directed_tests():
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DPMP_REGION=4 -DRLB -DSET_PMP_L=0 -DSET_PMP_L_PREV=0
 
-- test: pmp_mseccfg_test_rlb1_l0_1
+- test: pmp_mseccfg_test_rlb1_l0_1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -104,7 +104,7 @@ def add_configs_and_handwritten_directed_tests():
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DPMP_REGION=4 -DRLB -DSET_PMP_L=1 -DSET_PMP_L_PREV=0
 
-- test: pmp_mseccfg_test_rlb1_l1_0
+- test: pmp_mseccfg_test_rlb1_l1_0_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -116,7 +116,7 @@ def add_configs_and_handwritten_directed_tests():
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DPMP_REGION=4 -DRLB -DSET_PMP_L=0 -DSET_PMP_L_PREV=1
 
-- test: pmp_mseccfg_test_rlb1_l1_1
+- test: pmp_mseccfg_test_rlb1_l1_1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -128,7 +128,7 @@ def add_configs_and_handwritten_directed_tests():
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DPMP_REGION=4 -DRLB -DSET_PMP_L=1 -DSET_PMP_L_PREV=1
 
-- test: pmp_mseccfg_test_rlb0_l0_0
+- test: pmp_mseccfg_test_rlb0_l0_0_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -140,7 +140,7 @@ def add_configs_and_handwritten_directed_tests():
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DPMP_REGION=4 -DSET_PMP_L=0 -DSET_PMP_L_PREV=0
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -152,7 +152,7 @@ def add_configs_and_handwritten_directed_tests():
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -164,7 +164,7 @@ def add_configs_and_handwritten_directed_tests():
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -176,7 +176,7 @@ def add_configs_and_handwritten_directed_tests():
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_W1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_x1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_x1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -188,7 +188,7 @@ def add_configs_and_handwritten_directed_tests():
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_X1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -200,7 +200,7 @@ def add_configs_and_handwritten_directed_tests():
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_W1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_x1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_x1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -212,7 +212,7 @@ def add_configs_and_handwritten_directed_tests():
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_X1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1_x1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1_x1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -224,7 +224,7 @@ def add_configs_and_handwritten_directed_tests():
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_W1_X1
 
-- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1_x1
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1_x1_u0
   desc: >
     mseccfg test
   iterations: 1
@@ -235,6 +235,162 @@ def add_configs_and_handwritten_directed_tests():
             -I../../../vendor/riscv-test-env/p/
             -I../../../vendor/riscv-tests/isa/macros/scalar/
             -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_W1_X1
+
+- test: pmp_mseccfg_test_rlb1_l0_0_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=0 -DSET_PMP_L_PREV=0 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb1_l0_1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb1_l1_0_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=0 -DSET_PMP_L_PREV=1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb1_l1_1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DRLB -DSET_PMP_L=1 -DSET_PMP_L_PREV=1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_0_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DPMP_REGION=4 -DSET_PMP_L=0 -DSET_PMP_L_PREV=0 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_W1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_x1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_X1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_W1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_x1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_X1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_w1_x1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_W1_X1 -DU_MODE
+
+- test: pmp_mseccfg_test_rlb0_l0_1_next_l1_r1_w1_x1_u1
+  desc: >
+    mseccfg test
+  iterations: 1
+  test_srcs: pmp_mseccfg_test/pmp_mseccfg_test.S
+  config: riscv-tests
+  gcc_opts: -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+            -I../../../vendor/riscv-test-env/
+            -I../../../vendor/riscv-test-env/p/
+            -I../../../vendor/riscv-tests/isa/macros/scalar/
+            -DSET_PMP_L=1 -DSET_PMP_L_PREV=0 -DPMP_NEXT_L1_R1_W1_X1 -DU_MODE
 
 - test: access_pmp_overlap
   desc: >

--- a/dv/uvm/core_ibex/directed_tests/ibex_macros.h
+++ b/dv/uvm/core_ibex/directed_tests/ibex_macros.h
@@ -30,3 +30,8 @@
 // test result - should be stored at sign_addr[8]
 #define TEST_PASS 0x0
 #define TEST_FAIL 0x1
+
+#define CSR_MSECCFG 0x747
+#define MSECCFG_MML 0x1
+#define MSECCFG_MMWP 0x2
+#define MSECCFG_RLB 0x4

--- a/dv/uvm/core_ibex/directed_tests/pmp_mseccfg_test/pmp_mseccfg_test.S
+++ b/dv/uvm/core_ibex/directed_tests/pmp_mseccfg_test/pmp_mseccfg_test.S
@@ -1,0 +1,176 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+###############################################################################
+# Description:
+#   Setting mseccfg.mml 1 and mseccfg.rlb 0/1 with different PMP.LXWR 
+# permissions and check R/w access to that specific region. Access is
+# at start, mid and end of the PMP region.
+#   Target of test is to achieve functional coverage for rewriting 
+# permissions in PMP regions with RLB 0/1.
+
+#include "riscv_test.h"
+#include "test_macros.h"
+#include "custom_macros.h"
+
+#define PMP_GRAN 0x1000
+
+#if SET_PMP_L == 1
+  #define SET_PMP_L_BIT PMP_L
+#else
+  #define SET_PMP_L_BIT 0
+#endif
+
+#if SET_PMP_L_PREV == 1
+  #define SET_PMP_L_PREV PMP_L
+#else
+  #define SET_PMP_L_PREV 0
+#endif
+
+# Test specific macros
+#define SET_PMP_AND_ACCESS_TOR(pmp_permissions, region_high, region_low)                            \
+  SET_PMP_TOR(pmp_region_end, pmp_region_start, pmp_permissions | PMP_TOR, region_high, region_low) \
+  RW_ACCESSES(pmp_region_start, PMP_GRAN)
+
+#define SET_PMP_AND_ACCESS_NAPOT(pmp_permissions, region)                        \
+  SET_PMP_NAPOT(pmp_region_start, PMP_GRAN, pmp_permissions | PMP_NAPOT, region) \
+  RW_ACCESSES(pmp_region_start, PMP_GRAN)
+
+#define SET_DIFF_PMP_CFG(pmp_region, pmp_l, pmp_l_prev)               \
+  PREV_PMP_CFG(pmp_l_prev, pmp_region, pmp_l)                         \
+  PREV_PMP_CFG(pmp_l_prev | PMP_R, pmp_region, pmp_l)                 \
+  PREV_PMP_CFG(pmp_l_prev | PMP_W, pmp_region, pmp_l)                 \
+  PREV_PMP_CFG(pmp_l_prev | PMP_X, pmp_region, pmp_l)                 \
+  PREV_PMP_CFG(pmp_l_prev | PMP_R | PMP_W, pmp_region, pmp_l)         \
+  PREV_PMP_CFG(pmp_l_prev | PMP_R | PMP_X, pmp_region, pmp_l)         \
+  PREV_PMP_CFG(pmp_l_prev | PMP_W | PMP_X, pmp_region, pmp_l)         \
+  PREV_PMP_CFG(pmp_l_prev | PMP_R | PMP_W | PMP_X, pmp_region, pmp_l)
+
+#define PREV_PMP_CFG(prev_pmp, pmp_region, pmp_l)                    \
+  SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                     \
+  SET_PMP_AND_ACCESS_NAPOT(pmp_l, pmp_region)                        \
+  SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                     \
+  SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_R, pmp_region)                \
+  SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                     \
+  SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_W, pmp_region)                \
+  SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                     \
+  SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_X, pmp_region)                \
+  SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                     \
+  SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_R | PMP_W, pmp_region)        \
+  SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                     \
+  SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_R | PMP_X, pmp_region)        \
+  SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                     \
+  SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_W | PMP_X, pmp_region)        \
+  SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                     \
+  SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_R | PMP_W | PMP_X, pmp_region)
+
+#ifdef PMP_NEXT_L1
+  #define PREV_PMP_CFG_UNIQUE(prev_pmp, pmp_region, pmp_l)           \
+    SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                   \
+    SET_PMP_AND_ACCESS_NAPOT(pmp_l, pmp_region)
+#endif
+
+#ifdef PMP_NEXT_L1_R1
+  #define PREV_PMP_CFG_UNIQUE(prev_pmp, pmp_region, pmp_l)           \
+    SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                   \
+    SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_R, pmp_region)
+#endif
+
+#ifdef PMP_NEXT_L1_W1
+  #define PREV_PMP_CFG_UNIQUE(prev_pmp, pmp_region, pmp_l)           \
+    SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                   \
+    SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_W, pmp_region)
+#endif
+
+#ifdef PMP_NEXT_L1_X1
+  #define PREV_PMP_CFG_UNIQUE(prev_pmp, pmp_region, pmp_l)           \
+    SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                   \
+    SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_X, pmp_region)
+#endif
+
+#ifdef PMP_NEXT_L1_R1_W1
+  #define PREV_PMP_CFG_UNIQUE(prev_pmp, pmp_region, pmp_l)           \
+    SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                   \
+    SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_R | PMP_W, pmp_region)
+#endif
+
+#ifdef PMP_NEXT_L1_R1_X1
+  #define PREV_PMP_CFG_UNIQUE(prev_pmp, pmp_region, pmp_l)           \
+    SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                   \
+    SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_R | PMP_X, pmp_region)
+#endif
+
+#ifdef PMP_NEXT_L1_W1_X1
+  #define PREV_PMP_CFG_UNIQUE(prev_pmp, pmp_region, pmp_l)           \
+    SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                   \
+    SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_W | PMP_X, pmp_region)
+#endif
+
+#ifdef PMP_NEXT_L1_R1_W1_X1
+  #define PREV_PMP_CFG_UNIQUE(prev_pmp, pmp_region, pmp_l)           \
+    SET_PMP_AND_ACCESS_NAPOT(prev_pmp, pmp_region)                   \
+    SET_PMP_AND_ACCESS_NAPOT(pmp_l | PMP_R | PMP_W | PMP_X, pmp_region)
+#endif
+
+RVTEST_RV64M
+RVTEST_CODE_BEGIN
+
+  # setting machine handler
+  la   t0, mtvec_handler
+  csrw mtvec, t0
+
+  # resetting all PMP regions and mseccfg
+  RESET_PMP
+
+#ifdef RLB
+  SET_MSECCFG(MSECCFG_RLB)
+#endif
+
+  # setting M mode permissions as unmatched regions would be ignored when mml 1
+  SET_PMP_TOR(pmp_region_start, _start, PMP_L | PMP_R | PMP_X | PMP_TOR, 0, 0)
+
+  # MML 1
+  SET_MSECCFG(MSECCFG_MML)
+
+  # If RLB 1, PMP locked regions would be modifiable
+#ifdef RLB
+  SET_DIFF_PMP_CFG(PMP_REGION, SET_PMP_L_BIT, SET_PMP_L_PREV)
+#else
+  #if SET_PMP_L == 1
+    # If RLB 0, then once locked, not modifiable hence have to use
+    # different PMP regions to cover all transitions
+    PREV_PMP_CFG_UNIQUE(SET_PMP_L_PREV, 4, SET_PMP_L_BIT)
+    PREV_PMP_CFG_UNIQUE(SET_PMP_L_PREV | PMP_R, 5, SET_PMP_L_BIT)
+    PREV_PMP_CFG_UNIQUE(SET_PMP_L_PREV | PMP_W, 6, SET_PMP_L_BIT)
+    PREV_PMP_CFG_UNIQUE(SET_PMP_L_PREV | PMP_X, 7, SET_PMP_L_BIT)
+    PREV_PMP_CFG_UNIQUE(SET_PMP_L_PREV | PMP_R | PMP_W, 8, SET_PMP_L_BIT)
+    PREV_PMP_CFG_UNIQUE(SET_PMP_L_PREV | PMP_R | PMP_X, 9, SET_PMP_L_BIT)
+    PREV_PMP_CFG_UNIQUE(SET_PMP_L_PREV | PMP_W | PMP_X, 10, SET_PMP_L_BIT)
+    PREV_PMP_CFG_UNIQUE(SET_PMP_L_PREV | PMP_R | PMP_W | PMP_X, 11, SET_PMP_L_BIT)
+  #else
+    # If not locked, PMPCFG would be writable
+    SET_DIFF_PMP_CFG(PMP_REGION, SET_PMP_L_BIT, SET_PMP_L_PREV)
+  #endif
+#endif
+
+  j pass
+
+  TEST_PASSFAIL
+
+.balign 256
+mtvec_handler:
+  SKIP_PC
+  mret
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+.balign PMP_GRAN
+pmp_region_start: .zero PMP_GRAN
+pmp_region_end:
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/dv/uvm/core_ibex/directed_tests/pmp_mseccfg_test/pmp_mseccfg_test.S
+++ b/dv/uvm/core_ibex/directed_tests/pmp_mseccfg_test/pmp_mseccfg_test.S
@@ -9,6 +9,7 @@
 # at start, mid and end of the PMP region.
 #   Target of test is to achieve functional coverage for rewriting 
 # permissions in PMP regions with RLB 0/1.
+#   Test accesses in both M-mode and U-mode.
 
 #include "riscv_test.h"
 #include "test_macros.h"
@@ -33,9 +34,32 @@
   SET_PMP_TOR(pmp_region_end, pmp_region_start, pmp_permissions | PMP_TOR, region_high, region_low) \
   RW_ACCESSES(pmp_region_start, PMP_GRAN)
 
+#define ACCESS_REGION(region, offset) \
+  la t0, region;                      \
+  jalr a0, offset(t0);
+
+#define EXEC_ACCESS_IN_M_MODE(region) \
+  ACCESS_REGION(region, 0);           \
+  ACCESS_REGION(region, -2);
+
+#define EXEC_ACCESS_IN_U_MODE(region) \
+  SWITCH_TO_U_MODE_LABEL(region);     \
+  la s0, region;                      \
+  addi s0, s0, -2;                    \
+  SWITCH_TO_U_MODE_REG(s0);
+
+#ifdef U_MODE
+  #define EXEC_ACCESS(region)     \
+    EXEC_ACCESS_IN_U_MODE(region)
+#else
+  #define EXEC_ACCESS(region)     \
+    EXEC_ACCESS_IN_M_MODE(region)
+#endif
+
 #define SET_PMP_AND_ACCESS_NAPOT(pmp_permissions, region)                        \
   SET_PMP_NAPOT(pmp_region_start, PMP_GRAN, pmp_permissions | PMP_NAPOT, region) \
-  RW_ACCESSES(pmp_region_start, PMP_GRAN)
+  RW_ACCESSES(pmp_region_start, PMP_GRAN)                                        \
+  EXEC_ACCESS(pmp_region_start)
 
 #define SET_DIFF_PMP_CFG(pmp_region, pmp_l, pmp_l_prev)               \
   PREV_PMP_CFG(pmp_l_prev, pmp_region, pmp_l)                         \
@@ -123,6 +147,12 @@ RVTEST_CODE_BEGIN
   # resetting all PMP regions and mseccfg
   RESET_PMP
 
+  # placing 0xffffffff just before pmp_region_start so in
+  # order to deal with boundary instsr as uncompressed
+  li t0, 0xffffffff
+  la t1, pmp_region_start
+  sw t0, -4(t1)
+
 #ifdef RLB
   SET_MSECCFG(MSECCFG_RLB)
 #endif
@@ -160,7 +190,24 @@ RVTEST_CODE_BEGIN
 
 .balign 256
 mtvec_handler:
+  csrr t0, mcause
+  li t1, CAUSE_FETCH_ACCESS
+  beq t0, t1, restore_to_pc_before_access_fault
+  # jump to a valid PC if illegal instruction
+  # which would be when PMP has execute permissions
+  # in pmp_region_start
+  li t1, CAUSE_ILLEGAL_INSTRUCTION
+  beq t0, t1, restore_to_pc_before_access_fault
   SKIP_PC
+  j ret_from_mhandler
+
+restore_to_pc_before_access_fault:
+  csrw mepc, a0
+
+ret_from_mhandler:
+  # always return to m-mode
+  li t0, MSTATUS_MPP
+  csrs mstatus, t0
   mret
 
 RVTEST_CODE_END
@@ -169,7 +216,9 @@ RVTEST_CODE_END
 RVTEST_DATA_BEGIN
 
 .balign PMP_GRAN
-pmp_region_start: .zero PMP_GRAN
+pmp_region_start:
+  jr a0
+  .zero (PMP_GRAN-4)
 pmp_region_end:
   TEST_DATA
 


### PR DESCRIPTION
Added a directed test for covering all scenarios of mml=1 with rlb=0/1 with all combinations of PMP.LXWR and accessing that configured PMP region with RW accesses.