### PR TITLE
Added a makefile for running directed tests on verilator simple system

### DIFF
--- a/dv/uvm/core_ibex/directed_tests/ibex_macros.h
+++ b/dv/uvm/core_ibex/directed_tests/ibex_macros.h
@@ -3,13 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Ibex specific macros
-#define SIGNATURE_ADDR 0x8ffffff8
 
 // signatue type - should be stored at sign_addr[7:0]
-#define CORE_STATUS 0x0
 #define TEST_RESULT 0x1
 #define WRITE_GPR 0x2
 #define WRITE_CSR 0x3
+
+// writing 0x1 to signature address to end the test for simple system
+#ifdef SIMPLE_SYSTEM
+#define SIGNATURE_ADDR 0x20008
+#define CORE_STATUS 0x1
+#define FINISHED_IRQ 0x0
+#else
+#define SIGNATURE_ADDR 0x8ffffff8
+#define CORE_STATUS 0x0
+#define FINISHED_IRQ 0x7
+#endif
 
 // core status - should be stored at sign_addr[12:8]
 #define INITIALIZED 0x0
@@ -19,7 +28,6 @@
 #define IN_SUPERVISOR_MODE 0x4
 #define IN_USER_MODE 0x5
 #define HANDLING_IRQ 0x6
-#define FINISHED_IRQ 0x7
 #define HANDLING_EXCEPTION 0x8
 #define INSTR_FAULT_EXCEPTION 0x9
 #define ILLEGAL_INSTR_EXCEPTION 0xa

--- a/examples/sw/simple_system/Makefile
+++ b/examples/sw/simple_system/Makefile
@@ -1,0 +1,36 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+COSIM ?= lowrisc:ibex:ibex_simple_system_cosim
+LINKER ?= ./common/link.ld
+CFLAGS := -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+INCLUDE_FILES := -I../../../vendor/riscv-test-env/ \
+		 -I../../../vendor/riscv-test-env/p/ \
+		 -I../../../vendor/riscv-tests/isa/macros/scalar/ \
+		 -I../../../dv/uvm/core_ibex/directed_tests \
+		 -T$(LINKER) \
+		 -DSIMPLE_SYSTEM
+
+DIRECTED_TESTS_PATH ?= ../../../dv/uvm/core_ibex/directed_tests
+TEST_PATH ?= $(DIRECTED_TESTS_PATH)/empty/empty.S
+TEST := $(shell basename $(TEST_PATH) .S)
+
+RISCV_OBJDUMP := $(patsubst %-gcc,%-,$(RISCV_GCC))objdump
+
+run: build_rtl compile_prog run_prebuilt_rtl
+
+build_rtl:
+	fusesoc --cores-root=../../../ run --target=sim --setup --build $(COSIM) --RV32E=0 --RV32M=ibex_pkg::RV32MFast --PMPEnable=1
+
+compile_prog:
+	$(RISCV_GCC) $(CFLAGS) $(INCLUDE_FILES) -o $(TEST).elf $(TEST_PATH)
+	$(RISCV_OBJDUMP) -DS $(TEST).elf > $(TEST).dis
+
+run_prebuilt_rtl: compile_prog run_precompiled_test
+
+run_precompiled_test:
+	./build/lowrisc_ibex_ibex_simple_system_cosim_0/sim-verilator/Vibex_simple_system --meminit=ram,$(TEST).elf
+
+clean:
+	$(RM) -f *.o *.elf *.dis *.log


### PR DESCRIPTION
Changes:
- Added a Makefile to run directed tests using verilator simple system (with useful targets)
- Modified Ibex specific macros when SIMPLE_SYSTEM is defined (without editing the test environment code)

Note:
Used the common linker script which is already there for simple system.