### PR TITLE
[rtl] Fix MISA X bit for balanced bitmanip config

### DIFF
--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -139,7 +139,8 @@ module ibex_cs_registers #(
     return value;
   endfunction
 
-  localparam int unsigned RV32BExtra = (RV32B == RV32BOTEarlGrey) || (RV32B == RV32BFull) ? 1 : 0;
+  // All bitmanip configs enable non-ratified sub-extensions
+  localparam int unsigned RV32BExtra   = (RV32B != RV32BNone) ? 1 : 0;
   localparam int unsigned RV32MEnabled = (RV32M == RV32MNone) ? 0 : 1;
   localparam int unsigned PMPAddrWidth = (PMPGranularity > 0) ? 33 - PMPGranularity : 32;
 


### PR DESCRIPTION
All RV32B configs include non-ratified sub-extensions so the 'X' bit MISA must be set for all of them.

This will fix the failure in private CI