### PR TITLE
Avoid explicit module names references to signals

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -174,8 +174,8 @@ module ibex_controller #(
   always_ff @(negedge clk_i) begin
     // print warning in case of decoding errors
     if ((ctrl_fsm_cs == DECODE) && instr_valid_i && !instr_fetch_err_i && illegal_insn_d) begin
-      $display("%t: Illegal instruction (hart %0x) at PC 0x%h: 0x%h", $time, ibex_core.hart_id_i,
-               ibex_id_stage.pc_id_i, ibex_id_stage.instr_rdata_i);
+      $display("%t: Illegal instruction (hart %0x) at PC 0x%h: 0x%h", $time, u_ibex_core.hart_id_i,
+               pc_id_i, id_stage_i.instr_rdata_i);
     end
   end
   // synopsys translate_on


### PR DESCRIPTION
Hi there!

Some tools modify module names during their flow, or allow to do it optionally, such as the `-p` flag of [Morty](https://github.com/pulp-platform/morty).
However, there is one display occurrence which refers to explicit module names, which breaks compatibility with such passes.
Arguably this is a problem of the tool, but:
* Such absolute references are rare across designs and appear only here in Ibex afaik.
* It looks much easier to fix in Ibex than in the tools.

Please feel free to edit the fix in place!
Flavien