### PR TITLE
Ibex readme regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![Build Status](https://dev.azure.com/lowrisc/ibex/_apis/build/status/lowRISC.ibex?branchName=master)](https://dev.azure.com/lowrisc/ibex/_build/latest?definitionId=3&branchName=master)
+[Ibex OpenTitan configuration Nightly Regression](https://ibex.reports.lowrisc.org/opentitan/latest/report.html)
+<a href="https://ibex.reports.lowrisc.org/opentitan/latest/report.html">
+  <img src="https://ibex.reports.lowrisc.org/opentitan/latest/summary.svg">
+</a>
 
 # Ibex RISC-V Core
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ These are configurations on which lowRISC is focusing for performance evaluation
 | Performance (CoreMark/MHz) | 0.904 | 2.47 | 3.13 | 3.13 |
 | Area - Yosys (kGE) | 16.85 | 26.60 | 32.48 | 66.02 |
 | Area - Commercial (estimated kGE) | ~15 | ~24 | ~30 | ~61 |
-| Verification status | Red | Green | Amber | Amber |
+| Verification status | Red | Green | Green | Green |
 
 Notes:
 

--- a/dv/uvm/core_ibex/scripts/report_lib/svg.py
+++ b/dv/uvm/core_ibex/scripts/report_lib/svg.py
@@ -14,7 +14,8 @@ SVG_DASHBOARD_STYLE = dedent("""
     .text { font: 12px sans-serif;
             text-anchor: middle;
             dominant-baseline: middle;}
-    .name { font-weight: bold; }
+    .name { fill: white; }
+    .value { fill: black; }
 """)
 SVG_DASHBOARD_VALUE_WIDTH = 60
 SVG_DASHBOARD_NAME_BG_COLOUR = "#666"
@@ -146,6 +147,7 @@ def output_results_svg(test_summary_dict: Dict[str, Dict[str, int]],
     regression_dashboard = Dashboard(dashboard_elements, SVG_DASHBOARD_GAP)
     summary_svg = svg.SVG(
             width = regression_dashboard.calc_total_width(),
+            height = SVG_DASHBOARD_HEIGHT,
             elements = [svg.Style(text=SVG_DASHBOARD_STYLE)] +
                        regression_dashboard.create_svg_elements()
     )


### PR DESCRIPTION
I've manually edited the current summary.svg to be what it would be with the svg tweaks in this PR. If the nightly runs before we merge this we'll be back to the one with the bold black names on the labels and a bunch of whitespace.