### PR TITLE
[sw/simple_system] Declare `pcount_enable` function as inline

### DIFF
--- a/examples/sw/simple_system/common/simple_system_common.c
+++ b/examples/sw/simple_system/common/simple_system_common.c
@@ -102,18 +102,6 @@ void pcount_reset() {
       "csrw mhpmcounter31h, x0\n");
 }
 
-void pcount_enable(int enable) {
-  // Note cycle is disabled with everything else
-  unsigned int inhibit_val = enable ? 0x0 : 0xFFFFFFFF;
-  // CSR 0x320 was called `mucounteren` in the privileged spec v1.9.1, it was
-  // then dropped in v1.10, and then re-added in v1.11 with the name
-  // `mcountinhibit`. Unfortunately, the version of binutils we use only allows
-  // the old name, and LLVM only supports the new name (though this is changed
-  // on trunk to support both), so we use the numeric value here for maximum
-  // compatibility.
-  asm volatile("csrw  0x320, %0\n" : : "r"(inhibit_val));
-}
-
 unsigned int get_mepc() {
   uint32_t result;
   __asm__ volatile("csrr %0, mepc;" : "=r"(result));

--- a/examples/sw/simple_system/common/simple_system_common.h
+++ b/examples/sw/simple_system/common/simple_system_common.h
@@ -48,7 +48,17 @@ void sim_halt();
  *
  * @param enable if non-zero enables, otherwise disables
  */
-void pcount_enable(int enable);
+static inline void pcount_enable(int enable) {
+  // Note cycle is disabled with everything else
+  unsigned int inhibit_val = enable ? 0x0 : 0xFFFFFFFF;
+  // CSR 0x320 was called `mucounteren` in the privileged spec v1.9.1, it was
+  // then dropped in v1.10, and then re-added in v1.11 with the name
+  // `mcountinhibit`. Unfortunately, the version of binutils we use only allows
+  // the old name, and LLVM only supports the new name (though this is changed
+  // on trunk to support both), so we use the numeric value here for maximum
+  // compatibility.
+  asm volatile("csrw  0x320, %0\n" : : "r"(inhibit_val));
+}
 
 /**
  * Resets all performance counters.  This effects mcycle and minstret as well


### PR DESCRIPTION
The `pcount_enable` function can be used to selectively enable performance counters only for a specific code segment.  For example:
```c
pcount_enable(0);
pcount_reset();
pcount_enable(1);
/* code to be measured */
pcount_enable(0);
```

The `pcount_enable` function consists of a single CSR instruction, so the overhead and thus the impact on the measurement is potentially low. When the function is called, however, many instructions have to be executed in addition to the single CSR instruction, which influences measurements.

This commit moves the `pcount_enable` function to the `simple_system_common.h` header file and declares it as `inline` (and `static`, to prevent link-time collisions when the header file is included in multiple compilation units).  This helps the compiler inline the function even without LTO.