### PR TITLE
[ci] Specify typeguard version

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -14,7 +14,7 @@ junit-xml
 # dataclass  # needed for backports?
 pathlib3x  # Backports some useful features
 typing-utils  # Ditto
-typeguard
+typeguard ~= 2.13
 portalocker
 pydantic
 svg.py


### PR DESCRIPTION
The latest v3 is producing CI failures, pin to compatible with 2.13 for now to fix this.