### PR TITLE
[rtl] Add missing `include to ibex_if_stage

### DIFF
--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -11,6 +11,7 @@
  */
 
 `include "prim_assert.sv"
+`include "dv_fcov_macros.svh"
 
 module ibex_if_stage import ibex_pkg::*; #(
   parameter int unsigned DmHaltAddr        = 32'h1A110800,


### PR DESCRIPTION
The include is needed for a FCOV related macro. Lack of this include can cause issues in some simulators.