### PR TITLE
[util] Ignore Verilator stderr in version check

### DIFF
--- a/util/check_tool_requirements.py
+++ b/util/check_tool_requirements.py
@@ -199,7 +199,6 @@ class VerilatorToolReq(ToolReq):
             # relies on perl magic to parse command line arguments.
             version_str = subprocess.run('verilator --version', shell=True,
                                          check=True, stdout=subprocess.PIPE,
-                                         stderr=subprocess.STDOUT,
                                          universal_newlines=True)
         except subprocess.CalledProcessError as err:
             raise RuntimeError('Unable to call Verilator to check version: {}'


### PR DESCRIPTION
With funny CI environments, the locale might not be set properly, making perl complain. The version check will fail then. I believe it is sufficient to check for the tool version, stderr can be ignored safely, if I am not missing something.