### PR TITLE
[dv] Improve coverage of priv_mode_irq_cross

### DIFF
--- a/dv/uvm/core_ibex/fcov/core_ibex_fcov_if.sv
+++ b/dv/uvm/core_ibex/fcov/core_ibex_fcov_if.sv
@@ -640,10 +640,10 @@ interface core_ibex_fcov_if import ibex_pkg::*; (
     }
 
     priv_mode_irq_cross: cross cp_priv_mode_id, cp_interrupt_taken, cs_registers_i.mstatus_q.mie {
-      // No interrupt would be taken in M-mode when its mstatus.MIE = 0
+      // No interrupt would be taken in M-mode when its mstatus.MIE = 0 unless it's an NMI
       illegal_bins mmode_mstatus_mie =
         binsof(cs_registers_i.mstatus_q.mie) intersect {1'b0} &&
-        binsof(cp_priv_mode_id) intersect {PRIV_LVL_M};
+        binsof(cp_priv_mode_id) intersect {PRIV_LVL_M} with (cp_interrupt_taken[5:4] == 2'b00);
     }
 
     priv_mode_exception_cross: cross cp_priv_mode_id, cp_ls_pmp_exception, cp_ls_error_exception {

--- a/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -614,6 +614,7 @@
     +randomize_csr=1
     +enable_unaligned_load_store=1
     +suppress_pmp_setup=1
+    +enable_interrupt=1
   rtl_test: core_ibex_mem_error_test
   sim_opts: >
     +enable_mem_intg_err=1


### PR DESCRIPTION
This allows mie to be randomly enabled/disabled in memory integrity error tests. It also corrects the illegal bins.