### PR TITLE
Remove TODOs

### DIFF
--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -1494,7 +1494,6 @@ module ibex_core import ibex_pkg::*; #(
         if (i == 0) begin
           if (rvfi_id_done) begin
             rvfi_stage_halt[i]      <= '0;
-            // TODO: Sort this out for writeback stage
             rvfi_stage_trap[i]                 <= rvfi_trap_id;
             rvfi_stage_intr[i]                 <= rvfi_intr_d;
             rvfi_stage_order[i]                <= rvfi_stage_order_d;
@@ -1791,7 +1790,6 @@ module ibex_core import ibex_pkg::*; #(
           g_pmp.pmp_i.region_match_all[PMP_D][i_region] & data_req_out)
       // pmp_cfg[5:6] is reserved and because of that the width of it inside cs_registers module
       // is 6-bit.
-      // TODO: Cover writes to the reserved bits
       `DV_FCOV_SIGNAL(logic, warl_check_pmpcfg,
           fcov_csr_write &&
           (cs_registers_i.g_pmp_registers.g_pmp_csrs[i_region].u_pmp_cfg_csr.wr_data_i !=

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -518,7 +518,7 @@ module ibex_id_stage #(
     //   see any pending IRQs and consequently does not start to handle interrupts.
     // - When modifying any PMP CSR, PMP check of the next instruction might get invalidated.
     //   Hence, a pipeline flush is needed to instantiate another PMP check with the updated CSRs.
-    // - When modifying debug CSRs - TODO: Check if this is really needed
+    // - When modifying debug CSRs.
     if (csr_op_en_o == 1'b1 && (csr_op_o == CSR_OP_WRITE || csr_op_o == CSR_OP_SET)) begin
       if (csr_num_e'(instr_rdata_i[31:20]) == CSR_MSTATUS ||
           csr_num_e'(instr_rdata_i[31:20]) == CSR_MIE     ||


### PR DESCRIPTION
 - rvfi_trap now correctly handled for writeback
 - issue created to track coverpoint for pmpcfg reserved bits writes.
 - flush pipe on debug CSR writes is reasonable

For the debug CSR write it may be a pipeline flush isn't required but it's safer to do so and doesn't present any real performance concerns so we may as well leave it in.