### PR TITLE
Correct type in scripts_lib.py's run_one

### DIFF
--- a/dv/uvm/core_ibex/scripts/scripts_lib.py
+++ b/dv/uvm/core_ibex/scripts/scripts_lib.py
@@ -27,7 +27,7 @@ def run_one(verbose: bool,
             redirect_stdstreams: Optional[Union[str, pathlib.Path, IOBase]] = None,
             timeout_s: Optional[int] = None,
             reraise: bool = False,
-            env: Dict[str, str] = None) -> int:
+            env: Optional[Dict[str, str]] = None) -> int:
     """Run a command, returning its retcode.
 
     If verbose is true, print the command to stderr first (a bit like bash -x).


### PR DESCRIPTION
It seems that typeguard now spots if `env` happens to be None. We can just relax things: we're only using `env` by passing it through to `subprocess.run`, which handles a None `env` in the expected way.