### PR TITLE
Drop a double entry in rtl_simulation.yaml

### DIFF
--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -33,7 +33,6 @@
           -timescale=1ns/10ps
           -licqueue
           -LDFLAGS '-Wl,--no-as-needed'
-          -CFLAGS '--std=c99 -fno-extended-identifiers'
           -Mdir=<tb_dir>/vcs_simv.csrc
           -o <tb_dir>/vcs_simv
           -debug_access+pp


### PR DESCRIPTION
We ended up with the Unicode fix twice because of two colliding PR merges. We only need one copy of the -CFLAGS argument, and VCS generates a rather strange message about an unknown argument if you use it twice. Fortunately, it's easy to fix once you've worked out how to get the system to print out what it's doing.