### PR TITLE
Tweaks to Ibex to get core_ibex UVM to build with VCS

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_scoreboard.sv
+++ b/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_scoreboard.sv
@@ -6,7 +6,6 @@
 `include "cosim_dpi.svh"
 
 class ibex_cosim_scoreboard extends uvm_scoreboard;
-  import ibex_pkg::*;
   chandle cosim_handle;
 
   core_ibex_cosim_cfg cfg;
@@ -151,8 +150,10 @@ class ibex_cosim_scoreboard extends uvm_scoreboard;
 
       // Set performance counters through a pseudo-backdoor write
       for (int i=0; i < 10; i++) begin
-        riscv_cosim_set_csr(cosim_handle, CSR_MHPMCOUNTER3 + i, rvfi_instr.mhpmcounters[i]);
-        riscv_cosim_set_csr(cosim_handle, CSR_MHPMCOUNTER3H + i, rvfi_instr.mhpmcountersh[i]);
+        riscv_cosim_set_csr(cosim_handle,
+                            ibex_pkg::CSR_MHPMCOUNTER3 + i, rvfi_instr.mhpmcounters[i]);
+        riscv_cosim_set_csr(cosim_handle,
+                            ibex_pkg::CSR_MHPMCOUNTER3H + i, rvfi_instr.mhpmcountersh[i]);
       end
 
       riscv_cosim_set_ic_scr_key_valid(cosim_handle, rvfi_instr.ic_scr_key_valid);

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
@@ -22,4 +22,8 @@ package ibex_mem_intf_agent_pkg;
   `include "ibex_mem_intf_request_driver.sv"
   `include "ibex_mem_intf_request_agent.sv"
 
+  // Re-export parameters from ibex_mem_intf_pkg so that other packages can access them through this
+  // package.
+  export ibex_mem_intf_pkg::*;
+
 endpackage

--- a/dv/uvm/core_ibex/fcov/core_ibex_fcov_if.sv
+++ b/dv/uvm/core_ibex/fcov/core_ibex_fcov_if.sv
@@ -643,7 +643,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; (
       // No interrupt would be taken in M-mode when its mstatus.MIE = 0 unless it's an NMI
       illegal_bins mmode_mstatus_mie =
         binsof(cs_registers_i.mstatus_q.mie) intersect {1'b0} &&
-        binsof(cp_priv_mode_id) intersect {PRIV_LVL_M} with (cp_interrupt_taken[5:4] == 2'b00);
+        binsof(cp_priv_mode_id) intersect {PRIV_LVL_M} with (cp_interrupt_taken >> 4 == 6'd0);
     }
 
     priv_mode_exception_cross: cross cp_priv_mode_id, cp_ls_pmp_exception, cp_ls_error_exception {

--- a/dv/uvm/core_ibex/fcov/core_ibex_pmp_fcov_if.sv
+++ b/dv/uvm/core_ibex/fcov/core_ibex_pmp_fcov_if.sv
@@ -463,11 +463,12 @@ interface core_ibex_pmp_fcov_if import ibex_pkg::*; #(
              ((!pmp_region_priv_bits[2] && pmp_region_priv_bits != MML_XM_XU) ||
               pmp_region_priv_bits inside {MML_WRM_WRU, MML_RM_RU})) {
 
-          // Only interested in MML configuration
-          ignore_bins non_mml_in = binsof(pmp_region_priv_bits) with (!pmp_region_priv_bits[4]);
+          // Only interested in MML configuration, so ignore anything where the top bit is not set
+          ignore_bins non_mml_in =
+            binsof(pmp_region_priv_bits) with (pmp_region_priv_bits >> 4 == 5'b0);
 
           ignore_bins non_mml_out =
-            binsof(pmp_region_priv_bits_wr) with (!pmp_region_priv_bits_wr[4]);
+            binsof(pmp_region_priv_bits_wr) with (pmp_region_priv_bits_wr >> 4 == 5'b0);
 
           // Only interested in starting configs that weren't executable so ignore executable
           // regions

--- a/dv/uvm/core_ibex/riscv_dv_extension/ibex_asm_program_gen.sv
+++ b/dv/uvm/core_ibex/riscv_dv_extension/ibex_asm_program_gen.sv
@@ -54,7 +54,7 @@ class ibex_asm_program_gen extends riscv_asm_program_gen;
 
     riscv_csr_instr::create_csr_filter(cfg);
 
-    if ($value$plusargs("disable_pmp_exception_handler", disable_pmp_exception_handler) &&
+    if ($value$plusargs("disable_pmp_exception_handler=%d", disable_pmp_exception_handler) &&
         disable_pmp_exception_handler) begin
       cfg.pmp_cfg.enable_pmp_exception_handler = 0;
     end

--- a/dv/uvm/core_ibex/riscv_dv_extension/ibex_debug_triggers_overrides.sv
+++ b/dv/uvm/core_ibex/riscv_dv_extension/ibex_debug_triggers_overrides.sv
@@ -2,25 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class ibex_hardware_triggers_asm_program_gen extends ibex_asm_program_gen;
-
-  `uvm_object_utils(ibex_hardware_triggers_asm_program_gen)
-  `uvm_object_new
-
-  // Same implementation as the parent class, except substitute for our custom debug_rom class.
-  virtual function void gen_debug_rom(int hart);
-    `uvm_info(`gfn, "Creating debug ROM", UVM_LOW)
-    debug_rom = ibex_hardware_triggers_debug_rom_gen::
-                type_id::create("debug_rom", , {"uvm_test_top", ".", `gfn});
-    debug_rom.cfg = cfg;
-    debug_rom.hart = hart;
-    debug_rom.gen_program();
-    instr_stream = {instr_stream, debug_rom.instr_stream};
-  endfunction
-
-endclass
-
-
 class ibex_hardware_triggers_debug_rom_gen extends riscv_debug_rom_gen;
 
   `uvm_object_utils(ibex_hardware_triggers_debug_rom_gen)
@@ -122,6 +103,25 @@ class ibex_hardware_triggers_debug_rom_gen extends riscv_debug_rom_gen;
   endfunction
 
 endclass
+
+class ibex_hardware_triggers_asm_program_gen extends ibex_asm_program_gen;
+
+  `uvm_object_utils(ibex_hardware_triggers_asm_program_gen)
+  `uvm_object_new
+
+  // Same implementation as the parent class, except substitute for our custom debug_rom class.
+  virtual function void gen_debug_rom(int hart);
+    `uvm_info(`gfn, "Creating debug ROM", UVM_LOW)
+    debug_rom = ibex_hardware_triggers_debug_rom_gen::
+                type_id::create("debug_rom", , {"uvm_test_top", ".", `gfn});
+    debug_rom.cfg = cfg;
+    debug_rom.hart = hart;
+    debug_rom.gen_program();
+    instr_stream = {instr_stream, debug_rom.instr_stream};
+  endfunction
+
+endclass
+
 
 class ibex_hardware_triggers_illegal_instr extends riscv_illegal_instr;
 


### PR DESCRIPTION
We're not quite there yet, but it's much closer*! I've put sensible comments on all the commits in the PR, but they are mostly to do with cleaving more carefully to the IEEE SystemVerilog spec and not assuming things that happen to be true for a different simulator.

(*) With the current code, running something like `make IBEX_CONFIG=opentitan SIMULATOR=vcs ISS=spike ITERATIONS=1 SEED=1 TEST=riscv_arithmetic_basic_test WAVES=0 COV=0` gets as far as actually generating some binaries. Next: getting sensible trace logs!