### PR TITLE
Bump Spike minimum version

### DIFF
--- a/doc/03_reference/cosim.rst
+++ b/doc/03_reference/cosim.rst
@@ -22,7 +22,7 @@ These extended signals have the prefix ``rvfi_ext``
 Setup and Usage
 ---------------
 
-Clone the `lowRISC fork of Spike <https://github.com/lowRISC/riscv-isa-sim>`_ and check out the ``ibex-cosim-v0.3`` tag.
+Clone the `lowRISC fork of Spike <https://github.com/lowRISC/riscv-isa-sim>`_ and check out the ``ibex-cosim-v0.5`` tag.
 Other, later, versions called ``ibex-cosim-v*`` may also work but there's no guarantee of backwards compatibility.
 Follow the Spike build instructions to build and install Spike.
 The ``--enable-commitlog`` and ``--enable-misaligned`` options must be passed to ``configure``.


### PR DESCRIPTION
Some code we've got in Ibex uses some stuff we added to Spike last October. That, in turn, is now tagged in our riscv-isa-sim repository as ibex-cosim-v0.5. Update the version requirement here to match.