### PR TITLE
Minor tweaks to fix some Xcelium build warnings

### DIFF
--- a/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/examples/simple_system/rtl/ibex_simple_system.sv
@@ -212,7 +212,7 @@ module ibex_simple_system (
 
       .test_en_i              ('b0),
       .scan_rst_ni            (1'b1),
-      .ram_cfg_i              ('b0),
+      .ram_cfg_i              (prim_ram_1p_pkg::RAM_1P_CFG_DEFAULT),
 
       .hart_id_i              (32'b0),
       // First instruction executed is at 0x0 + 0x80

--- a/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/examples/simple_system/rtl/ibex_simple_system.sv
@@ -210,7 +210,7 @@ module ibex_simple_system (
       .clk_i                  (clk_sys),
       .rst_ni                 (rst_sys_n),
 
-      .test_en_i              ('b0),
+      .test_en_i              (1'b0),
       .scan_rst_ni            (1'b1),
       .ram_cfg_i              (prim_ram_1p_pkg::RAM_1P_CFG_DEFAULT),
 
@@ -249,7 +249,7 @@ module ibex_simple_system (
       .scramble_nonce_i       ('0),
       .scramble_req_o         (),
 
-      .debug_req_i            ('b0),
+      .debug_req_i            (1'b0),
       .crash_dump_o           (),
       .double_fault_seen_o    (),
 

--- a/shared/rtl/sim/simulator_ctrl.sv
+++ b/shared/rtl/sim/simulator_ctrl.sv
@@ -42,7 +42,7 @@ module simulator_ctrl #(
   localparam logic [7:0] SIM_CTRL_ADDR = 8'h2;
 
   logic [7:0] ctrl_addr;
-  logic [2:0] sim_finish = 3'b000;
+  logic [2:0] sim_finish;
 
   integer log_fd;
 


### PR DESCRIPTION
These changes are mostly in `simple_system`, to get Xcelium to build it into something sensible.

(I should confess that I've not actually managed to get the simulation to *do* anything useful yet, but hopefully this is a step in the right direction!)