### PR TITLE
Add support for ZiCond(Conditional move)

### DIFF
--- a/rtl/ibex_alu.sv
+++ b/rtl/ibex_alu.sv
@@ -1312,6 +1312,19 @@ module ibex_alu #(
     assign imd_val_we_o        = '{default: '0};
   end
 
+  ////////////
+  // Zicond //
+  ////////////
+  logic [31:0] zicond_result;
+  always_comb begin
+    zicond_result = 0;
+    unique case (operator_i)
+      ALU_CZERO_EQZ: zicond_result = (operand_b_i ==0 ) ? (0) : (operand_a_i);
+      ALU_CZERO_NEZ: zicond_result = (operand_b_i != 0) ? (0) : (operand_a_i);
+      default: zicond_result = 0;
+    endcase
+  end
+
   ////////////////
   // Result mux //
   ////////////////
@@ -1389,6 +1402,9 @@ module ibex_alu #(
       // Carry-less Multiply Operations (RV32B)
       ALU_CLMUL, ALU_CLMULR,
       ALU_CLMULH: result_o = clmul_result;
+      //ZiCond
+      ALU_CZERO_EQZ,
+      ALU_CZERO_NEZ: result_o = zicond_result;
 
       default: ;
     endcase

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -551,6 +551,9 @@ module ibex_decoder #(
               multdiv_signed_mode_o = 2'b00;
               illegal_insn          = (RV32M == RV32MNone) ? 1'b1 : 1'b0;
             end
+            //zicond
+            {7'b000_0111, 3'b101},
+            {7'b000_0111, 3'b111}:illegal_insn = 1'b0;
             default: begin
               illegal_insn = 1'b1;
             end

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -182,6 +182,11 @@ package ibex_pkg;
     ALU_CRC32C_H,
     ALU_CRC32_W,
     ALU_CRC32C_W
+    
+    //zicond(Conditional move)
+    ALU_CZERO_EQZ,
+    ALU_CZERO_NEZ
+
   } alu_op_e;
 
   typedef enum logic [1:0] {

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -1062,6 +1062,10 @@ module ibex_tracer (
         INSN_CRC32C_H:   decode_r1_insn("crc32c.h");
         INSN_CRC32C_W:   decode_r1_insn("crc32c.w");
 
+        //ZiCond
+        INSN_CZERO_EQZ:  decode_r_insn("czero.eqz");
+        INSN_CZERO_NEZ:  decode_r_insn("czero.nez");
+
         default:         decode_mnemonic("INVALID");
       endcase
     end

--- a/rtl/ibex_tracer_pkg.sv
+++ b/rtl/ibex_tracer_pkg.sv
@@ -123,6 +123,10 @@ package ibex_tracer_pkg;
   parameter logic [31:0] INSN_BINV = { 7'b0110100, 10'h?, 3'b001, 5'h?, {OPCODE_OP} };
   parameter logic [31:0] INSN_BEXT = { 7'b0100100, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
 
+  //ZiCond
+  parameter logic [31:0] INSN_CZERO_EQZ = { 7'b0000111, 10'h?, 3'b101, 5'h?, {OPCODE_OP} };
+  parameter logic [31:0] INSN_CZERO_NEZ = { 7'b0000111, 10'h?, 3'b111, 5'h?, {OPCODE_OP} };
+
   // ZBP
   // grevi
   // Only log2(XLEN) bits of the immediate are used. For RV32, this means only the bits in


### PR DESCRIPTION
Add support for the Zicond extension added v1.0-rc. The new instructions added are:


- czero.eqz
- czero.nez
