### PR TITLE
[credits] Add names of recent contributors

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -13,34 +13,68 @@ in the form of source code, bug reports, testing, marketing, or any other form,
 please feel free to open a pull request to get your name added to this file.
 
 - Alex Bradbury
+- Andreas Kurth
 - Andreas Traber
 - Antonio Pullini
+- Bryan Cantrill
+- Canberk Topal
+- Cathal Minnock
+- Daniel Mlynek
+- Dawid Zimonczyk
 - Eunchan Kim
+- Felix Yan
+- Flavian Solt
 - Florian Zaruba
 - Francesco Conti
+- Gary Guo
 - Germain Haugou
 - Greg Chadwick
+- Harry Callahan
+- Hai Hoang Dang
+- Henner Zeller
+- Hodjat Asghari Esfeden
 - Igor Loi
 - Ioannis Karageorgos
-- Markus Wegmann
 - Ivan Ribeiro
+- Karol Gugala
+- Leon Woestenberg
+- Luís Marques
+- Marek Pikuła
+- Markus Wegmann
+- Marno van der Maas
 - Matthias Baer
+- Mehmet Burak Aykenar
 - Michael Gautschi
+- Michael Gielda
+- Michael Munday
+- Michael Platzer
 - Michael Schaffner
 - Nils Graf
 - Noah Huesser
 - Noam Gallmann
 - Pasquale Davide Schiavone
+- Paul O'Keeffe
 - Philipp Wagner
 - Pirmin Vogel
+- Prajwala Puttappa
 - Rahul Behl
 - Rhys Thomas
 - Renzo Andri
 - Robert Schilling
+- Rupert Swarbick
+- Sam Elliott
 - Scott Johnson
+- Stefan Mach
+- Stefan Tauner
 - Stefan Wallentowitz
 - Sven Stucki
 - Tao Liu
 - Tobias Wölfel
 - Tom Roberts
+- Tudor Timi
 - Udi Jonnalagadda
+- Vladimir Rozic
+- Yuichi Sugiyama
+- Yusef Karim
+- Zachary Snow
+- Zeeshan Rafique


### PR DESCRIPTION
Add names of missing contributors. Currently there are only a few letters which are not represented with the first names of Ibex contributors: J, O, Q, W and X. If your first name starts with any of those letters make a contribution to Ibex to help us round of this list, and if your name does not start with those letters than still do make your contribution because that's the beauty of open source!

Please also do accept my apologies if I have missed your name from browsing through the commit history, feel free to add your name to this file through a PR.

Thank you to everyone who has contributed to Ibex over the years!