### PR TITLE
Remove (empty) Verible waiver file

### DIFF
--- a/ibex_core.core
+++ b/ibex_core.core
@@ -42,10 +42,6 @@ filesets:
     files:
       - lint/verilator_waiver.vlt: {file_type: vlt}
 
-  files_lint_verible:
-    files:
-      - lint/verible_waiver.vbw: {file_type: veribleLintWaiver}
-
   files_check_tool_requirements:
     depend:
      - lowrisc:tool:check_tool_requirements
@@ -170,7 +166,6 @@ targets:
   default: &default_target
     filesets:
       - tool_verilator ? (files_lint_verilator)
-      - tool_veriblelint ? (files_lint_verible)
       - files_rtl
       - files_check_tool_requirements
     toplevel: ibex_core

--- a/ibex_top.core
+++ b/ibex_top.core
@@ -27,10 +27,6 @@ filesets:
     files:
       - lint/verilator_waiver.vlt: {file_type: vlt}
 
-  files_lint_verible:
-    files:
-      - lint/verible_waiver.vbw: {file_type: veribleLintWaiver}
-
   files_check_tool_requirements:
     depend:
      - lowrisc:tool:check_tool_requirements
@@ -155,7 +151,6 @@ targets:
   default: &default_target
     filesets:
       - tool_verilator ? (files_lint_verilator)
-      - tool_veriblelint ? (files_lint_verible)
       - files_rtl
       - files_check_tool_requirements
     toplevel: ibex_top


### PR DESCRIPTION
The recent versions of Verible that I've tried die when they are given an empty waiver file. The error message is "Fatal error: Broken waiver config handle". I can't see a way to add a comment ("// No waiver" or similar), so I think the best way to keep everything alive is to delete the empty file.

(This is motivated by trying to get a separate change that I was working on to pass CI. The first step was to reproduce the CI lint check that was failing for it!)