### PR TITLE
[doc] Bump minimum Verilator version

### DIFF
--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -5,7 +5,7 @@
 # Version requirements for various tools. Checked by tooling (e.g. fusesoc),
 # and inserted into the Sphinx-generated documentation.
 __TOOL_REQUIREMENTS__ = {
-    'verilator': '4.028',
+    'verilator': '4.104',
     'edalize':   '0.2.0',
     'vcs': {
         'min_version': '2020.03-SP2',


### PR DESCRIPTION
It turns out that we use split_var in the code, which was added in version 4.030 (and several bugs were fixed in following versions). Change the minimum required version to match what we're using in CI (and presumably works!)

Closes #2080.