### PR TITLE
[vendor] Update lowrisc_ip from OpenTitan

### DIFF
--- a/dv/uvm/common_project_cfg.hjson
+++ b/dv/uvm/common_project_cfg.hjson
@@ -5,6 +5,7 @@
   project:          ibex
 
   // These keys are expected by dvsim.py, so we have to set them to something.
+  book:              bogus.book.domain
   doc_server:        bogus.doc.server
   results_server:    bogus.results.server
   results_html_name: report.html

--- a/vendor/lowrisc_ip.lock.hjson
+++ b/vendor/lowrisc_ip.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/opentitan
-    rev: 0deeaa99e5760ee4f5c0a08e5fc1670509d22744
+    rev: e6a0e9a1363d33789283ea6ba3c4d94d41f2dee5
   }
 }

--- a/vendor/lowrisc_ip/dv/sv/dv_utils/dv_macros.svh
+++ b/vendor/lowrisc_ip/dv/sv/dv_utils/dv_macros.svh
@@ -642,6 +642,6 @@
 // Do not leave this macro in other source files in the remote repo.
 `ifndef OTDBG
   `define OTDBG(x) \
-  $write($sformatf("%t:OTDBG:",$time));\
+  $write($sformatf("%t:OTDBG:%s:%d:",$time,`__FILE__, `__LINE__));\
   $display($sformatf x);
 `endif

--- a/vendor/lowrisc_ip/dv/sv/mem_bkdr_util/mem_bkdr_util__sram.sv
+++ b/vendor/lowrisc_ip/dv/sv/mem_bkdr_util/mem_bkdr_util__sram.sv
@@ -5,6 +5,7 @@
 // Wrapper functions for SRAM's encrypted read/write operations.
 // This file is included in `mem_bkdr_util.sv` as a continuation of `mem_bkdr_util` class.
 
+// Returns the address after scrambling it using the given nonce.
 function logic [bus_params_pkg::BUS_AW-1:0] get_sram_encrypt_addr (
   logic [bus_params_pkg::BUS_AW-1:0] addr,
   logic [SRAM_BLOCK_WIDTH-1:0] nonce,
@@ -22,27 +23,27 @@ function logic [bus_params_pkg::BUS_AW-1:0] get_sram_encrypt_addr (
     addr_arr[i] = addr[addr_lsb + i];
   end
 
-  // calculate scrambled address
   scr_addr_arr = sram_scrambler_pkg::encrypt_sram_addr(addr_arr, full_addr_width, nonce_arr);
 
-  // convert to bus address output
+  // Convert to bus address output.
   for (int i = 0; i < addr_lsb; i++) begin
     scr_addr[i] = addr[i];
   end
-
   for (int i = 0; i < full_addr_width; i++) begin
     scr_addr[addr_lsb + i] = scr_addr_arr[i];
   end
-
   return scr_addr;
+endfunction : get_sram_encrypt_addr
 
-endfunction // get_sram_encrypt_addr
-
+// Returns the data after adding integrity bits and encrypting it with the given key and nonce.
+// If flip_bits is non-zero it may introduce integrity errors, but notice there is a small chance
+// after descrambling the data the errors will not be detected.
 function logic [38:0] get_sram_encrypt32_intg_data (
   logic [bus_params_pkg::BUS_AW-1:0] addr,
   logic [31:0]                       data,
   logic [SRAM_KEY_WIDTH-1:0]         key,
   logic [SRAM_BLOCK_WIDTH-1:0]       nonce,
+  bit   [38:0]                       flip_bits = '0,
   int                                extra_addr_bits=0);
 
   logic [38:0]                       integ_data;
@@ -61,25 +62,35 @@ function logic [38:0] get_sram_encrypt32_intg_data (
     addr_arr[i] = addr[addr_lsb + i];
   end
 
-  // Calculate the integrity constant
   integ_data = prim_secded_pkg::prim_secded_inv_39_32_enc(data);
+  integ_data ^= flip_bits;
 
-  // Calculate the scrambled data
   wdata_arr = {<<{integ_data}};
   wdata_arr = sram_scrambler_pkg::encrypt_sram_data(
       wdata_arr, 39, 39, addr_arr, full_addr_width, key_arr, nonce_arr
   );
   scrambled_data = {<<{wdata_arr}};
-
   return scrambled_data;
+endfunction : get_sram_encrypt32_intg_data
 
-endfunction // get_sram_encrypt32_intg_data
-
+// Returns the data at the given address after descrambling the address and decrypting the data.
+// It simply ignores the integrity bits.
 virtual function logic [38:0] sram_encrypt_read32_integ(logic [bus_params_pkg::BUS_AW-1:0] addr,
                                                         logic [SRAM_KEY_WIDTH-1:0]         key,
                                                         logic [SRAM_BLOCK_WIDTH-1:0]       nonce);
-  logic [bus_params_pkg::BUS_AW-1:0] scr_addr;
-  logic [38:0]                       rdata = '0;
+  logic [bus_params_pkg::BUS_AW-1:0] scr_addr = get_sram_encrypt_addr(addr, nonce);
+  logic [38:0] rdata39 = _sram_decrypt_read39(addr, scr_addr, key, nonce);
+  return rdata39[31:0];
+endfunction : sram_encrypt_read32_integ
+
+// This reads the data at a scrambled address and decrypts it. It returns the data and
+// integrity bits.
+local function logic [38:0] _sram_decrypt_read39(
+    logic [bus_params_pkg::BUS_AW-1:0] addr,
+    logic [bus_params_pkg::BUS_AW-1:0] scr_addr,
+    logic [SRAM_KEY_WIDTH-1:0]   key,
+    logic [SRAM_BLOCK_WIDTH-1:0] nonce);
+  logic [38:0]                       rdata39 = '0;
 
   logic rdata_arr     [] = new[39];
   logic addr_arr      [] = new[addr_width];
@@ -92,59 +103,68 @@ virtual function logic [38:0] sram_encrypt_read32_integ(logic [bus_params_pkg::B
     addr_arr[i] = addr[addr_lsb + i];
   end
 
-  // Calculate the scrambled address
-  scr_addr = get_sram_encrypt_addr(addr, nonce);
-
-  // Read memory and return the decrypted data
-  rdata = read39integ(scr_addr);
-  `uvm_info(`gfn, $sformatf("scr data: 0x%0x", rdata), UVM_HIGH)
-  rdata_arr = {<<{rdata}};
+  rdata39 = read39integ(scr_addr);
+  `uvm_info(`gfn, $sformatf("scr data: 0x%0x", rdata39), UVM_HIGH)
+  rdata_arr = {<<{rdata39}};
   rdata_arr = sram_scrambler_pkg::decrypt_sram_data(
       rdata_arr, 39, 39, addr_arr, addr_width, key_arr, nonce_arr
   );
-  rdata = {<<{rdata_arr}};
-  // Only return the data payload without ECC bits.
-  return rdata[31:0];
+  rdata39 = {<<{rdata_arr}};
+  return rdata39;
+endfunction : _sram_decrypt_read39
 
-endfunction
-
+// Writes the data at the given address. It scrambles the address and encrypts the data after
+// adding integrity bits. If flip_bits is non-zero it may introduce ecc errors.
 virtual function void sram_encrypt_write32_integ(logic [bus_params_pkg::BUS_AW-1:0] addr,
                                                  logic [31:0]                       data,
                                                  logic [SRAM_KEY_WIDTH-1:0]         key,
                                                  logic [SRAM_BLOCK_WIDTH-1:0]       nonce,
                                                  bit   [38:0]                       flip_bits = 0);
-  logic [bus_params_pkg::BUS_AW-1:0] scr_addr;
-  logic [38:0]                       integ_data;
-  logic [38:0]                       scrambled_data;
+  logic [bus_params_pkg::BUS_AW-1:0] scr_addr = get_sram_encrypt_addr(addr, nonce);
+  _sram_encrypt_write39(addr, scr_addr, data, key, nonce, flip_bits);
+endfunction : sram_encrypt_write32_integ
 
-  logic wdata_arr      [] = new[39];
-  logic addr_arr       [] = new[addr_width];
-  logic key_arr        [] = new[SRAM_KEY_WIDTH];
-  logic nonce_arr      [] = new[SRAM_BLOCK_WIDTH];
-
-  key_arr   = {<<{key}};
-  nonce_arr = {<<{nonce}};
-
-  for (int i = 0; i < addr_width; i++) begin
-    addr_arr[i] = addr[addr_lsb + i];
-  end
-
-  // Calculate the scrambled address
-  scr_addr = get_sram_encrypt_addr(addr, nonce);
-
-  // Calculate the integrity constant
-  integ_data = prim_secded_pkg::prim_secded_inv_39_32_enc(data);
-
-  // flip some bits to inject integrity fault
-  integ_data ^= flip_bits;
-
-  // Calculate the scrambled data
-  wdata_arr = {<<{integ_data}};
-  wdata_arr = sram_scrambler_pkg::encrypt_sram_data(
-      wdata_arr, 39, 39, addr_arr, addr_width, key_arr, nonce_arr
-  );
-  scrambled_data = {<<{wdata_arr}};
-
-  // Write the scrambled data to memory
+// This encrypts, possibly flips some bits to inject errors, and writes the resulting data
+// to a scrambled address.
+local function void _sram_encrypt_write39(logic [bus_params_pkg::BUS_AW-1:0] addr,
+                                          logic [bus_params_pkg::BUS_AW-1:0] scr_addr,
+                                          logic [31:0]                 data,
+                                          logic [SRAM_KEY_WIDTH-1:0]   key,
+                                          logic [SRAM_BLOCK_WIDTH-1:0] nonce,
+                                          bit [38:0]                   flip_bits);
+  logic [38:0] scrambled_data = get_sram_encrypt32_intg_data(addr, data, key, nonce, flip_bits);
   write39integ(scr_addr, scrambled_data);
-endfunction
+endfunction : _sram_encrypt_write39
+
+// This injects integrity errors in sram for an original address and the corresponding
+// scrambled address. It needs to pass both addresses even though only the scrambled address
+// is affected, since the original address is used to encrypt the data.
+//
+// This code needs to try multiple random data since it is possible after encryption the
+// bit pattern will not result in a data error, as described in issue #10976
+virtual function void sram_inject_integ_error(logic [bus_params_pkg::BUS_AW-1:0] addr,
+                                              logic [bus_params_pkg::BUS_AW-1:0] scr_addr,
+                                              logic [SRAM_KEY_WIDTH-1:0]   key,
+                                              logic [SRAM_BLOCK_WIDTH-1:0] nonce);
+  int max_attempts = 40;
+  int attempt = 0;
+
+  while (attempt < max_attempts) begin
+    bit [31:0] data = $urandom();
+    bit [38:0] rdata_integ;
+    prim_secded_pkg::secded_inv_39_32_t dec;
+    // The specific bits to be flipped should be irrelevant.
+    _sram_encrypt_write39(addr, scr_addr, data, key, nonce, 39'h1001);
+    rdata_integ = _sram_decrypt_read39(addr, scr_addr, key, nonce);
+    dec = prim_secded_pkg::prim_secded_inv_39_32_dec(rdata_integ);
+    if (dec.err) begin
+      `uvm_info(`gfn, $sformatf(
+                "sram_inject_integ_error addr 0x%x, data 0x%x injects error %b after %0d attempts",
+                addr, rdata_integ, dec.err, attempt),
+                UVM_MEDIUM)
+      break;
+    end
+    ++attempt;
+  end
+  `DV_CHECK_LT(attempt, max_attempts, "Too many attempts in sram_inject_ecc_error")
+endfunction : sram_inject_integ_error

--- a/vendor/lowrisc_ip/dv/sv/mem_bkdr_util/sram_scrambler_pkg.sv
+++ b/vendor/lowrisc_ip/dv/sv/mem_bkdr_util/sram_scrambler_pkg.sv
@@ -211,7 +211,7 @@ package sram_scrambler_pkg;
 
   endfunction : encrypt_sram_addr
 
-  // Deccrypts the target SRAM address using the custom S&P network.
+  // Decrypts the target SRAM address using the custom S&P network.
   function automatic state_t decrypt_sram_addr(logic addr[], int addr_width,
                                                logic full_nonce[]);
 

--- a/vendor/lowrisc_ip/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
+++ b/vendor/lowrisc_ip/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
@@ -187,6 +187,33 @@ class push_pull_agent_cfg #(parameter int HostDataWidth = 32,
     return (d_user_data_q.size() > 0);
   endfunction
 
+  // Return true if the interface is completely silent
+  virtual function logic is_silent();
+    return !((agent_type == PushAgent) ?
+             (vif.mon_cb.valid || vif.mon_cb.ready) :
+             (vif.mon_cb.req || vif.mon_cb.ack));
+  endfunction
+
+  // Return true if there's a stalled transaction
+  //
+  // If this is a pull agent, there is a stalled transaction when the req signal is high (so
+  // something is trying to read data), but the ack signal is low (there's no data available). If it
+  // is a push agent, there is a stalled transaction when the valid signal is high (so something is
+  // trying to provide data) but the ready signal is low (the data isn't being consumed).
+  virtual function logic is_stalled();
+    return ((agent_type == PushAgent) ?
+            (vif.mon_cb.valid && !vif.mon_cb.ready) :
+            (vif.mon_cb.req && !vif.mon_cb.ack));
+  endfunction
+
+  // Wait for any current transaction to finish
+  //
+  virtual task wait_while_running();
+    while (is_stalled()) @(vif.mon_cb);
+    // Add one last cycle to wait past the final cycle for the transaction that was stalled.
+    @(vif.mon_cb);
+  endtask
+
   `uvm_object_param_utils_begin(push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth))
     `uvm_field_enum(push_pull_agent_e, agent_type,         UVM_DEFAULT)
     `uvm_field_enum(pull_handshake_e, pull_handshake_type, UVM_DEFAULT)

--- a/vendor/lowrisc_ip/dv/tools/dvsim/sim.mk
+++ b/vendor/lowrisc_ip/dv/tools/dvsim/sim.mk
@@ -83,7 +83,7 @@ ifneq (${sw_images},)
 		index=`echo $$sw_image | cut -d: -f 3`; \
 		flags=(`echo $$sw_image | cut -d: -f 4- --output-delimiter " "`); \
 		bazel_label="`echo $$sw_image | cut -d: -f 1-2`"; \
-		if [[ $${index} != 4 ]]; then \
+		if [[ $${index} != 4 && $${index} != 5 ]]; then \
 			bazel_label="$${bazel_label}_$${sw_build_device}"; \
 			bazel_cquery="labels(data, $${bazel_label}) union labels(srcs, $${bazel_label})"; \
 		else \
@@ -117,27 +117,54 @@ ifneq (${sw_images},)
 			fi; \
 			echo "Building with command: $${bazel_cmd} build $${bazel_opts} $${bazel_label}"; \
 			$${bazel_cmd} build $${bazel_airgapped_opts} $${bazel_opts} $${bazel_label}; \
-			for dep in $$($${bazel_cmd} cquery $${bazel_airgapped_opts} \
-				$${bazel_cquery} \
+			kind=$$($${bazel_cmd} cquery $${bazel_airgapped_opts} \
+				$${bazel_label} \
 				--ui_event_filters=-info \
 				--noshow_progress \
-				--output=starlark); do \
-				if [[ $$dep == //hw/ip/otp_ctrl/data* ]] || \
-				  ([[ $$dep != //hw* ]] && [[ $$dep != //util* ]] && [[ $$dep != //sw/host* ]]); then \
-					for artifact in $$($${bazel_cmd} cquery $${bazel_airgapped_opts} $${dep} \
-						--ui_event_filters=-info \
-						--noshow_progress \
-						--output=starlark \
-						--starlark:expr="\"\\n\".join([f.path for f in target.files.to_list()])"); do \
+				--output=label_kind | cut -f1 -d' '); \
+			if [[ $${kind} == "opentitan_test" \
+					|| $${bazel_label} == "//sw/device/lib/testing/test_rom:test_rom_sim_dv" \
+					|| $${bazel_label} == "//sw/device/silicon_creator/rom:rom_with_fake_keys_sim_dv" ]]; then \
+				for artifact in $$($${bazel_cmd} cquery $${bazel_airgapped_opts} \
+					$${bazel_label} \
+					--ui_event_filters=-info \
+					--noshow_progress \
+					--output=starlark \
+					`# An opentitan_test rule has all of its needed files in its runfiles.` \
+					--starlark:expr='"\n".join([f.path for f in target.data_runfiles.files.to_list()])'); do \
 						cp -f $${artifact} $${run_dir}/$$(basename $${artifact}); \
 						if [[ $$artifact == *.bin && \
 							-f "$$(echo $${artifact} | cut -d. -f 1).elf" ]]; then \
 							cp -f "$$(echo $${artifact} | cut -d. -f 1).elf" \
 								$${run_dir}/$$(basename -s .bin $${artifact}).elf; \
 						fi; \
-					done; \
-				fi; \
-			done; \
+				done; \
+			else \
+				for dep in $$($${bazel_cmd} cquery $${bazel_airgapped_opts} \
+					$${bazel_cquery} \
+					--ui_event_filters=-info \
+					--noshow_progress \
+					--output=starlark \
+					`# Bazel 6 cquery outputs repository targets in canonical format (@//blabla) whereas bazel 5 does not, ` \
+					`# so we use a custom starlark printer to remove in leading @ when needed.` \
+					--starlark:expr='str(target.label)[1:] if str(target.label).startswith("@//") else target.label'); do \
+					if [[ $$dep == //hw/ip/otp_ctrl/data* ]] || \
+					  ([[ $$dep != //hw* ]] && [[ $$dep != //util* ]] && [[ $$dep != //sw/host* ]]); then \
+						for artifact in $$($${bazel_cmd} cquery $${bazel_airgapped_opts} $${dep} \
+							--ui_event_filters=-info \
+							--noshow_progress \
+							--output=starlark \
+							--starlark:expr="\"\\n\".join([f.path for f in target.files.to_list()])"); do \
+							cp -f $${artifact} $${run_dir}/$$(basename $${artifact}); \
+							if [[ $$artifact == *.bin && \
+								-f "$$(echo $${artifact} | cut -d. -f 1).elf" ]]; then \
+								cp -f "$$(echo $${artifact} | cut -d. -f 1).elf" \
+									$${run_dir}/$$(basename -s .bin $${artifact}).elf; \
+							fi; \
+						done; \
+					fi; \
+				done; \
+			fi; \
 		fi; \
 	done;
 endif

--- a/vendor/lowrisc_ip/dv/tools/dvsim/vcs.hjson
+++ b/vendor/lowrisc_ip/dv/tools/dvsim/vcs.hjson
@@ -106,6 +106,9 @@
                "-error=ENUMASSIGN",
                // Tasks must not be enabled in functions. Other tools do not allow this.
                "-error=TEIF"
+               // This helps avoid races in flops per Synopsys CASE 01552811.
+               // It causes flops to always use the sampled data value.
+               "-deraceclockdata"
                ]
 
   run_opts:   ["-licqueue",

--- a/vendor/lowrisc_ip/ip/prim/README.md
+++ b/vendor/lowrisc_ip/ip/prim/README.md
@@ -1,5 +1,35 @@
 # lowRISC Hardware Primitives
 
+[`prim_alert`](https://reports.opentitan.org/hw/ip/prim/dv/prim_alert/latest/report.html):
+![](https://dashboards.lowrisc.org/badges/dv/prim_alert/test.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_alert/passing.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_alert/functional.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_alert/code.svg)
+
+[`prim_esc`](https://reports.opentitan.org/hw/ip/prim/dv/prim_esc/latest/report.html):
+![](https://dashboards.lowrisc.org/badges/dv/prim_esc/test.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_esc/passing.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_esc/functional.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_esc/code.svg)
+
+[`prim_lfsr`](https://reports.opentitan.org/hw/ip/prim/dv/prim_lfsr/latest/report.html):
+![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/test.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/passing.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/functional.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_lfsr/code.svg)
+
+[`prim_present`](https://reports.opentitan.org/hw/ip/prim/dv/prim_lfsr/latest/report.html):
+![](https://dashboards.lowrisc.org/badges/dv/prim_present/test.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_present/passing.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_present/functional.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_present/code.svg)
+
+[`prim_prince`](https://reports.opentitan.org/hw/ip/prim/dv/prim_lfsr/latest/report.html):
+![](https://dashboards.lowrisc.org/badges/dv/prim_prince/test.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_prince/passing.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_prince/functional.svg)
+![](https://dashboards.lowrisc.org/badges/dv/prim_prince/code.svg)
+
 ## Concepts
 
 This directory contains basic building blocks to create a hardware design,

--- a/vendor/lowrisc_ip/ip/prim/doc/prim_lfsr.md
+++ b/vendor/lowrisc_ip/ip/prim/doc/prim_lfsr.md
@@ -10,8 +10,7 @@ with the shift register, whereas the latter combines several shift register taps
 and reduces them with an XNOR tree. For more information, refer to
 [this page](https://en.wikipedia.org/wiki/Linear-feedback_shift_register). Both
 LFSR flavors have maximal period (`2^LfsrDw - 1`). The recommendation is to use
-the Galois type and fall back to the Fibonacci type depending on the polynomial
-width availability in the lookup table (see below).
+the Galois type.
 
 
 ## Parameters
@@ -70,18 +69,15 @@ LFSR with the `DefaultSeed` in the next cycle.
 
 The LFSR coefficients are taken from an internal set of lookup tables with
 precomputed coefficients. Alternatively, a custom polynomial can be provided
-using the `Custom` parameter. The lookup tables contain polynomials for both
-LFSR forms and range from 4bit to 64bit for the Galois form and 3bit to 168bit
-for the Fibonacci form. The polynomial coefficients have been obtained from
-[this page](https://users.ece.cmu.edu/~koopman/lfsr/) and
+using the `Custom` parameter. The lookup table contains polynomials for both
+LFSR forms and range from 3bit to 168bit.
+The polynomial coefficients have been obtained from
 [Xilinx application note 52](https://www.xilinx.com/support/documentation/application_notes/xapp052.pdf).
 The script `./script/get-lfsr-coeffs.py` can be used to download, parse and dump
 these coefficients in SV format as follows:
 ```
 $ script/get-lfsr-coeffs.py -o <output_file>
 ```
-The default is to get the Galois coefficients. If the Fibonacci coefficients
-are needed, add the `--fib` switch to the above command.
 
 The implementation of the state transition function of both polynomials have
 been formally verified. Further, all polynomials up to 34bit in length have been

--- a/vendor/lowrisc_ip/ip/prim/doc/prim_xoshiro256pp.md
+++ b/vendor/lowrisc_ip/ip/prim/doc/prim_xoshiro256pp.md
@@ -1,8 +1,7 @@
 # Primitive Component: XoShiRo256++
 
-# Overviewtitle
 
-`prim_xoshiro256pp` is a PRNG with 256 bit state.
+`prim_xoshiro256pp` is a PRNG with 256-bit state.
 For more information refer to [this page](https://arxiv.org/pdf/1805.01407.pdf).
 
 ## Parameters
@@ -42,22 +41,22 @@ entropy_i    |   DefaultSeed  |  all_zero_o
 ```
 
 Xoshiro256++ PRNG consists of:
- * 256b state
+ * A 256-bit state
  * A single-cycle state-update function.
  * A state output function.
 
-The basic xoshiro256++ PRNG has a 64 bit output.
-This implementation enables the output size to be any multiple of 64 bits.
-The output size controlled using the `OutputDW` parameter.
+The basic xoshiro256++ PRNG has a 64-bit output.
+This implementation supports an output size of any multiple of 64 bits.
+The output size is controlled using the `OutputDW` parameter.
 
 The xoshiro256++ module has an enable input and an additional entropy input that is
-XOR'ed into the PRNG state (connect to zero if this feature is unused).
+XORed into the PRNG state (connect to zero if this feature is unused).
 As the PRNG may jump into the all-zero state (e.g. due to an active attack), the PRNG
 state-update function contains a lockup protection which re-seeds the state with
 `DefaultSeed` and raises the alert signal `all_zero_o`, once this condition is detected.
 
 When the seed enable signal `seed_en_i` is raised, the internal state of xoshiro256++ is updated
-with the value provided at the 256b input 'seed_i'.
+with the value provided at the 256-bit input 'seed_i'.
 The state is internally updated in every clock cycle whenever the enable signal `xoshiro_en_i` is raised.
 The timing diagram below visualizes this process.
 

--- a/vendor/lowrisc_ip/ip/prim/dv/prim_lfsr/prim_lfsr_tb.sv
+++ b/vendor/lowrisc_ip/ip/prim/dv/prim_lfsr/prim_lfsr_tb.sv
@@ -50,6 +50,8 @@ module prim_lfsr_tb;
   logic [MaxLfsrDw-1:0] lfsr_periods [MaxLfsrDw+1];
   logic [MaxLfsrDw-1:0] entropy      [MaxLfsrDw+1];
   logic [MaxLfsrDw-1:0] seed         [MaxLfsrDw+1];
+  logic [MaxLfsrDw-1:0] rand_entropy;
+  logic [MaxLfsrDw-1:0] rand_seed;
 
 
   for (genvar k = MinLfsrDw; k <= MaxLfsrDw; k++) begin : gen_duts
@@ -224,10 +226,12 @@ module prim_lfsr_tb;
       repeat ($urandom_range(5000, 10000)) begin
         // Do random reset sometimes
         if ($urandom_range(0, 10) == 0) main_clk.apply_reset();
-        randomize(seed[k]);
-        randomize(entropy[k]);
-        randomize(lfsr_en[k]);
-        randomize(seed_en[k]);
+        randomize(rand_seed);
+        randomize(rand_entropy);
+        seed[k] = rand_seed;
+        entropy[k] = rand_entropy;
+        lfsr_en[k] = $urandom_range(0, 1);
+        seed_en[k] = $urandom_range(0, 1);
         main_clk.wait_clks(1);
       end
 

--- a/vendor/lowrisc_ip/ip/prim/lint/prim_cipher.vlt
+++ b/vendor/lowrisc_ip/ip/prim/lint/prim_cipher.vlt
@@ -6,9 +6,11 @@
 
 // Tell the Verilator scheduler to split up these variables into
 // separate pieces when it's figuring out process scheduling. This
-// avoids spurious UNOPTFLAT warnings caused by the fact that the
-// arrays feed into themselves (with different bits for different
-// positions in the tree).
+// avoids spurious UNOPTFLAT warnings caused by the fact that (if you
+// don't track the indices carefully) it looks like the arrays feed
+// into themselves.
 split_var -module "prim_present" -var "data_state"
 split_var -module "prim_present" -var "round_idx"
 split_var -module "prim_present" -var "round_key"
+split_var -module "prim_prince" -var "data_state_lo"
+split_var -module "prim_prince" -var "data_state_hi"

--- a/vendor/lowrisc_ip/ip/prim/lint/prim_clock_div.waiver
+++ b/vendor/lowrisc_ip/ip/prim/lint/prim_clock_div.waiver
@@ -4,18 +4,11 @@
 #
 # waiver file for prim_clock_div
 
-waive -rules CLOCK_EDGE -location {prim_clock_div.sv} -msg {Falling edge of clock 'clk_i' used here, should use rising edge} \
-      -comment "The clock switch signal is synchronized on negative edge to ensure it is away from any transition"
-
-waive -rules DUAL_EDGE_CLOCK -location {prim_clock_div.sv} -regexp {.*} \
-      -comment "The clock switch signal is synchronized on negative edge to ensure it is away from any transition"
+waive -rules {STAR_PORT_CONN_USE} -location {prim_clock_div.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."
 
 waive -rules CLOCK_MUX -location {prim_clock_div.sv} -regexp {.*reaches a multiplexer here, used as a clock.*} \
       -comment "A mux is used during scan bypass, and for switching between div by 2 and div by 1 clocks"
 
-waive -rules CLOCK_USE -location {prim_clock_div.sv} -regexp {'clk_i' is connected to 'prim_clock_mux2' port 'clk1_i', and used as a clock} \
-      -comment "This clock mux usage is OK."
-
-waive -rules SAME_NAME_TYPE -location {prim_clock_div.sv} -regexp {'ResetValue' is used as a parameter here, and as an enumeration value at} \
-      -comment "Reused parameter name."
-
+waive -rules {SAME_NAME_TYPE} -location {prim_clock_div.sv} -regexp {'ResetValue' is used as a parameter here, and as an enumeration value at prim.*} \
+      -comment "Parameter name reuse."

--- a/vendor/lowrisc_ip/ip/prim/lint/prim_subreg.waiver
+++ b/vendor/lowrisc_ip/ip/prim/lint/prim_subreg.waiver
@@ -4,3 +4,6 @@
 
 waive -rules INPUT_NOT_READ       -location {prim_subreg.sv} -regexp {Input port 'wd' is not read from} \
       -comment "for RO wd is not used"
+
+waive -rules {PARAM_NOT_USED} -location {prim_subreg_shadow.sv} -regexp {Mubi} \
+      -comment "Mubi is not yet supported in prim_subreg_shadow."

--- a/vendor/lowrisc_ip/ip/prim/prim.core
+++ b/vendor/lowrisc_ip/ip/prim/prim.core
@@ -15,6 +15,7 @@ filesets:
       - lowrisc:prim:pad_wrapper
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:clock_mux2
+      - lowrisc:prim:clock_inv
       - lowrisc:prim:buf
       - lowrisc:prim:flop
       - lowrisc:prim:flop_en

--- a/vendor/lowrisc_ip/ip/prim/prim_clock_div.core
+++ b/vendor/lowrisc_ip/ip/prim/prim_clock_div.core
@@ -6,15 +6,17 @@ CAPI=2:
 name: "lowrisc:prim:clock_div"
 description: "Generic clock divide"
 filesets:
-  files_rtl:
+  primgen_dep:
     depend:
       - lowrisc:prim:prim_pkg
-      - lowrisc:prim:flop
-      - lowrisc:prim:clock_inv
-      - lowrisc:prim:clock_buf
+      - lowrisc:prim:primgen
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
     files:
-      - rtl/prim_clock_div.sv
-    file_type: systemVerilogSource
+    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
@@ -24,8 +26,23 @@ filesets:
       - lint/prim_clock_div.waiver
     file_type: waiver
 
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+generate:
+  impl:
+    generator: primgen
+    parameters:
+      prim_name: clock_div
+
 targets:
   default:
     filesets:
-      - tool_ascentlint ? (files_ascentlint_waiver)
-      - files_rtl
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - primgen_dep
+    generate:
+      - impl

--- a/vendor/lowrisc_ip/ip/prim/prim_subreg.core
+++ b/vendor/lowrisc_ip/ip/prim/prim_subreg.core
@@ -18,6 +18,7 @@ filesets:
     file_type: systemVerilogSource
     depend:
       - lowrisc:prim:assert
+      - lowrisc:prim:mubi
 
   files_verilator_waiver:
     depend:

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_lc_dec.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_lc_dec.sv
@@ -5,9 +5,11 @@
 // Decoder for life cycle control signals with additional
 // input buffers.
 
-module prim_lc_dec (
-  input lc_ctrl_pkg::lc_tx_t lc_en_i,
-  output logic lc_en_dec_o
+module prim_lc_dec
+  import lc_ctrl_pkg::*;
+(
+  input  lc_tx_t lc_en_i,
+  output logic   lc_en_dec_o
 );
 
 logic [lc_ctrl_pkg::TxWidth-1:0] lc_en;
@@ -16,13 +18,13 @@ assign lc_en = lc_en_i;
 
 // The buffer cells have a don't touch constraint on them
 // such that synthesis tools won't collapse them
-for (genvar k = 0; k < lc_ctrl_pkg::TxWidth; k++) begin : gen_bits
+for (genvar k = 0; k < TxWidth; k++) begin : gen_bits
   prim_buf u_prim_buf (
     .in_i ( lc_en[k] ),
     .out_o ( lc_en_out[k] )
   );
 end
 
-assign lc_en_dec_o = (lc_en_out == lc_ctrl_pkg::On);
+assign lc_en_dec_o = lc_tx_test_true_strict(lc_tx_t'(lc_en_out));
 
 endmodule : prim_lc_dec

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_lfsr.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_lfsr.sv
@@ -5,8 +5,8 @@
 // This module implements different LFSR types:
 //
 // 0) Galois XOR type LFSR ([1], internal XOR gates, very fast).
-//    Parameterizable width from 4 to 64 bits.
-//    Coefficients obtained from [2].
+//    Parameterizable width from 3 to 168 bits.
+//    Coefficients obtained from [3].
 //
 // 1) Fibonacci XNOR type LFSR, parameterizable from 3 to 168 bits.
 //    Coefficients obtained from [3].
@@ -73,73 +73,8 @@ module prim_lfsr #(
 );
 
   // automatically generated with util/design/get-lfsr-coeffs.py script
-  localparam int unsigned GAL_XOR_LUT_OFF = 4;
-  localparam logic [63:0] GAL_XOR_COEFFS [61] =
-    '{ 64'h9,
-       64'h12,
-       64'h21,
-       64'h41,
-       64'h8E,
-       64'h108,
-       64'h204,
-       64'h402,
-       64'h829,
-       64'h100D,
-       64'h2015,
-       64'h4001,
-       64'h8016,
-       64'h10004,
-       64'h20013,
-       64'h40013,
-       64'h80004,
-       64'h100002,
-       64'h200001,
-       64'h400010,
-       64'h80000D,
-       64'h1000004,
-       64'h2000023,
-       64'h4000013,
-       64'h8000004,
-       64'h10000002,
-       64'h20000029,
-       64'h40000004,
-       64'h80000057,
-       64'h100000029,
-       64'h200000073,
-       64'h400000002,
-       64'h80000003B,
-       64'h100000001F,
-       64'h2000000031,
-       64'h4000000008,
-       64'h800000001C,
-       64'h10000000004,
-       64'h2000000001F,
-       64'h4000000002C,
-       64'h80000000032,
-       64'h10000000000D,
-       64'h200000000097,
-       64'h400000000010,
-       64'h80000000005B,
-       64'h1000000000038,
-       64'h200000000000E,
-       64'h4000000000025,
-       64'h8000000000004,
-       64'h10000000000023,
-       64'h2000000000003E,
-       64'h40000000000023,
-       64'h8000000000004A,
-       64'h100000000000016,
-       64'h200000000000031,
-       64'h40000000000003D,
-       64'h800000000000001,
-       64'h1000000000000013,
-       64'h2000000000000034,
-       64'h4000000000000001,
-       64'h800000000000000D };
-
-  // automatically generated with get-lfsr-coeffs.py script
-  localparam int unsigned FIB_XNOR_LUT_OFF = 3;
-  localparam logic [167:0] FIB_XNOR_COEFFS [166] =
+  localparam int unsigned LUT_OFF = 3;
+  localparam logic [167:0] LFSR_COEFFS [166] =
     '{ 168'h6,
        168'hC,
        168'h14,
@@ -351,10 +286,10 @@ module prim_lfsr #(
     if (CustomCoeffs > 0) begin : gen_custom
       assign coeffs = CustomCoeffs[LfsrDw-1:0];
     end else begin : gen_lut
-      assign coeffs = GAL_XOR_COEFFS[LfsrDw-GAL_XOR_LUT_OFF][LfsrDw-1:0];
+      assign coeffs = LFSR_COEFFS[LfsrDw-LUT_OFF][LfsrDw-1:0];
       // check that the most significant bit of polynomial is 1
-      `ASSERT_INIT(MinLfsrWidth_A, LfsrDw >= $low(GAL_XOR_COEFFS)+GAL_XOR_LUT_OFF)
-      `ASSERT_INIT(MaxLfsrWidth_A, LfsrDw <= $high(GAL_XOR_COEFFS)+GAL_XOR_LUT_OFF)
+      `ASSERT_INIT(MinLfsrWidth_A, LfsrDw >= $low(LFSR_COEFFS)+LUT_OFF)
+      `ASSERT_INIT(MaxLfsrWidth_A, LfsrDw <= $high(LFSR_COEFFS)+LUT_OFF)
     end
 
     // calculate next state using internal XOR feedback and entropy input
@@ -376,10 +311,10 @@ module prim_lfsr #(
     if (CustomCoeffs > 0) begin : gen_custom
       assign coeffs = CustomCoeffs[LfsrDw-1:0];
     end else begin : gen_lut
-      assign coeffs = FIB_XNOR_COEFFS[LfsrDw-FIB_XNOR_LUT_OFF][LfsrDw-1:0];
+      assign coeffs = LFSR_COEFFS[LfsrDw-LUT_OFF][LfsrDw-1:0];
       // check that the most significant bit of polynomial is 1
-      `ASSERT_INIT(MinLfsrWidth_A, LfsrDw >= $low(FIB_XNOR_COEFFS)+FIB_XNOR_LUT_OFF)
-      `ASSERT_INIT(MaxLfsrWidth_A, LfsrDw <= $high(FIB_XNOR_COEFFS)+FIB_XNOR_LUT_OFF)
+      `ASSERT_INIT(MinLfsrWidth_A, LfsrDw >= $low(LFSR_COEFFS)+LUT_OFF)
+      `ASSERT_INIT(MaxLfsrWidth_A, LfsrDw <= $high(LFSR_COEFFS)+LUT_OFF)
     end
 
     // calculate next state using external XNOR feedback and entropy input

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_mubi_pkg.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_mubi_pkg.sv
@@ -27,7 +27,7 @@ package prim_mubi_pkg;
   // This is a prerequisite for the multibit functions below to work.
   `ASSERT_STATIC_IN_PACKAGE(CheckMuBi4ValsComplementary_A, MuBi4True == ~MuBi4False)
 
-  // Test whether the value is supplied is one of the valid enumerations
+  // Test whether the multibit value is one of the valid enumerations
   function automatic logic mubi4_test_invalid(mubi4_t val);
     return ~(val inside {MuBi4True, MuBi4False});
   endfunction : mubi4_test_invalid
@@ -140,7 +140,7 @@ package prim_mubi_pkg;
   endfunction : mubi4_or_lo
 
   // Performs a logical AND operation between two multibit values.
-  // Tlos treats "False" as logical 1, and all other values are
+  // This treats "False" as logical 1, and all other values are
   // treated as 0.
   function automatic mubi4_t mubi4_and_lo(mubi4_t a, mubi4_t b);
     return mubi4_and(a, b, MuBi4False);
@@ -159,7 +159,7 @@ package prim_mubi_pkg;
   // This is a prerequisite for the multibit functions below to work.
   `ASSERT_STATIC_IN_PACKAGE(CheckMuBi8ValsComplementary_A, MuBi8True == ~MuBi8False)
 
-  // Test whether the value is supplied is one of the valid enumerations
+  // Test whether the multibit value is one of the valid enumerations
   function automatic logic mubi8_test_invalid(mubi8_t val);
     return ~(val inside {MuBi8True, MuBi8False});
   endfunction : mubi8_test_invalid
@@ -272,7 +272,7 @@ package prim_mubi_pkg;
   endfunction : mubi8_or_lo
 
   // Performs a logical AND operation between two multibit values.
-  // Tlos treats "False" as logical 1, and all other values are
+  // This treats "False" as logical 1, and all other values are
   // treated as 0.
   function automatic mubi8_t mubi8_and_lo(mubi8_t a, mubi8_t b);
     return mubi8_and(a, b, MuBi8False);
@@ -291,7 +291,7 @@ package prim_mubi_pkg;
   // This is a prerequisite for the multibit functions below to work.
   `ASSERT_STATIC_IN_PACKAGE(CheckMuBi12ValsComplementary_A, MuBi12True == ~MuBi12False)
 
-  // Test whether the value is supplied is one of the valid enumerations
+  // Test whether the multibit value is one of the valid enumerations
   function automatic logic mubi12_test_invalid(mubi12_t val);
     return ~(val inside {MuBi12True, MuBi12False});
   endfunction : mubi12_test_invalid
@@ -404,7 +404,7 @@ package prim_mubi_pkg;
   endfunction : mubi12_or_lo
 
   // Performs a logical AND operation between two multibit values.
-  // Tlos treats "False" as logical 1, and all other values are
+  // This treats "False" as logical 1, and all other values are
   // treated as 0.
   function automatic mubi12_t mubi12_and_lo(mubi12_t a, mubi12_t b);
     return mubi12_and(a, b, MuBi12False);
@@ -423,7 +423,7 @@ package prim_mubi_pkg;
   // This is a prerequisite for the multibit functions below to work.
   `ASSERT_STATIC_IN_PACKAGE(CheckMuBi16ValsComplementary_A, MuBi16True == ~MuBi16False)
 
-  // Test whether the value is supplied is one of the valid enumerations
+  // Test whether the multibit value is one of the valid enumerations
   function automatic logic mubi16_test_invalid(mubi16_t val);
     return ~(val inside {MuBi16True, MuBi16False});
   endfunction : mubi16_test_invalid
@@ -536,7 +536,7 @@ package prim_mubi_pkg;
   endfunction : mubi16_or_lo
 
   // Performs a logical AND operation between two multibit values.
-  // Tlos treats "False" as logical 1, and all other values are
+  // This treats "False" as logical 1, and all other values are
   // treated as 0.
   function automatic mubi16_t mubi16_and_lo(mubi16_t a, mubi16_t b);
     return mubi16_and(a, b, MuBi16False);

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_prince.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_prince.sv
@@ -106,20 +106,14 @@ module prim_prince #(
   //////////////
 
   // State variable for holding the rounds
-  //
-  // The "split_var" hint that we pass to verilator here tells it to schedule the different parts of
-  // data_state separately. This avoids an UNOPTFLAT error where it would otherwise see a dependency
-  // chain
-  //
-  //    data_state -> data_state_round -> data_state_xor -> data_state
-  //
-  logic [NumRoundsHalf*2+1:0][DataWidth-1:0] data_state /* verilator split_var */;
+  logic [NumRoundsHalf:0][DataWidth-1:0] data_state_lo;
+  logic [NumRoundsHalf:0][DataWidth-1:0] data_state_hi;
 
   // pre-round XOR
   always_comb begin : p_pre_round_xor
-    data_state[0] = data_i ^ k0;
-    data_state[0] ^= k1_d;
-    data_state[0] ^= prim_cipher_pkg::PRINCE_ROUND_CONST[0][DataWidth-1:0];
+    data_state_lo[0] = data_i ^ k0;
+    data_state_lo[0] ^= k1_d;
+    data_state_lo[0] ^= prim_cipher_pkg::PRINCE_ROUND_CONST[0][DataWidth-1:0];
   end
 
   // forward pass
@@ -127,7 +121,7 @@ module prim_prince #(
     logic [DataWidth-1:0] data_state_round;
     if (DataWidth == 64) begin : gen_fwd_d64
       always_comb begin : p_fwd_d64
-        data_state_round = prim_cipher_pkg::sbox4_64bit(data_state[k-1],
+        data_state_round = prim_cipher_pkg::sbox4_64bit(data_state_lo[k-1],
             prim_cipher_pkg::PRINCE_SBOX4);
         data_state_round = prim_cipher_pkg::prince_mult_prime_64bit(data_state_round);
         data_state_round = prim_cipher_pkg::prince_shiftrows_64bit(data_state_round,
@@ -135,7 +129,7 @@ module prim_prince #(
       end
     end else begin : gen_fwd_d32
       always_comb begin : p_fwd_d32
-        data_state_round = prim_cipher_pkg::sbox4_32bit(data_state[k-1],
+        data_state_round = prim_cipher_pkg::sbox4_32bit(data_state_lo[k-1],
             prim_cipher_pkg::PRINCE_SBOX4);
         data_state_round = prim_cipher_pkg::prince_mult_prime_32bit(data_state_round);
         data_state_round = prim_cipher_pkg::prince_shiftrows_32bit(data_state_round,
@@ -147,9 +141,9 @@ module prim_prince #(
                             prim_cipher_pkg::PRINCE_ROUND_CONST[k][DataWidth-1:0];
     // improved keyschedule proposed by https://eprint.iacr.org/2014/656.pdf
     if (k % 2 == 1) begin : gen_fwd_key_odd
-      assign data_state[k]  = data_state_xor ^ k0_new_d;
+      assign data_state_lo[k]  = data_state_xor ^ k0_new_d;
     end else begin : gen_fwd_key_even
-      assign data_state[k]  = data_state_xor ^ k1_d;
+      assign data_state_lo[k]  = data_state_xor ^ k1_d;
     end
   end
 
@@ -157,7 +151,7 @@ module prim_prince #(
   logic [DataWidth-1:0] data_state_middle_d, data_state_middle_q, data_state_middle;
   if (DataWidth == 64) begin : gen_middle_d64
     always_comb begin : p_middle_d64
-      data_state_middle_d = prim_cipher_pkg::sbox4_64bit(data_state[NumRoundsHalf],
+      data_state_middle_d = prim_cipher_pkg::sbox4_64bit(data_state_lo[NumRoundsHalf],
           prim_cipher_pkg::PRINCE_SBOX4);
       data_state_middle = prim_cipher_pkg::prince_mult_prime_64bit(data_state_middle_q);
       data_state_middle = prim_cipher_pkg::sbox4_64bit(data_state_middle,
@@ -193,16 +187,16 @@ module prim_prince #(
     assign valid_o = valid_i;
   end
 
-  assign data_state[NumRoundsHalf+1] = data_state_middle;
+  assign data_state_hi[0] = data_state_middle;
 
   // backward pass
   for (genvar k = 1; k <= NumRoundsHalf; k++) begin : gen_bwd_pass
     logic [DataWidth-1:0] data_state_xor0, data_state_xor1;
     // improved keyschedule proposed by https://eprint.iacr.org/2014/656.pdf
     if ((NumRoundsHalf + k + 1) % 2 == 1) begin : gen_bkwd_key_odd
-      assign data_state_xor0 = data_state[NumRoundsHalf+k] ^ k0_new_q;
+      assign data_state_xor0 = data_state_hi[k-1] ^ k0_new_q;
     end else begin : gen_bkwd_key_even
-      assign data_state_xor0 = data_state[NumRoundsHalf+k] ^ k1_q;
+      assign data_state_xor0 = data_state_hi[k-1] ^ k1_q;
     end
     // the construction is reflective, hence the subtraction with NumRoundsHalf
     assign data_state_xor1 = data_state_xor0 ^
@@ -214,7 +208,7 @@ module prim_prince #(
         data_state_bwd = prim_cipher_pkg::prince_shiftrows_64bit(data_state_xor1,
             prim_cipher_pkg::PRINCE_SHIFT_ROWS64_INV);
         data_state_bwd = prim_cipher_pkg::prince_mult_prime_64bit(data_state_bwd);
-        data_state[NumRoundsHalf+k+1] = prim_cipher_pkg::sbox4_64bit(data_state_bwd,
+        data_state_hi[k] = prim_cipher_pkg::sbox4_64bit(data_state_bwd,
             prim_cipher_pkg::PRINCE_SBOX4_INV);
       end
     end else begin : gen_bwd_d32
@@ -222,7 +216,7 @@ module prim_prince #(
         data_state_bwd = prim_cipher_pkg::prince_shiftrows_32bit(data_state_xor1,
             prim_cipher_pkg::PRINCE_SHIFT_ROWS64_INV);
         data_state_bwd = prim_cipher_pkg::prince_mult_prime_32bit(data_state_bwd);
-        data_state[NumRoundsHalf+k+1] = prim_cipher_pkg::sbox4_32bit(data_state_bwd,
+        data_state_hi[k] = prim_cipher_pkg::sbox4_32bit(data_state_bwd,
             prim_cipher_pkg::PRINCE_SBOX4_INV);
       end
     end
@@ -230,7 +224,7 @@ module prim_prince #(
 
   // post-rounds
   always_comb begin : p_post_round_xor
-    data_o  = data_state[2*NumRoundsHalf+1] ^
+    data_o  = data_state_hi[NumRoundsHalf] ^
               prim_cipher_pkg::PRINCE_ROUND_CONST[11][DataWidth-1:0];
     data_o ^= k1_q;
     data_o ^= k0_prime_q;

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_subreg.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_subreg.sv
@@ -9,7 +9,8 @@ module prim_subreg
 #(
   parameter int            DW       = 32,
   parameter sw_access_e    SwAccess = SwAccessRW,
-  parameter logic [DW-1:0] RESVAL   = '0    // reset value
+  parameter logic [DW-1:0] RESVAL   = '0 ,   // reset value
+  parameter bit            Mubi     = 1'b0
 ) (
   input clk_i,
   input rst_ni,
@@ -39,7 +40,8 @@ module prim_subreg
 
   prim_subreg_arb #(
     .DW       ( DW       ),
-    .SwAccess ( SwAccess )
+    .SwAccess ( SwAccess ),
+    .Mubi     ( Mubi     )
   ) wr_en_data_arb (
     .we,
     .wd,
@@ -61,6 +63,13 @@ module prim_subreg
   // feed back out for consolidation
   assign ds = wr_en ? wr_data : qs;
   assign qe = wr_en;
-  assign qs = q;
+
+  if (SwAccess == SwAccessRC) begin : gen_rc
+    // In case of a SW RC colliding with a HW write, SW gets the value written by HW
+    // but the register is cleared to 0. See #5416 for a discussion.
+    assign qs = de && we ? d : q;
+  end else begin : gen_no_rc
+    assign qs = q;
+  end
 
 endmodule

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_subreg_arb.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_subreg_arb.sv
@@ -8,7 +8,8 @@ module prim_subreg_arb
   import prim_subreg_pkg::*;
 #(
   parameter int         DW       = 32,
-  parameter sw_access_e SwAccess = SwAccessRW
+  parameter sw_access_e SwAccess = SwAccessRW,
+  parameter bit         Mubi     = 1'b0
 ) (
   // From SW: valid for RW, WO, W1C, W1S, W0C, RC.
   // In case of RC, top connects read pulse to we.
@@ -26,13 +27,18 @@ module prim_subreg_arb
   output logic          wr_en,
   output logic [DW-1:0] wr_data
 );
+  import prim_mubi_pkg::*;
 
   if (SwAccess inside {SwAccessRW, SwAccessWO}) begin : gen_w
     assign wr_en   = we | de;
     assign wr_data = (we == 1'b1) ? wd : d; // SW higher priority
     // Unused q - Prevent lint errors.
     logic [DW-1:0] unused_q;
+    //VCS coverage off
+    // pragma coverage off
     assign unused_q = q;
+    //VCS coverage on
+    // pragma coverage on
   end else if (SwAccess == SwAccessRO) begin : gen_ro
     assign wr_en   = de;
     assign wr_data = d;
@@ -40,32 +46,128 @@ module prim_subreg_arb
     logic          unused_we;
     logic [DW-1:0] unused_wd;
     logic [DW-1:0] unused_q;
+    //VCS coverage off
+    // pragma coverage off
     assign unused_we = we;
     assign unused_wd = wd;
     assign unused_q  = q;
+    //VCS coverage on
+    // pragma coverage on
   end else if (SwAccess == SwAccessW1S) begin : gen_w1s
     // If SwAccess is W1S, then assume hw tries to clear.
     // So, give a chance HW to clear when SW tries to set.
     // If both try to set/clr at the same bit pos, SW wins.
     assign wr_en   = we | de;
-    assign wr_data = (de ? d : q) | (we ? wd : '0);
+    if (Mubi) begin : gen_mubi
+      if (DW == 4) begin : gen_mubi4
+        assign wr_data = prim_mubi_pkg::mubi4_or_hi(prim_mubi_pkg::mubi4_t'(de ? d : q),
+                                                    (we ? prim_mubi_pkg::mubi4_t'(wd) :
+                                                          prim_mubi_pkg::MuBi4False));
+      end else if (DW == 8) begin : gen_mubi8
+        assign wr_data = prim_mubi_pkg::mubi8_or_hi(prim_mubi_pkg::mubi8_t'(de ? d : q),
+                                                    (we ? prim_mubi_pkg::mubi8_t'(wd) :
+                                                          prim_mubi_pkg::MuBi8False));
+      end else if (DW == 12) begin : gen_mubi12
+        assign wr_data = prim_mubi_pkg::mubi12_or_hi(prim_mubi_pkg::mubi12_t'(de ? d : q),
+                                                     (we ? prim_mubi_pkg::mubi12_t'(wd) :
+                                                           prim_mubi_pkg::MuBi12False));
+      end else if (DW == 16) begin : gen_mubi16
+        assign wr_data = prim_mubi_pkg::mubi16_or_hi(prim_mubi_pkg::mubi16_t'(de ? d : q),
+                                                     (we ? prim_mubi_pkg::mubi16_t'(wd) :
+                                                           prim_mubi_pkg::MuBi16False));
+      end else begin : gen_invalid_mubi
+        $error("%m: Invalid width for MuBi");
+      end
+    end else begin : gen_non_mubi
+      assign wr_data = (de ? d : q) | (we ? wd : '0);
+    end
   end else if (SwAccess == SwAccessW1C) begin : gen_w1c
     // If SwAccess is W1C, then assume hw tries to set.
     // So, give a chance HW to set when SW tries to clear.
     // If both try to set/clr at the same bit pos, SW wins.
     assign wr_en   = we | de;
-    assign wr_data = (de ? d : q) & (we ? ~wd : '1);
+    if (Mubi) begin : gen_mubi
+      if (DW == 4) begin : gen_mubi4
+        assign wr_data = prim_mubi_pkg::mubi4_and_hi(prim_mubi_pkg::mubi4_t'(de ? d : q),
+                                                     (we ? prim_mubi_pkg::mubi4_t'(~wd) :
+                                                           prim_mubi_pkg::MuBi4True));
+      end else if (DW == 8) begin : gen_mubi8
+        assign wr_data = prim_mubi_pkg::mubi8_and_hi(prim_mubi_pkg::mubi8_t'(de ? d : q),
+                                                     (we ? prim_mubi_pkg::mubi8_t'(~wd) :
+                                                           prim_mubi_pkg::MuBi8True));
+      end else if (DW == 12) begin : gen_mubi12
+        assign wr_data = prim_mubi_pkg::mubi12_and_hi(prim_mubi_pkg::mubi12_t'(de ? d : q),
+                                                      (we ? prim_mubi_pkg::mubi12_t'(~wd) :
+                                                            prim_mubi_pkg::MuBi12True));
+      end else if (DW == 16) begin : gen_mubi16
+        assign wr_data = prim_mubi_pkg::mubi16_and_hi(prim_mubi_pkg::mubi16_t'(de ? d : q),
+                                                      (we ? prim_mubi_pkg::mubi16_t'(~wd) :
+                                                            prim_mubi_pkg::MuBi16True));
+      end else begin : gen_invalid_mubi
+        $error("%m: Invalid width for MuBi");
+      end
+    end else begin : gen_non_mubi
+      assign wr_data = (de ? d : q) & (we ? ~wd : '1);
+    end
   end else if (SwAccess == SwAccessW0C) begin : gen_w0c
     assign wr_en   = we | de;
-    assign wr_data = (de ? d : q) & (we ? wd : '1);
+    if (Mubi) begin : gen_mubi
+      if (DW == 4) begin : gen_mubi4
+        assign wr_data = prim_mubi_pkg::mubi4_and_hi(prim_mubi_pkg::mubi4_t'(de ? d : q),
+                                                     (we ? prim_mubi_pkg::mubi4_t'(wd) :
+                                                           prim_mubi_pkg::MuBi4True));
+      end else if (DW == 8) begin : gen_mubi8
+        assign wr_data = prim_mubi_pkg::mubi8_and_hi(prim_mubi_pkg::mubi8_t'(de ? d : q),
+                                                     (we ? prim_mubi_pkg::mubi8_t'(wd) :
+                                                           prim_mubi_pkg::MuBi8True));
+      end else if (DW == 12) begin : gen_mubi12
+        assign wr_data = prim_mubi_pkg::mubi12_and_hi(prim_mubi_pkg::mubi12_t'(de ? d : q),
+                                                      (we ? prim_mubi_pkg::mubi12_t'(wd) :
+                                                            prim_mubi_pkg::MuBi12True));
+      end else if (DW == 16) begin : gen_mubi16
+        assign wr_data = prim_mubi_pkg::mubi16_and_hi(prim_mubi_pkg::mubi16_t'(de ? d : q),
+                                                      (we ? prim_mubi_pkg::mubi16_t'(wd) :
+                                                            prim_mubi_pkg::MuBi16True));
+      end else begin : gen_invalid_mubi
+        $error("%m: Invalid width for MuBi");
+      end
+    end else begin : gen_non_mubi
+      assign wr_data = (de ? d : q) & (we ? wd : '1);
+    end
   end else if (SwAccess == SwAccessRC) begin : gen_rc
     // This swtype is not recommended but exists for compatibility.
     // WARN: we signal is actually read signal not write enable.
     assign wr_en  = we | de;
-    assign wr_data = (de ? d : q) & (we ? '0 : '1);
+    if (Mubi) begin : gen_mubi
+      if (DW == 4) begin : gen_mubi4
+        assign wr_data = prim_mubi_pkg::mubi4_and_hi(prim_mubi_pkg::mubi4_t'(de ? d : q),
+                                                     (we ? prim_mubi_pkg::MuBi4False :
+                                                           prim_mubi_pkg::MuBi4True));
+      end else if (DW == 8) begin : gen_mubi8
+        assign wr_data = prim_mubi_pkg::mubi8_and_hi(prim_mubi_pkg::mubi8_t'(de ? d : q),
+                                                     (we ? prim_mubi_pkg::MuBi8False :
+                                                           prim_mubi_pkg::MuBi8True));
+      end else if (DW == 12) begin : gen_mubi12
+        assign wr_data = prim_mubi_pkg::mubi12_and_hi(prim_mubi_pkg::mubi12_t'(de ? d : q),
+                                                      (we ? prim_mubi_pkg::MuBi12False :
+                                                            prim_mubi_pkg::MuBi12True));
+      end else if (DW == 16) begin : gen_mubi16
+        assign wr_data = prim_mubi_pkg::mubi16_and_hi(prim_mubi_pkg::mubi16_t'(de ? d : q),
+                                                      (we ? prim_mubi_pkg::mubi16_t'(wd) :
+                                                            prim_mubi_pkg::MuBi16True));
+      end else begin : gen_invalid_mubi
+        $error("%m: Invalid width for MuBi");
+      end
+    end else begin : gen_non_mubi
+      assign wr_data = (de ? d : q) & (we ? '0 : '1);
+    end
     // Unused wd - Prevent lint errors.
     logic [DW-1:0] unused_wd;
+    //VCS coverage off
+    // pragma coverage off
     assign unused_wd = wd;
+    //VCS coverage on
+    // pragma coverage on
   end else begin : gen_hw
     assign wr_en   = de;
     assign wr_data = d;
@@ -73,9 +175,13 @@ module prim_subreg_arb
     logic          unused_we;
     logic [DW-1:0] unused_wd;
     logic [DW-1:0] unused_q;
+    //VCS coverage off
+    // pragma coverage off
     assign unused_we = we;
     assign unused_wd = wd;
     assign unused_q  = q;
+    //VCS coverage on
+    // pragma coverage on
   end
 
 endmodule

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_subreg_shadow.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_subreg_shadow.sv
@@ -11,7 +11,8 @@ module prim_subreg_shadow
 #(
   parameter int            DW       = 32,
   parameter sw_access_e    SwAccess = SwAccessRW,
-  parameter logic [DW-1:0] RESVAL   = '0    // reset value
+  parameter logic [DW-1:0] RESVAL   = '0,    // reset value
+  parameter bit            Mubi     = 1'b0
 ) (
   input clk_i,
   input rst_ni,
@@ -186,5 +187,8 @@ module prim_subreg_shadow
   assign qe = committed_qe;
   assign q  = committed_q;
   assign qs = committed_qs;
+
+  // prim_subreg_shadow does not support multi-bit software access yet
+  `ASSERT_NEVER(MubiIsNotYetSupported_A, Mubi)
 
 endmodule

--- a/vendor/lowrisc_ip/ip/prim_generic/lint/prim_generic_clock_div.waiver
+++ b/vendor/lowrisc_ip/ip/prim_generic/lint/prim_generic_clock_div.waiver
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_generic_clock_div
+
+waive -rules CLOCK_EDGE -location {prim_generic_clock_div.sv} -msg {Falling edge of clock 'clk_i' used here, should use rising edge} \
+      -comment "The clock switch signal is synchronized on negative edge to ensure it is away from any transition"
+
+waive -rules DUAL_EDGE_CLOCK -location {prim_generic_clock_div.sv} -regexp {.*} \
+      -comment "The clock switch signal is synchronized on negative edge to ensure it is away from any transition"
+
+waive -rules CLOCK_MUX -location {prim_generic_clock_div.sv} -regexp {.*reaches a multiplexer here, used as a clock.*} \
+      -comment "A mux is used during scan bypass, and for switching between div by 2 and div by 1 clocks"
+
+waive -rules CLOCK_USE -location {prim_generic_clock_div.sv} -regexp {'clk_i' is connected to 'prim_clock_mux2' port 'clk1_i', and used as a clock} \
+      -comment "This clock mux usage is OK."
+
+waive -rules SAME_NAME_TYPE -location {prim_generic_clock_div.sv} -regexp {'ResetValue' is used as a parameter here, and as an enumeration value at} \
+      -comment "Reused parameter name."

--- a/vendor/lowrisc_ip/ip/prim_generic/prim_generic_clock_div.core
+++ b/vendor/lowrisc_ip/ip/prim_generic/prim_generic_clock_div.core
@@ -1,0 +1,31 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_generic:clock_div"
+description: "Generic clock divide"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:prim_pkg
+      - lowrisc:prim:flop
+      - lowrisc:prim:clock_inv
+      - lowrisc:prim:clock_buf
+    files:
+      - rtl/prim_generic_clock_div.sv
+    file_type: systemVerilogSource
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_clock_div.waiver
+    file_type: waiver
+
+targets:
+  default:
+    filesets:
+      - tool_ascentlint ? (files_ascentlint_waiver)
+      - files_rtl

--- a/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_generic_clock_div.sv
+++ b/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_generic_clock_div.sv
@@ -4,7 +4,7 @@
 
 `include "prim_assert.sv"
 
-module prim_clock_div #(
+module prim_generic_clock_div #(
   parameter int unsigned Divisor = 2,
   parameter logic ResetValue = 0
 ) (

--- a/vendor/lowrisc_ip/lint/README.md
+++ b/vendor/lowrisc_ip/lint/README.md
@@ -13,7 +13,7 @@ The lint flow run scripts and waiver files are available in the GitHub repositor
 However, the _"lowRISC Lint Rules"_ are available as part of the default policies in AscentLint release 2019.A.p3 or newer (as `LRLR-v1.0.policy`).
 This enables designers that have access to this tool to run the lint flow provided locally on their premises.
 
-Our linting flow leverages FuseSoC to resolve dependencies, build file lists and call the linting tools. See [here](https://github.com/olofk/fusesoc) for an introduction to this open source package manager and [here](https://opentitan.org/guides/getting_started) for installation instructions.
+Our linting flow leverages FuseSoC to resolve dependencies, build file lists and call the linting tools. See [here](https://github.com/olofk/fusesoc) for an introduction to this open source package manager and [here](../../doc/getting_started/README.md) for installation instructions.
 
 In order to run lint on a [comportable IP](../../doc/contributing/hw/comportability/README.md) block, the corresponding FuseSoC core file must have a lint target and include (optional) waiver files as shown in the following example taken from the FuseSoC core of the AES comportable IP:
 ```

--- a/vendor/lowrisc_ip/util/dvsim/Deploy.py
+++ b/vendor/lowrisc_ip/util/dvsim/Deploy.py
@@ -567,7 +567,7 @@ class RunTest(Deploy):
             if RunTest.fixed_seed:
                 return RunTest.fixed_seed
             for i in range(1000):
-                seed = random.getrandbits(32)
+                seed = random.getrandbits(256)
                 RunTest.seeds.append(seed)
         return RunTest.seeds.pop(0)
 

--- a/vendor/lowrisc_ip/util/dvsim/README.md
+++ b/vendor/lowrisc_ip/util/dvsim/README.md
@@ -18,7 +18,7 @@ The following flows are currently supported:
 
 # Installation
 
-Clone the OpenTitan repository by following the [Getting Started](https://opentitan.org/guides/getting_started) steps.
+Clone the OpenTitan repository by following the [Getting Started](../../doc/getting_started/README.md) steps.
 The rest of the documentation will assume `$REPO_TOP` as the root of the local OpenTitan repository.
 DVSim is located at `$REPO_TOP/util/dvsim/dvsim.py`.
 

--- a/vendor/lowrisc_ip/util/dvsim/dvsim.py
+++ b/vendor/lowrisc_ip/util/dvsim/dvsim.py
@@ -518,11 +518,11 @@ def parse_args():
     seedg.add_argument("--build-seed",
                        nargs="?",
                        type=int,
-                       const=random.getrandbits(32),
+                       const=random.getrandbits(256),
                        metavar="S",
                        help=('Randomize the build. Uses the seed value passed '
                              'an additional argument, else it randomly picks '
-                             'a 32-bit unsigned integer.'))
+                             'a 256-bit unsigned integer.'))
 
     seedg.add_argument("--seeds",
                        "-s",

--- a/vendor/lowrisc_ip/util/dvsim/results_server.py
+++ b/vendor/lowrisc_ip/util/dvsim/results_server.py
@@ -1,0 +1,129 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Code for a wrapper class which represents the "results server".
+
+This is hosted with Google cloud.
+"""
+
+import datetime
+import logging as log
+import subprocess
+from shutil import which
+from typing import List, Optional
+
+
+class NoGCPError(Exception):
+    """Exception to represent "GCP tools are not installed"."""
+
+    pass
+
+
+class ResultsServer:
+    """A class representing connections to GCP (the results server)."""
+
+    def __init__(self, bucket_name: str):
+        """Construct results server; check gsutil is accessible."""
+        self.bucket_name = bucket_name
+
+        # A lazy "half check", which tries to check the GCP tools are available
+        # on this machine. We could move this check to later (in the methods
+        # that actually try to communicate with the server), at which point we
+        # could also do permissions checks. But then it's a bit more fiddly to
+        # work out what to do when something fails.
+        if which('gsutil') is None or which('gcloud') is None:
+            raise NoGCPError()
+
+    def _path_in_bucket(self, path: str) -> str:
+        """Return path in a format that gsutil understands in our bucket."""
+        return "gs://{}/{}".format(self.bucket_name, path)
+
+    def ls(self, path: str) -> List[str]:
+        """Find all the files at the given path on the results server.
+
+        This uses "gsutil ls". If gsutil fails, raise a
+        subprocess.CalledProcessError.
+        """
+        process = subprocess.run(['gsutil', 'ls', self._path_in_bucket(path)],
+                                 capture_output=True,
+                                 universal_newlines=True,
+                                 check=True)
+        # Get the list of files by splitting into lines, then dropping the
+        # empty line at the end.
+        return process.stdout.split('\n')[:-1]
+
+    def get_creation_time(self, path: str) -> Optional[datetime.datetime]:
+        """Get the creation time at path as a datetime.
+
+        If the file does not exist (or we can't see the creation time for some
+        reason), returns None.
+        """
+        bucket_pfx = 'gs://' + self.bucket_name
+        try:
+            process = subprocess.run(['gsutil', 'ls', '-l', bucket_pfx + '/' + path],
+                                     capture_output=True,
+                                     universal_newlines=True,
+                                     check=True)
+        except subprocess.CalledProcessError:
+            log.error("Failed to run ls -l over GCP on {}".format(path))
+            return None
+
+        # With gsutil, ls -l on a file prints out something like the following:
+        #
+        #     35079  2023-07-27T13:26:04Z  gs://rjs-ot-scratch/path/to/my.file
+        #
+        # Grab the second word on the first (only) line and parse it into a
+        # datetime object. Recent versions of Python (3.11+) parse this format
+        # with fromisoformat but we can't do that with the minimum version we
+        # support.
+        timestamp = process.stdout.split()[1]
+        try:
+            return datetime.datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S%z')
+        except ValueError:
+            log.error("Could not parse creation time ({}) from GCP"
+                      .format(timestamp))
+            return None
+
+    def mv(self, from_path: str, to_path: str) -> None:
+        """Use gsutil mv to move a file/directory."""
+        try:
+            subprocess.run(['gsutil', 'mv',
+                            self._path_in_bucket(from_path),
+                            self._path_in_bucket(to_path)],
+                           check=True)
+        except subprocess.CalledProcessError:
+            # If we failed to move the file, print an error message but also
+            # fail with an error: we might not want anything downstream to keep
+            # going if it assumes some precious object has been moved to a
+            # place of safety!
+            log.error('Failed to use gsutil to move {} to {}'
+                      .format(from_path, to_path))
+            raise
+
+    def upload(self,
+               local_path: str,
+               dst_path: str,
+               recursive: bool = False) -> None:
+        """Upload a file to GCP.
+
+        Like the "cp" command, dst_path can either be the target directory or
+        it can be the name of the file/directory that you're creating inside.
+
+        On failure, prints a message to the log but returns as normal.
+        """
+        try:
+            sub_cmd = ['cp']
+            if recursive:
+                sub_cmd.append('-r')
+            subprocess.run(['gsutil'] + sub_cmd +
+                           [local_path,
+                            self._path_in_bucket(dst_path)],
+                           check=True)
+        except subprocess.CalledProcessError:
+            # If we failed to copy the file, print an error message but
+            # otherwise keep going. We don't want our failed upload to kill the
+            # rest of the job.
+            log.error('Failed to use gsutil to copy {} to {}'
+                      .format(local_path, dst_path))

--- a/vendor/lowrisc_ip/util/dvsim/testplanner.py
+++ b/vendor/lowrisc_ip/util/dvsim/testplanner.py
@@ -27,7 +27,7 @@ def main():
                         '-o',
                         type=argparse.FileType('w'),
                         default=sys.stdout,
-                        help='output HTML file (without CSS)')
+                        help='output markdown file')
     args = parser.parse_args()
     outfile = args.outfile
 
@@ -36,9 +36,8 @@ def main():
         if args.sim_results:
             outfile.write(
                 testplan.get_sim_results(args.sim_results, fmt="html"))
-
         else:
-            outfile.write(testplan.get_testplan_table("html"))
+            testplan.write_testplan_doc(outfile)
 
         outfile.write('\n')
 


### PR DESCRIPTION
Pull the latest version of lowrisc_ip from the current head of the OpenTitan repository.

One handy result (the reason for re-vendoring!) is that prim_prince.sv has been rewritten to avoid triggering errors with recent versions of Verilator. See https://github.com/lowRISC/opentitan/pull/19785 for an explanation.