### PR TITLE
[ci] Run CI in merge queue and not master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ name: Ibex CI
 
 on:
   push:
-    branches:
-      - "*"
     tags:
       - "*"
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -10,7 +10,12 @@ name: pr-lint
 
 # Triggers when there is any activity on a pull request, e.g. opened, updated.
 on:
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
+    branches:
+      - "*"
 
 jobs:
   verible-lint:


### PR DESCRIPTION
This change updates the GitHub actions workflows to run on PR updates and within the GitHub merge queue, but not on the push to the master branch.

Because we use merge queues, the re-run for the master branch would be redundant.