### PR TITLE
[ci] switch CI runner from Ubuntu 20.04 to 22.04

### DIFF
--- a/.github/workflows/private-ci.yml
+++ b/.github/workflows/private-ci.yml
@@ -16,59 +16,23 @@ on:
       - "*"
 
 permissions:
-  statuses: write
+  contents: write # For repository dispatch
 
 jobs:
   trigger:
     name: Trigger Private CI
     runs-on: ubuntu-latest
     steps:
-      # Find a merge commit. We cannot use merge_commit_sha from context directly because
-      # mergeability check is asynchronous to pull_request_target trigger..
-      - name: Find the merge commit
-        id: merge
-        if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            for (let i = 0; i <= 5; i++) {
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number,
-              });
-
-              if (i != 5 && pr.mergeable == null) {
-                console.log("Mergeability check in progress");
-                await new Promise(r => setTimeout(r, 2000));
-                continue;
-              }
-
-              if (pr.mergeable) {
-                core.setOutput('merge_sha', pr.merge_commit_sha);
-              } else {
-                core.setFailed('Pull request is not mergeable');
-              }
-              break;
-            }
-
-      # Create pending statuses to block merge group and give indication before jobs are picked up.
-      - name: Create pending statuses
-        run: |
-          gh api --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha || github.sha }} \
-            -f state='pending' \
-            -f context='Ibex Private CI' \
-            -f description='Queued'
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
       - name: Trigger Private CI
         run: |
-          gh workflow run ibex-private-ci.yml --repo lowRISC/lowrisc-private-ci \
-            -f ref="${{ github.event.pull_request.head.sha || github.sha }}" \
-            -f sha="${{ steps.merge.outputs.merge_sha || github.sha }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.LOWRISC_PRIVATE_CI_PAT }}
+          PAYLOAD='"target":"${{ github.repository_owner }}/lowrisc-private-ci/master/ibex-private-ci.yml","sha":"${{ github.event.pull_request.head.sha || github.sha }}"'
+          if ${{ github.event_name == 'pull_request_target' }}; then
+            PAYLOAD+=',"pull_request":${{ github.event.pull_request.number }}'
+          fi
+          curl -fL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/dispatches \
+            -d '{"event_type":"cross-repo-ci","client_payload":{'"$PAYLOAD"'}}'


### PR DESCRIPTION
Update GitHub CI runner to 22.04 from 20.04 per @GregAC's suggestion.