### PR TITLE
[util] Update check_tool_requirements.py

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -8,6 +8,7 @@ git+https://github.com/lowRISC/edalize.git@ot
 # Development version with OT-specific changes
 git+https://github.com/lowRISC/fusesoc.git@ot
 
+packaging
 pyyaml
 mako
 junit-xml

--- a/util/check_tool_requirements.py
+++ b/util/check_tool_requirements.py
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-from distutils.version import StrictVersion
+from importlib.metadata import version
 import logging as log
 import os
+from packaging.version import Version
 import re
 import shlex
 import subprocess
@@ -156,7 +157,7 @@ class ToolReq:
                     'Failed to convert requirement to semantic version: {}'
                     .format(err))
         try:
-            min_sv = StrictVersion(min_semver)
+            min_sv = Version(min_semver)
         except ValueError as err:
             return (False,
                     'Bad semver inferred from required version ({}): {}'
@@ -174,7 +175,7 @@ class ToolReq:
                     'Failed to convert installed to semantic version: {}'
                     .format(err))
         try:
-            actual_sv = StrictVersion(actual_semver)
+            actual_sv = Version(actual_semver)
         except ValueError as err:
             return (False,
                     'Bad semver inferred from installed version ({}): {}'
@@ -212,7 +213,7 @@ class VeribleToolReq(ToolReq):
 
     def to_semver(self, version, from_req):
         # Drop the hash suffix and convert into version string that
-        # is compatible with StrictVersion in check_version below.
+        # is compatible with Version in check_version below.
         # Example: v0.0-808-g1e17daa -> 0.0.808
         m = re.fullmatch(r'v([0-9]+)\.([0-9]+)-([0-9]+)-g[0-9a-f]+$', version)
         if m is None:
@@ -237,7 +238,7 @@ class VcsToolReq(ToolReq):
         # already. A version always has the "2020.03" (year and month) part,
         # and may also have an -SP<n> and/or -<patch> suffix.
         #
-        # Since StrictVersion expects a 3 digit versioning scheme, we multiply
+        # Since Version expects a 3 digit versioning scheme, we multiply
         # any SP number by 100, which should work as long as the patch version
         # isn't greater than 99.
         #
@@ -261,11 +262,11 @@ class VcsToolReq(ToolReq):
 
 class PyModuleToolReq(ToolReq):
     '''A tool in a Python module (its version can be found by running pip)'''
-    version_regex = re.compile(r'Version: (.*)')
 
-    def _get_tool_cmd(self):
-        return ['pip3', 'show', self.tool]
-
+    # For Python modules, use metadata directly instead of call into pip3, which
+    # may not always be available for some systems.
+    def get_version(self):
+        return version(self.tool)
 
 def dict_to_tool_req(path, tool, raw):
     '''Parse a dict (as read from Python) as a ToolReq


### PR DESCRIPTION
`distutils` is deprecated and will generate warnings when used. Replace it with packaging.version instead.

pip3 command line invocation is replaced with importlib.metadata, which removes dependency on pip3 being present.