### PR TITLE
[dv] Fix paths in `merge_cov.py`

### DIFF
--- a/dv/uvm/core_ibex/scripts/merge_cov.py
+++ b/dv/uvm/core_ibex/scripts/merge_cov.py
@@ -42,11 +42,11 @@ def merge_cov_vcs(md: RegressionMetadata, cov_dirs: Set[pathlib.Path]) -> int:
     logging.info("Generating merged coverage directory")
     cmd = (['urg', '-full64',
             '-format', 'both',
-            '-dbname', str(md.cov_dir/'merged.vdb'),
-            '-report', str(md.cov_dir/'report'),
-            '-log', str(md.cov_dir/'merge.log'),
+            '-dbname', str(md.dir_cov/'merged.vdb'),
+            '-report', str(md.dir_cov/'report'),
+            '-log', str(md.dir_cov/'merge.log'),
             '-dir'] +
-           list(cov_dirs))
+           [str(cov_dir) for cov_dir in list(cov_dirs)])
     return run_one(md.verbose, cmd, redirect_stdstreams='/dev/null')
 
 


### PR DESCRIPTION
1. In [`metadata.py`](dv/uvm/core_ibex/scripts/metadata.py), class `RegressionMetadata` has a field named `dir_cov`, not `cov_dir`:
https://github.com/lowRISC/ibex/blob/38da151a251de5b13afeedf9c5947707f87c5992/dv/uvm/core_ibex/scripts/metadata.py#L117
https://github.com/lowRISC/ibex/blob/38da151a251de5b13afeedf9c5947707f87c5992/dv/uvm/core_ibex/scripts/metadata.py#L153
But in [`merge_cov.py`](dv/uvm/core_ibex/scripts/merge_cov.py), it refers to a field named `cov_dir` that does not exist in class `RegressionMetadata`:
https://github.com/lowRISC/ibex/blob/38da151a251de5b13afeedf9c5947707f87c5992/dv/uvm/core_ibex/scripts/merge_cov.py#L45-L47
This results in an `AttributeError` during dv process:
> AttributeError: 'RegressionMetadata' object has no attribute 'cov_dir'
---
2. In [`scripts_lib.py`](https://github.com/lowRISC/ibex/blob/38da151a251de5b13afeedf9c5947707f87c5992/dv/uvm/core_ibex/scripts/scripts_lib.py), type of parameter `cmd` in function `run_one` is `List[str]`:
https://github.com/lowRISC/ibex/blob/38da151a251de5b13afeedf9c5947707f87c5992/dv/uvm/core_ibex/scripts/scripts_lib.py#L25-L26
But in [`merge_cov.py`](dv/uvm/core_ibex/scripts/merge_cov.py), it passes a `list` (`list(cov_dirs)`) with type `List[pathlib3x.pathlib3x.PosixPath]` to function `run_one` as a parameter:
https://github.com/lowRISC/ibex/blob/38da151a251de5b13afeedf9c5947707f87c5992/dv/uvm/core_ibex/scripts/merge_cov.py#L41-L50
This results in a `TypeError` during dv process:
> TypeError: type of argument "cmd"[11] must be str; got pathlib3x.pathlib3x.PosixPath instead