### PR TITLE
[doc] Update cosim version

### DIFF
--- a/doc/03_reference/verification.rst
+++ b/doc/03_reference/verification.rst
@@ -111,8 +111,7 @@ In order to run the co-simulation flow, you'll need:
   + Some custom CSRs
   + Custom NMI behavior
 
-  Ibex verification should work with the Spike version that is tagged as ``ibex-cosim-v0.3``.
-  Other, later, versions called ``ibex-cosim-v*`` may also work but there's no guarantee of backwards compatibility.
+  Ibex verification should work with the Spike version that is tagged as ``ibex-cosim-v0.5``.
 
   Spike must be built with the ``--enable-commitlog`` and ``--enable-misaligned`` options.
   ``--enable-commitlog`` is needed to produce log output to track the instructions that were executed.


### PR DESCRIPTION
Not sure if this is helpful, but:

Currently, the verification documentation recommends to using ibex-cosim-v0.3. However, this version of spike causes some compilation issues for `spike_cosim `on my side:
`class "processor_t" has no member "set_mhpm_counter_num`
when calling `make` in `dv/uvm/core_ibex/`.
This issue occurs when using the latest pre-build lowrisc toolchain "20231205-1" or "20230427-1".

When using ibex-cosim-v0.5 DV works.