### PR TITLE
Update verilator version

### DIFF
--- a/ci/vars.env
+++ b/ci/vars.env
@@ -5,7 +5,7 @@
 # Pipeline variables, used by the public and private CI pipelines
 # Quote values to ensure they are parsed as string (version numbers might
 # end up as float otherwise).
-VERILATOR_VERSION=v4.104
+VERILATOR_VERSION=v4.210
 IBEX_COSIM_VERSION=15fbd568
 RISCV_TOOLCHAIN_TAR_VERSION=20220210-1
 RISCV_TOOLCHAIN_TAR_VARIANT=lowrisc-toolchain-gcc-rv32imcb

--- a/ci/vars.yml
+++ b/ci/vars.yml
@@ -6,7 +6,7 @@
 # Quote values to ensure they are parsed as string (version numbers might
 # end up as float otherwise).
 variables:
-  VERILATOR_VERSION: "v4.104"
+  VERILATOR_VERSION: "v4.210"
   IBEX_COSIM_VERSION: "15fbd568"
   RISCV_TOOLCHAIN_TAR_VERSION: "20220210-1"
   RISCV_TOOLCHAIN_TAR_VARIANT: "lowrisc-toolchain-gcc-rv32imcb"

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -5,7 +5,7 @@
 # Version requirements for various tools. Checked by tooling (e.g. fusesoc),
 # and inserted into the Sphinx-generated documentation.
 __TOOL_REQUIREMENTS__ = {
-    'verilator': '4.104',
+    'verilator': '4.210',
     'edalize':   '0.2.0',
     'vcs': {
         'min_version': '2020.03-SP2',


### PR DESCRIPTION
To be consistent between projects, this PR updates the Verilator version to 4.210, which is also used by OpenTitan. The reason for this change is that in #2129 Verilator linting issues occured that did not occur in OpenTitan.

Closes #2131.