### PR TITLE
[tracer] Fix reporting of load/store data

### DIFF
--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -136,10 +136,10 @@ module ibex_tracer (
     if ((data_accessed & MEM) != 0) begin
       $fwrite(fh, " PA:0x%08x", rvfi_mem_addr);
 
-      if (rvfi_mem_rmask != 4'b0000) begin
+      if (rvfi_mem_wmask != 4'b0000) begin
         $fwrite(fh, " store:0x%08x", rvfi_mem_wdata);
       end
-      if (rvfi_mem_wmask != 4'b0000) begin
+      if (rvfi_mem_rmask != 4'b0000) begin
         $fwrite(fh, " load:0x%08x", rvfi_mem_rdata);
       end
     end


### PR DESCRIPTION
Modify the tracer to use the appropriate read/write masks when logging load/store traffic from the Load Store Unit.
The logging code was using the wrong strobes when appending the loaded/stored values to the report as may be seen in the following snippet from a core trace:

```
         249402	    104397	000081cc	0062ae23	sw	x6,28(x5)	  x5:0x30470000  x6:0x03b9aca0 PA:0x3047001c store:0x03b9aca0 load:0x00000000
         249404	    104398	000081d0	4305	c.li	x6,1	  x6=0x00000001
         249442	    104417	000081d2	0062aa23	sw	x6,20(x5)	  x5:0x30470000  x6:0x00000001 PA:0x30470014 store:0x00000001 load:0x00000000
         249444	    104418	000081d6	30134537	lui	x10,0x30134	 x10=0x30134000
         249554	    104473	000081da	3d852283	lw	x5,984(x10)	 x10:0x30134000  x5=0x00000000 PA:0x301343d8 store:0x00000000
```

Specifically, when storing data the indicated 'store' value is correct but there is a spurious additional 'load: 0x00000000' indication, and when loading data, the trace instead shows 'store: 0x00000000'