### PR TITLE
[doc] Require sphinx version >= 7.0

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 setuptools_scm
-sphinx~=4.2
+sphinx>=7.0
 sphinx_rtd_theme
 sphinxcontrib-wavedrom
 wavedrom>=1.9.0rc1


### PR DESCRIPTION
The previous ~= 4.2 was failing build on readthedocs

This will (hopefully) fix https://github.com/lowRISC/ibex/issues/2132