### PR TITLE
Fix stale merge commit issue in private CI

### DIFF
--- a/.github/workflows/private-ci.yml
+++ b/.github/workflows/private-ci.yml
@@ -23,6 +23,35 @@ jobs:
     name: Trigger Private CI
     runs-on: ubuntu-latest
     steps:
+      # Find a merge commit. We cannot use merge_commit_sha from context directly because
+      # mergeability check is asynchronous to pull_request_target trigger..
+      - name: Find the merge commit
+        id: merge
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            for (let i = 0; i <= 5; i++) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+              });
+
+              if (i != 5 && pr.mergeable == null) {
+                console.log("Mergeability check in progress");
+                await new Promise(r => setTimeout(r, 2000));
+                continue;
+              }
+
+              if (pr.mergeable) {
+                core.setOutput('merge_sha', pr.merge_commit_sha);
+              } else {
+                core.setFailed('Pull request is not mergeable');
+              }
+              break;
+            }
+
       # Create pending statuses to block merge group and give indication before jobs are picked up.
       - name: Create pending statuses
         run: |
@@ -40,6 +69,6 @@ jobs:
         run: |
           gh workflow run ibex-private-ci.yml --repo lowRISC/lowrisc-private-ci \
             -f ref="${{ github.event.pull_request.head.sha || github.sha }}" \
-            -f sha="${{ github.event.pull_request.merge_commit_sha || github.sha }}"
+            -f sha="${{ steps.merge.outputs.merge_sha || github.sha }}"
         env:
           GITHUB_TOKEN: ${{ secrets.LOWRISC_PRIVATE_CI_PAT }}


### PR DESCRIPTION
This is a very rare condition where GitHub triggers the workflow a little bit too fast before the asynchronous mergeability check has completed (only an issue for pull_request_target because pull_request would block on mergeability check completion). To address this issue I added a polling loop to do a few retries.

An example run is here: https://github.com/nbdd0121/ibex/actions/runs/7728003457/job/21067811451 (it fails in a later step due to lack of secrets, but that's expected).