### PR TITLE
Update old `cpuctrl` CSR name in `cs_registers.rst`

### DIFF
--- a/doc/03_reference/cs_registers.rst
+++ b/doc/03_reference/cs_registers.rst
@@ -72,7 +72,7 @@ Ibex implements all the Control and Status Registers (CSRs) listed in the follow
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x7B3  | ``dscratch1``      | RW     | Debug Scratch Register 1                      |
 +---------+--------------------+--------+-----------------------------------------------+
-|  0x7C0  | ``cpuctrl``        | WARL   | CPU Control Register (Custom CSR)             |
+|  0x7C0  | ``cpuctrlsts``     | WARL   | CPU Control and Status Register (Custom CSR)  |
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x7C1  | ``secureseed``     | WARL   | Security feature random seed (Custom CSR)     |
 +---------+--------------------+--------+-----------------------------------------------+


### PR DESCRIPTION
The commit 70186c57 renamed the CSR `cpuctrl` to `cpuctrlsts` but did not update the table in `doc/03_reference/cs_registers.rst`. Fix that.