### PR TITLE
Require Pydantic 2 or above

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -17,7 +17,7 @@ pathlib3x  # Backports some useful features
 typing-utils  # Ditto
 typeguard ~= 2.13
 portalocker
-pydantic
+pydantic >= 2
 svg.py
 
 # Needed by dvsim.py (not actually used in Ibex)


### PR DESCRIPTION
We need Pydantic 2 or higher to use the `field_validator` functionality used in Ibex DV.