### PR TITLE
[ci] Add missing sudo in CI

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -85,7 +85,7 @@ case "$ID-$VERSION_ID" in
     cd build/verible
     curl -Ls -o verible.tar.gz "https://github.com/google/verible/releases/download/$VERIBLE_VERSION/verible-$VERIBLE_VERSION-Ubuntu-$VERSION_ID-$VERSION_CODENAME-x86_64.tar.gz"
     $SUDO_CMD mkdir -p /tools/verible && $SUDO_CMD chmod 777 /tools/verible
-    tar -C /tools/verible -xf verible.tar.gz --strip-components=1
+    $SUDO_CMD tar -C /tools/verible -xf verible.tar.gz --strip-components=1
     echo "##vso[task.prependpath]/tools/verible/bin"
     echo "/tools/verible/bin" >> $GITHUB_PATH
     ;;
@@ -101,6 +101,6 @@ TOOLCHAIN_URL="https://github.com/lowRISC/lowrisc-toolchains/releases/download/$
 mkdir -p build/toolchain
 curl -Ls -o build/toolchain/rv32-toolchain.tar.xz "$TOOLCHAIN_URL"
 $SUDO_CMD mkdir -p /tools/riscv && $SUDO_CMD chmod 777 /tools/riscv
-tar -C /tools/riscv -xf build/toolchain/rv32-toolchain.tar.xz --strip-components=1
+$SUDO_CMD tar -C /tools/riscv -xf build/toolchain/rv32-toolchain.tar.xz --strip-components=1
 echo "##vso[task.prependpath]/tools/riscv/bin"
 echo "/tools/riscv/bin" >> $GITHUB_PATH


### PR DESCRIPTION
We are switching to use non-root GitHub action runners, which need sudo for global package installation.