### PR TITLE
[icache,dv] Fix types in ibex_icache_sim_cfg.hjson

### DIFF
--- a/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
+++ b/dv/uvm/icache/dv/ibex_icache_sim_cfg.hjson
@@ -29,12 +29,11 @@
 
   sim_tops: ["ibex_icache_fcov_bind"]
 
-  build_modes: [
-    {
-      name: default
+  build_modes: {
+    default: {
       en_build_modes: ["{tool}_memutil_dpi_scrambled_build_opts"]
     }
-  ]
+  }
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50


### PR DESCRIPTION
I actually made this change in OpenTitan (editing the vendored Ibex code by accident). Oops! The easiest path to getting everything in sync again is probably to manually make the identical change here and then re-vendor the result into OpenTitan.

For reviewers who also happen to be on the OT side: this was a silly mistake from me, and it seems that a bug in the CI code in OpenTitan means we can't currently see the mistake. But I've just fixed the CI bug... which means CI checks in OpenTitan are currently failing, for silly reasons. This is the simplest path I can see to getting everything green again.