### PR TITLE
[simple_system] Bump C++ version in core files

### DIFF
--- a/dv/riscv_compliance/ibex_riscv_compliance.core
+++ b/dv/riscv_compliance/ibex_riscv_compliance.core
@@ -161,6 +161,6 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_riscv_compliance -g"'
+          - '-CFLAGS "-std=c++14 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_riscv_compliance -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"

--- a/dv/verilator/simple_system_cosim/ibex_simple_system_cosim.core
+++ b/dv/verilator/simple_system_cosim/ibex_simple_system_cosim.core
@@ -179,7 +179,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++11 -Wall -DVL_USER_STOP -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g `pkg-config --cflags riscv-riscv riscv-disasm riscv-fdt`"'
+          - '-CFLAGS "-std=c++14 -Wall -DVL_USER_STOP -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g `pkg-config --cflags riscv-riscv riscv-disasm riscv-fdt`"'
           - '-LDFLAGS "-pthread -lutil -lelf `pkg-config --libs riscv-riscv riscv-disasm riscv-fdt`"'
           - "-Wall"
           - "-Wwarn-IMPERFECTSCH"

--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -175,7 +175,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g"'
+          - '-CFLAGS "-std=c++14 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           - "-Wwarn-IMPERFECTSCH"


### PR DESCRIPTION
This sets the C++ standard that's being used for a compiler that's building a Verilator simulation. Recent versions of Verilator (since 5.020) require the compiler to be in C++14 mode, so passing -std=c++11 breaks the build with them.

Looking at history, -std=c++14 has been supported since GCC 6.1 (released in 2016), so I don't think this argument is going to cause any tooling problems.

Fixes #2153.