### PR TITLE
Add missing copyright headers

### DIFF
--- a/dv/uvm/icache/dv/fcov/ibex_icache_fcov_if.sv
+++ b/dv/uvm/icache/dv/fcov/ibex_icache_fcov_if.sv
@@ -1,3 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 interface ibex_icache_fcov_if import ibex_pkg::*; #(
   parameter int NUM_FB = 4
 ) (

--- a/rtl/ibex_core.f
+++ b/rtl/ibex_core.f
@@ -1,3 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 ibex_pkg.sv
 ibex_alu.sv
 ibex_compressed_decoder.sv

--- a/rtl/ibex_counter.sv
+++ b/rtl/ibex_counter.sv
@@ -1,3 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 module ibex_counter #(
   parameter int CounterWidth = 32,
   // When set `counter_val_upd_o` provides an incremented version of the counter value, otherwise

--- a/util/Makefile
+++ b/util/Makefile
@@ -1,3 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 .PHONY: lint
 lint:
 	mypy --strict sv2v_in_place.py


### PR DESCRIPTION
These four files were missing copyright headers and license tags.

I can see from https://github.com/lowRISC/ibex/blob/master/vendor/google_riscv-dv/files.f that `.f` files can have `//`-style comments.