### PR TITLE
[rtl] Expose ICacheScrNumPrinceRoundsHalf parameter

### DIFF
--- a/rtl/ibex_top.sv
+++ b/rtl/ibex_top.sv
@@ -13,28 +13,29 @@
  * Top level module of the ibex RISC-V core
  */
 module ibex_top import ibex_pkg::*; #(
-  parameter bit          PMPEnable        = 1'b0,
-  parameter int unsigned PMPGranularity   = 0,
-  parameter int unsigned PMPNumRegions    = 4,
-  parameter int unsigned MHPMCounterNum   = 0,
-  parameter int unsigned MHPMCounterWidth = 40,
-  parameter bit          RV32E            = 1'b0,
-  parameter rv32m_e      RV32M            = RV32MFast,
-  parameter rv32b_e      RV32B            = RV32BNone,
-  parameter regfile_e    RegFile          = RegFileFF,
-  parameter bit          BranchTargetALU  = 1'b0,
-  parameter bit          WritebackStage   = 1'b0,
-  parameter bit          ICache           = 1'b0,
-  parameter bit          ICacheECC        = 1'b0,
-  parameter bit          BranchPredictor  = 1'b0,
-  parameter bit          DbgTriggerEn     = 1'b0,
-  parameter int unsigned DbgHwBreakNum    = 1,
-  parameter bit          SecureIbex       = 1'b0,
-  parameter bit          ICacheScramble   = 1'b0,
-  parameter lfsr_seed_t  RndCnstLfsrSeed  = RndCnstLfsrSeedDefault,
-  parameter lfsr_perm_t  RndCnstLfsrPerm  = RndCnstLfsrPermDefault,
-  parameter int unsigned DmHaltAddr       = 32'h1A110800,
-  parameter int unsigned DmExceptionAddr  = 32'h1A110808,
+  parameter bit          PMPEnable                    = 1'b0,
+  parameter int unsigned PMPGranularity               = 0,
+  parameter int unsigned PMPNumRegions                = 4,
+  parameter int unsigned MHPMCounterNum               = 0,
+  parameter int unsigned MHPMCounterWidth             = 40,
+  parameter bit          RV32E                        = 1'b0,
+  parameter rv32m_e      RV32M                        = RV32MFast,
+  parameter rv32b_e      RV32B                        = RV32BNone,
+  parameter regfile_e    RegFile                      = RegFileFF,
+  parameter bit          BranchTargetALU              = 1'b0,
+  parameter bit          WritebackStage               = 1'b0,
+  parameter bit          ICache                       = 1'b0,
+  parameter bit          ICacheECC                    = 1'b0,
+  parameter bit          BranchPredictor              = 1'b0,
+  parameter bit          DbgTriggerEn                 = 1'b0,
+  parameter int unsigned DbgHwBreakNum                = 1,
+  parameter bit          SecureIbex                   = 1'b0,
+  parameter bit          ICacheScramble               = 1'b0,
+  parameter int unsigned ICacheScrNumPrinceRoundsHalf = 2,
+  parameter lfsr_seed_t  RndCnstLfsrSeed              = RndCnstLfsrSeedDefault,
+  parameter lfsr_perm_t  RndCnstLfsrPerm              = RndCnstLfsrPermDefault,
+  parameter int unsigned DmHaltAddr                   = 32'h1A110800,
+  parameter int unsigned DmExceptionAddr              = 32'h1A110808,
   // Default seed and nonce for scrambling
   parameter logic [SCRAMBLE_KEY_W-1:0]   RndCnstIbexKey   = RndCnstIbexKeyDefault,
   parameter logic [SCRAMBLE_NONCE_W-1:0] RndCnstIbexNonce = RndCnstIbexNonceDefault
@@ -560,11 +561,12 @@ module ibex_top import ibex_pkg::*; #(
         // SEC_CM: ICACHE.MEM.SCRAMBLE
         // Tag RAM instantiation
         prim_ram_1p_scr #(
-          .Width            (TagSizeECC),
-          .Depth            (IC_NUM_LINES),
-          .DataBitsPerMask  (TagSizeECC),
-          .EnableParity     (0),
-          .NumAddrScrRounds (NumAddrScrRounds)
+          .Width              (TagSizeECC),
+          .Depth              (IC_NUM_LINES),
+          .DataBitsPerMask    (TagSizeECC),
+          .EnableParity       (0),
+          .NumPrinceRoundsHalf(ICacheScrNumPrinceRoundsHalf),
+          .NumAddrScrRounds   (NumAddrScrRounds)
         ) tag_bank (
           .clk_i,
           .rst_ni,
@@ -596,6 +598,7 @@ module ibex_top import ibex_pkg::*; #(
           .DataBitsPerMask    (LineSizeECC),
           .ReplicateKeyStream (1),
           .EnableParity       (0),
+          .NumPrinceRoundsHalf(ICacheScrNumPrinceRoundsHalf),
           .NumAddrScrRounds   (NumAddrScrRounds)
         ) data_bank (
           .clk_i,


### PR DESCRIPTION
This parameter allows integrators controlling the number of PRINCE half rounds in the scrambled ICache SRAM primitives, e.g., to balance timing impact and security guarantees.