### PR TITLE
[rtl] Guard against false memory responses for secure configurations

### DIFF
--- a/rtl/ibex_ex_block.sv
+++ b/rtl/ibex_ex_block.sv
@@ -196,4 +196,22 @@ module ibex_ex_block #(
   // final cycle of ALU operation).
   assign ex_valid_o = multdiv_sel ? multdiv_valid : ~(|alu_imd_val_we);
 
+`ifdef INC_ASSERT
+  // This is intended to be accessed via hierarchal references so isn't output from this module nor
+  // used in any logic in this module
+  logic sva_multdiv_fsm_idle;
+
+  if (RV32M == RV32MSlow) begin : gen_multdiv_sva_idle_slow
+    assign sva_multdiv_fsm_idle = gen_multdiv_slow.multdiv_i.sva_fsm_idle;
+  end else if (RV32M == RV32MFast || RV32M == RV32MSingleCycle) begin : gen_multdiv_sva_idle_fast
+    assign sva_multdiv_fsm_idle = gen_multdiv_fast.multdiv_i.sva_fsm_idle;
+  end else begin : gen_multdiv_sva_idle_none
+    assign sva_multdiv_fsm_idle = 1'b1;
+  end
+
+  // Mark the sva_multdiv_fsm_idle as unused to avoid lint issues
+  logic unused_sva_multdiv_fsm_idle;
+  assign unused_sva_multdiv_fsm_idle = sva_multdiv_fsm_idle;
+`endif
+
 endmodule

--- a/rtl/ibex_multdiv_slow.sv
+++ b/rtl/ibex_multdiv_slow.sv
@@ -327,6 +327,7 @@ module ibex_multdiv_slow
     end // (mult_sel_i || div_sel_i)
   end
 
+
   //////////////////////////////////////////
   // Mutliplier / Divider state registers //
   //////////////////////////////////////////
@@ -368,6 +369,17 @@ module ibex_multdiv_slow
   `ASSERT(IbexMultDivStateValid, md_state_q inside {
       MD_IDLE, MD_ABS_A, MD_ABS_B, MD_COMP, MD_LAST, MD_CHANGE_SIGN, MD_FINISH
       }, clk_i, !rst_ni)
+
+`ifdef INC_ASSERT
+  logic sva_fsm_idle;
+  logic unused_sva_fsm_idle;
+
+  // This is intended to be accessed via hierarchal references so isn't output from this module nor
+  // used in any logic in this module
+  assign sva_fsm_idle = (md_state_q == MD_IDLE);
+  // Mark the sva_fsm_idle as unused to avoid lint issues
+  assign unused_sva_fsm_idle = sva_fsm_idle;
+`endif
 
 `ifdef FORMAL
   `ifdef YOSYS

--- a/rtl/ibex_wb_stage.sv
+++ b/rtl/ibex_wb_stage.sv
@@ -166,8 +166,7 @@ module ibex_wb_stage #(
     // that returns too late to be used on the forwarding path.
     assign rf_wdata_fwd_wb_o = rf_wdata_wb_q;
 
-    // For FI hardening, only forward LSU write enable if we're actually waiting for it.
-    assign rf_wdata_wb_mux_we[1] = outstanding_load_wb_o & rf_we_lsu_i;
+    assign rf_wdata_wb_mux_we[1] = rf_we_lsu_i;
 
     if (DummyInstructions) begin : g_dummy_instr_wb
       logic dummy_instr_wb_q;


### PR DESCRIPTION
With this change all memory responses are only acted on if Ibex is expecting them for all secure configurations. Previously an error response that was injected onto the bus would trigger an exception that shouldn't occur (in particular breaking the functioning of the multiply state machine). In addition for configurations without the writeback stage an injected load data response could trigger an incorrect write to the register file.

This is only applied to the secure configurations, non-secure configurations assume correct adherence to the bus protocol meaning a response will only be seen if a request is outstanding.

Fixes https://github.com/lowRISC/ibex/issues/2144