### PR TITLE
[dv] Add spurious responses to memory agent

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf.sv
@@ -26,6 +26,7 @@ interface ibex_mem_intf#(
   wire                     misaligned_second;
   wire                     misaligned_first_saw_error;
   wire                     m_mode_access;
+  wire                     spurious_response;
 
   clocking request_driver_cb @(posedge clk);
     input   reset;
@@ -40,6 +41,7 @@ interface ibex_mem_intf#(
     input   rdata;
     input   rintg;
     input   error;
+    input   spurious_response;
   endclocking
 
   clocking response_driver_cb @(posedge clk);
@@ -55,6 +57,7 @@ interface ibex_mem_intf#(
     output  rdata;
     output  rintg;
     output  error;
+    output  spurious_response;
   endclocking
 
   clocking monitor_cb @(posedge clk);
@@ -74,6 +77,7 @@ interface ibex_mem_intf#(
     input misaligned_second;
     input misaligned_first_saw_error;
     input m_mode_access;
+    input spurious_response;
   endclocking
 
   task automatic wait_clks(input int num);

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_monitor.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_monitor.sv
@@ -10,18 +10,28 @@ class ibex_mem_intf_monitor extends uvm_monitor;
 
   protected virtual ibex_mem_intf vif;
 
+  // The monitor tick event fires every clock cycle once any writes to
+  // outstanding_access_port and addr_ph_ports have occurred.
+  event monitor_tick;
+
   mailbox #(ibex_mem_intf_seq_item)          collect_response_queue;
   uvm_analysis_port#(ibex_mem_intf_seq_item) item_collected_port;
   uvm_analysis_port#(ibex_mem_intf_seq_item) addr_ph_port;
+  // The number of outstanding accesses is written to this port every clock cycle
+  uvm_analysis_port#(int)                    outstanding_accesses_port;
 
   `uvm_component_utils(ibex_mem_intf_monitor)
   `uvm_component_new
+
+  int outstanding_accesses = 0;
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     item_collected_port = new("item_collected_port", this);
     addr_ph_port = new("addr_ph_port_monitor", this);
     collect_response_queue = new();
+    outstanding_accesses_port = new("outstanding_accesses_port", this);
+
     if(!uvm_config_db#(virtual ibex_mem_intf)::get(this, "", "vif", vif)) begin
        `uvm_fatal("NOVIF",{"virtual interface must be set for: ",get_full_name(),".vif"});
     end
@@ -52,9 +62,23 @@ class ibex_mem_intf_monitor extends uvm_monitor;
 
   virtual protected task collect_address_phase();
     ibex_mem_intf_seq_item trans_collected;
+
+
     forever begin
+      @(vif.monitor_cb);
+
       trans_collected = ibex_mem_intf_seq_item::type_id::create("trans_collected");
-      while(!(vif.monitor_cb.request && vif.monitor_cb.grant)) @(vif.monitor_cb);
+
+      while (!(vif.monitor_cb.request && vif.monitor_cb.grant)) begin
+        if (vif.monitor_cb.rvalid && !vif.monitor_cb.spurious_response) begin
+          outstanding_accesses--;
+        end
+        outstanding_accesses_port.write(outstanding_accesses);
+
+        -> monitor_tick;
+        @(vif.monitor_cb);
+      end
+
       trans_collected.addr                       = vif.monitor_cb.addr;
       trans_collected.be                         = vif.monitor_cb.be;
       trans_collected.misaligned_first           = vif.monitor_cb.misaligned_first;
@@ -63,7 +87,7 @@ class ibex_mem_intf_monitor extends uvm_monitor;
       trans_collected.m_mode_access              = vif.monitor_cb.m_mode_access;
       `uvm_info(get_full_name(), $sformatf("Detect request with address: %0x",
                 trans_collected.addr), UVM_HIGH)
-      if(vif.monitor_cb.we) begin
+      if (vif.monitor_cb.we) begin
         trans_collected.read_write = WRITE;
         trans_collected.data = vif.monitor_cb.wdata;
         trans_collected.intg = vif.monitor_cb.wintg;
@@ -73,7 +97,14 @@ class ibex_mem_intf_monitor extends uvm_monitor;
       addr_ph_port.write(trans_collected);
       `uvm_info(get_full_name(),"Send through addr_ph_port", UVM_HIGH)
       collect_response_queue.put(trans_collected);
-      @(vif.monitor_cb);
+
+      outstanding_accesses++;
+      if (vif.monitor_cb.rvalid && !vif.monitor_cb.spurious_response) begin
+        outstanding_accesses--;
+      end
+      outstanding_accesses_port.write(outstanding_accesses);
+
+      -> monitor_tick;
     end
   endtask : collect_address_phase
 
@@ -83,7 +114,7 @@ class ibex_mem_intf_monitor extends uvm_monitor;
       collect_response_queue.get(trans_collected);
       do
         @(vif.monitor_cb);
-      while(vif.monitor_cb.rvalid === 0);
+      while(vif.monitor_cb.rvalid === 0 || vif.monitor_cb.spurious_response === 1);
 
       if (trans_collected.read_write == READ) begin
         trans_collected.data = vif.monitor_cb.rdata;

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_request_driver.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_request_driver.sv
@@ -81,7 +81,7 @@ class ibex_mem_intf_request_driver extends uvm_driver #(ibex_mem_intf_seq_item);
     forever begin
       rdata_queue.get(tr);
       vif.wait_clks(1);
-      while(vif.rvalid !== 1'b1) vif.wait_clks(1);
+      while((vif.rvalid !== 1'b1 || vif.spurious_response === 1'b1)) vif.wait_clks(1);
       if(tr.read_write == READ)
         tr.data = vif.request_driver_cb.rdata;
         tr.intg = vif.request_driver_cb.rintg;

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent.sv
@@ -44,9 +44,12 @@ class ibex_mem_intf_response_agent extends uvm_agent;
     if(get_is_active() == UVM_ACTIVE) begin
       driver.seq_item_port.connect(sequencer.seq_item_export);
       monitor.addr_ph_port.connect(sequencer.addr_ph_port.analysis_export);
+      monitor.outstanding_accesses_port.connect(sequencer.outstanding_accesses_imp);
     end
     driver.cfg = cfg;
     sequencer.cfg = cfg;
+
+    sequencer.monitor_tick = monitor.monitor_tick;
   endfunction : connect_phase
 
   function void reset();

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent_cfg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_agent_cfg.sv
@@ -39,19 +39,25 @@ class ibex_mem_intf_response_agent_cfg extends uvm_object;
   // CONTROL_KNOB : enable/disable to generation of bad integrity upon uninit accesses
   bit enable_bad_intg_on_uninit_access = 0;
 
+  int unsigned spurious_response_delay_min = 0;
+  int unsigned spurious_response_delay_max = 100;
+
   constraint zero_delays_c {
     zero_delays dist {1 :/ zero_delay_pct,
                       0 :/ 100 - zero_delay_pct};
   }
 
   `uvm_object_utils_begin(ibex_mem_intf_response_agent_cfg)
-    `uvm_field_int(fixed_data_write_response, UVM_DEFAULT)
-    `uvm_field_int(gnt_delay_min,             UVM_DEFAULT)
-    `uvm_field_int(gnt_delay_max,             UVM_DEFAULT)
-    `uvm_field_int(valid_delay_min,           UVM_DEFAULT)
-    `uvm_field_int(valid_delay_max,           UVM_DEFAULT)
-    `uvm_field_int(zero_delays,               UVM_DEFAULT)
-    `uvm_field_int(zero_delay_pct,            UVM_DEFAULT)
+    `uvm_field_int(fixed_data_write_response,   UVM_DEFAULT)
+    `uvm_field_int(gnt_delay_min,               UVM_DEFAULT)
+    `uvm_field_int(gnt_delay_max,               UVM_DEFAULT)
+    `uvm_field_int(valid_delay_min,             UVM_DEFAULT)
+    `uvm_field_int(valid_delay_max,             UVM_DEFAULT)
+    `uvm_field_int(zero_delays,                 UVM_DEFAULT)
+    `uvm_field_int(zero_delay_pct,              UVM_DEFAULT)
+    `uvm_field_int(spurious_response_delay_min, UVM_DEFAULT)
+    `uvm_field_int(spurious_response_delay_max, UVM_DEFAULT)
+
   `uvm_object_utils_end
 
   function new(string name = "");

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_sequencer.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_response_sequencer.sv
@@ -10,18 +10,27 @@ class ibex_mem_intf_response_sequencer extends uvm_sequencer #(ibex_mem_intf_seq
 
   // TLM port to peek the address phase from the response monitor
   uvm_tlm_analysis_fifo #(ibex_mem_intf_seq_item) addr_ph_port;
+  uvm_analysis_imp #(int, ibex_mem_intf_response_sequencer) outstanding_accesses_imp;
   ibex_mem_intf_response_agent_cfg cfg;
+
+  event monitor_tick = null;
+  int outstanding_accesses = 0;
 
   `uvm_component_utils(ibex_mem_intf_response_sequencer)
 
   function new (string name, uvm_component parent);
     super.new(name, parent);
     addr_ph_port = new("addr_ph_port_sequencer", this);
+    outstanding_accesses_imp = new("outstanding_access_imp", this);
   endfunction : new
 
   // On reset, empty the tlm fifo
   function void reset();
     addr_ph_port.flush();
+  endfunction
+
+  function void write(int x);
+    outstanding_accesses = x;
   endfunction
 
 endclass : ibex_mem_intf_response_sequencer

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_seq_item.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_seq_item.sv
@@ -17,6 +17,7 @@ class ibex_mem_intf_seq_item extends uvm_sequence_item;
   rand bit [3:0]                req_delay;
   rand bit [5:0]                rvalid_delay;
   rand bit                      error;
+       bit                      spurious_response;
        bit                      misaligned_first;
        bit                      misaligned_second;
        bit                      misaligned_first_saw_error;
@@ -35,6 +36,7 @@ class ibex_mem_intf_seq_item extends uvm_sequence_item;
     `uvm_field_int      (misaligned_second,          UVM_DEFAULT)
     `uvm_field_int      (misaligned_first_saw_error, UVM_DEFAULT)
     `uvm_field_int      (m_mode_access,              UVM_DEFAULT)
+    `uvm_field_int      (spurious_response,          UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/dv/uvm/core_ibex/env/core_ibex_env_cfg.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_env_cfg.sv
@@ -31,6 +31,14 @@ class core_ibex_env_cfg extends uvm_object;
   // If '1', reaching the timeout in seconds fatally ends the test.
   // If '0', we end the test with a pass.
   bit                          is_timeout_s_fatal = 1;
+  // If '1' core_ibex_vseq will randomly choose to enable spurious responses in the data side memory
+  // agent. This will also disable assertions that check the memory interface protocol as spurious
+  // responses violate them.
+  bit                          enable_spurious_dside_responses = 1;
+
+  // If spurious responses are enabled what percentage of tests will enable them
+  int unsigned spurious_response_pct = 20;
+
 
   `uvm_object_utils_begin(core_ibex_env_cfg)
     `uvm_field_int(enable_double_fault_detector, UVM_DEFAULT)

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -168,6 +168,19 @@ module core_ibex_tb_top;
   `DV_ASSERT_CTRL("tb_rf_rd_mux_b_onehot",
     `IBEX_RF_PATH.gen_rdata_mux_check.u_rdata_b_mux.SelIsOnehot_A)
 
+  `DV_ASSERT_CTRL("tb_no_spurious_response",
+    core_ibex_tb_top.dut.u_ibex_top.u_ibex_core.NoMemResponseWithoutPendingAccess)
+  `DV_ASSERT_CTRL("tb_no_spurious_response",
+    core_ibex_tb_top.dut.u_ibex_top.MaxOutstandingDSideAccessesCorrect)
+  `DV_ASSERT_CTRL("tb_no_spurious_response",
+    core_ibex_tb_top.dut.u_ibex_top.PendingAccessTrackingCorrect)
+
+  if (SecureIbex) begin : g_lockstep_assert_ctrl
+    `define IBEX_LOCKSTEP_PATH core_ibex_tb_top.dut.u_ibex_top.gen_lockstep.u_ibex_lockstep
+    `DV_ASSERT_CTRL("tb_no_spurious_response",
+      `IBEX_LOCKSTEP_PATH.u_shadow_core.NoMemResponseWithoutPendingAccess)
+  end
+
   assign dut.u_ibex_top.u_ibex_core.u_fcov_bind.rf_we_glitch_err =
     dut.u_ibex_top.rf_alert_major_internal;
 

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -90,6 +90,7 @@ class core_ibex_base_test extends uvm_test;
     bit [31:0] mhpm_counter_num;
     bit        secure_ibex;
     bit        icache;
+    bit        disable_spurious_dside_responses;
 
     super.build_phase(phase);
     $value$plusargs("timeout_in_cycles=%0d", timeout_in_cycles);
@@ -165,6 +166,16 @@ class core_ibex_base_test extends uvm_test;
 
     uvm_config_db#(core_ibex_env_cfg)::set(this, "*", "cfg", cfg);
     mem = mem_model_pkg::mem_model#()::type_id::create("mem");
+
+    disable_spurious_dside_responses = 0;
+    void'($value$plusargs("disable_spurious_dside_responses=%0d",
+      disable_spurious_dside_responses));
+
+    // Disable spurious reponses for non secure configs or when disabled through plusarg
+    if ((secure_ibex == 0) || disable_spurious_dside_responses) begin
+      cfg.enable_spurious_dside_responses = 0;
+    end
+
     // Create virtual sequence and assign memory handle
     vseq = core_ibex_vseq::type_id::create("vseq");
     vseq.mem = mem;


### PR DESCRIPTION
A spurious response is one that isn't associated with any on-going request. With this new feature the memory agent can generate them randomly when the interface is idle (i.e. there are no outstanding requests).