### PR TITLE
[rtl] Remove ECC related data_rdata_i -> instr_X_o feedthroughs

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -352,7 +352,7 @@ module ibex_controller #(
 
     // As integrity error is the only internal interrupt implement, set irq_nm_* signals directly
     // within this generate block.
-    assign irq_nm_int       = mem_resp_intg_err_irq_set | mem_resp_intg_err_irq_pending_q;
+    assign irq_nm_int       = mem_resp_intg_err_irq_pending_q;
     assign irq_nm_int_cause = NMI_INT_CAUSE_ECC;
     assign irq_nm_int_mtval = mem_resp_intg_err_addr_q;
   end else begin : g_no_intg_irq_int


### PR DESCRIPTION
Prior to this commit an ECC failure on the incoming data memory response factored directly into the outputs for the instruction memory interfaces. This existed due to a desire to take an NMI on an ECC failure as soon as possible but causes timing issues so it has been altered.

Now rather than directly raise the NMI the same cycle the assertion of 'irq_nm_int' is delayed by a cycle which breaks the feedthrough path.