### PR TITLE
[dv,py] Tweak ISS linker arg construction for Xcelium

### DIFF
--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -256,7 +256,7 @@
       <ISS_LIBS>
       <ISS_CFLAGS>
       <EXTRA_COSIM_CFLAGS>
-      -Wld,<ISS_LDFLAGS>
+      <ISS_LDFLAGS>
       -lstdc++
   sim:
     cmd:


### PR DESCRIPTION
The previous code here was a bit too hacky, so implement a solution that directly follows the suggestion in the Cadence support article. An example was also added to make it clear what this transformation is achieving.

Additionally, cleanup some of the other code in the module, renaming for clarity and adding comments. Move some variable declarations around to be closer to their use. Add some more typehints.

Fixes #2205