### PR TITLE
[rtl] Fix wrong address in latch RF

### DIFF
--- a/rtl/ibex_register_file_latch.sv
+++ b/rtl/ibex_register_file_latch.sv
@@ -118,7 +118,7 @@ module ibex_register_file_latch #(
       .clk_i,
       .rst_ni,
       .oh_i   (raddr_onehot_a_buf),
-      .addr_i (raddr_b_int),
+      .addr_i (raddr_a_int),
       // Set enable=1 as address is always valid.
       .en_i   (1'b1),
       .err_o  (oh_raddr_a_err)


### PR DESCRIPTION
This commit fixes a typo that used the wrong read address (raddr_b instead of raddr_a) for port A.