### PR TITLE
ibex_pcounts: resolve uninitialize warning

### DIFF
--- a/dv/verilator/pcount/cpp/ibex_pcounts.cc
+++ b/dv/verilator/pcount/cpp/ibex_pcounts.cc
@@ -53,10 +53,9 @@ static bool has_hpm_counter(int index) {
 
 std::string ibex_pcount_string(bool csv) {
   char separator = csv ? ',' : ':';
-  std::string::size_type longest_name_length;
+  std::string::size_type longest_name_length = 0;
 
   if (!csv) {
-    longest_name_length = 0;
     for (int i = 0; i < ibex_counter_names.size(); ++i) {
       if (has_hpm_counter(i)) {
         longest_name_length =


### PR DESCRIPTION
Although the current code isn't wrong as far as I can tell, it would be better to initialize the lognest_name_length variable when it is declared to avoid a build warning with older Verilator versions.