### PR TITLE
[rtl] Drive oh_raddr_*_err if RdataMuxCheck=0

### DIFF
--- a/rtl/ibex_register_file_fpga.sv
+++ b/rtl/ibex_register_file_fpga.sv
@@ -155,6 +155,9 @@ module ibex_register_file_fpga #(
 
     // async_read b
     assign rdata_b_o = (raddr_b_i == '0) ? WordZeroVal : mem[raddr_b_i];
+
+    assign oh_raddr_a_err = 1'b0;
+    assign oh_raddr_b_err = 1'b0;
   end
 
   // we select


### PR DESCRIPTION
These errors aren't detected or reported if the mux is disabled, but the RTL didn't actually drive them at all.

Fixes #2239.