### PR TITLE
[ibex_register_file_fpga] Drop two confusing comments

### DIFF
--- a/rtl/ibex_register_file_fpga.sv
+++ b/rtl/ibex_register_file_fpga.sv
@@ -150,10 +150,7 @@ module ibex_register_file_fpga #(
     assign rdata_a_o = (raddr_a_i == '0) ? WordZeroVal : mem_o_a;
     assign rdata_b_o = (raddr_b_i == '0) ? WordZeroVal : mem_o_b;
   end else begin : gen_no_rdata_mux_check
-    // async_read a
     assign rdata_a_o = (raddr_a_i == '0) ? WordZeroVal : mem[raddr_a_i];
-
-    // async_read b
     assign rdata_b_o = (raddr_b_i == '0) ? WordZeroVal : mem[raddr_b_i];
 
     assign oh_raddr_a_err = 1'b0;


### PR DESCRIPTION
These were noticed by someone responding to issue #2230. I think the author's original logic was to point out that there's a path from e.g. raddr_a_i to rdata_a_o which doesn't depend on any clock, so is "asynchronous".

But that's the same in the other modes and also for the other register file implementations, which don't have analogous comments.

Drop these ones.