### PR TITLE
[ibex] Pass mvendorid and mimpid as top-level params

### DIFF
--- a/doc/03_reference/cs_registers.rst
+++ b/doc/03_reference/cs_registers.rst
@@ -606,7 +606,7 @@ CSR Address: ``0xF11``
 
 Reset Value: ``0x0000_0000``
 
-Use the ``CSR_MVENDORID_VALUE`` parameter in :file:`rtl/ibex_pkg.sv` to change the fixed value.
+Use the top-level parameter ``CsrMvendorId`` in :file:`rtl/ibex_top.sv` to change the fixed value.
 Details of what the ID represents can be found in the RISC-V Privileged Specification.
 
 Machine Architecture ID (marchid)
@@ -628,7 +628,7 @@ CSR Address: ``0xF13``
 
 Reset Value: ``0x0000_0000``
 
-Use the ``CSR_MIMPID_VALUE`` parameter in :file:`rtl/ibex_pkg.sv` to change the fixed value.
+Use the top-level parameter ``CsrMimpId`` in :file:`rtl/ibex_top.sv` to change the fixed value.
 Details of what the ID represents can be found in the RISC-V Privileged Specification.
 
 .. _csr-mhartid:

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -47,7 +47,11 @@ module ibex_core import ibex_pkg::*; #(
   parameter int unsigned            DmBaseAddr       = 32'h1A110000,
   parameter int unsigned            DmAddrMask       = 32'h00000FFF,
   parameter int unsigned            DmHaltAddr       = 32'h1A110800,
-  parameter int unsigned            DmExceptionAddr  = 32'h1A110808
+  parameter int unsigned            DmExceptionAddr  = 32'h1A110808,
+  // mvendorid: encoding of manufacturer/provider
+  parameter logic [31:0]            CsrMvendorId     = 32'b0,
+  // marchid: encoding of base microarchitecture
+  parameter logic [31:0]            CsrMimpId        = 32'b0
 ) (
   // Clock and Reset
   input  logic                         clk_i,
@@ -1061,7 +1065,9 @@ module ibex_core import ibex_pkg::*; #(
     .PMPRstMsecCfg    (PMPRstMsecCfg),
     .RV32E            (RV32E),
     .RV32M            (RV32M),
-    .RV32B            (RV32B)
+    .RV32B            (RV32B),
+    .CsrMvendorId     (CsrMvendorId),
+    .CsrMimpId        (CsrMimpId)
   ) cs_registers_i (
     .clk_i (clk_i),
     .rst_ni(rst_ni),

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -26,7 +26,11 @@ module ibex_cs_registers #(
   parameter ibex_pkg::pmp_mseccfg_t PMPRstMsecCfg     = ibex_pkg::PmpMseccfgRst,
   parameter bit                     RV32E             = 0,
   parameter ibex_pkg::rv32m_e RV32M                   = ibex_pkg::RV32MFast,
-  parameter ibex_pkg::rv32b_e RV32B                   = ibex_pkg::RV32BNone
+  parameter ibex_pkg::rv32b_e RV32B                   = ibex_pkg::RV32BNone,
+  // mvendorid: encoding of manufacturer/provider
+  parameter logic [31:0]            CsrMvendorId      = 32'b0,
+  // mimpid: encoding of processor implementation version
+  parameter logic [31:0]            CsrMimpId         = 32'b0
 ) (
   // Clock and Reset
   input  logic                 clk_i,
@@ -332,11 +336,11 @@ module ibex_cs_registers #(
 
     unique case (csr_addr_i)
       // mvendorid: encoding of manufacturer/provider
-      CSR_MVENDORID: csr_rdata_int = CSR_MVENDORID_VALUE;
+      CSR_MVENDORID: csr_rdata_int = CsrMvendorId;
       // marchid: encoding of base microarchitecture
       CSR_MARCHID: csr_rdata_int = CSR_MARCHID_VALUE;
       // mimpid: encoding of processor implementation version
-      CSR_MIMPID: csr_rdata_int = CSR_MIMPID_VALUE;
+      CSR_MIMPID: csr_rdata_int = CsrMimpId;
       // mhartid: unique hardware thread id
       CSR_MHARTID: csr_rdata_int = hart_id_i;
       // mconfigptr: pointer to configuration data structre

--- a/rtl/ibex_pkg.sv
+++ b/rtl/ibex_pkg.sv
@@ -617,22 +617,11 @@ package ibex_pkg;
   parameter int unsigned CSR_MSECCFG_MMWP_BIT = 1;
   parameter int unsigned CSR_MSECCFG_RLB_BIT  = 2;
 
-  // Vendor ID
-  // No JEDEC ID has been allocated to lowRISC so the value is 0 to indicate the field is not
-  // implemented
-  localparam logic [31:0] CSR_MVENDORID_VALUE  = 32'b0;
-
   // Architecture ID
   // Top bit is unset to indicate an open source project. The lower bits are an ID allocated by the
   // RISC-V Foundation. Note this is allocated specifically to Ibex, should significant changes be
   // made a different architecture ID should be supplied.
   localparam logic [31:0] CSR_MARCHID_VALUE = {1'b0, 31'd22};
-
-  // Implementation ID
-  // 0 indicates this field is not implemeted. Ibex implementors may wish to indicate an RTL/netlist
-  // version here using their own unique encoding (e.g. 32 bits of the git hash of the implemented
-  // commit).
-  localparam logic [31:0] CSR_MIMPID_VALUE = 32'b0;
 
   // Machine Configuration Pointer
   // 0 indicates the configuration data structure does not eixst. Ibex implementors may wish to

--- a/rtl/ibex_top.sv
+++ b/rtl/ibex_top.sv
@@ -43,7 +43,16 @@ module ibex_top import ibex_pkg::*; #(
   parameter int unsigned            DmExceptionAddr              = 32'h1A110808,
   // Default seed and nonce for scrambling
   parameter logic [SCRAMBLE_KEY_W-1:0]   RndCnstIbexKey          = RndCnstIbexKeyDefault,
-  parameter logic [SCRAMBLE_NONCE_W-1:0] RndCnstIbexNonce        = RndCnstIbexNonceDefault
+  parameter logic [SCRAMBLE_NONCE_W-1:0] RndCnstIbexNonce        = RndCnstIbexNonceDefault,
+  // mvendorid: encoding of manufacturer/provider
+  // 0 indicates this field is not implemented. Ibex implementors may wish to set their
+  // own JEDEC ID here.
+  parameter logic [31:0]            CsrMvendorId                 = 32'b0,
+  // mimpid: encoding of processor implementation version
+  // 0 indicates this field is not implemented. Ibex implementors may wish to indicate an
+  // RTL/netlist version here using their own unique encoding (e.g. 32 bits of the git hash of the
+  // implemented commit).
+  parameter logic [31:0]            CsrMimpId                    = 32'b0
 ) (
   // Clock and Reset
   input  logic                         clk_i,
@@ -318,7 +327,9 @@ module ibex_top import ibex_pkg::*; #(
     .DmBaseAddr       (DmBaseAddr),
     .DmAddrMask       (DmAddrMask),
     .DmHaltAddr       (DmHaltAddr),
-    .DmExceptionAddr  (DmExceptionAddr)
+    .DmExceptionAddr  (DmExceptionAddr),
+    .CsrMvendorId     (CsrMvendorId),
+    .CsrMimpId        (CsrMimpId)
   ) u_ibex_core (
     .clk_i(clk),
     .rst_ni,


### PR DESCRIPTION
Instead of using default values from a package, create a top-level parameter to define these and pass them down. This allows integrators to specify them on a per-instance basis.