### PR TITLE
[rtl] Minor tweak to decoder to avoid dead code

### DIFF
--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -433,11 +433,10 @@ module ibex_decoder #(
                   end
                 end
                 5'b0_0001: begin
-                  if (instr[26] == 1'b0) begin                                        // unshfl
-                    illegal_insn = (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) ? 1'b0 : 1'b1;
-                  end else begin
-                    illegal_insn = 1'b1;
-                  end
+                  // Since instr[26] is known to be 0, this must be the "unshfl" instruction, which
+                  // is part of the RISC-V bitmanip extension. This is supported for the
+                  // RV32BOTEarlGrey and RV32BFull bitmanip configurations.
+                  illegal_insn = (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) ? 1'b0 : 1'b1;
                 end
 
                 default: illegal_insn = 1'b1;


### PR DESCRIPTION
The "else" part of the if/else check here wasn't possible because the surrounding else branch (starting at line 406) is already in the case where instr[26] is zero.

Fixes #2268.