### PR TITLE
Disable Verilator's IMPERFECTSCH warnings

### DIFF
--- a/dv/verilator/simple_system_cosim/ibex_simple_system_cosim.core
+++ b/dv/verilator/simple_system_cosim/ibex_simple_system_cosim.core
@@ -182,7 +182,6 @@ targets:
           - '-CFLAGS "-std=c++14 -Wall -DVL_USER_STOP -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g `pkg-config --cflags riscv-riscv riscv-disasm riscv-fdt`"'
           - '-LDFLAGS "-pthread -lutil -lelf `pkg-config --libs riscv-riscv riscv-disasm riscv-fdt`"'
           - "-Wall"
-          - "-Wwarn-IMPERFECTSCH"
           # RAM primitives wider than 64bit (required for ECC) fail to build in
           # Verilator without increasing the unroll count (see Verilator#1266)
           - "--unroll-count 72"

--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -178,7 +178,6 @@ targets:
           - '-CFLAGS "-std=c++14 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
-          - "-Wwarn-IMPERFECTSCH"
           # RAM primitives wider than 64bit (required for ECC) fail to build in
           # Verilator without increasing the unroll count (see Verilator#1266)
           - "--unroll-count 72"

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -51,11 +51,7 @@ module ibex_core import ibex_pkg::*; #(
 ) (
   // Clock and Reset
   input  logic                         clk_i,
-  // Internally generated resets in ibex_lockstep cause IMPERFECTSCH warnings.
-  // TODO: Remove when upgrading Verilator #2134.
-  /* verilator lint_off IMPERFECTSCH */
   input  logic                         rst_ni,
-  /* verilator lint_on IMPERFECTSCH */
 
   input  logic [31:0]                  hart_id_i,
   input  logic [31:0]                  boot_addr_i,

--- a/rtl/ibex_lockstep.sv
+++ b/rtl/ibex_lockstep.sv
@@ -128,7 +128,7 @@ module ibex_lockstep import ibex_pkg::*; #(
   logic [LockstepOffsetW-1:0] rst_shadow_cnt;
   logic                       rst_shadow_cnt_err;
   ibex_mubi_t                 rst_shadow_set_d, rst_shadow_set_q;
-  logic                       rst_shadow_n, rst_shadow_set_single_bit;
+  logic                       rst_shadow_n;
   ibex_mubi_t                 enable_cmp_d, enable_cmp_q;
 
   // This counter primitive starts counting to LockstepOffset after a system
@@ -161,10 +161,6 @@ module ibex_lockstep import ibex_pkg::*; #(
   // Enable lockstep comparison.
   assign enable_cmp_d = rst_shadow_set_q;
 
-  // This assignment is needed in order to avoid "Warning-IMPERFECTSCH" messages.
-  // TODO: Remove when updating Verilator #2134.
-  assign rst_shadow_set_single_bit = rst_shadow_set_q[0];
-
   // The primitives below are used to place size-only constraints in order to prevent
   // synthesis optimizations and preserve anchor points for constraining backend tools.
   prim_flop #(
@@ -190,7 +186,7 @@ module ibex_lockstep import ibex_pkg::*; #(
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
   ) u_prim_rst_shadow_n_mux2 (
-    .clk0_i(rst_shadow_set_single_bit),
+    .clk0_i(rst_shadow_set_q[0]),
     .clk1_i(scan_rst_ni),
     .sel_i (test_en_i),
     .clk_o (rst_shadow_n)


### PR DESCRIPTION
Our current version of Verilator issues "IMPERFECTSCH" warnings, which sometimes appear spurious. According to the [manual](https://verilator.org/guide/latest/warnings.html#cmdoption-arg-IMPERFECTSCH) this warning is disabled by default, but we explicitly enabled it a while back in https://github.com/lowRISC/ibex/pull/1250 and created some RTL workarounds to avoid it in https://github.com/lowRISC/ibex/pull/2129.

Now, the same warning has reappeared at the same point due to the changes in https://github.com/lowRISC/ibex/pull/2267. However, this PR does not touch the code that leads to the warning, which is why I propose removing the warning altogether now and updating Verilator in the near future. Alternatively, we could disable it for the specific lines where it appears in https://github.com/lowRISC/ibex/pull/2267 as a hotfix.

This PR disables the warning in Verilator and reverts the workarounds introduced in https://github.com/lowRISC/ibex/pull/2129.

For reference, this is the warning triggered by https://github.com/lowRISC/ibex/pull/2267:
```sh
INFO: verilator -f lowrisc_ibex_ibex_simple_system_cosim_0.vc --trace --trace-fst --trace-structs --trace-params --trace-max-array 1024 -CFLAGS "-std=c++14 -Wall -DVL_USER_STOP -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g `pkg-config --cflags riscv-riscv riscv-disasm riscv-fdt`" -LDFLAGS "-pthread -lutil -lelf `pkg-config --libs riscv-riscv riscv-disasm riscv-fdt`" -Wall -Wwarn-IMPERFECTSCH --unroll-count 72

ERROR: %Warning-IMPERFECTSCH: ../src/lowrisc_ibex_ibex_top_0.1/rtl/ibex_lockstep.sv:131:45: Imperfect scheduling of variable: 'ibex_simple_system.u_top.u_ibex_top.gen_lockstep.u_ibex_lockstep.rst_shadow_set_single_bit'
                                                                                   : ... In instance ibex_simple_system
  131 |   logic                       rst_shadow_n, rst_shadow_set_single_bit;
      |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~
                       ... For warning description see https://verilator.org/warn/IMPERFECTSCH?v=4.210
                       ... Use "/* verilator lint_off IMPERFECTSCH */" and lint_on around source to disable this message.
%Error: Exiting due to 1 warning(s)
```