### PR TITLE
[simple_system] Use correct RAM base address and size

### DIFF
--- a/examples/simple_system/ibex_simple_system.cc
+++ b/examples/simple_system/ibex_simple_system.cc
@@ -71,7 +71,7 @@ int SimpleSystem::Setup(int argc, char **argv, bool &exit_app) {
   simctrl.SetTop(&_top, &_top.IO_CLK, &_top.IO_RST_N,
                  VerilatorSimCtrlFlags::ResetPolarityNegative);
 
-  _memutil.RegisterMemoryArea("ram", 0x0, &_ram);
+  _memutil.RegisterMemoryArea("ram", kRAM_BaseAddr, &_ram);
   simctrl.RegisterExtension(&_memutil);
 
   exit_app = false;

--- a/examples/simple_system/ibex_simple_system.h
+++ b/examples/simple_system/ibex_simple_system.h
@@ -7,6 +7,9 @@
 
 class SimpleSystem {
  public:
+  static constexpr uint32_t kRAM_BaseAddr = 0x100000u;
+  static constexpr uint32_t kRAM_SizeBytes = 0x100000u;
+
   SimpleSystem(const char *ram_hier_path, int ram_size_words);
   virtual ~SimpleSystem() {}
   virtual int Main(int argc, char **argv);

--- a/examples/simple_system/ibex_simple_system_main.cc
+++ b/examples/simple_system/ibex_simple_system_main.cc
@@ -7,7 +7,7 @@
 int main(int argc, char **argv) {
   SimpleSystem simple_system(
       "TOP.ibex_simple_system.u_ram.u_ram.gen_generic.u_impl_generic",
-      1024 * 1024);
+      SimpleSystem::kRAM_SizeBytes / 4);
 
   return simple_system.Main(argc, argv);
 }


### PR DESCRIPTION
Correct the base address and size of the RAM memory model within the simulator environment. Previously the error in the RAM size was masking the incorrect base address (zero) and it simulated as intended but could fail if the base address and/or RAM size were modified.