### PR TITLE
Environment Setup and Makefile Target Errors

### DIFF
--- a/dv/cs_registers/Makefile
+++ b/dv/cs_registers/Makefile
@@ -23,11 +23,21 @@ LDFLAGS  = -shared
 CC       = $(CXX)
 
 # Add svdpi include
-TOOLDIR = $(subst bin/$(TOOL),,$(shell which $(TOOL)))
 ifeq ($(TOOL),vcs)
+  # For VCS, add include path
+  TOOLDIR = $(subst bin/$(TOOL),,$(shell which $(TOOL)))
   INCLUDES += -I$(TOOLDIR)include
 else
-  INCLUDES += -I$(TOOLDIR)share/verilator/include/vltstd
+  # For Verilator, use verilator command to find root directory
+  ifeq ($(shell which verilator),)
+    $(error "Verilator not found in PATH. Please install Verilator or add it to your PATH")
+  endif
+  VERILATOR_ROOT = $(shell verilator --getenv VERILATOR_ROOT 2>/dev/null)
+  ifeq ($(VERILATOR_ROOT),)
+    $(error "Could not determine VERILATOR_ROOT. Please make sure Verilator is properly installed")
+  endif
+  # Add both main include directory and vltstd directory where svdpi.h is located
+  INCLUDES += -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd
 endif
 
 .PHONY: all clean

--- a/dv/cs_registers/Makefile
+++ b/dv/cs_registers/Makefile
@@ -23,21 +23,41 @@ LDFLAGS  = -shared
 CC       = $(CXX)
 
 # Add svdpi include
-ifeq ($(TOOL),vcs)
-  # For VCS, add include path
-  TOOLDIR = $(subst bin/$(TOOL),,$(shell which $(TOOL)))
-  INCLUDES += -I$(TOOLDIR)include
+# Check if VERILATOR_ROOT is set, use it first if available
+ifdef VERILATOR_ROOT
+  VERILATOR_INCLUDE = $(VERILATOR_ROOT)/include
 else
-  # For Verilator, use verilator command to find root directory
-  ifeq ($(shell which verilator),)
-    $(error "Verilator not found in PATH. Please install Verilator or add it to your PATH")
+  # Try to find Verilator installation directory
+  TOOLDIR = $(subst bin/$(TOOL),,$(shell which $(TOOL) 2>/dev/null))
+  
+  # Define list of possible Verilator include paths to check
+  VERILATOR_INCLUDE_PATHS := \
+    $(TOOLDIR)share/verilator/include \
+    $(TOOLDIR)share/verilator/include/vltstd \
+    /usr/share/verilator/include \
+    /usr/local/share/verilator/include \
+    /opt/verilator/share/verilator/include \
+    $(HOME)/verilator/include
+    
+  # Find first valid include path
+  VERILATOR_INCLUDE := $(firstword $(foreach dir,$(VERILATOR_INCLUDE_PATHS),$(if $(wildcard $(dir)/svdpi.h),$(dir),)))
+  
+  # If include path not found, provide error messages
+  ifeq ($(VERILATOR_INCLUDE),)
+    $(warning WARNING: Could not find Verilator include directory with svdpi.h)
+    $(warning Searched in: $(VERILATOR_INCLUDE_PATHS))
+    $(warning You can manually specify it using: make build-csr-test INCLUDES="-I/path/to/verilator/include -I./env -I./rst_driver -I./reg_driver -I./model")
+    $(warning Or set VERILATOR_ROOT environment variable pointing to your Verilator installation)
   endif
-  VERILATOR_ROOT = $(shell verilator --getenv VERILATOR_ROOT 2>/dev/null)
-  ifeq ($(VERILATOR_ROOT),)
-    $(error "Could not determine VERILATOR_ROOT. Please make sure Verilator is properly installed")
+endif
+
+# Add appropriate includes based on tool
+ifeq ($(TOOL),vcs)
+  INCLUDES += -I$(TOOLDIR)include
+else ifeq ($(TOOL),verilator)
+  ifdef VERILATOR_INCLUDE
+    INCLUDES += -I$(VERILATOR_INCLUDE) -I$(VERILATOR_INCLUDE)/vltstd
   endif
-  # Add both main include directory and vltstd directory where svdpi.h is located
-  INCLUDES += -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd
 endif
 
 .PHONY: all clean

--- a/dv/cs_registers/tb_cs_registers.core
+++ b/dv/cs_registers/tb_cs_registers.core
@@ -121,7 +121,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++14 -Wall -DTOPLEVEL_NAME=tb_cs_registers -DVM_TRACE_FMT_FST -g"'
-          - '-LDFLAGS "-pthread -lutil -lelf"'
+          - '-CFLAGS "-std=c++14 -Wall -DTOPLEVEL_NAME=tb_cs_registers -DVM_TRACE_FMT_FST -g -fexceptions -I$(shell verilator --getenv VERILATOR_ROOT)/include -I$(shell verilator --getenv VERILATOR_ROOT)/include/vltstd"'
+          - '-LDFLAGS "-pthread -lutil -lelf -fexceptions"'
           - "-Wall"
           - '-Wno-fatal' # Do not fail on (style) issues, only warn about them.

--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -175,7 +175,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++14 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g"'
+          - '-CFLAGS "-std=c++14 -Wall -fexceptions -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           # RAM primitives wider than 64bit (required for ECC) fail to build in

--- a/examples/sw/simple_system/common/common.mk
+++ b/examples/sw/simple_system/common/common.mk
@@ -19,9 +19,9 @@ SRCS = $(COMMON_SRCS) $(PROGRAM_C) $(EXTRA_SRCS)
 C_SRCS = $(filter %.c, $(SRCS))
 ASM_SRCS = $(filter %.S, $(SRCS))
 
-CC = riscv32-unknown-elf-gcc
+CC = /home/wajahat/RISCV/riscv64-unknown-elf-toolchain/riscv/bin/riscv64-unknown-elf-gcc
 
-CROSS_COMPILE = $(patsubst %-gcc,%-,$(CC))
+CROSS_COMPILE = /home/wajahat/RISCV/riscv64-unknown-elf-toolchain/riscv/bin/riscv64-unknown-elf-
 OBJCOPY ?= $(CROSS_COMPILE)objcopy
 OBJDUMP ?= $(CROSS_COMPILE)objdump
 

--- a/examples/sw/simple_system/common/common.mk
+++ b/examples/sw/simple_system/common/common.mk
@@ -8,7 +8,7 @@ COMMON_SRCS = $(wildcard $(COMMON_DIR)/*.c)
 INCS := -I$(COMMON_DIR)
 
 # ARCH = rv32im # to disable compressed instructions
-ARCH ?= rv32imc
+ARCH ?= rv32imc_zicsr
 
 ifdef PROGRAM
 PROGRAM_C := $(PROGRAM).c
@@ -19,9 +19,9 @@ SRCS = $(COMMON_SRCS) $(PROGRAM_C) $(EXTRA_SRCS)
 C_SRCS = $(filter %.c, $(SRCS))
 ASM_SRCS = $(filter %.S, $(SRCS))
 
-CC = /home/wajahat/RISCV/riscv64-unknown-elf-toolchain/riscv/bin/riscv64-unknown-elf-gcc
+CC = riscv32-unknown-elf-gcc
 
-CROSS_COMPILE = /home/wajahat/RISCV/riscv64-unknown-elf-toolchain/riscv/bin/riscv64-unknown-elf-
+CROSS_COMPILE = $(patsubst %-gcc,%-,$(CC))
 OBJCOPY ?= $(CROSS_COMPILE)objcopy
 OBJDUMP ?= $(CROSS_COMPILE)objdump
 

--- a/vendor/lowrisc_ip/dv/verilator/memutil_dpi.core
+++ b/vendor/lowrisc_ip/dv/verilator/memutil_dpi.core
@@ -30,3 +30,9 @@ targets:
         vcs_options:
           - '-CFLAGS -I../../src/lowrisc_dv_verilator_memutil_dpi_0/cpp'
           - '-lelf'
+      verilator:
+        verilator_options:
+          - '-CFLAGS'
+          - '-fexceptions'
+          - '-LDFLAGS'
+          - '-fexceptions'


### PR DESCRIPTION
I cloned the repository and followed the steps outlined in the README.md. To verify functionality, I ran the following Makefile targets. However, I encountered errors in both cases. Screenshots of the corresponding error logs are attached below.
 
**Target/Issue No. 1: make build-simple-system**

When I run `make build-simple-system` I get the following error:

![image](https://github.com/user-attachments/assets/693b281f-e42f-4d8d-8bd9-34ae6bec8744)
 
**Target/Issue No. 2: make build-csr-test**

When I run `make build-csr-test` I get the following error: 

![image](https://github.com/user-attachments/assets/8eac6419-7723-402d-a7d9-28d6a81b3ca1)


**Environment Details**
- FuseSoC version: 0.1
- Verilator version: 5.035 (development version: v5.034-27-g258becd17)
- RISC-V Toolchain version: 13.2.0
- Operating System: Ubuntu 24.10 (Codename: oracular)

Please let me know if any additional setup steps are required or if the errors are known issues with the current branch/version. I'm happy to help troubleshoot further.