### PR TITLE
Fix `dsim` support

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/ibex_directed_instr_lib.sv
+++ b/dv/uvm/core_ibex/riscv_dv_extension/ibex_directed_instr_lib.sv
@@ -79,7 +79,7 @@ class ibex_rand_mseccfg_stream extends riscv_directed_instr_stream;
     csrrw_instr = riscv_instr::get_instr(CSRRWI);
     csrrw_instr.atomic = 1'b0;
     csrrw_instr.csr = MSECCFG;
-    csrrw_instr.rd = '0;
+    csrrw_instr.rd = ZERO;
     // Randomize between 3'b000 and 3'b111 to hit every combination of RLB/MMWP/MML bits.
     csrrw_instr.imm_str = $sformatf("0x%0x", $urandom_range(7,0));
     instr_list = {csrrw_instr};
@@ -159,7 +159,7 @@ class ibex_rand_cpuctrlsts_stream extends riscv_directed_instr_stream;
     instrs[3] = riscv_instr::get_instr(CSRRW);
     instrs[3].atomic = 1'b0;
     instrs[3].csr = 12'h7c0;
-    instrs[3].rd = '0;
+    instrs[3].rd = ZERO;
     instrs[3].rs1 = cfg.gpr[0];
 
     instr_list = instrs;
@@ -191,7 +191,7 @@ class ibex_valid_na4_stream extends riscv_directed_instr_stream;
     cfg_csrrw_instr.atomic = 1'b1;
     cfg_csrrw_instr.has_label = 1'b0;
     cfg_csrrw_instr.csr = PMPCFG0;
-    cfg_csrrw_instr.rd = '0;
+    cfg_csrrw_instr.rd = ZERO;
     cfg_csrrw_instr.imm_str = $sformatf("%0d", $urandom_range(16,23));
 
     // Use a label to use it for setting pmpaddr CSR.
@@ -222,7 +222,7 @@ class ibex_valid_na4_stream extends riscv_directed_instr_stream;
     addr_csrrw_instr.atomic = 1'b1;
     addr_csrrw_instr.csr = PMPADDR0;
     addr_csrrw_instr.rs1 = cfg.gpr[1];
-    addr_csrrw_instr.rd = '0;
+    addr_csrrw_instr.rd = ZERO;
     instr_list = {cfg_csrrw_instr, nop_instr, la_instr, srli_instr, addr_csrrw_instr};
   endfunction
 
@@ -395,7 +395,7 @@ class ibex_make_pmp_region_exec_stream extends riscv_directed_instr_stream;
     instrs[5] = riscv_instr::get_instr(CSRRW);
     instrs[5].atomic = 1'b0;
     instrs[5].csr = PMPCFG0 + pmpcfg_num;
-    instrs[5].rd = '0;
+    instrs[5].rd = ZERO;
     instrs[5].rs1 = cfg.gpr[2];
 
     // Immediately read back what we wrote, to check it has been dealt with correctly (i.e. write
@@ -404,7 +404,7 @@ class ibex_make_pmp_region_exec_stream extends riscv_directed_instr_stream;
     instrs[6].atomic = 1'b0;
     instrs[6].csr = PMPCFG0 + pmpcfg_num;
     instrs[6].rd = cfg.gpr[0];
-    instrs[6].rs1 = 0;
+    instrs[6].rs1 = ZERO;
 
     instr_list = instrs;
 

--- a/dv/uvm/core_ibex/riscv_dv_extension/riscv_core_setting.tpl.sv
+++ b/dv/uvm/core_ibex/riscv_dv_extension/riscv_core_setting.tpl.sv
@@ -131,8 +131,8 @@ const privileged_reg_t implemented_csr[] = {
     MTVAL,            // Machine bad address or instruction
     MIE,              // Machine interrupt enable
     MIP,              // Machine interrupt pending
-    12'h7c0,          // CPU Control and Status (Ibex Specific)
-    12'h7c1,          // Secure Seed (Ibex Specific)
+    //12'h7c0,          // CPU Control and Status (Ibex Specific)
+    //12'h7c1,          // Secure Seed (Ibex Specific)
     MCYCLE,           // Machine cycle counter (lower 32 bits)
     MCYCLEH,          // Machine cycle counter (upper 32 bits)
     //MINSTRET,         // Machine instructions retired counter (lower 32 bits)

--- a/dv/uvm/core_ibex/riscv_dv_extension/riscv_core_setting.tpl.sv
+++ b/dv/uvm/core_ibex/riscv_dv_extension/riscv_core_setting.tpl.sv
@@ -131,8 +131,10 @@ const privileged_reg_t implemented_csr[] = {
     MTVAL,            // Machine bad address or instruction
     MIE,              // Machine interrupt enable
     MIP,              // Machine interrupt pending
-    //12'h7c0,          // CPU Control and Status (Ibex Specific)
-    //12'h7c1,          // Secure Seed (Ibex Specific)
+`ifndef DSIM
+    12'h7c0,          // CPU Control and Status (Ibex Specific)
+    12'h7c1,          // Secure Seed (Ibex Specific)
+`endif
     MCYCLE,           // Machine cycle counter (lower 32 bits)
     MCYCLEH,          // Machine cycle counter (upper 32 bits)
     //MINSTRET,         // Machine instructions retired counter (lower 32 bits)

--- a/dv/uvm/core_ibex/scripts/run_instr_gen.py
+++ b/dv/uvm/core_ibex/scripts/run_instr_gen.py
@@ -65,6 +65,11 @@ def reloc_word(simulator: str,
             # For Xcelium, the build directory gets passed as the
             # "-xmlibdirpath" argument.
             (placeholder_dir, build_dir)
+        ],
+        'dsim': [
+            # DSim build path
+            (os.path.join(placeholder_dir, 'dsim'),
+             os.path.join(build_dir, 'dsim'))
         ]
     }
     always_relocs = [

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -358,7 +358,7 @@ class core_ibex_base_test extends uvm_test;
 
 
   virtual task wait_for_mem_txn(
-    input bit [ibex_mem_intf_pkg:ADDR_WIDTH-1:0] ref_addr,
+    input bit [ibex_mem_intf_pkg::ADDR_WIDTH-1:0] ref_addr,
     input signature_type_t ref_type,
     input uvm_tlm_analysis_fifo #(ibex_mem_intf_seq_item) txn_port = item_collected_port
     );

--- a/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_base_test.sv
@@ -26,8 +26,8 @@ class core_ibex_base_test extends uvm_test;
   // code, the test will wait for the specifield number of cycles before starting stimulus
   // sequences (irq and debug)
   int unsigned                                    stimulus_delay = 800;
-  bit[ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0]    signature_data_q[$];
-  bit[ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0]    signature_data;
+  bit[ibex_mem_intf_pkg::DATA_WIDTH-1:0]    signature_data_q[$];
+  bit[ibex_mem_intf_pkg::DATA_WIDTH-1:0]    signature_data;
   uvm_tlm_analysis_fifo #(ibex_mem_intf_seq_item) item_collected_port;
   uvm_tlm_analysis_fifo #(ibex_mem_intf_seq_item) test_done_port;
   uvm_tlm_analysis_fifo #(irq_seq_item)           irq_collected_port;
@@ -358,7 +358,7 @@ class core_ibex_base_test extends uvm_test;
 
 
   virtual task wait_for_mem_txn(
-    input bit [ibex_mem_intf_agent_pkg::ADDR_WIDTH-1:0] ref_addr,
+    input bit [ibex_mem_intf_pkg:ADDR_WIDTH-1:0] ref_addr,
     input signature_type_t ref_type,
     input uvm_tlm_analysis_fifo #(ibex_mem_intf_seq_item) txn_port = item_collected_port
     );

--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -755,17 +755,17 @@ class core_ibex_debug_intr_basic_test extends core_ibex_base_test;
   `uvm_component_utils(core_ibex_debug_intr_basic_test)
   `uvm_component_new
 
-  bit [ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0] core_init_mstatus;
-  bit [ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0] core_init_mie;
+  bit [ibex_mem_intf_pkg::DATA_WIDTH-1:0] core_init_mstatus;
+  bit [ibex_mem_intf_pkg::DATA_WIDTH-1:0] core_init_mie;
   priv_lvl_e                                    init_operating_mode;
   priv_lvl_e                                    operating_mode;
   bit [$clog2(irq_agent_pkg::DATA_WIDTH)-1:0]   irq_id;
   irq_seq_item                                  irq_txn;
   bit [irq_agent_pkg::DATA_WIDTH-1:0]           irq;
-  bit [ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0] mstatus;
-  bit [ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0] mcause;
-  bit [ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0] mip;
-  bit [ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0] mie;
+  bit [ibex_mem_intf_pkg::DATA_WIDTH-1:0] mstatus;
+  bit [ibex_mem_intf_pkg::DATA_WIDTH-1:0] mcause;
+  bit [ibex_mem_intf_pkg::DATA_WIDTH-1:0] mip;
+  bit [ibex_mem_intf_pkg::DATA_WIDTH-1:0] mie;
   bit                                           in_nested_trap;
 
   virtual task send_stimulus();
@@ -966,14 +966,14 @@ class core_ibex_debug_intr_basic_test extends core_ibex_base_test;
     return have_irq;
   endfunction
 
-  virtual task check_mcause(bit irq_or_exc, bit[ibex_mem_intf_agent_pkg::DATA_WIDTH-2:0] cause);
-    bit[ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0] mcause;
+  virtual task check_mcause(bit irq_or_exc, bit[ibex_mem_intf_pkg::DATA_WIDTH-2:0] cause);
+    bit[ibex_mem_intf_pkg::DATA_WIDTH-1:0] mcause;
     wait_for_csr_write(CSR_MCAUSE, 10000);
     mcause = signature_data;
     `uvm_info(`gfn, $sformatf("mcause: 0x%0x", mcause), UVM_LOW)
-    `DV_CHECK_EQ_FATAL(mcause[ibex_mem_intf_agent_pkg::DATA_WIDTH-1], irq_or_exc,
+    `DV_CHECK_EQ_FATAL(mcause[ibex_mem_intf_pkg::DATA_WIDTH-1], irq_or_exc,
                         $sformatf("mcause.interrupt is not set to 0x%0x", irq_or_exc))
-    `DV_CHECK_EQ_FATAL(mcause[ibex_mem_intf_agent_pkg::DATA_WIDTH-2:0], cause,
+    `DV_CHECK_EQ_FATAL(mcause[ibex_mem_intf_pkg::DATA_WIDTH-2:0], cause,
                        "mcause.exception_code is encoding the wrong exception type")
   endtask
 
@@ -1161,7 +1161,7 @@ class core_ibex_directed_test extends core_ibex_debug_intr_basic_test;
   // currently in the ID stage against the global seen_instr[$] queue.
   // If we've seen the same type of instruction before, return 0, otherwise add it to the
   // seen_instr[$] queue and return 1.
-  virtual function bit decode_instr(bit [ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0] instr);
+  virtual function bit decode_instr(bit [ibex_mem_intf_pkg::DATA_WIDTH-1:0] instr);
     ibex_pkg::opcode_e                            opcode;
     bit [2:0]                                     funct3;
     bit [6:0]                                     funct7;
@@ -1670,8 +1670,8 @@ class core_ibex_debug_ebreak_test extends core_ibex_directed_test;
   `uvm_component_utils(core_ibex_debug_ebreak_test)
   `uvm_component_new
 
-  bit[ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0] dpc;
-  bit[ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0] dcsr;
+  bit[ibex_mem_intf_pkg::DATA_WIDTH-1:0] dpc;
+  bit[ibex_mem_intf_pkg::DATA_WIDTH-1:0] dcsr;
 
   virtual task check_stimulus();
     forever begin
@@ -1885,7 +1885,7 @@ class core_ibex_umode_tw_test extends core_ibex_directed_test;
   `uvm_component_new
 
   virtual task check_stimulus();
-    bit [ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0] mcause;
+    bit [ibex_mem_intf_pkg::DATA_WIDTH-1:0] mcause;
     forever begin
       wait (dut_vif.dut_cb.wfi === 1'b1);
       check_illegal_insn("Core did not treat U-mode WFI as illegal");

--- a/dv/uvm/core_ibex/tests/core_ibex_vseq.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_vseq.sv
@@ -19,7 +19,7 @@ class core_ibex_vseq extends uvm_sequence;
   debug_seq                                     debug_seq_single_h;
   fetch_enable_seq                              fetch_enable_seq_h;
   core_ibex_env_cfg                             cfg;
-  bit[ibex_mem_intf_agent_pkg::DATA_WIDTH-1:0]  data;
+  bit[ibex_mem_intf_pkg::DATA_WIDTH-1:0]  data;
 
   `uvm_object_utils(core_ibex_vseq)
   `uvm_declare_p_sequencer(core_ibex_vseqr)

--- a/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -143,7 +143,7 @@
           +acc+rwb
           -f <core_ibex>/ibex_dv.f
           -l <tb_build_log>
-          -suppress EnumMustBePositive"
+          -suppress EnumMustBePositive
   sim:
     cmd:
       - >-

--- a/util/ibex_config.py
+++ b/util/ibex_config.py
@@ -273,7 +273,7 @@ def main():
         SimOpts('xlm_opts', 'Xcelium compile',
                 lambda p, v: ['-defparam',  p + '=' + v],
                 lambda d, v: ['-define', d + '=' + v], '.'),
-        SimOpts('dsim_compile_opts', 'DSim compile',
+        SimOpts('dsim_opts', 'DSim compile',
                 lambda p, v: ['+define+' + p + '=' + v],
                 lambda d, v: [], '/'),
     ]


### PR DESCRIPTION
This PR fixes up Ibex testbench support for `dsim` simulator. Several things had to be fixed:

- Simulator compatibility: `dsim` requires that enum values must use enum constants
    - Use `ZERO` enum value instead of `'0` and `0` for instr enums
    - Protect Ibex-specific CSRs with  \`ifndef DSIM to ensure these are not included in `implemented_csr[]`. `dsim` requires that all array values be enumerated in `privileged_reg_t`, which they are currently not
- Simulator compatibility: `dsim` does not appear to respect "re-exports"
    - Replace all re-exported `ibex_mem_intf_agent_pkg::ADDR_WIDTH` and  `ibex_mem_intf_agent_pkg::DATA_WIDTH` with `ibex_mem_intf_pkg::ADDR_WIDTH` and  `ibex_mem_intf_pkg::DATA_WIDTH`
- Script fix: Add `dsim` case for `reloc_word` in [dv/uvm/core_ibex/scripts/run_instr_gen.py](https://github.com/lowRISC/ibex/compare/master...Silimate:ibex:dsim_fixes?expand=1#diff-5415dd86d435fd7155622795acb1fb1c440b6e2e595c0c1a857b891fdc6d9e65)
- Script fix: Remove extra quote in [dv/uvm/core_ibex/yaml/rtl_simulation.yaml](https://github.com/lowRISC/ibex/compare/master...Silimate:ibex:dsim_fixes?expand=1#diff-01ac65450dedc1df3421dee3e0874335b0bb15d6b8db2035aef4b0d77af903cd)
- Script fix: Replace `dsim_compile_opts` with `dsim_opts` in [util/ibex_config.py](https://github.com/lowRISC/ibex/compare/master...Silimate:ibex:dsim_fixes?expand=1#diff-0a9f6797b07226a176327f28cfe58b039f1eb20d18e7bdee723ec94668f3be01)