### PR TITLE
Change '/bin/bash' shebangs to '/usr/bin/env bash'

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/ci/run-cosim-test.sh
+++ b/ci/run-cosim-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/dv/uvm/core_ibex/scripts/objdump.sh
+++ b/dv/uvm/core_ibex/scripts/objdump.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 _GET_OBJS=$(find ./out/run -type f -iregex '.*test\.o')
 if [[ -z "${RISCV_TOOLCHAIN}" ]]; then
    echo "Please define RISCV_TOOLCHAIN to have access to objdump."

--- a/dv/uvm/core_ibex/scripts/prettify.sh
+++ b/dv/uvm/core_ibex/scripts/prettify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 _GET_TRACES=$(find . -type f -iregex '.*trace_core.*\.log')
 for trace in $_GET_TRACES; do
     column -t -s $'\t' -o ' ' -R 1,2,3,4,5 "$trace" > "$(dirname "$trace")"/trace_pretty.log

--- a/examples/simple_system/spike-simple-system.sh
+++ b/examples/simple_system/spike-simple-system.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -u
 set -e

--- a/syn/lec_sv2v.sh
+++ b/syn/lec_sv2v.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.

--- a/syn/python/build_translated_names.py
+++ b/syn/python/build_translated_names.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.

--- a/syn/python/get_kge.py
+++ b/syn/python/get_kge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.

--- a/syn/python/translate_timing_csv.py
+++ b/syn/python/translate_timing_csv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.

--- a/syn/syn_setup.example.sh
+++ b/syn/syn_setup.example.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.

--- a/syn/syn_yosys.sh
+++ b/syn/syn_yosys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.

--- a/syn/translate_timing_rpts.sh
+++ b/syn/translate_timing_rpts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.


### PR DESCRIPTION
This improves portability across different unix-like operating systems by using bash from the PATH, instead of bash from a hardcoded location.