### PR TITLE
[simple_system] Add CSR to architecture extensions

### DIFF
--- a/examples/sw/simple_system/common/common.mk
+++ b/examples/sw/simple_system/common/common.mk
@@ -8,7 +8,8 @@ COMMON_SRCS = $(wildcard $(COMMON_DIR)/*.c)
 INCS := -I$(COMMON_DIR)
 
 # ARCH = rv32im # to disable compressed instructions
-ARCH ?= rv32imc
+# ARCH ?= rv32imc # to disable control and status register access instructions
+ARCH ?= rv32imc_zicsr
 
 ifdef PROGRAM
 PROGRAM_C := $(PROGRAM).c


### PR DESCRIPTION
Simple system uses CSR's and thus this is required.

Closes #2288 
