### PR TITLE
[c++] Enable project wide C++17 Support

### DIFF
--- a/dv/cs_registers/Makefile
+++ b/dv/cs_registers/Makefile
@@ -17,7 +17,7 @@ OBJS    := $(patsubst %.$(SRCEXT),$(OBJDIR)/%.o,$(SRCS))
 
 DEBUG    = -g
 INCLUDES = -I./env -I./rst_driver -I./reg_driver -I./model
-CFLAGS   = -std=c++14 -m64 -fPIC -Wall -pedantic $(DEBUG) $(INCLUDES)
+CFLAGS   = -std=c++17 -m64 -fPIC -Wall -pedantic $(DEBUG) $(INCLUDES)
 LDFLAGS  = -shared
 
 CC       = $(CXX)

--- a/dv/cs_registers/tb_cs_registers.core
+++ b/dv/cs_registers/tb_cs_registers.core
@@ -121,7 +121,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++14 -Wall -DTOPLEVEL_NAME=tb_cs_registers -DVM_TRACE_FMT_FST -g"'
+          - '-CFLAGS "-std=c++17 -Wall -DTOPLEVEL_NAME=tb_cs_registers -DVM_TRACE_FMT_FST -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           - '-Wno-fatal' # Do not fail on (style) issues, only warn about them.

--- a/dv/riscv_compliance/ibex_riscv_compliance.core
+++ b/dv/riscv_compliance/ibex_riscv_compliance.core
@@ -161,6 +161,6 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++14 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_riscv_compliance -g"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_riscv_compliance -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"

--- a/dv/verilator/simple_system_cosim/ibex_simple_system_cosim.core
+++ b/dv/verilator/simple_system_cosim/ibex_simple_system_cosim.core
@@ -179,7 +179,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++14 -Wall -DVL_USER_STOP -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g `pkg-config --cflags riscv-riscv riscv-disasm riscv-fdt`"'
+          - '-CFLAGS "-std=c++17 -Wall -DVL_USER_STOP -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g `pkg-config --cflags riscv-riscv riscv-disasm riscv-fdt`"'
           - '-LDFLAGS "-pthread -lutil -lelf `pkg-config --libs riscv-riscv riscv-disasm riscv-fdt`"'
           - "-Wall"
           # RAM primitives wider than 64bit (required for ECC) fail to build in

--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -175,7 +175,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++14 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g"'
+          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           # RAM primitives wider than 64bit (required for ECC) fail to build in


### PR DESCRIPTION
This change updates the C++ language version to C++17, project wide. Previously, C++14 was used.

The same update is being made to OpenTitan via https://github.com/lowRISC/opentitan/pull/27530.