### PR TITLE
Support testbench elaboration with Verific

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_agent_pkg.sv
+++ b/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_agent_pkg.sv
@@ -7,6 +7,7 @@ package ibex_cosim_agent_pkg;
   import ibex_mem_intf_pkg::*;
 
   `include "uvm_macros.svh"
+  `include "dv_macros.svh"
 
   `include "ibex_cosim_cfg.sv"
   `include "ibex_rvfi_seq_item.sv"

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_agent_pkg.sv
@@ -10,6 +10,7 @@ package ibex_mem_intf_agent_pkg;
   import ibex_cosim_agent_pkg::*;
 
   `include "uvm_macros.svh"
+  `include "dv_macros.svh"
 
   typedef uvm_sequencer#(ibex_mem_intf_seq_item) ibex_mem_intf_request_sequencer;
 

--- a/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_pkg.sv
+++ b/dv/uvm/core_ibex/common/ibex_mem_intf_agent/ibex_mem_intf_pkg.sv
@@ -13,6 +13,7 @@ package ibex_mem_intf_pkg;
   typedef enum { READ, WRITE } rw_e;
 
   `include "uvm_macros.svh"
+  `include "dv_macros.svh"
   `include "ibex_mem_intf_seq_item.sv"
 
 endpackage

--- a/dv/uvm/core_ibex/common/irq_agent/irq_agent_pkg.sv
+++ b/dv/uvm/core_ibex/common/irq_agent/irq_agent_pkg.sv
@@ -10,6 +10,7 @@ package irq_agent_pkg;
   parameter int ADDR_WIDTH = 32;
 
   `include "uvm_macros.svh"
+  `include "dv_macros.svh"
   `include "irq_seq_item.sv"
 
   typedef uvm_sequencer#(irq_seq_item) irq_request_sequencer;

--- a/dv/uvm/core_ibex/env/core_ibex_dut_probe_if.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_dut_probe_if.sv
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "uvm_macros.svh"
+`include "dv_macros.svh"
+
 // Interface to probe DUT internal signal
 interface core_ibex_dut_probe_if(input logic clk);
 

--- a/dv/uvm/core_ibex/env/core_ibex_env_pkg.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_env_pkg.sv
@@ -6,6 +6,9 @@
 // Core ibex environment package
 // ---------------------------------------------
 
+`include "uvm_macros.svh"
+`include "dv_macros.svh"
+
 package core_ibex_env_pkg;
 
   import uvm_pkg::*;

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "uvm_macros.svh"
+`include "dv_macros.svh"
 `include "prim_assert.sv"
 
 module core_ibex_tb_top;
@@ -190,11 +192,13 @@ module core_ibex_tb_top;
       `IBEX_LOCKSTEP_PATH.u_shadow_core.NoMemResponseWithoutPendingAccess)
   end
 
+`ifndef DV_FCOV_DISABLE
   assign dut.u_ibex_top.u_ibex_core.u_fcov_bind.rf_we_glitch_err =
     dut.u_ibex_top.rf_alert_major_internal;
 
   assign dut.u_ibex_top.u_ibex_core.u_fcov_bind.lockstep_glitch_err =
     dut.u_ibex_top.lockstep_alert_major_internal;
+`endif
 
   // Data load/store vif connection
   assign data_mem_vif.reset = ~rst_n;

--- a/dv/uvm/core_ibex/tests/core_ibex_seq_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_seq_lib.sv
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "uvm_macros.svh"
+`include "dv_macros.svh"
+
 // Base sequence
 class core_base_seq #(type REQ = uvm_sequence_item) extends uvm_sequence#(REQ);
 


### PR DESCRIPTION
This PR adds support for testbench elaboration using [Verific](https://www.verific.com/), which is the backbone of many EDA tools that do static analysis on SystemVerilog.

Verific is a bit more strict than other parsers about DV includes. It also does not support functional coverage binding. I've added the necessary includes and protection around functional coverage binding assigns.

Let me know if any changes are needed!