### PR TITLE
Use +define instead of -define to fix unknown option compiling with vcs

### DIFF
--- a/dv/uvm/core_ibex/scripts/compile_tb.py
+++ b/dv/uvm/core_ibex/scripts/compile_tb.py
@@ -119,9 +119,9 @@ def _main() -> int:
                 # Base address of the debug module. This is passed as a parameter
                 # at compile time as the PMP module must always allow debug mode
                 # accesses to it.
-                r" -define DM_ADDR=1A11_0000 " + \
-                r" -define DM_ADDR_MASK=0000_0FFF" + \
-                r" -define BOOT_ADDR=8000_0000 " + \
+                r" +define+DM_ADDR=1A11_0000 " + \
+                r" +define+DM_ADDR_MASK=0000_0FFF" + \
+                r" +define+BOOT_ADDR=8000_0000 " + \
                 # Spike sets the following parameters via the preprocessor defines
                 # DEBUG_ROM_ENTRY and DEBUG_ROM_TVEC.
                 # As they cannot be moved without recompiling the ISS, treat them as
@@ -131,8 +131,8 @@ def _main() -> int:
                 # The generated RISCV-DV assembly programs move the default vector
                 # table (via MTVEC), and place jump instructions at these two
                 # addresses to the generated debug test sections.
-                r" -define DEBUG_MODE_HALT_ADDR=8000_0000 " + \
-                r" -define DEBUG_MODE_EXCEPTION_ADDR=8000_0008 ",
+                r" +define+DEBUG_MODE_HALT_ADDR=8000_0000 " + \
+                r" +define+DEBUG_MODE_EXCEPTION_ADDR=8000_0008 ",
             'dir_shared_cov': (md.dir_shared_cov if md.cov else ''),
             'xlm_cov_cfg_file': f"{md.ot_xcelium_cov_scripts}/cover.ccf",
             'dut_cov_rtl_path': md.dut_cov_rtl_path


### PR DESCRIPTION
Commit 7a66bf9 breaks riscv-dv flow on vcs, since vcs won't take the -define as a macro definition. Using -define instead of +define leads to the following output:

<img width="600" height="473" alt="image" src="https://github.com/user-attachments/assets/8ed7d71c-d36c-4d97-9b88-f98b722d714f" />

And since the marco is not correctly defined, vcs failed to build the sim

<img width="701" height="133" alt="image" src="https://github.com/user-attachments/assets/a1414f34-b616-4c9e-b07f-07e463dcb6e8" />

Fixing this by using +define instead of -define in build options.
Tested on vcs and xlm.