### PR TITLE
Fix incorrect privilege mode detection causing failed dret riscv-dv tests

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -1125,7 +1125,7 @@ class core_ibex_directed_test extends core_ibex_debug_intr_basic_test;
     // we are blocking the current instruction until the instruction from WB stage is ready.
     wait (dut_vif.dut_cb.ctrl_fsm_cs == FLUSH);
     clk_vif.wait_clks(2);
-    check_priv_mode(PRIV_LVL_M);
+    check_priv_mode(init_operating_mode);
     wait_ret("mret", 15000);
   endtask
 
@@ -1657,7 +1657,7 @@ class core_ibex_dret_test extends core_ibex_directed_test;
 
   virtual task check_stimulus();
     forever begin
-      wait (dut_vif.dut_cb.dret === 1'b1);
+      @(negedge dut_vif.dut_cb.dret);
       check_illegal_insn("Core did not treat dret like illegal instruction");
     end
   endtask


### PR DESCRIPTION
The testbench of the riscv-dv flow failed to compare the privilege mode of the DUT correctly and failing the riscv_dret_test. The testbench assumes the DUT will always be in machine mode while different random seeds can generate a testcase that would bring the DUT into either user mode or machine mode at the point of comparison. 
Some seeds of the riscv_dret_test that leads to failure: 
VCS:  1574
XLM:  28930

<img width="277" height="46" alt="image" src="https://github.com/user-attachments/assets/93e792a7-903a-4914-9f18-bc82bd96fef2" />

<img width="1075" height="105" alt="image" src="https://github.com/user-attachments/assets/7f809cbe-5347-40eb-b553-ad7036d78b31" />


This commit fixed the comparison and make riscv_dret_test of the riscv-dv pass under either circumstances.
<img width="294" height="126" alt="image" src="https://github.com/user-attachments/assets/c1395554-8ecd-4077-acea-0dd155bbb6a7" />
