### PR TITLE
[doc] Fix typo'd alert name

### DIFF
--- a/doc/03_reference/security.rst
+++ b/doc/03_reference/security.rst
@@ -11,7 +11,7 @@ Outputs
 
 Ibex has three alert outputs for signalling security issues.
 The internal major alert (**alert_major_internal_o**) indicates a critical security issue from which the core cannot recover which was detected internally in `ibex_top`.
-The bus major alert (**alert_major_internal_o**) indicates a critical security issue from which the core cannot recover which was detected on incoming bus data.
+The bus major alert (**alert_major_bus_o**) indicates a critical security issue from which the core cannot recover which was detected on incoming bus data.
 The minor alert (**alert_minor_o**) indicates potential security issues which can be monitored over time by a system.
 
 Data Independent Timing


### PR DESCRIPTION
`alert_major_internal_o` was repeated twice when I think the second alert should be `alert_major_bus_o`.