### PR TITLE
Bring out debug_mode_o port

### DIFF
--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -113,7 +113,8 @@ module ibex_core import ibex_pkg::*; #(
   output logic                         irq_pending_o,
 
   // Debug Interface
-  input  logic                         debug_req_i,
+  input  logic                         debug_req_i,    // Request from Top to Core to enter debug mode
+  output logic                         debug_mode_o,   // Indicates that the Core has entered debug mode
   output crash_dump_t                  crash_dump_o,
   // SEC_CM: EXCEPTION.CTRL_FLOW.LOCAL_ESC
   // SEC_CM: EXCEPTION.CTRL_FLOW.GLOBAL_ESC
@@ -705,6 +706,9 @@ module ibex_core import ibex_pkg::*; #(
     .perf_div_wait_o  (perf_div_wait),
     .instr_id_done_o  (instr_id_done)
   );
+
+  // Debug Mode output
+  assign debug_mode_o = debug_mode;
 
   // for RVFI only
   assign unused_illegal_insn_id = illegal_insn_id;

--- a/rtl/ibex_top.sv
+++ b/rtl/ibex_top.sv
@@ -100,7 +100,8 @@ module ibex_top import ibex_pkg::*; #(
   output logic                         scramble_req_o,
 
   // Debug Interface
-  input  logic                         debug_req_i,
+  input  logic                         debug_req_i,   // Request to Core to enter debug mode
+  output logic                         debug_mode_o,  // Indicates that the core has entered debug mode
   output crash_dump_t                  crash_dump_o,
   output logic                         double_fault_seen_o,
 
@@ -385,6 +386,7 @@ module ibex_top import ibex_pkg::*; #(
     .irq_pending_o(irq_pending),
 
     .debug_req_i,
+    .debug_mode_o(debug_mode_o),
     .crash_dump_o,
     .double_fault_seen_o,
 


### PR DESCRIPTION
This brings out a port called 'debug_mode_o' from the core and at the top, signifying the state of debug mode when IBEX is connected to other peripherals dependent on the debug mode to update their operation like halt, etc. No functional changes to it.