### PR TITLE
Add missing zicsr to -march in example Makefile

### DIFF
--- a/examples/sw/simple_system/common/common.mk
+++ b/examples/sw/simple_system/common/common.mk
@@ -7,8 +7,8 @@ COMMON_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 COMMON_SRCS = $(wildcard $(COMMON_DIR)/*.c)
 INCS := -I$(COMMON_DIR)
 
-# ARCH = rv32im # to disable compressed instructions
-ARCH ?= rv32imc
+# ARCH = rv32im_zicsr # to disable compressed instructions
+ARCH ?= rv32imc_zicsr
 
 ifdef PROGRAM
 PROGRAM_C := $(PROGRAM).c


### PR DESCRIPTION
Newer GCC toolchains require you to explicitly enable zicsr otherwise you get errors when trying to compile code with CSR access instructions.