### PR TITLE
Remove dependency on srecord

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -45,7 +45,6 @@ case "$ID-$VERSION_ID" in
         python3-wheel \
         python3-yaml \
         python3-dev \
-        srecord \
         zlib1g-dev \
         git \
         make \

--- a/dv/riscv_compliance/README.md
+++ b/dv/riscv_compliance/README.md
@@ -18,13 +18,12 @@ How to run RISC-V Compliance on Ibex
    have the following tools installed:
    - Verilator
    - fusesoc
-   - srecord (for `srec_cat`)
    - A RV32 compiler
 
    On Ubuntu/Debian, install the required tools like this:
 
    ```sh
-   sudo apt-get install srecord python3-pip
+   sudo apt-get install python3-pip
    pip3 install --user -U fusesoc
    ```
 

--- a/examples/simple_system/README.md
+++ b/examples/simple_system/README.md
@@ -21,9 +21,6 @@ run stand-alone binaries. It contains:
   <https://github.com/lowRISC/lowrisc-toolchains/releases>
 * libelf and its development libraries.
   On Debian/Ubuntu, install it by running `apt-get install libelf-dev`.
-* srecord.
-  On Debian/Ubuntu, install it by running `apt-get install srecord`.
-  (Optional, needed for generating a vmem file)
 
 ## Building Simulation
 

--- a/examples/sw/benchmarks/coremark/ibex/core_portme.mak
+++ b/examples/sw/benchmarks/coremark/ibex/core_portme.mak
@@ -92,8 +92,8 @@ $(OPATH)$(PORT_DIR)/%$(OEXT) : %.s
 port_postbuild:
 	riscv32-unknown-elf-objdump -SD $(OPATH)coremark.elf > $(OPATH)coremark.dis
 	riscv32-unknown-elf-objcopy -O binary $(OPATH)coremark.elf $(OPATH)coremark.bin
-	srec_cat $(OPATH)coremark.bin -binary -offset 0x0000 -byte-swap 4 -o  $(OPATH)coremark.vmem -vmem
-
+	riscv32-unknown-elf-objcopy -O verilog --reverse-bytes=4 --verilog-data-width=4 \
+	    $(OPATH)coremark.elf $(OPATH)coremark.vmem
 
 # FLAG : OPATH
 # Path to the output folder. Default - current folder.

--- a/examples/sw/simple_system/common/common.mk
+++ b/examples/sw/simple_system/common/common.mk
@@ -52,15 +52,11 @@ endif
 %.dis: %.elf
 	$(OBJDUMP) -fhSD $^ > $@
 
-# Note: this target requires the srecord package to be installed.
-# XXX: This could be replaced by objcopy once
-# https://sourceware.org/bugzilla/show_bug.cgi?id=19921
-# is widely available.
-%.vmem: %.bin
-	srec_cat $^ -binary -offset 0x0000 -byte-swap 4 -o $@ -vmem
+%.vmem: %.elf
+	$(OBJCOPY) -O verilog --reverse-bytes=4 --verilog-data-width=4 $< $@
 
 %.bin: %.elf
-	$(OBJCOPY) -O binary $^ $@
+	$(OBJCOPY) -O binary $< $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) -MMD -c $(INCS) -o $@ $<


### PR DESCRIPTION
The linked issue was resolved 6 years ago so it's probably safe to use the new flag.

Draft because I'm not sure how to actually test this. Is it used anywhere with Verilator?