### PR TITLE
[rtl] Stop rvfi from reporting load information on stores

### DIFF
--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -1630,7 +1630,7 @@ module ibex_core import ibex_pkg::*; #(
             rvfi_stage_rs3_addr[i]             <= rvfi_rs3_addr_d;
             rvfi_stage_pc_rdata[i]             <= pc_id;
             rvfi_stage_pc_wdata[i]             <= pc_set ? branch_target_ex : pc_if;
-            rvfi_stage_mem_rmask[i]            <= rvfi_mem_mask_int;
+            rvfi_stage_mem_rmask[i]            <= data_we_o ? 4'b0000 : rvfi_mem_mask_int;
             rvfi_stage_mem_wmask[i]            <= data_we_o ? rvfi_mem_mask_int : 4'b0000;
             rvfi_stage_rs1_rdata[i]            <= rvfi_rs1_data_d;
             rvfi_stage_rs2_rdata[i]            <= rvfi_rs2_data_d;


### PR DESCRIPTION
This PR ensures that the trace does not incorrectly report load data during memory store operations. Currently, the tracer uses the `rmask` and `wmask` to print information about loads and stores:

https://github.com/lowRISC/ibex/blob/0a13971f31691153c9c3f552f22f859888cdbfa0/rtl/ibex_tracer.sv#L136-L145

While the `wmask` was already gated in the `rvfi`, the `rmask` was always enabled, which led to load data being reported even during a store.