### PR TITLE
Fix the `riscv_dret_test`

### DIFF
--- a/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
+++ b/dv/uvm/core_ibex/tests/core_ibex_test_lib.sv
@@ -1118,14 +1118,16 @@ class core_ibex_directed_test extends core_ibex_debug_intr_basic_test;
 
   // Illegal instruction checker
   virtual task check_illegal_insn(string exception_msg);
-    check_next_core_status(HANDLING_EXCEPTION, "Core did not jump to vectored exception handler", 10000);
-    check_next_core_status(ILLEGAL_INSTR_EXCEPTION, exception_msg, 10000);
-    check_mcause(1'b0, ExcCauseIllegalInsn);
-    // Ibex will wait to change the privilege mode until it is allowed to FLUSH. This happens because
-    // we are blocking the current instruction until the instruction from WB stage is ready.
+    // Ibex will wait to change the privilege mode until it is allowed to FLUSH. This happens
+    // because it is blocking the current instruction until the instruction from WB stage is ready.
     wait (dut_vif.dut_cb.ctrl_fsm_cs == FLUSH);
     clk_vif.wait_clks(2);
     check_priv_mode(PRIV_LVL_M);
+    check_next_core_status(HANDLING_EXCEPTION,
+                           "Core did not jump to vectored exception handler",
+                           10000);
+    check_next_core_status(ILLEGAL_INSTR_EXCEPTION, exception_msg, 10000);
+    check_mcause(1'b0, ExcCauseIllegalInsn);
     wait_ret("mret", 15000);
   endtask
 


### PR DESCRIPTION
The test checked for the exception handler to launch and then waited for the core to flush its pipeline. However, the flush happened immediately after the exception, which led the test to miss the first exception handler and the `check_priv_mode` to fail, since the check only executed after the flush leaving the exception handlers. This also means that on later executions, we were not checking the exception handlers as we go, but instead, the exception handler from the exception before. Accordingly, this test only failed if Ibex initially started in USER mode. Otherwise, it was anyway always in MACHINE mode.

The failure in the [nightly regression](https://ibex.reports.lowrisc.org/opentitan/ibex-regr-report-17-11-2025.html) are all due to:
> `Check failed dut_vif.dut_cb.priv_mode == mode (0 [0x0] vs 3 [0x3]) Incorrect privilege mode`

Alternatively, I tried using a fork/join to check for entering the exception handler and the flush independently. This also works, but is an overkill IMO, because the flush will always be instant and communicating that the exception handler starts will always take a few cycles after the flush completed.