### PR TITLE
[dv] Use `id_done` to accurately track instruction monitor

### DIFF
--- a/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_scoreboard.sv
+++ b/dv/uvm/core_ibex/common/ibex_cosim_agent/ibex_cosim_scoreboard.sv
@@ -268,8 +268,7 @@ class ibex_cosim_scoreboard extends uvm_scoreboard;
     bit [31:0] aligned_next_addr;
     forever begin
       // Wait for new instruction to appear in ID stage
-      wait (instr_vif.instr_cb.valid_id &&
-            instr_vif.instr_cb.instr_new_id &&
+      wait (instr_vif.instr_cb.rvfi_id_done &&
             latest_order != instr_vif.instr_cb.rvfi_order_id);
 
       latest_order = instr_vif.instr_cb.rvfi_order_id;
@@ -320,9 +319,9 @@ class ibex_cosim_scoreboard extends uvm_scoreboard;
       // Wait for a new instruction or a writeback exception. When a new instruction has entered the
       // ID stage and we haven't seen a writeback exception we know the instruction associated with the
       // error just added to the queue isn't getting flushed.
-      wait (instr_vif.instr_cb.instr_new_id || dut_vif.dut_cb.wb_exception);
+      wait (instr_vif.instr_cb.rvfi_id_done || dut_vif.dut_cb.wb_exception);
 
-      if (!instr_vif.instr_cb.instr_new_id && dut_vif.dut_cb.wb_exception) begin
+      if (!instr_vif.instr_cb.rvfi_id_done && dut_vif.dut_cb.wb_exception) begin
         // If we hit a writeback exception without seeing a new instruction then the newly added
         // error relates to an instruction just flushed from the ID stage so pop it from the
         // queue.

--- a/dv/uvm/core_ibex/env/core_ibex_instr_monitor_if.sv
+++ b/dv/uvm/core_ibex/env/core_ibex_instr_monitor_if.sv
@@ -15,7 +15,7 @@ interface core_ibex_instr_monitor_if #(
   // ID stage
   logic                   reset;
   logic                   valid_id;
-  logic                   instr_new_id;
+  logic                   rvfi_id_done;
   logic                   err_id;
   logic                   is_compressed_id;
   logic [15:0]            instr_compressed_id;
@@ -30,7 +30,7 @@ interface core_ibex_instr_monitor_if #(
   clocking instr_cb @(posedge clk);
     input reset;
     input valid_id;
-    input instr_new_id;
+    input rvfi_id_done;
     input err_id;
     input is_compressed_id;
     input instr_compressed_id;

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -274,7 +274,7 @@ module core_ibex_tb_top;
   // Instruction monitor connections
   assign instr_monitor_if.reset        = ~rst_n;
   assign instr_monitor_if.valid_id     = dut.u_ibex_top.u_ibex_core.id_stage_i.instr_valid_i;
-  assign instr_monitor_if.instr_new_id = dut.u_ibex_top.u_ibex_core.instr_new_id;
+  assign instr_monitor_if.rvfi_id_done = dut.u_ibex_top.u_ibex_core.rvfi_id_done;
 
   assign instr_monitor_if.err_id =
     dut.u_ibex_top.u_ibex_core.id_stage_i.controller_i.instr_fetch_err;


### PR DESCRIPTION
This refactors `instr_vif` to use `rvfi_id_done` instead of `instr_new_id` to track when a new instruction appears in the ID stage. This interface and signal are only used to keep track of instruction fetch errors by using the aforementioned valid signal and checking whether the `rvfi_order_id` has advanced. However, `instr_new_id` will be gated if an instruction fetch error occurs after another error, causing us to overlook the `fetch_err` in the verification. With this change, we also no longer need to look at `valid_id` since the `rvfi_id_done` already contains this information.

This will fix failing `riscv_mem_error_test` in the nightly runs and the failing CI in https://github.com/lowRISC/ibex/pull/2324