### PR TITLE
[simple_system] Argument parsing fix

### DIFF
--- a/examples/simple_system/README.md
+++ b/examples/simple_system/README.md
@@ -32,9 +32,9 @@ with different configurations of Ibex, specified by parameters. To build the
 "small" configuration, run the following command from the Ibex repository root.
 
 
-```
-fusesoc --cores-root=. run --target=sim --setup --build \
-        lowrisc:ibex:ibex_simple_system $(util/ibex_config.py small fusesoc_opts)
+```sh
+util/ibex_config.py small fusesoc_opts | fusesoc --cores-root=. run --target=sim --setup \
+    --build lowrisc:ibex:ibex_simple_system
 ```
 
 To see performance counters other than the total number of instructions

--- a/examples/sw/benchmarks/README.md
+++ b/examples/sw/benchmarks/README.md
@@ -11,7 +11,7 @@ All of these benchmarks run on Simple System. A verilator simulation suitable
 for running them can be built with:
 
 ```
-fusesoc --cores-root=. run --target=sim --setup --build lowrisc:ibex:ibex_simple_system `./util/ibex_config.py maxperf fusesoc_opts`
+util/ibex_config.py maxperf fusesoc_opts | fusesoc --cores-root=. run --target=sim --setup --build lowrisc:ibex:ibex_simple_system
 ```
 
 This will build a simulation of Ibex in the 'maxperf' configuration.

--- a/util/ibex_config.py
+++ b/util/ibex_config.py
@@ -129,7 +129,7 @@ class FusesocOpts:
         fusesoc_cmd = []
         for fld, typ in Config.known_fields:
             val = config.params[fld]
-            fusesoc_cmd.append(shlex.quote(f'--{fld}={val}'))
+            fusesoc_cmd.append(f'--{fld} {val}')
 
         return ' '.join(fusesoc_cmd)
 


### PR DESCRIPTION
All these commands were working in Bash but not in Fish. This commit removes the = between the field and the value and replaces this with the more portable space. It also changes the commands in the readme to use the pipe input instead of setting the argument variable. This is because otherwise shells like fish interpret the output of the ibex_config.py scripts as one long string instead of multiple arguments.