### PR TITLE
[doc] Fixup for bullet list

### DIFF
--- a/doc/04_developer/concierge.rst
+++ b/doc/04_developer/concierge.rst
@@ -25,6 +25,7 @@ The concierge duties rotate between several core developers on a weekly basis.
 You can find today's concierge on duty in a `public calendar <https://calendar.google.com/calendar/embed?src=lowrisc.org_s0pdodkddnggdp40jusjij27h4%40group.calendar.google.com>`_.
 
 Besides the concierge on duty you can also contact the following people for urgent matters:
+
 * Marno van der Maas (`@marnovandermaas <https://github.com/marnovandermaas>`_)
 * Rupert Swarbrick (`@rswarbrick <https://github.com/rswarbrick>`_)
 


### PR DESCRIPTION
Unfortunately the rendered document looks like:
<img width="1173" height="253" alt="image" src="https://github.com/user-attachments/assets/8eedd995-ed82-4b33-bb14-e6b504be5386" />

This commit adds an enter so that the bullet list is rendered correctly.