### PR TITLE
[rtl] Scramble lint fix

### DIFF
--- a/rtl/ibex_top.sv
+++ b/rtl/ibex_top.sv
@@ -573,7 +573,9 @@ module ibex_top import ibex_pkg::*; #(
 
     logic unused_scramble_inputs = scramble_key_valid_i & (|scramble_key_i) & (|RndCnstIbexKey) &
                                    (|scramble_nonce_i) & (|RndCnstIbexNonce) & scramble_req_q &
-                                   ic_scr_key_req & scramble_key_valid_d & scramble_req_d;
+                                   ic_scr_key_req & scramble_key_valid_d & scramble_req_d &
+                                   (|scramble_key_q) & (|scramble_nonce_q) & scramble_key_valid_q &
+                                   scramble_key_valid_d;
 
     assign scramble_req_d       = 1'b0;
     assign scramble_req_q       = 1'b0;
@@ -762,8 +764,6 @@ module ibex_top import ibex_pkg::*; #(
     assign ram_cfg_rsp_icache_data_o = '0;
     assign unused_ram_inputs = (|ic_tag_req) & ic_tag_write & (|ic_tag_addr) & (|ic_tag_wdata) &
                                (|ic_data_req) & ic_data_write & (|ic_data_addr) & (|ic_data_wdata) &
-                               (|scramble_key_q) & (|scramble_nonce_q) & scramble_key_valid_q &
-                               scramble_key_valid_d & (|scramble_nonce_q) &
                                (|NumAddrScrRounds);
 
     assign ic_tag_rdata      = '{default:'b0};


### PR DESCRIPTION
When instruction cache is enabled and scrambling is disabled there was an unused signal warning in Verilator. This commit moves the unused signals to the right block.