### PR TITLE
[simple_system] RV32ZC parameter added

### DIFF
--- a/examples/simple_system/ibex_simple_system.core
+++ b/examples/simple_system/ibex_simple_system.core
@@ -31,6 +31,12 @@ parameters:
     paramtype: vlogdefine
     description: "Bitmanip implementation parameter enum. See the ibex_pkg::rv32b_e enum in ibex_pkg.sv for permitted values."
 
+  RV32ZC:
+    datatype: str
+    default: ibex_pkg::RV32ZcaZcbZcmp
+    paramtype: vlogdefine
+    description: "Compressed instructions parameter enum. See the ibex_pkg::rv32zc_e enum in ibex_pkg.sv for permitted values."
+
   RegFile:
     datatype: str
     default: ibex_pkg::RegFileFF
@@ -129,6 +135,7 @@ targets:
       - RV32E
       - RV32M
       - RV32B
+      - RV32ZC
       - RegFile
       - ICache
       - ICacheScramble


### PR DESCRIPTION
This fixes the use of ibex_config.py in conjunction with the Simple System FuseSoC command.