### PR TITLE
Fix: Ensure safe control signal reset on illegal instruction

### DIFF
--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -663,6 +663,12 @@ module ibex_decoder #(
       jump_set_o      = 1'b0;
       branch_in_dec_o = 1'b0;
       csr_access_o    = 1'b0;
+
+      rf_ren_a_o      = 1'b0;
+      rf_ren_b_o      = 1'b0;
+      icache_inval_o  = 1'b0;
+
+      csr_op_o        = CSR_OP_READ; 
     end
   end
 


### PR DESCRIPTION
This PR improves decoder robustness by ensuring all relevant control
signals are safely reset when an illegal instruction is detected.

Previously, signals like rf_ren_a_o, rf_ren_b_o, icache_inval_o and csr_op_o
could retain stale values, potentially causing unintended hardware behavior.

This change aligns the decoder with safe hardware design practices
and improves reliability.
