### PR TITLE
decoder: Ensure safe handling of illegal instructions by blocking all side effects

### DIFF
--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -656,16 +656,24 @@ module ibex_decoder #(
     // insufficient privileges), or when accessing non-available registers in RV32E,
     // these cases are not handled here
     if (illegal_insn) begin
-      rf_we           = 1'b0;
-      data_req_o      = 1'b0;
-      data_we_o       = 1'b0;
-      jump_in_dec_o   = 1'b0;
-      jump_set_o      = 1'b0;
-      branch_in_dec_o = 1'b0;
-      csr_access_o    = 1'b0;
-    end
-  end
+  
+  rf_we           = 1'b0;
+  data_req_o      = 1'b0;
+  data_we_o       = 1'b0;
+  csr_access_o    = 1'b0;
 
+  jump_in_dec_o   = 1'b0;
+  jump_set_o      = 1'b0;
+  branch_in_dec_o = 1'b0;
+
+  rf_ren_a_o      = 1'b0;
+  rf_ren_b_o      = 1'b0;
+  icache_inval_o  = 1'b0;
+
+  csr_op_o        = CSR_OP_READ;
+
+  end
+  end 
   /////////////////////////////
   // Decoder for ALU control //
   /////////////////////////////


### PR DESCRIPTION
This change strengthens the handling of illegal instructions in the decoder
by ensuring that no unintended side effects are triggered when an illegal
instruction is detected.

In addition to disabling write and control signals, this update explicitly:
- disables register read enables (rf_ren_a_o, rf_ren_b_o)
- blocks instruction cache invalidation (icache_inval_o)
- forces CSR operations to a safe read-only mode

This prevents any unintended data access, control flow changes, or CSR
side effects from occurring due to partially decoded illegal instructions.

The change is non-intrusive and aligns with safe CPU design practices,
ensuring that illegal instructions are fully contained within the decoder
stage without affecting downstream pipeline behavior.