### PR TITLE
decoder: Strengthen illegal instruction containment and add verification testbench

### DIFF
--- a/dv/tb_illegal_instr_safe.sv
+++ b/dv/tb_illegal_instr_safe.sv
@@ -1,0 +1,50 @@
+`timescale 1ns/1ps
+
+module tb_illegal_instr_safe;
+
+  logic clk;
+  logic rst_n;
+
+  logic [31:0] instr_rdata_i;
+  logic [31:0] instr_rdata_alu_i;
+
+  logic rf_we_o;
+  logic data_req_o;
+  logic jump_in_dec_o;
+
+  // clock
+  always #5 clk = ~clk;
+
+  ibex_decoder dut (
+    .clk_i(clk),
+    .rst_ni(rst_n),
+
+    .instr_rdata_i(instr_rdata_i),
+    .instr_rdata_alu_i(instr_rdata_alu_i),
+
+    .rf_we_o(rf_we_o),
+    .data_req_o(data_req_o),
+    .jump_in_dec_o(jump_in_dec_o)
+  );
+
+  initial begin
+    clk = 0;
+    rst_n = 0;
+    #10 rst_n = 1;
+
+    // Inject illegal instruction
+    instr_rdata_i     = 32'hFFFFFFFF;
+    instr_rdata_alu_i = 32'hFFFFFFFF;
+
+    #10;
+
+    // Checks
+    if (rf_we_o !== 0) $fatal("FAIL: rf_we_o not zero");
+    if (data_req_o !== 0) $fatal("FAIL: data_req_o not zero");
+    if (jump_in_dec_o !== 0) $fatal("FAIL: jump not zero");
+
+    $display("PASS: Illegal instruction handled safely");
+    $finish;
+  end
+
+endmodule

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -656,14 +656,21 @@ module ibex_decoder #(
     // insufficient privileges), or when accessing non-available registers in RV32E,
     // these cases are not handled here
     if (illegal_insn) begin
-      rf_we           = 1'b0;
-      data_req_o      = 1'b0;
-      data_we_o       = 1'b0;
-      jump_in_dec_o   = 1'b0;
-      jump_set_o      = 1'b0;
-      branch_in_dec_o = 1'b0;
-      csr_access_o    = 1'b0;
-    end
+  rf_we           = 1'b0;
+  data_req_o      = 1'b0;
+  data_we_o       = 1'b0;
+  jump_in_dec_o   = 1'b0;
+  jump_set_o      = 1'b0;
+  branch_in_dec_o = 1'b0;
+  csr_access_o    = 1'b0;
+
+  rf_ren_a_o      = 1'b0;
+  rf_ren_b_o      = 1'b0;
+  icache_inval_o  = 1'b0;
+
+  data_type_o           = 2'b00;
+  data_sign_extension_o = 1'b0;
+end
   end
 
   /////////////////////////////


### PR DESCRIPTION
This PR enhances illegal instruction handling in the decoder by ensuring
all side-effect-causing signals are safely disabled, including memory
control signals.

Additionally, a dedicated testbench is added to verify correct behavior
when illegal instructions are encountered.

The test injects an illegal instruction and confirms that no register
writes, memory requests, or control flow changes are triggered.

This improves robustness and aligns behavior with real hardware safety expectations.