### PR TITLE
decoder: Prevent memory side-effects on taken branch and add verification testbench

### DIFF
--- a/dv/dv/tb_branch_flush.sv
+++ b/dv/dv/tb_branch_flush.sv
@@ -1,0 +1,50 @@
+`timescale 1ns/1ps
+
+module tb_branch_flush;
+
+  logic clk;
+  logic rst_n;
+
+  logic branch_taken_i;
+  logic [31:0] instr_rdata_i;
+  logic [31:0] instr_rdata_alu_i;
+
+  logic data_req_o;
+  logic data_we_o;
+
+  always #5 clk = ~clk;
+
+  ibex_decoder dut (
+    .clk_i(clk),
+    .rst_ni(rst_n),
+    .branch_taken_i(branch_taken_i),
+    .instr_rdata_i(instr_rdata_i),
+    .instr_rdata_alu_i(instr_rdata_alu_i),
+    .data_req_o(data_req_o),
+    .data_we_o(data_we_o)
+  );
+
+  initial begin
+    clk = 0;
+    rst_n = 0;
+    branch_taken_i = 0;
+
+    #10 rst_n = 1;
+
+    // Simulate branch instruction
+    instr_rdata_i     = 32'h00000063; // BEQ type
+    instr_rdata_alu_i = 32'h00000063;
+
+    branch_taken_i = 1;
+
+    #10;
+
+    // Check memory is blocked
+    if (data_req_o !== 0) $fatal("FAIL: data_req_o should be 0 on branch");
+    if (data_we_o  !== 0) $fatal("FAIL: data_we_o should be 0 on branch");
+
+    $display("PASS: Branch flush safe");
+    $finish;
+  end
+
+endmodule

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -289,6 +289,10 @@ module ibex_decoder #(
 
         rf_ren_a_o = 1'b1;
         rf_ren_b_o = 1'b1;
+        if (branch_taken_i) begin
+           data_req_o = 1'b0;
+            data_we_o  = 1'b0;
+      end
       end
 
       ////////////////


### PR DESCRIPTION
This PR improves pipeline safety by ensuring that no memory
requests are issued when a branch is taken.

This avoids unintended memory accesses during control flow changes.

A testbench is added to verify that data_req_o and data_we_o
are correctly disabled when branch_taken_i is asserted.

This aligns the decoder behavior with real hardware expectations
and improves pipeline correctness.