### PR TITLE
decoder: Add formal-style safety assertions for control, memory, and illegal instruction handling

### DIFF
--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -1206,6 +1206,35 @@ module ibex_decoder #(
   // Assertions //
   ////////////////
 
+// 1. No register write on illegal instruction
+`ASSERT(NoWriteOnIllegal,
+  illegal_insn_o |-> !rf_we_o
+)
+
+// 2. No memory request on illegal instruction
+`ASSERT(NoMemReqOnIllegal,
+  illegal_insn_o |-> !data_req_o
+)
+
+// 3. No branch + jump at same time
+`ASSERT(NoBranchAndJump,
+  !(branch_in_dec_o && jump_in_dec_o)
+)
+
+// 4. No CSR access on illegal instruction
+`ASSERT(NoCSRAccessOnIllegal,
+  illegal_insn_o |-> !csr_access_o
+)
+
+// 5. Branch should not trigger memory
+`ASSERT(NoMemDuringBranch,
+  branch_in_dec_o |-> !data_req_o
+)
+// 6. No register read on illegal instruction
+`ASSERT(NoRFReadOnIllegal,
+  illegal_insn_o |-> !(rf_ren_a_o || rf_ren_b_o)
+)
+
   // Selectors must be known/valid.
   `ASSERT(IbexRegImmAluOpKnown, (opcode == OPCODE_OP_IMM) |->
       !$isunknown(instr[14:12]))


### PR DESCRIPTION
This PR introduces a set of safety assertions in the decoder to
improve verification and ensure correct control behavior.

The assertions cover:
- No register writes on illegal instructions
- No memory requests during illegal or branch conditions
- Mutual exclusion of branch and jump signals
- No CSR access on illegal instructions
- No register reads on illegal instructions

These checks align the decoder behavior with real hardware
verification practices and improve robustness against unintended
side effects.

This enhances confidence in control-path correctness and makes
the design more verification-friendly.