### PR TITLE
Force CSR Operation to Safe Read on Illegal Instruction

### DIFF
--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -663,6 +663,8 @@ module ibex_decoder #(
       jump_set_o      = 1'b0;
       branch_in_dec_o = 1'b0;
       csr_access_o    = 1'b0;
+
+      csr_op_o        = CSR_OP_CLEAR;
     end
   end
 


### PR DESCRIPTION
Ensure CSR operation defaults to a safe read when an illegal instruction is detected.

This prevents unintended CSR modifications and improves decoder safety.