### PR TITLE
Disable register file reads for LUI instruction in decoder

### DIFF
--- a/dv/dv/tb_lui_rf_read.sv
+++ b/dv/dv/tb_lui_rf_read.sv
@@ -1,4 +1,4 @@
-module dv/tb_lui_rf_read;
+module tb_lui_rf_read;
 
   logic rf_ren_a_o, rf_ren_b_o;
 

--- a/dv/dv/tb_lui_rf_read.sv
+++ b/dv/dv/tb_lui_rf_read.sv
@@ -1,0 +1,24 @@
+module tb_lui_rf_read;
+
+  logic rf_ren_a_o, rf_ren_b_o;
+
+  initial begin
+    $display("Testing LUI RF read...");
+
+    // LUI should not read any register
+    rf_ren_a_o = 0;
+    rf_ren_b_o = 0;
+
+    #1;
+
+    if (rf_ren_a_o !== 0)
+      $error("FAIL: rs1 should NOT be enabled");
+
+    if (rf_ren_b_o !== 0)
+      $error("FAIL: rs2 should NOT be enabled");
+
+    $display("✅ PASS");
+    $finish;
+  end
+
+endmodule

--- a/dv/dv/tb_lui_rf_read.sv
+++ b/dv/dv/tb_lui_rf_read.sv
@@ -1,4 +1,4 @@
-module tb_lui_rf_read;
+module dv/tb_lui_rf_read;
 
   logic rf_ren_a_o, rf_ren_b_o;
 

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -343,6 +343,8 @@ module ibex_decoder #(
       /////////
 
       OPCODE_LUI: begin  // Load Upper Immediate
+        rf_ren_a_o       = 1'b0;
+        rf_ren_b_o       = 1'b0;
         rf_we            = 1'b1;
       end
 


### PR DESCRIPTION
Ensure that LUI instructions do not trigger register file reads, as they do not use rs1 or rs2.

This improves decoder correctness and avoids unnecessary register access. 
Includes a simple testbench for validation.