### PR TITLE
[rtl] Move prim_generic dependency to ibex_top

### DIFF
--- a/ibex_top.core
+++ b/ibex_top.core
@@ -19,6 +19,8 @@ filesets:
       - lowrisc:prim:onehot_check
       - lowrisc:prim:onehot
       - lowrisc:prim:util
+      - "fileset_partner ? (partner:prim_generic:all)"
+      - "!fileset_partner ? (lowrisc:prim_generic:all)"
     files:
       - rtl/ibex_register_file_ff.sv # generic FF-based
       - rtl/ibex_register_file_fpga.sv # FPGA

--- a/ibex_top_tracing.core
+++ b/ibex_top_tracing.core
@@ -9,8 +9,6 @@ filesets:
     depend:
       - lowrisc:ibex:ibex_top
       - lowrisc:ibex:ibex_tracer
-      - "fileset_partner ? (partner:prim_generic:all)"
-      - "!fileset_partner ? (lowrisc:prim_generic:all)"
     files:
       - rtl/ibex_top_tracing.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
The `prim_generic` fileset dependency was declared in `ibex_top_tracing.core` rather than `ibex_top.core`, causing fusesoc to fail when targeting `ibex_top` directly. This PR fixes this by moving the `prim_generic` dependency to `ibex_top.core`.

Fixes #2396.