### PR TITLE
[ci] Reduce limit for the formal CI

### DIFF
--- a/.github/workflows/ci-formal.yml
+++ b/.github/workflows/ci-formal.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Setup env
         run: |
-          echo "MAX_MEM_GB=100" >> $GITHUB_ENV # Maximum memory available to conductor.py, which is inversely proportional to time. 200GB -> 40 mins
+          echo "MAX_MEM_GB=60" >> $GITHUB_ENV # Maximum memory available to conductor.py, which is inversely proportional to time. 200GB -> 40 mins
           echo "NIX_CONFIG=accept-flake-config = true" >> $GITHUB_ENV
 
       - name: Notify about queued execution


### PR DESCRIPTION
It seems the some runners have less memory available and more threads, which leads to the formal crashing. In my latest PR (https://github.com/lowRISC/ibex/pull/2403), I always got the cosmic-nix-4 machine, which crashed:

- [cosmic-nix-4](https://github.com/lowRISC/ibex/actions/runs/26087022021/job/76702603701) reports: _Process runner will have a maximum of 126 processes, and currently sees 66.413GB free._ and crashes with limit set to 100GB.
- [pomona-nix-2](https://github.com/lowRISC/ibex/actions/runs/24888842543/job/72875543792) reports _Process runner will have a maximum of 62 processes, and currently sees 100.000GB free._ runs fine with previous limit.