### PR TITLE
[dv] Add exception handler to CSR test generator (Fixes #1337)

### DIFF
--- a/vendor/google_riscv-dv/scripts/gen_csr_test.py
+++ b/vendor/google_riscv-dv/scripts/gen_csr_test.py
@@ -255,6 +255,8 @@ def gen_setup(test_file):
     test_file.write(".option norvc\n")
     test_file.write(".org 0x80\n")
     test_file.write("_start:\n")
+    test_file.write("la x1, csr_fail\n")
+    test_file.write("csrw mtvec, x1\n")
 
 
 def gen_csr_test_fail(test_file, end_addr):


### PR DESCRIPTION
Currently, the gen_csr_test.py script generates CSR test assembly that lacks a Machine Trap-Vector (mtvec) initialization sequence. If the generated test attempts an illegal access (such as writing to certain read-only fields), it triggers an Illegal Instruction exception. Without a trap handler configured, the core jumps to 0x0, executing garbage memory until the simulation times out.

Changes

Modified gen_setup() in vendor/google_riscv-dv/scripts/gen_csr_test.py to initialize mtvec.

The trap vector is now explicitly loaded with the address of the existing csr_fail label.

Impact
Illegal CSR accesses that trigger an exception will now be caught by the trap handler, gracefully forcing an immediate test failure rather than hanging the simulator for the duration of the timeout period.
