### PR TITLE
[rtl] Two LTP shortenings: decoder illegal_insn don't-care + controller csr_pipe_flush qualifier

### DIFF
--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -194,7 +194,17 @@ module ibex_controller #(
   assign dret_insn       = dret_insn_i       & instr_valid_i;
   assign wfi_insn        = wfi_insn_i        & instr_valid_i;
   assign ebrk_insn       = ebrk_insn_i       & instr_valid_i;
-  assign csr_pipe_flush  = csr_pipe_flush_i  & instr_valid_i;
+  // csr_pipe_flush_i is already qualified by instr_valid_i at the source
+  // (id_stage builds it from csr_op_en_o = csr_access_o & instr_executing &
+  // instr_id_done_o, and instr_executing already AND-includes instr_valid_i),
+  // so the extra `& instr_valid_i` here is redundant. Dropping it removes one
+  // gate from the long combinational chain
+  //   csr_op_en_o -> csr_pipe_flush_i -> csr_pipe_flush ->
+  //     special_req_flush_only -> special_req -> halt_if ->
+  //     id_in_ready_o -> ctrl_fsm_ns
+  // which is the dominant post-stall_id portion of the longest topological
+  // path on the small-config Ibex.
+  assign csr_pipe_flush  = csr_pipe_flush_i;
   assign instr_fetch_err = instr_fetch_err_i & instr_valid_i;
 
   // This is recorded in the illegal_insn_q flop to help timing.  Specifically

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -662,7 +662,25 @@ module ibex_decoder #(
       jump_in_dec_o   = 1'b0;
       jump_set_o      = 1'b0;
       branch_in_dec_o = 1'b0;
-      csr_access_o    = 1'b0;
+      // csr_access_o intentionally NOT masked here: doing so creates a
+      // critical-path arc from decoder/illegal_insn through
+      // ibex_cs_registers/illegal_csr_insn_o back into id_stage/illegal_insn_o.
+      // Functional safety is preserved by downstream gating:
+      //   * csr_op_en_o = csr_access_o & instr_executing & instr_id_done_o,
+      //     and instr_executing is forced low whenever an illegal_insn raises
+      //     id_exception, so no CSR side-effect can occur.
+      //   * Any illegal_insn_dec=1 case is OR-merged into illegal_insn_o
+      //     regardless of what illegal_csr_insn_o reports.
+      //
+      // SECURITY NOTE: leaving csr_access_o asserted for an illegal
+      // instruction means cs_registers performs its internal address decode
+      // for the illegal opcode's CSR field even though no architectural CSR
+      // side-effect occurs (csr_op_en_o is gated low). In threat models that
+      // include timing or power side-channels on illegal-instruction handling,
+      // this is a side-channel surface that the original csr_access_o = 1'b0
+      // mask did not expose. Deployments where this is a concern (e.g.
+      // OpenTitan-style security-sensitive cores) may prefer to retain the
+      // mask and accept the gate cost.
     end
   end
 


### PR DESCRIPTION
## Summary

Two independent combinational-restructuring cleanups in the same region of the longest topological path (LTP) on the small-config Ibex. Each is a separate commit; both are pure functional no-ops (no register added, no pipeline-stage change, no architectural side-effect difference) and each shortens one arc of the LTP. The two commits are independent and can be merged separately if reviewers want to accept one but not the other.

### The changes:

1. ibex_decoder.sv — drop the csr_access_o = 1'b0 mask inside the illegal_insn catch-all. The mask is a functional no-op (downstream gating already prevents CSR side-effects for illegal instructions) but creates a long arc from decoder/illegal_insn through cs_registers/illegal_csr_insn_o back into id_stage/illegal_insn_o.
2. ibex_controller.sv — drop the redundant & instr_valid_i from the csr_pipe_flush assignment. csr_pipe_flush_i is already qualified by instr_valid_i at the source (id_stage builds it from csr_op_en_o = csr_access_o & instr_executing & instr_id_done_o, and instr_executing AND-includes instr_valid_i), so the local AND is a logical identity.

Each change has its full safety argument in the commit message and inline code comment.

### Critical path

Both changes target arcs in the dominant post-stall_id portion of the LTP:

- csr_op_en_o → csr_pipe_flush_i → csr_pipe_flush → special_req_flush_only → special_req → halt_if → id_in_ready_o → ctrl_fsm_ns
- The decoder commit additionally removes the back-arc from illegal_insn through csr_access_o → cs_registers.illegal_csr_insn_o → id_stage.illegal_insn_o → controller.exc_req_d → instr_kill that converges into the same chain.

### Measurements
Pending per-PR isolated synthesis (Yosys + ltp on small-config Ibex; same flow as #2440). To be added before requesting final review.

Functional verification (small-config Ibex, both commits applied; rv32im, RV32MFast, RV32Zca, WB=1, BP=1, no PMP/icache/security):

| test | result |
|--------|--------|
| CoreMark 100i cycles | unchanged (37,362,985)  |
| CoreMark CRCs | 0xe714 / 0x1fd7 / 0x8e3a (golden) |
| return42 / hello / fwd_test | all pass with identical cycle counts |

### Security disclosure — decoder commit
The decoder commit leaves csr_access_o asserted for illegal instructions, which means cs_registers performs its internal CSR-address decode for the illegal opcode's CSR field. No architectural side-effect occurs — csr_op_en_o is gated low by instr_executing, which is forced low on illegal_insn. However, in threat models that include timing or power side-channels on illegal-instruction handling, the cs_registers internal decode is a side-channel surface that the original csr_access_o = 1'b0 mask did not expose.

For security-sensitive deployments (e.g. OpenTitan-style cores where illegal-instruction-decode side-channels may be in scope), reviewers may prefer to reject the decoder commit and accept the gate cost. The csr_pipe_flush commit has no equivalent concern.