### PR TITLE
[dv] Mask read-only fields in CSR test generator (Fixes #1337)

### DIFF
--- a/vendor/google_riscv-dv/scripts/gen_csr_test.py
+++ b/vendor/google_riscv-dv/scripts/gen_csr_test.py
@@ -349,15 +349,18 @@ def gen_csr_instr(original_csr_map, csr_instructions, xlen,
                                                                         csr_write_fields,
                                                                         csr_read_mask)))
                         else:
+                            safe_rs1_val = csr_val.copy()
+                            csr_write(rand_rs1_val, safe_rs1_val, csr_write_fields)
+
                             first_li = "\tli {}, 0x{}\n".format(source_reg,
-                                                                rand_rs1_val.hex)
+                                                                safe_rs1_val.hex)
                             csr_inst = "\t{} {}, {}, {}\n".format(op, dest_reg,
                                                                   csr_address,
                                                                   source_reg)
                             predict_li = ("\tli {}, "
                                           "{}\n".format(source_reg,
                                                         predict_csr_val(op,
-                                                                        rand_rs1_val,
+                                                                        safe_rs1_val,
                                                                         csr_val,
                                                                         csr_write_fields,
                                                                         csr_read_mask)))

--- a/vendor/patches/google_riscv-dv/0001-mask-readonly-csr-fields.patch
+++ b/vendor/patches/google_riscv-dv/0001-mask-readonly-csr-fields.patch
@@ -1,0 +1,25 @@
+diff --git a/vendor/google_riscv-dv/scripts/gen_csr_test.py b/vendor/google_riscv-dv/scripts/gen_csr_test.py
+index ca4be2a6..36aec705 100644
+--- a/vendor/google_riscv-dv/scripts/gen_csr_test.py
++++ b/vendor/google_riscv-dv/scripts/gen_csr_test.py
+@@ -351,15 +351,18 @@ def gen_csr_instr(original_csr_map, csr_instructions, xlen,
+                                                                         csr_write_fields,
+                                                                         csr_read_mask)))
+                         else:
++                            safe_rs1_val = csr_val.copy()
++                            csr_write(rand_rs1_val, safe_rs1_val, csr_write_fields)
++
+                             first_li = "\tli {}, 0x{}\n".format(source_reg,
+-                                                                rand_rs1_val.hex)
++                                                                safe_rs1_val.hex)
+                             csr_inst = "\t{} {}, {}, {}\n".format(op, dest_reg,
+                                                                   csr_address,
+                                                                   source_reg)
+                             predict_li = ("\tli {}, "
+                                           "{}\n".format(source_reg,
+                                                         predict_csr_val(op,
+-                                                                        rand_rs1_val,
++                                                                        safe_rs1_val,
+                                                                         csr_val,
+                                                                         csr_write_fields,
+                                                                         csr_read_mask)))


### PR DESCRIPTION
This PR pivots to fixing the root cause of the timeouts (Bullet Point 1 of #1337): the Python script generates csrrw/csrrs/csrrc instructions that attempt to overwrite RO (Read-Only) fields, which triggers an Illegal Instruction exception in the hardware and hangs the simulation.

Changes

Modified the data generation loop in gen_csr_test.py.

Before writing the raw rand_rs1_val to the assembly payload, it is now passed through the internal csr_write() function to explicitly mask out read-only bits based on the YAML definitions.

Generated a .patch file in vendor/patches/google_riscv-dv/ to persist this fix across upstream vendor updates.

Impact
The generated assembly now strictly respects read-only boundaries. It prevents the core from triggering hardware exceptions during standard register checks, eliminating the timeouts without breaking reset value predictions.