### PR TITLE
[rtl] Fix prim_generic mapping in ibex_top

### DIFF
--- a/ibex_top.core
+++ b/ibex_top.core
@@ -19,8 +19,6 @@ filesets:
       - lowrisc:prim:onehot_check
       - lowrisc:prim:onehot
       - lowrisc:prim:util
-      - "fileset_partner ? (partner:prim_generic:all)"
-      - "!fileset_partner ? (lowrisc:prim_generic:all)"
     files:
       - rtl/ibex_register_file_ff.sv # generic FF-based
       - rtl/ibex_register_file_fpga.sv # FPGA

--- a/ibex_top.core
+++ b/ibex_top.core
@@ -27,6 +27,11 @@ filesets:
       - rtl/ibex_top.sv
     file_type: systemVerilogSource
 
+  # Map the prims listed above to the prim_generic implementations for linting
+  files_map_prim_generic:
+      depend:
+        - lowrisc:prim_generic:all
+
   files_lint_verilator:
     files:
       - lint/verilator_waiver.vlt: {file_type: vlt}
@@ -161,6 +166,7 @@ targets:
   default: &default_target
     filesets:
       - tool_verilator ? (files_lint_verilator)
+      - tool_verilator ? (files_map_prim_generic)
       - files_rtl
       - files_check_tool_requirements
     toplevel: ibex_top
@@ -168,6 +174,8 @@ targets:
       - tool_vivado ? (FPGA_XILINX=true)
   lint:
     <<: *default_target
+    filesets:
+      - files_map_prim_generic
     parameters:
       - SYNTHESIS=true
       - RVFI=true

--- a/ibex_top_tracing.core
+++ b/ibex_top_tracing.core
@@ -9,6 +9,9 @@ filesets:
     depend:
       - lowrisc:ibex:ibex_top
       - lowrisc:ibex:ibex_tracer
+      # Map the prims in ibex_top to prim_generic implementations for simulation and linting
+      - "fileset_partner ? (partner:prim_generic:all)"
+      - "!fileset_partner ? (lowrisc:prim_generic:all)"
     files:
       - rtl/ibex_top_tracing.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
This PR course-corrects https://github.com/lowRISC/ibex/pull/2397, where I mistakenly moved `prim_generic` into `ibex_top.core`. While that change fixed an immediate FuseSoC failure, it broke the core-file's technology-independent abstraction layer.

`ibex_top` is designed to rely strictly on **virtual** primitive dependencies (`prim:*`). It isn't meant to act as a final top-level module. Instead, wrappers like `ibex_top_tracing` are supposed to bind these abstract primitives to a concrete implementation, e.g., to `prim_generic`. This keeps `ibex_top` technology-independent and an FPGA wrapper can use `prim_xilinx` for example. 

I previously treated the `lowrisc:prim_generic:all` dependency as a standard source file dependency. Because `ibex_top` is the module actually implementing Ibex, it felt logical to put the dependency there instead of the wrapper to make `ibex_top`'s dependency list complete on its own. However, in my current understanding, this dependency actually serves to define the **instantiation mapping**. Because `ibex_top` already declares its source dependencies virtually, hardcoding `prim_generic` there stripped away the ability for wrappers to cleanly set their own primitives' implementation.

The original mistake stemmed from our documentation, which instructs users to run linting or generate filelists targeting `ibex_top` directly. Doing so bypasses the standard wrappers, leaving FuseSoC with no idea which implementation of the virtual prims to use, and to choose randomly, which then failed.

To fix this cleanly now, this PR:
* Removes the global `prim_generic` dependency from `ibex_top.core` again and moves it back to `ibex_top_tracing.core`.
* Explicitly maps the virtual prims to `prim_generic` **only for the linter and Verilator targets** within `ibex_top`.

This restores FPGA builds and ensures the documented linting/filelist workflows still work.