### PR TITLE
[rtl] Fix the `minstret` counter

### DIFF
--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -1076,9 +1076,15 @@ module ibex_id_stage #(
   end
 
   // Signal which instructions to count as retired in minstret, all traps along with ebrk and
-  // ecall instructions are not counted.
+  // ecall instructions are not counted. Writes to minstret/minstreth themselves are also excluded
+  // to avoid incrementing right after a write.
+  logic minstret_write;
+  assign minstret_write = csr_access_o &
+      (csr_op_o inside {CSR_OP_WRITE, CSR_OP_SET, CSR_OP_CLEAR}) &
+      (csr_addr_o inside {CSR_MINSTRET, CSR_MINSTRETH});
+
   assign instr_perf_count_id_o = ~ebrk_insn & ~ecall_insn_dec & ~illegal_insn_dec &
-      ~illegal_csr_insn_i & ~instr_fetch_err_i;
+      ~illegal_csr_insn_i & ~instr_fetch_err_i & ~minstret_write;
 
   // An instruction is ready to move to the writeback stage (or retire if there is no writeback
   // stage)

--- a/rtl/ibex_wb_stage.sv
+++ b/rtl/ibex_wb_stage.sv
@@ -155,7 +155,7 @@ module ibex_wb_stage #(
     // Speculative versions of the signals do not factor in exceptions and whether the instruction
     // is done yet. These are used to get correct values for instructions reading the relevant
     // performance counters in the ID stage.
-    assign perf_instr_ret_wb_spec_o            = wb_count_q;
+    assign perf_instr_ret_wb_spec_o            = wb_count_q & wb_valid_q;
     assign perf_instr_ret_compressed_wb_spec_o = perf_instr_ret_wb_spec_o & wb_compressed_q;
     assign perf_instr_ret_wb_o                 = instr_done_wb_o & wb_count_q &
                                                  ~(lsu_resp_valid_i & lsu_resp_err_i);


### PR DESCRIPTION
This PR resolves two different RTL issues that lead to inaccurate `instret` counts.

### Fix `minstret` update after explicit write:
Previously, a write to `minstret` would set the value in the ID stage and then increment it in the WB stage again. This doesn't match the RISC-V Specification Section 6.1: 

> Some CSRs, such as the instructions-retired counter, instret, may be modified as side effects of instruction execution. In these cases, if a CSR access instruction reads a CSR, it reads the value prior to the execution of the instruction. If a CSR access instruction writes such a CSR, the explicit write is done instead of the update from the side effect. In particular, a value written to instret by one instruction will be the value read by the following instruction. 
 
### Fix speculative `minstret` increment:
Prevents over-counting by validating the `wb_count_q` signal. This ensures the counter is only speculatively incremented during back-to-back instruction execution, fixing a bug where stale signals caused the counter to jump ahead after a stall cycle.

The following figures explain the behavior. We are looking at the relevant signals for two back to back CSR reads of `minstret` after some stall cycles (empty WB stage). The counter is initially on `0x3c` retired instructions. The CSRs are read in cycle 2 & 3.

#### Previous behavior
<img width="760" height="440" alt="wavedrom" src="https://github.com/user-attachments/assets/f5f5a134-c202-4b6f-9839-2526acc89306" />

Both CSR reads return the same value (`0x3d`). Whenever `instr_ret_spec` is set, we read the `minstret_next` value (the counter's increment) because we assume that there is an instruction retiring in the WB stage ahead of us. Otherwise, we read the `minstret_raw` signal (the current counter value). `instr_ret_spec` was previously directly connected to `wb_count_q` and therefore, we would always read the incremented value, because this just stores whether the _current/last_ instruction in the WB stage counted towards the `instret` count. The counter increment is triggered by `instr_ret`, which happens in cycle 3 for the first CSR read and the counter stores the increment in cycle 4. Note that if we read the counter again in cycle 5, the counter already reads `0x3f` even though there is no instruction in the WB stage retiring and we only retired `0x3e` instructions by then.

#### Fixed behavior
<img width="760" height="440" alt="wavedrom" src="https://github.com/user-attachments/assets/6922e08b-1115-436e-af9b-bd71e8a53914" />

We now validate `instr_ret_spec` with `wb_valid_q`. This invalidates it in the first cycles, when the WB stage is empty, and reading `minstret` returns the actual counter value `0x3c` in cycle 2. In cycle 3, the previous read is retiring, but the counter did not have time to update and will do so in the next cycle. Now `instr_ret_spec` is set and we read the speculative/incremented counter value `0x3d` in our second read. Similarly, in cycle 4 we would read the incremented value because the second read is retiring. In cycle 5 we would again see the counters unmodified value since it had a change to update after the last instruction retired.

### Verification

The current CSR tests seem to exclude the cosim and focus on making sure that the access behavior/rights is correct but not the counter value. Since we noticed this bug when adding verification for the `mcounteren` CSR where we access and compare the `minstret` with the cosim enabled, I extended that test to verify both testcases. This test was able to catch both of those errors together with the cosim. In the future, a fully randomzied test would be ideal.

I suggest we use https://github.com/lowRISC/ibex/pull/2403 for the verification for now instead of waiting with those fixes until we have a full blown DV environment for the `minstret`.