### PR TITLE
actions/checkout: v4 -> v6

### DIFF
--- a/.github/workflows/ci-formal.yml
+++ b/.github/workflows/ci-formal.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           echo "Warning: This job will block other oss-fv jobs until it finishes, since it uses a lot of memory."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Nix
         uses: cachix/install-nix-action@v27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     name: Run quality checks (Lint and DV)
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Fetch all history so that we can run git diff on the base branch
           fetch-depth: 0

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       verible_config: "vendor/lowrisc_ip/lint/tools/veriblelint/lowrisc-styleguide.rules.verible_lint"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Display Verible config
         run: |
           echo "::group::Verible config"


### PR DESCRIPTION
This fixes CI breakage due to the deprecation of NodeJS20 support in the default action runners.