### PR TITLE
[simple_system] Fix initial assignment of `clk_sys`

### DIFF
--- a/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/examples/simple_system/rtl/ibex_simple_system.sv
@@ -65,7 +65,7 @@ module ibex_simple_system (
   parameter bit                 BranchPredictor          = 1'b0;
   parameter                     SRAMInitFile             = "";
 
-  logic clk_sys = 1'b0, rst_sys_n;
+  logic clk_sys, rst_sys_n;
 
   typedef enum logic {
     CoreD
@@ -137,9 +137,12 @@ module ibex_simple_system (
       #8
       rst_sys_n = 1'b1;
     end
-    always begin
-      #1 clk_sys = 1'b0;
-      #1 clk_sys = 1'b1;
+    initial begin
+      clk_sys = 1'b0;
+      forever begin
+        #1 clk_sys = 1'b0;
+        #1 clk_sys = 1'b1;
+      end
     end
   `endif
 


### PR DESCRIPTION
Remove the in-line initialization of the clock from the simple system, and handle the clock generation in a separate `initial` block instead.

Fixes https://github.com/lowRISC/ibex/issues/2447