### PR TITLE
refactor: Fix get_unix_timestamp return type to use standard time_t

### DIFF
--- a/dv/uvm/core_ibex/common/date.c
+++ b/dv/uvm/core_ibex/common/date.c
@@ -3,4 +3,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <time.h>
-long int get_unix_timestamp() { return time(NULL); }
+time_t get_unix_timestamp() { return time(NULL); }


### PR DESCRIPTION
### 问题背景
The function `get_unix_timestamp()` previously declared its return type as `long int`, but it returns the result of the standard `time(NULL)` function, which returns `time_t`. While these types might be the same on many common platforms (like Linux), `time_t` is the portable and correct type as specified by the C standard. Using `long int` could lead to compilation warnings or errors on platforms where `time_t` is defined differently.

### 修改内容
- **修改了什么:** Changed the return type of the `get_unix_timestamp()` function from `long int` to `time_t`.
- **为什么这样改:** This aligns the function signature with the standard return type of `time()`, ensuring code correctness and portability across different platforms and compilers.
- **对代码质量/性能/安全性的提升:** **代码质量/可移植性提升:** Eliminates a potential source of non-portable code and compiler warnings. The change is purely a type correction and has zero impact on runtime behavior or performance.

### 验证方式
- **是否通过了现有测试:** This change is a simple type correction. All existing tests that use this function should continue to pass, as the returned value's bit pattern is unchanged.
- **是否添加了新的测试:** No new tests are required, as the change does not alter any functionality.
- **是否进行了手动验证:** Verified that the code compiles correctly with the updated type.

### 其他信息
- **是否有 breaking changes:** **理论上 yes, 实践上 no.** The function's public signature is changed. However, `time_t` is typically defined as a `long` or `long int` on most UNIX-like systems. Code calling this function and assigning the result to a `long int` variable will still work, possibly with an implicit conversion or a minor warning on some compilers. It is a breaking change in the strictest sense, but it is a necessary correction for portability.
- **是否需要更新文档:** No. The function's behavior and purpose are unchanged.
- **是否有已知的限制:** None.