### PR TITLE
[syn] Fix Yosys synthesis failure by removing simulation tracing wrapper

### DIFF
--- a/syn/syn_yosys.sh
+++ b/syn/syn_yosys.sh
@@ -102,6 +102,7 @@ rm -f "$LR_SYNTH_OUT_DIR"/generated/ibex_tracer.v
 rm -f "$LR_SYNTH_OUT_DIR"/generated/ibex_register_file_ff.v
 rm -f "$LR_SYNTH_OUT_DIR"/generated/ibex_register_file_fpga.v
 
+rm -f "$LR_SYNTH_OUT_DIR"/generated/ibex_top_tracing.v
 yosys -c ./tcl/yosys_run_synth.tcl |& teelog syn || {
     error "Failed to synthesize RTL with Yosys"
 }


### PR DESCRIPTION
###Fixes
Fixes #2260 

### Context
While testing and modernizing the experimental Yosys synthesis flow using updated tooling environments, the default end-to-end synthesis run finishes successfully. However, when evaluating adjustments to the tool's elaboration order—specifically when removing the `-defer` flag from the Yosys frontend read commands—the synthesis engine experiences a critical crash.

### The Problem
Removing `-defer` forces Yosys to immediately parse and evaluate AST representations line-by-line rather than deferring elaboration until a global hierarchy pass. During this eager evaluation, Yosys processes the simulation-only wrapper `ibex_top_tracing.v`.

Because `ibex_top_tracing.v` contains a non-synthesizable simulation block containing a system `$finish` task, Yosys encounters it as an active runtime execution constraint and aborts the frontend compilation entirely with an error.

### The Solution
This PR adds `ibex_top_tracing.v` to the list of discarded tracking and simulation-only files cleaned out by `syn_yosys.sh` right before invoking Yosys[cite: 1]. This matches the existing cleanup behavior used for `ibex_tracer.v` and alternative register file implementations[cite: 1]. With this addition, the script executes flawlessly regardless of the specific frontend elaboration configurations.

### Tooling & Environment Info
* **OS:** Ubuntu 24.04.4 LTS
* **Yosys:** 0.66
* **OpenSTA:** 3.1.0
* **sv2v:** v0.0.13

---

<details>
<summary><b>Click to expand the exact Yosys Error Log</b></summary>

```text
26. Executing Verilog-2005 frontend: syn_out/ibex_26_06_2026_21_54_22/generated/ibex_top_tracing.v
Parsing SystemVerilog input from `syn_out/ibex_26_06_2026_21_54_22/generated/ibex_top_tracing.v' to AST representation.
Generating RTLIL representation for module `\ibex_top_tracing'.
syn_out/ibex_26_06_2026_21_54_22/generated/ibex_top_tracing.v:151: ERROR: System task `$finish' executed.
Failed to synthesize RTL with Yosys