### PR TITLE
[rtl] Generalize SRAM configuration interfaces

### DIFF
--- a/doc/02_user/integration.rst
+++ b/doc/02_user/integration.rst
@@ -118,7 +118,10 @@ Instantiation Template
       .rst_ni                   (),
       .test_en_i                (),
       .scan_rst_ni              (),
-      .ram_cfg_i                (),
+      .ram_cfg_icache_tag_i     (),
+      .ram_cfg_icache_tag_o     (),
+      .ram_cfg_icache_data_i    (),
+      .ram_cfg_icache_data_o    (),
 
       // Configuration
       .hart_id_i                (),
@@ -284,8 +287,17 @@ Interfaces
 | ``scan_rst_ni``            | 1                       | in  | Test controlled reset.  If DFT not     |
 |                            |                         |     | used, tie off to 1.                    |
 +----------------------------+-------------------------+-----+----------------------------------------+
-| ``ram_cfg_i``              | 10                      | in  | RAM configuration inputs, routed to    |
-|                            |                         |     | the icache RAMs                        |
+| ``ram_cfg_icache_tag_i``   | ram_1p_cfg_req_t        | in  | Per-way icache tag RAM config input,   |
+|                            |                         |     | routed to the icache tag RAMs          |
++----------------------------+-------------------------+-----+----------------------------------------+
+| ``ram_cfg_icache_tag_o``   | ram_1p_cfg_rsp_t        | out | Per-way icache tag RAM config          |
+|                            |                         |     | response from the icache tag RAMs      |
++----------------------------+-------------------------+-----+----------------------------------------+
+| ``ram_cfg_icache_data_i``  | ram_1p_cfg_req_t        | in  | Per-way icache data RAM config input,  |
+|                            |                         |     | routed to the icache data RAMs         |
++----------------------------+-------------------------+-----+----------------------------------------+
+| ``ram_cfg_icache_data_o``  | ram_1p_cfg_rsp_t        | out | Per-way icache data RAM config         |
+|                            |                         |     | response from the icache data RAMs     |
 +----------------------------+-------------------------+-----+----------------------------------------+
 | ``hart_id_i``              | 32                      | in  | Hart ID, usually static, can be read   |
 |                            |                         |     | from :ref:`csr-mhartid` CSR            |

--- a/dv/formal/check/top.sv
+++ b/dv/formal/check/top.sv
@@ -51,10 +51,10 @@ module top import ibex_pkg::*; #(
   `endif
 
   input  logic                                                         test_en_i,
-  input  prim_ram_1p_pkg::ram_1p_cfg_t                                 ram_cfg_icache_tag_i,
-  output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_rsp_icache_tag_o,
-  input  prim_ram_1p_pkg::ram_1p_cfg_t                                 ram_cfg_icache_data_i,
-  output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_rsp_icache_data_o,
+  input  prim_ram_1p_pkg::ram_1p_cfg_req_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_icache_tag_i,
+  output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_icache_tag_o,
+  input  prim_ram_1p_pkg::ram_1p_cfg_req_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_icache_data_i,
+  output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_icache_data_o,
 
   input  logic [31:0]                                                  hart_id_i,
   input  logic [31:0]                                                  boot_addr_i,

--- a/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
+++ b/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
@@ -171,10 +171,10 @@ module ibex_riscv_compliance (
 
       .test_en_i                 ('b0                  ),
       .scan_rst_ni               (1'b1                 ),
-      .ram_cfg_icache_tag_i      ('b0                  ),
-      .ram_cfg_rsp_icache_tag_o  (                     ),
-      .ram_cfg_icache_data_i     ('b0                  ),
-      .ram_cfg_rsp_icache_data_o (                     ),
+      .ram_cfg_icache_tag_i      ('{default: prim_ram_1p_pkg::RAM_1P_CFG_REQ_DEFAULT}),
+      .ram_cfg_icache_tag_o      (                     ),
+      .ram_cfg_icache_data_i     ('{default: prim_ram_1p_pkg::RAM_1P_CFG_REQ_DEFAULT}),
+      .ram_cfg_icache_data_o     (                     ),
 
       .hart_id_i                 (32'b0                ),
       // First instruction executed is at 0x0 + 0x80

--- a/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -125,10 +125,10 @@ module core_ibex_tb_top;
 
     .test_en_i                 (1'b0                       ),
     .scan_rst_ni               (1'b1                       ),
-    .ram_cfg_icache_tag_i      ('b0                        ),
-    .ram_cfg_rsp_icache_tag_o  (                           ),
-    .ram_cfg_icache_data_i     ('b0                        ),
-    .ram_cfg_rsp_icache_data_o (                           ),
+    .ram_cfg_icache_tag_i      ('{default: prim_ram_1p_pkg::RAM_1P_CFG_REQ_DEFAULT}),
+    .ram_cfg_icache_tag_o      (                           ),
+    .ram_cfg_icache_data_i     ('{default: prim_ram_1p_pkg::RAM_1P_CFG_REQ_DEFAULT}),
+    .ram_cfg_icache_data_o     (                           ),
 
     .hart_id_i                 (32'b0                      ),
     .boot_addr_i               (BootAddr                   ),

--- a/dv/uvm/icache/dv/tb/tb.sv
+++ b/dv/uvm/icache/dv/tb/tb.sv
@@ -160,7 +160,8 @@ module tb #(
       .rvalid_o         (ram_if.ic_tag_rvalid[way]),
       .raddr_o          (),
       .rerror_o         (),
-      .cfg_i            ('0),
+      .cfg_i            ('{default: prim_ram_1p_pkg::RAM_1P_CFG_REQ_DEFAULT}),
+      .cfg_o            (),
       .wr_collision_o   (),
       .write_pending_o  (),
       .alert_o          ()
@@ -195,7 +196,8 @@ module tb #(
       .rvalid_o         (ram_if.ic_data_rvalid[way]),
       .raddr_o          (),
       .rerror_o         (),
-      .cfg_i            ('0),
+      .cfg_i            ('{default: prim_ram_1p_pkg::RAM_1P_CFG_REQ_DEFAULT}),
+      .cfg_o            (),
       .wr_collision_o   (),
       .write_pending_o  (),
       .alert_o          ()

--- a/examples/simple_system/rtl/ibex_simple_system.sv
+++ b/examples/simple_system/rtl/ibex_simple_system.sv
@@ -231,10 +231,10 @@ module ibex_simple_system (
 
       .test_en_i                 (1'b0),
       .scan_rst_ni               (1'b1),
-      .ram_cfg_icache_tag_i      (prim_ram_1p_pkg::RAM_1P_CFG_DEFAULT),
-      .ram_cfg_rsp_icache_tag_o  (),
-      .ram_cfg_icache_data_i     (prim_ram_1p_pkg::RAM_1P_CFG_DEFAULT),
-      .ram_cfg_rsp_icache_data_o (),
+      .ram_cfg_icache_tag_i      ('{default: prim_ram_1p_pkg::RAM_1P_CFG_REQ_DEFAULT}),
+      .ram_cfg_icache_tag_o      (),
+      .ram_cfg_icache_data_i     ('{default: prim_ram_1p_pkg::RAM_1P_CFG_REQ_DEFAULT}),
+      .ram_cfg_icache_data_o     (),
 
       .hart_id_i                 (32'b0),
       // First instruction executed is at 0x0 + 0x80

--- a/rtl/ibex_top.sv
+++ b/rtl/ibex_top.sv
@@ -65,10 +65,10 @@ module ibex_top import ibex_pkg::*; #(
 
   // enable all clock gates for testing
   input  logic                                                         test_en_i,
-  input  prim_ram_1p_pkg::ram_1p_cfg_t                                 ram_cfg_icache_tag_i,
-  output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_rsp_icache_tag_o,
-  input  prim_ram_1p_pkg::ram_1p_cfg_t                                 ram_cfg_icache_data_i,
-  output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_rsp_icache_data_o,
+  input  prim_ram_1p_pkg::ram_1p_cfg_req_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_icache_tag_i,
+  output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_icache_tag_o,
+  input  prim_ram_1p_pkg::ram_1p_cfg_req_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_icache_data_i,
+  output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_icache_data_o,
 
   input  logic [31:0]                                                  hart_id_i,
   input  logic [31:0]                                                  boot_addr_i,
@@ -633,8 +633,8 @@ module ibex_top import ibex_pkg::*; #(
           .rvalid_o         (),
           .raddr_o          (),
           .rerror_o         (),
-          .cfg_i            (ram_cfg_icache_tag_i),
-          .cfg_rsp_o        (ram_cfg_rsp_icache_tag_o[way]),
+          .cfg_i            (ram_cfg_icache_tag_i[way]),
+          .cfg_o            (ram_cfg_icache_tag_o[way]),
           .wr_collision_o   (),
           .write_pending_o  (),
 
@@ -671,8 +671,8 @@ module ibex_top import ibex_pkg::*; #(
           .rvalid_o         (),
           .raddr_o          (),
           .rerror_o         (),
-          .cfg_i            (ram_cfg_icache_data_i),
-          .cfg_rsp_o        (ram_cfg_rsp_icache_data_o[way]),
+          .cfg_i            (ram_cfg_icache_data_i[way]),
+          .cfg_o            (ram_cfg_icache_data_o[way]),
           .wr_collision_o   (),
           .write_pending_o  (),
 
@@ -728,8 +728,8 @@ module ibex_top import ibex_pkg::*; #(
           .wmask_i     ({TagSizeECC{1'b1}}),
 
           .rdata_o     (ic_tag_rdata[way]),
-          .cfg_i       (ram_cfg_icache_tag_i),
-          .cfg_rsp_o   (ram_cfg_rsp_icache_tag_o[way])
+          .cfg_i       (ram_cfg_icache_tag_i[way]),
+          .cfg_o       (ram_cfg_icache_tag_o[way])
         );
 
         // Data RAM instantiation
@@ -749,8 +749,8 @@ module ibex_top import ibex_pkg::*; #(
           .wmask_i     ({LineSizeECC{1'b1}}),
 
           .rdata_o     (ic_data_rdata[way]),
-          .cfg_i       (ram_cfg_icache_data_i),
-          .cfg_rsp_o   (ram_cfg_rsp_icache_data_o[way])
+          .cfg_i       (ram_cfg_icache_data_i[way]),
+          .cfg_o       (ram_cfg_icache_data_o[way])
         );
 
         assign icache_tag_alert  = '{default:'b0};
@@ -763,12 +763,12 @@ module ibex_top import ibex_pkg::*; #(
     logic unused_ram_cfg;
     logic unused_ram_inputs;
 
-    assign unused_ram_cfg    = |{ram_cfg_icache_tag_i, ram_cfg_icache_data_i};
-    assign ram_cfg_rsp_icache_tag_o  = '0;
-    assign ram_cfg_rsp_icache_data_o = '0;
-    assign unused_ram_inputs = (|ic_tag_req) & ic_tag_write & (|ic_tag_addr) & (|ic_tag_wdata) &
-                               (|ic_data_req) & ic_data_write & (|ic_data_addr) & (|ic_data_wdata) &
-                               (|NumAddrScrRounds);
+    assign unused_ram_cfg        = |{ram_cfg_icache_tag_i, ram_cfg_icache_data_i};
+    assign ram_cfg_icache_tag_o  = '{default: prim_ram_1p_pkg::RAM_1P_CFG_RSP_DEFAULT};
+    assign ram_cfg_icache_data_o = '{default: prim_ram_1p_pkg::RAM_1P_CFG_RSP_DEFAULT};
+    assign unused_ram_inputs     = (|ic_tag_req) & ic_tag_write & (|ic_tag_addr) &
+                                   (|ic_tag_wdata) & (|ic_data_req) & ic_data_write &
+                                   (|ic_data_addr) & (|ic_data_wdata) & (|NumAddrScrRounds);
 
     assign ic_tag_rdata      = '{default:'b0};
     assign ic_data_rdata     = '{default:'b0};

--- a/rtl/ibex_top_tracing.sv
+++ b/rtl/ibex_top_tracing.sv
@@ -44,10 +44,10 @@ module ibex_top_tracing import ibex_pkg::*; #(
   // enable all clock gates for testing
   input  logic                                                         test_en_i,
   input  logic                                                         scan_rst_ni,
-  input  prim_ram_1p_pkg::ram_1p_cfg_t                                 ram_cfg_icache_tag_i,
-  output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_rsp_icache_tag_o,
-  input  prim_ram_1p_pkg::ram_1p_cfg_t                                 ram_cfg_icache_data_i,
-  output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_rsp_icache_data_o,
+  input  prim_ram_1p_pkg::ram_1p_cfg_req_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_icache_tag_i,
+  output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_icache_tag_o,
+  input  prim_ram_1p_pkg::ram_1p_cfg_req_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_icache_data_i,
+  output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [ibex_pkg::IC_NUM_WAYS-1:0] ram_cfg_icache_data_o,
 
 
   input  logic [31:0]                                                  hart_id_i,
@@ -232,9 +232,9 @@ module ibex_top_tracing import ibex_pkg::*; #(
     .test_en_i,
     .scan_rst_ni,
     .ram_cfg_icache_tag_i,
-    .ram_cfg_rsp_icache_tag_o,
+    .ram_cfg_icache_tag_o,
     .ram_cfg_icache_data_i,
-    .ram_cfg_rsp_icache_data_o,
+    .ram_cfg_icache_data_o,
 
     .hart_id_i,
     .boot_addr_i,

--- a/shared/rtl/ram_1p.sv
+++ b/shared/rtl/ram_1p.sv
@@ -66,6 +66,6 @@ module ram_1p #(
       .wmask_i   (wmask),
       .rdata_o   (rdata_o),
       .cfg_i     ('0),
-      .cfg_rsp_o ()
+      .cfg_o     ()
     );
 endmodule

--- a/shared/rtl/ram_2p.sv
+++ b/shared/rtl/ram_2p.sv
@@ -109,7 +109,7 @@ module ram_2p #(
     .b_wmask_i (b_wmask),
     .b_rdata_o (b_rdata_d),
     .cfg_i     ('0),
-    .cfg_rsp_o ()
+    .cfg_o     ()
   );
 
 endmodule

--- a/vendor/lowrisc_ip.vendor.hjson
+++ b/vendor/lowrisc_ip.vendor.hjson
@@ -46,9 +46,21 @@
 
         {from: "hw/dv/verilator",    to: "dv/verilator"},
 
-        {from: "hw/ip/prim",         to: "ip/prim"},
-        {from: "hw/ip/prim_generic", to: "ip/prim_generic"},
-        {from: "hw/ip/prim_xilinx",  to: "ip/prim_xilinx"},
+        {
+            from:      "hw/ip/prim",
+            to:        "ip/prim",
+            patch_dir: "prim",
+        },
+        {
+            from:      "hw/ip/prim_generic",
+            to:        "ip/prim_generic",
+            patch_dir: "prim_generic",
+        },
+        {
+            from:      "hw/ip/prim_xilinx",
+            to:        "ip/prim_xilinx",
+            patch_dir: "prim_xilinx",
+        },
 
         {from: "hw/lint",            to: "lint"},
 

--- a/vendor/lowrisc_ip/ip/prim/fpv/tb/prim_fifo_async_sram_adapter_tb.sv
+++ b/vendor/lowrisc_ip/ip/prim/fpv/tb/prim_fifo_async_sram_adapter_tb.sv
@@ -128,7 +128,7 @@ if (FpgaSram == 1) begin : g_sram_fpga
     .b_rdata_o (r_sram_rdata ),
 
     .cfg_i     ('0),
-    .cfg_rsp_o ()
+    .cfg_o     ()
   );
 end else begin : g_sram_ff
   logic [SramDw-1:0] mem [2**SramAw];

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1p_adv.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1p_adv.sv
@@ -53,8 +53,8 @@ module prim_ram_1p_adv import prim_ram_1p_pkg::*; #(
   output logic [1:0]                  rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
 
   // config
-  input  ram_1p_cfg_t     [NumRamInst-1:0] cfg_i,
-  output ram_1p_cfg_rsp_t [NumRamInst-1:0] cfg_rsp_o,
+  input  ram_1p_cfg_req_t [NumRamInst-1:0] cfg_i,
+  output ram_1p_cfg_rsp_t [NumRamInst-1:0] cfg_o,
 
   // When detecting multi-bit encoding errors, raise alert.
   output logic                             alert_o
@@ -165,7 +165,7 @@ module prim_ram_1p_adv import prim_ram_1p_pkg::*; #(
       .wmask_i   (wmask_q),
       .rdata_o   (inst_rdata[i]),
       .cfg_i     (cfg_i[i]),
-      .cfg_rsp_o (cfg_rsp_o[i])
+      .cfg_o     (cfg_o[i])
     );
   end
 

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1p_scr.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -86,8 +86,8 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
   output logic [AddrWidth-1:0]             raddr_o,  // Read address for error reporting.
 
   // config
-  input  ram_1p_cfg_t     [NumRamInst-1:0] cfg_i,
-  output ram_1p_cfg_rsp_t [NumRamInst-1:0] cfg_rsp_o,
+  input  ram_1p_cfg_req_t [NumRamInst-1:0] cfg_i,
+  output ram_1p_cfg_rsp_t [NumRamInst-1:0] cfg_o,
 
 
   // Write currently pending inside this module.
@@ -505,7 +505,7 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
     .rvalid_o ( ),
     .rerror_o,
     .cfg_i,
-    .cfg_rsp_o,
+    .cfg_o,
     .alert_o  ( ram_alert   )
   );
 

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1r1w_adv.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1r1w_adv.sv
@@ -15,7 +15,7 @@
 
 `include "prim_assert.sv"
 
-module prim_ram_1r1w_adv import prim_ram_2p_pkg::*; #(
+module prim_ram_1r1w_adv import prim_ram_1r1w_pkg::*; #(
   parameter  int Depth                = 512,
   parameter  int Width                = 32,
   parameter  int DataBitsPerMask      = 1,  // Number of data bits per bit of write mask
@@ -50,8 +50,8 @@ module prim_ram_1r1w_adv import prim_ram_2p_pkg::*; #(
   output logic             b_rvalid_o, // read response (b_rdata_o) is valid
   output logic [1:0]       b_rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
 
-  input  ram_2p_cfg_t      cfg_i,
-  output ram_2p_cfg_rsp_t  cfg_rsp_o
+  input  ram_1r1w_cfg_req_t cfg_i,
+  output ram_1r1w_cfg_rsp_t cfg_o
 );
 
   prim_ram_1r1w_async_adv #(
@@ -79,7 +79,7 @@ module prim_ram_1r1w_adv import prim_ram_2p_pkg::*; #(
     .b_rvalid_o,
     .b_rerror_o,
     .cfg_i,
-    .cfg_rsp_o
+    .cfg_o
   );
 
 endmodule : prim_ram_1r1w_adv

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1r1w_async_adv.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1r1w_async_adv.sv
@@ -15,7 +15,7 @@
 
 `include "prim_assert.sv"
 
-module prim_ram_1r1w_async_adv import prim_ram_2p_pkg::*; #(
+module prim_ram_1r1w_async_adv import prim_ram_1r1w_pkg::*; #(
   parameter  int Depth                = 512,
   parameter  int Width                = 32,
   parameter  int DataBitsPerMask      = 1,  // Number of data bits per bit of write mask
@@ -53,8 +53,8 @@ module prim_ram_1r1w_async_adv import prim_ram_2p_pkg::*; #(
   output logic [1:0]       b_rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
 
   // config
-  input  ram_2p_cfg_t      cfg_i,
-  output ram_2p_cfg_rsp_t  cfg_rsp_o
+  input  ram_1r1w_cfg_req_t cfg_i,
+  output ram_1r1w_cfg_rsp_t cfg_o
 );
 
 
@@ -115,7 +115,7 @@ module prim_ram_1r1w_async_adv import prim_ram_2p_pkg::*; #(
     .b_rdata_o  (b_rdata_sram),
 
     .cfg_i,
-    .cfg_rsp_o
+    .cfg_o
   );
 
   always_ff @(posedge clk_b_i or negedge rst_b_ni) begin

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_2p_adv.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_2p_adv.sv
@@ -55,7 +55,8 @@ module prim_ram_2p_adv import prim_ram_2p_pkg::*; #(
   output logic             b_rvalid_o, // read response (b_rdata_o) is valid
   output logic [1:0]       b_rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
 
-  input ram_2p_cfg_t       cfg_i
+  input  ram_2p_cfg_req_t  cfg_i,
+  output ram_2p_cfg_rsp_t  cfg_o
 );
 
   prim_ram_2p_async_adv #(
@@ -89,7 +90,8 @@ module prim_ram_2p_adv import prim_ram_2p_pkg::*; #(
     .b_rdata_o,
     .b_rvalid_o,
     .b_rerror_o,
-    .cfg_i
+    .cfg_i,
+    .cfg_o
   );
 
 endmodule : prim_ram_2p_adv

--- a/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_2p_async_adv.sv
+++ b/vendor/lowrisc_ip/ip/prim/rtl/prim_ram_2p_async_adv.sv
@@ -58,8 +58,8 @@ module prim_ram_2p_async_adv import prim_ram_2p_pkg::*; #(
   output logic [1:0]       b_rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
 
   // config
-  input  ram_2p_cfg_t      cfg_i,
-  output ram_2p_cfg_rsp_t  cfg_rsp_o
+  input  ram_2p_cfg_req_t  cfg_i,
+  output ram_2p_cfg_rsp_t  cfg_o
 );
 
 
@@ -131,7 +131,7 @@ module prim_ram_2p_async_adv import prim_ram_2p_pkg::*; #(
     .b_rdata_o  (b_rdata_sram),
 
     .cfg_i,
-    .cfg_rsp_o
+    .cfg_o
   );
 
   always_ff @(posedge clk_a_i or negedge rst_a_ni) begin

--- a/vendor/lowrisc_ip/ip/prim_generic/prim_generic.core
+++ b/vendor/lowrisc_ip/ip/prim_generic/prim_generic.core
@@ -52,6 +52,7 @@ mapping:
   "lowrisc:prim:pad_wrapper"  : "lowrisc:prim_generic:pad_wrapper"
   "lowrisc:prim:ram_1p"       : "lowrisc:prim_generic:ram_1p"
   "lowrisc:prim:ram_1r1w"     : "lowrisc:prim_generic:ram_1r1w"
+  "lowrisc:prim:ram_1r1w_pkg" : "lowrisc:prim_generic:ram_1r1w_pkg"
   "lowrisc:prim:ram_2p"       : "lowrisc:prim_generic:ram_2p"
   "lowrisc:prim:rom"          : "lowrisc:prim_generic:rom"
   "lowrisc:prim:usb_diff_rx"  : "lowrisc:prim_generic:usb_diff_rx"

--- a/vendor/lowrisc_ip/ip/prim_generic/prim_generic_ram_1r1w.core
+++ b/vendor/lowrisc_ip/ip/prim_generic/prim_generic_ram_1r1w.core
@@ -12,7 +12,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
-      - lowrisc:prim_generic:ram_2p_pkg
+      - lowrisc:prim_generic:ram_1r1w_pkg
       - lowrisc:prim:util_memload
     files:
       - rtl/prim_ram_1r1w.sv

--- a/vendor/lowrisc_ip/ip/prim_generic/prim_generic_ram_1r1w_pkg.core
+++ b/vendor/lowrisc_ip/ip/prim_generic/prim_generic_ram_1r1w_pkg.core
@@ -1,0 +1,22 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_generic:ram_1r1w_pkg"
+description: "Ram 1r1w package"
+virtual:
+  - "lowrisc:prim:ram_1r1w_pkg"
+
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim_generic:ram_2p_pkg
+    files:
+      - rtl/prim_ram_1r1w_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_generic_flash_bank.sv
+++ b/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_generic_flash_bank.sv
@@ -418,7 +418,7 @@ module prim_generic_flash_bank #(
     .wmask_i  ({DataWidth{1'b1}}),
     .rdata_o  (rd_data_main),
     .cfg_i    ('0),
-    .cfg_rsp_o()
+    .cfg_o    ()
   );
 
   for (genvar info_type = 0; info_type < InfoTypes; info_type++) begin : gen_info_types
@@ -444,7 +444,7 @@ module prim_generic_flash_bank #(
       .wmask_i  ({DataWidth{1'b1}}),
       .rdata_o  (rd_nom_data_info[info_type]),
       .cfg_i    ('0),
-      .cfg_rsp_o()
+      .cfg_o    ()
     );
   end
 

--- a/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_ram_1p.sv
+++ b/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_ram_1p.sv
@@ -23,8 +23,8 @@ module prim_ram_1p import prim_ram_1p_pkg::*; #(
   input  logic [Width-1:0] wdata_i,
   input  logic [Width-1:0] wmask_i,
   output logic [Width-1:0] rdata_o, // Read data. Data is returned one cycle after req_i is high.
-  input  ram_1p_cfg_t      cfg_i,
-  output ram_1p_cfg_rsp_t  cfg_rsp_o
+  input  ram_1p_cfg_req_t  cfg_i,
+  output ram_1p_cfg_rsp_t  cfg_o
 );
 
 // For certain synthesis experiments we compile the design with generic models to get an unmapped
@@ -42,7 +42,7 @@ module prim_ram_1p import prim_ram_1p_pkg::*; #(
 
   logic unused_signals;
   assign unused_signals = ^{cfg_i, rst_ni};
-  assign cfg_rsp_o      = '0;
+  assign cfg_o          = RAM_1P_CFG_RSP_DEFAULT;
 
   // Width of internal write mask. Note wmask_i input into the module is always assumed
   // to be the full bit mask

--- a/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_ram_1p_pkg.sv
+++ b/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_ram_1p_pkg.sv
@@ -5,21 +5,18 @@
 
 package prim_ram_1p_pkg;
 
-  typedef struct packed {
-    logic       test;
-    logic       cfg_en;
-    logic [3:0] cfg;
-  } cfg_t;
+  parameter int unsigned Ram1pReqWidth = 32'd12;
+  parameter int unsigned Ram1pRspWidth = 32'd1;
 
   typedef struct packed {
-    cfg_t ram_cfg;  // configuration for ram
-    cfg_t rf_cfg;   // configuration for regfile
-  } ram_1p_cfg_t;
+    logic [Ram1pReqWidth-1:0] req;
+  } ram_1p_cfg_req_t;
 
   typedef struct packed {
-    logic done;
+    logic [Ram1pRspWidth-1:0] rsp;
   } ram_1p_cfg_rsp_t;
 
-  parameter ram_1p_cfg_t RAM_1P_CFG_DEFAULT = '0;
+  parameter ram_1p_cfg_req_t RAM_1P_CFG_REQ_DEFAULT = '0;
+  parameter ram_1p_cfg_rsp_t RAM_1P_CFG_RSP_DEFAULT = '0;
 
 endpackage // prim_ram_1p_pkg

--- a/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_ram_1r1w.sv
+++ b/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_ram_1r1w.sv
@@ -6,7 +6,7 @@
 //   This module is for simulation and small size SRAM.
 //   Implementing ECC should be done inside wrapper not this model.
 `include "prim_assert.sv"
-module prim_ram_1r1w import prim_ram_2p_pkg::*; #(
+module prim_ram_1r1w import prim_ram_1r1w_pkg::*; #(
   parameter  int Width           = 32, // bit
   parameter  int Depth           = 128,
   parameter  int DataBitsPerMask = 1, // Number of data bits per bit of write mask
@@ -30,8 +30,8 @@ module prim_ram_1r1w import prim_ram_2p_pkg::*; #(
   input        [Aw-1:0]    b_addr_i,
   output logic [Width-1:0] b_rdata_o,
 
-  input  ram_2p_cfg_t      cfg_i,
-  output ram_2p_cfg_rsp_t  cfg_rsp_o
+  input  ram_1r1w_cfg_req_t cfg_i,
+  output ram_1r1w_cfg_rsp_t cfg_o
 );
 
 // For certain synthesis experiments we compile the design with generic models to get an unmapped
@@ -46,7 +46,7 @@ module prim_ram_1r1w import prim_ram_2p_pkg::*; #(
 
   logic unused_signals;
   assign unused_signals = ^{cfg_i, rst_a_ni, rst_b_ni};
-  assign cfg_rsp_o      = '0;
+  assign cfg_o          = RAM_1R1W_CFG_RSP_DEFAULT;
 
   // Width of internal write mask. Note *_wmask_i input into the module is always assumed
   // to be the full bit mask.

--- a/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_ram_1r1w_pkg.sv
+++ b/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_ram_1r1w_pkg.sv
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package prim_ram_1r1w_pkg;
+
+  // The SPI device can be switched to either use 1r1w or true 2p memories. To ensure
+  // a compatibility between the two choices without increasing the parametrization effort,
+  // derive the 1r1w type from the 2p.
+  parameter int unsigned Ram1r1wReqWidth = prim_ram_2p_pkg::Ram2pReqWidth;
+  parameter int unsigned Ram1r1wRspWidth = prim_ram_2p_pkg::Ram2pRspWidth;
+
+  typedef prim_ram_2p_pkg::ram_2p_cfg_req_t ram_1r1w_cfg_req_t;
+  typedef prim_ram_2p_pkg::ram_2p_cfg_rsp_t ram_1r1w_cfg_rsp_t;
+
+  parameter ram_1r1w_cfg_req_t RAM_1R1W_CFG_REQ_DEFAULT = '0;
+  parameter ram_1r1w_cfg_rsp_t RAM_1R1W_CFG_RSP_DEFAULT = '0;
+
+endpackage // prim_ram_1r1w_pkg

--- a/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_ram_2p.sv
+++ b/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_ram_2p.sv
@@ -32,8 +32,8 @@ module prim_ram_2p import prim_ram_2p_pkg::*; #(
   input  logic [Width-1:0] b_wmask_i,
   output logic [Width-1:0] b_rdata_o,
 
-  input  ram_2p_cfg_t      cfg_i,
-  output ram_2p_cfg_rsp_t  cfg_rsp_o
+  input  ram_2p_cfg_req_t  cfg_i,
+  output ram_2p_cfg_rsp_t  cfg_o
 );
 
 // For certain synthesis experiments we compile the design with generic models to get an unmapped
@@ -48,7 +48,7 @@ module prim_ram_2p import prim_ram_2p_pkg::*; #(
 
   logic unused_cfg;
   assign unused_cfg = ^cfg_i;
-  assign cfg_rsp_o  = '0;
+  assign cfg_o      = RAM_2P_CFG_RSP_DEFAULT;
 
   // Width of internal write mask. Note *_wmask_i input into the module is always assumed
   // to be the full bit mask.

--- a/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_ram_2p_pkg.sv
+++ b/vendor/lowrisc_ip/ip/prim_generic/rtl/prim_ram_2p_pkg.sv
@@ -5,23 +5,18 @@
 
 package prim_ram_2p_pkg;
 
-  typedef struct packed {
-    logic       test;
-    logic       cfg_en;
-    logic [3:0] cfg;
-  } cfg_t;
+  parameter int unsigned Ram2pReqWidth = 32'd7;
+  parameter int unsigned Ram2pRspWidth = 32'd1;
 
   typedef struct packed {
-    cfg_t a_ram_fcfg;  // configuration for a port
-    cfg_t b_ram_fcfg;  // configuration for b port
-    cfg_t a_ram_lcfg;  // configuration for a port
-    cfg_t b_ram_lcfg;  // configuration for b port
-  } ram_2p_cfg_t;
-
-  parameter ram_2p_cfg_t RAM_2P_CFG_DEFAULT = '0;
+    logic [Ram2pReqWidth-1:0] req;
+  } ram_2p_cfg_req_t;
 
   typedef struct packed {
-    logic done;
+    logic [Ram2pRspWidth-1:0] rsp;
   } ram_2p_cfg_rsp_t;
+
+  parameter ram_2p_cfg_req_t RAM_2P_CFG_REQ_DEFAULT = '0;
+  parameter ram_2p_cfg_rsp_t RAM_2P_CFG_RSP_DEFAULT = '0;
 
 endpackage // prim_ram_2p_pkg

--- a/vendor/lowrisc_ip/ip/prim_xilinx/rtl/prim_ram_1p.sv
+++ b/vendor/lowrisc_ip/ip/prim_xilinx/rtl/prim_ram_1p.sv
@@ -23,8 +23,8 @@ module prim_ram_1p import prim_ram_1p_pkg::*; #(
   input  logic [Width-1:0] wdata_i,
   input  logic [Width-1:0] wmask_i,
   output logic [Width-1:0] rdata_o, // Read data. Data is returned one cycle after req_i is high.
-  input ram_1p_cfg_t       cfg_i,
-  output ram_1p_cfg_rsp_t  cfg_rsp_o
+  input ram_1p_cfg_req_t   cfg_i,
+  output ram_1p_cfg_rsp_t  cfg_o
 );
 
   localparam int PrimMaxWidth = prim_xilinx_pkg::get_ram_max_width(Width, Depth);
@@ -70,7 +70,7 @@ module prim_ram_1p import prim_ram_1p_pkg::*; #(
 
     logic unused_signals;
     assign unused_signals = ^{rst_ni, cfg_i};
-    assign cfg_rsp_o      = '0;
+    assign cfg_o          = RAM_1P_CFG_RSP_DEFAULT;
 
     for (genvar k = 0; k < Width; k = k + PrimMaxWidth) begin : gen_split
       localparam int PrimWidth = ((Width - k) > PrimMaxWidth) ? PrimMaxWidth : Width - k;

--- a/vendor/patches/lowrisc_ip/prim/0001-sram-cfg-interface.patch
+++ b/vendor/patches/lowrisc_ip/prim/0001-sram-cfg-interface.patch
@@ -1,0 +1,175 @@
+diff --git a/fpv/tb/prim_fifo_async_sram_adapter_tb.sv b/fpv/tb/prim_fifo_async_sram_adapter_tb.sv
+index cb02d7f3..234e5faf 100644
+--- a/fpv/tb/prim_fifo_async_sram_adapter_tb.sv
++++ b/fpv/tb/prim_fifo_async_sram_adapter_tb.sv
+@@ -128,7 +128,7 @@ if (FpgaSram == 1) begin : g_sram_fpga
+     .b_rdata_o (r_sram_rdata ),
+ 
+     .cfg_i     ('0),
+-    .cfg_rsp_o ()
++    .cfg_o     ()
+   );
+ end else begin : g_sram_ff
+   logic [SramDw-1:0] mem [2**SramAw];
+diff --git a/rtl/prim_ram_1p_adv.sv b/rtl/prim_ram_1p_adv.sv
+index 83087d2b..729e04d9 100644
+--- a/rtl/prim_ram_1p_adv.sv
++++ b/rtl/prim_ram_1p_adv.sv
+@@ -53,8 +53,8 @@ module prim_ram_1p_adv import prim_ram_1p_pkg::*; #(
+   output logic [1:0]                  rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
+ 
+   // config
+-  input  ram_1p_cfg_t     [NumRamInst-1:0] cfg_i,
+-  output ram_1p_cfg_rsp_t [NumRamInst-1:0] cfg_rsp_o,
++  input  ram_1p_cfg_req_t [NumRamInst-1:0] cfg_i,
++  output ram_1p_cfg_rsp_t [NumRamInst-1:0] cfg_o,
+ 
+   // When detecting multi-bit encoding errors, raise alert.
+   output logic                             alert_o
+@@ -165,7 +165,7 @@ module prim_ram_1p_adv import prim_ram_1p_pkg::*; #(
+       .wmask_i   (wmask_q),
+       .rdata_o   (inst_rdata[i]),
+       .cfg_i     (cfg_i[i]),
+-      .cfg_rsp_o (cfg_rsp_o[i])
++      .cfg_o     (cfg_o[i])
+     );
+   end
+ 
+diff --git a/rtl/prim_ram_1p_scr.sv b/rtl/prim_ram_1p_scr.sv
+index 16a0732c..5ab1f600 100644
+--- a/rtl/prim_ram_1p_scr.sv
++++ b/rtl/prim_ram_1p_scr.sv
+@@ -86,8 +86,8 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
+   output logic [AddrWidth-1:0]             raddr_o,  // Read address for error reporting.
+ 
+   // config
+-  input  ram_1p_cfg_t     [NumRamInst-1:0] cfg_i,
+-  output ram_1p_cfg_rsp_t [NumRamInst-1:0] cfg_rsp_o,
++  input  ram_1p_cfg_req_t [NumRamInst-1:0] cfg_i,
++  output ram_1p_cfg_rsp_t [NumRamInst-1:0] cfg_o,
+ 
+ 
+   // Write currently pending inside this module.
+@@ -505,7 +505,7 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
+     .rvalid_o ( ),
+     .rerror_o,
+     .cfg_i,
+-    .cfg_rsp_o,
++    .cfg_o,
+     .alert_o  ( ram_alert   )
+   );
+ 
+diff --git a/rtl/prim_ram_1r1w_adv.sv b/rtl/prim_ram_1r1w_adv.sv
+index ff0511f1..9e5799c1 100644
+--- a/rtl/prim_ram_1r1w_adv.sv
++++ b/rtl/prim_ram_1r1w_adv.sv
+@@ -15,7 +15,7 @@
+ 
+ `include "prim_assert.sv"
+ 
+-module prim_ram_1r1w_adv import prim_ram_2p_pkg::*; #(
++module prim_ram_1r1w_adv import prim_ram_1r1w_pkg::*; #(
+   parameter  int Depth                = 512,
+   parameter  int Width                = 32,
+   parameter  int DataBitsPerMask      = 1,  // Number of data bits per bit of write mask
+@@ -50,8 +50,8 @@ module prim_ram_1r1w_adv import prim_ram_2p_pkg::*; #(
+   output logic             b_rvalid_o, // read response (b_rdata_o) is valid
+   output logic [1:0]       b_rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
+ 
+-  input  ram_2p_cfg_t      cfg_i,
+-  output ram_2p_cfg_rsp_t  cfg_rsp_o
++  input  ram_1r1w_cfg_req_t cfg_i,
++  output ram_1r1w_cfg_rsp_t cfg_o
+ );
+ 
+   prim_ram_1r1w_async_adv #(
+@@ -79,7 +79,7 @@ module prim_ram_1r1w_adv import prim_ram_2p_pkg::*; #(
+     .b_rvalid_o,
+     .b_rerror_o,
+     .cfg_i,
+-    .cfg_rsp_o
++    .cfg_o
+   );
+ 
+ endmodule : prim_ram_1r1w_adv
+diff --git a/rtl/prim_ram_1r1w_async_adv.sv b/rtl/prim_ram_1r1w_async_adv.sv
+index 40e06976..93ed0665 100644
+--- a/rtl/prim_ram_1r1w_async_adv.sv
++++ b/rtl/prim_ram_1r1w_async_adv.sv
+@@ -15,7 +15,7 @@
+ 
+ `include "prim_assert.sv"
+ 
+-module prim_ram_1r1w_async_adv import prim_ram_2p_pkg::*; #(
++module prim_ram_1r1w_async_adv import prim_ram_1r1w_pkg::*; #(
+   parameter  int Depth                = 512,
+   parameter  int Width                = 32,
+   parameter  int DataBitsPerMask      = 1,  // Number of data bits per bit of write mask
+@@ -53,8 +53,8 @@ module prim_ram_1r1w_async_adv import prim_ram_2p_pkg::*; #(
+   output logic [1:0]       b_rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
+ 
+   // config
+-  input  ram_2p_cfg_t      cfg_i,
+-  output ram_2p_cfg_rsp_t  cfg_rsp_o
++  input  ram_1r1w_cfg_req_t cfg_i,
++  output ram_1r1w_cfg_rsp_t cfg_o
+ );
+ 
+ 
+@@ -115,7 +115,7 @@ module prim_ram_1r1w_async_adv import prim_ram_2p_pkg::*; #(
+     .b_rdata_o  (b_rdata_sram),
+ 
+     .cfg_i,
+-    .cfg_rsp_o
++    .cfg_o
+   );
+ 
+   always_ff @(posedge clk_b_i or negedge rst_b_ni) begin
+diff --git a/rtl/prim_ram_2p_adv.sv b/rtl/prim_ram_2p_adv.sv
+index 951ae981..24b17ec6 100644
+--- a/rtl/prim_ram_2p_adv.sv
++++ b/rtl/prim_ram_2p_adv.sv
+@@ -55,7 +55,8 @@ module prim_ram_2p_adv import prim_ram_2p_pkg::*; #(
+   output logic             b_rvalid_o, // read response (b_rdata_o) is valid
+   output logic [1:0]       b_rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
+ 
+-  input ram_2p_cfg_t       cfg_i
++  input  ram_2p_cfg_req_t  cfg_i,
++  output ram_2p_cfg_rsp_t  cfg_o
+ );
+ 
+   prim_ram_2p_async_adv #(
+@@ -89,7 +90,8 @@ module prim_ram_2p_adv import prim_ram_2p_pkg::*; #(
+     .b_rdata_o,
+     .b_rvalid_o,
+     .b_rerror_o,
+-    .cfg_i
++    .cfg_i,
++    .cfg_o
+   );
+ 
+ endmodule : prim_ram_2p_adv
+diff --git a/rtl/prim_ram_2p_async_adv.sv b/rtl/prim_ram_2p_async_adv.sv
+index 79f1a619..32c65d54 100644
+--- a/rtl/prim_ram_2p_async_adv.sv
++++ b/rtl/prim_ram_2p_async_adv.sv
+@@ -58,8 +58,8 @@ module prim_ram_2p_async_adv import prim_ram_2p_pkg::*; #(
+   output logic [1:0]       b_rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
+ 
+   // config
+-  input  ram_2p_cfg_t      cfg_i,
+-  output ram_2p_cfg_rsp_t  cfg_rsp_o
++  input  ram_2p_cfg_req_t  cfg_i,
++  output ram_2p_cfg_rsp_t  cfg_o
+ );
+ 
+ 
+@@ -131,7 +131,7 @@ module prim_ram_2p_async_adv import prim_ram_2p_pkg::*; #(
+     .b_rdata_o  (b_rdata_sram),
+ 
+     .cfg_i,
+-    .cfg_rsp_o
++    .cfg_o
+   );
+ 
+   always_ff @(posedge clk_a_i or negedge rst_a_ni) begin

--- a/vendor/patches/lowrisc_ip/prim_generic/0001-sram-cfg-interface.patch
+++ b/vendor/patches/lowrisc_ip/prim_generic/0001-sram-cfg-interface.patch
@@ -1,0 +1,251 @@
+diff --git a/prim_generic.core b/prim_generic.core
+index e7f3a43d..187ffc80 100644
+--- a/prim_generic.core
++++ b/prim_generic.core
+@@ -52,6 +52,7 @@ mapping:
+   "lowrisc:prim:pad_wrapper"  : "lowrisc:prim_generic:pad_wrapper"
+   "lowrisc:prim:ram_1p"       : "lowrisc:prim_generic:ram_1p"
+   "lowrisc:prim:ram_1r1w"     : "lowrisc:prim_generic:ram_1r1w"
++  "lowrisc:prim:ram_1r1w_pkg" : "lowrisc:prim_generic:ram_1r1w_pkg"
+   "lowrisc:prim:ram_2p"       : "lowrisc:prim_generic:ram_2p"
+   "lowrisc:prim:rom"          : "lowrisc:prim_generic:rom"
+   "lowrisc:prim:usb_diff_rx"  : "lowrisc:prim_generic:usb_diff_rx"
+diff --git a/prim_generic_ram_1r1w.core b/prim_generic_ram_1r1w.core
+index e2dd35e8..b6fc7e39 100644
+--- a/prim_generic_ram_1r1w.core
++++ b/prim_generic_ram_1r1w.core
+@@ -12,7 +12,7 @@ filesets:
+   files_rtl:
+     depend:
+       - lowrisc:prim:assert
+-      - lowrisc:prim_generic:ram_2p_pkg
++      - lowrisc:prim_generic:ram_1r1w_pkg
+       - lowrisc:prim:util_memload
+     files:
+       - rtl/prim_ram_1r1w.sv
+diff --git a/prim_generic_ram_1r1w_pkg.core b/prim_generic_ram_1r1w_pkg.core
+new file mode 100644
+index 00000000..b1b6d482
+--- /dev/null
++++ b/prim_generic_ram_1r1w_pkg.core
+@@ -0,0 +1,22 @@
++CAPI=2:
++# Copyright lowRISC contributors (OpenTitan project).
++# Licensed under the Apache License, Version 2.0, see LICENSE for details.
++# SPDX-License-Identifier: Apache-2.0
++
++name: "lowrisc:prim_generic:ram_1r1w_pkg"
++description: "Ram 1r1w package"
++virtual:
++  - "lowrisc:prim:ram_1r1w_pkg"
++
++filesets:
++  files_rtl:
++    depend:
++      - lowrisc:prim_generic:ram_2p_pkg
++    files:
++      - rtl/prim_ram_1r1w_pkg.sv
++    file_type: systemVerilogSource
++
++targets:
++  default:
++    filesets:
++      - files_rtl
+diff --git a/rtl/prim_generic_flash_bank.sv b/rtl/prim_generic_flash_bank.sv
+index 5ecb7ec2..459dd311 100644
+--- a/rtl/prim_generic_flash_bank.sv
++++ b/rtl/prim_generic_flash_bank.sv
+@@ -418,7 +418,7 @@ module prim_generic_flash_bank #(
+     .wmask_i  ({DataWidth{1'b1}}),
+     .rdata_o  (rd_data_main),
+     .cfg_i    ('0),
+-    .cfg_rsp_o()
++    .cfg_o    ()
+   );
+ 
+   for (genvar info_type = 0; info_type < InfoTypes; info_type++) begin : gen_info_types
+@@ -444,7 +444,7 @@ module prim_generic_flash_bank #(
+       .wmask_i  ({DataWidth{1'b1}}),
+       .rdata_o  (rd_nom_data_info[info_type]),
+       .cfg_i    ('0),
+-      .cfg_rsp_o()
++      .cfg_o    ()
+     );
+   end
+ 
+diff --git a/rtl/prim_ram_1p.sv b/rtl/prim_ram_1p.sv
+index e224107f..d78b5e81 100644
+--- a/rtl/prim_ram_1p.sv
++++ b/rtl/prim_ram_1p.sv
+@@ -23,8 +23,8 @@ module prim_ram_1p import prim_ram_1p_pkg::*; #(
+   input  logic [Width-1:0] wdata_i,
+   input  logic [Width-1:0] wmask_i,
+   output logic [Width-1:0] rdata_o, // Read data. Data is returned one cycle after req_i is high.
+-  input  ram_1p_cfg_t      cfg_i,
+-  output ram_1p_cfg_rsp_t  cfg_rsp_o
++  input  ram_1p_cfg_req_t  cfg_i,
++  output ram_1p_cfg_rsp_t  cfg_o
+ );
+ 
+ // For certain synthesis experiments we compile the design with generic models to get an unmapped
+@@ -42,7 +42,7 @@ module prim_ram_1p import prim_ram_1p_pkg::*; #(
+ 
+   logic unused_signals;
+   assign unused_signals = ^{cfg_i, rst_ni};
+-  assign cfg_rsp_o      = '0;
++  assign cfg_o          = RAM_1P_CFG_RSP_DEFAULT;
+ 
+   // Width of internal write mask. Note wmask_i input into the module is always assumed
+   // to be the full bit mask
+diff --git a/rtl/prim_ram_1p_pkg.sv b/rtl/prim_ram_1p_pkg.sv
+index f8d45dd4..f8ec137d 100644
+--- a/rtl/prim_ram_1p_pkg.sv
++++ b/rtl/prim_ram_1p_pkg.sv
+@@ -5,21 +5,18 @@
+ 
+ package prim_ram_1p_pkg;
+ 
+-  typedef struct packed {
+-    logic       test;
+-    logic       cfg_en;
+-    logic [3:0] cfg;
+-  } cfg_t;
++  parameter int unsigned Ram1pReqWidth = 32'd12;
++  parameter int unsigned Ram1pRspWidth = 32'd1;
+ 
+   typedef struct packed {
+-    cfg_t ram_cfg;  // configuration for ram
+-    cfg_t rf_cfg;   // configuration for regfile
+-  } ram_1p_cfg_t;
++    logic [Ram1pReqWidth-1:0] req;
++  } ram_1p_cfg_req_t;
+ 
+   typedef struct packed {
+-    logic done;
++    logic [Ram1pRspWidth-1:0] rsp;
+   } ram_1p_cfg_rsp_t;
+ 
+-  parameter ram_1p_cfg_t RAM_1P_CFG_DEFAULT = '0;
++  parameter ram_1p_cfg_req_t RAM_1P_CFG_REQ_DEFAULT = '0;
++  parameter ram_1p_cfg_rsp_t RAM_1P_CFG_RSP_DEFAULT = '0;
+ 
+ endpackage // prim_ram_1p_pkg
+diff --git a/rtl/prim_ram_1r1w.sv b/rtl/prim_ram_1r1w.sv
+index a64876b0..1a57780c 100644
+--- a/rtl/prim_ram_1r1w.sv
++++ b/rtl/prim_ram_1r1w.sv
+@@ -6,7 +6,7 @@
+ //   This module is for simulation and small size SRAM.
+ //   Implementing ECC should be done inside wrapper not this model.
+ `include "prim_assert.sv"
+-module prim_ram_1r1w import prim_ram_2p_pkg::*; #(
++module prim_ram_1r1w import prim_ram_1r1w_pkg::*; #(
+   parameter  int Width           = 32, // bit
+   parameter  int Depth           = 128,
+   parameter  int DataBitsPerMask = 1, // Number of data bits per bit of write mask
+@@ -30,8 +30,8 @@ module prim_ram_1r1w import prim_ram_2p_pkg::*; #(
+   input        [Aw-1:0]    b_addr_i,
+   output logic [Width-1:0] b_rdata_o,
+ 
+-  input  ram_2p_cfg_t      cfg_i,
+-  output ram_2p_cfg_rsp_t  cfg_rsp_o
++  input  ram_1r1w_cfg_req_t cfg_i,
++  output ram_1r1w_cfg_rsp_t cfg_o
+ );
+ 
+ // For certain synthesis experiments we compile the design with generic models to get an unmapped
+@@ -46,7 +46,7 @@ module prim_ram_1r1w import prim_ram_2p_pkg::*; #(
+ 
+   logic unused_signals;
+   assign unused_signals = ^{cfg_i, rst_a_ni, rst_b_ni};
+-  assign cfg_rsp_o      = '0;
++  assign cfg_o          = RAM_1R1W_CFG_RSP_DEFAULT;
+ 
+   // Width of internal write mask. Note *_wmask_i input into the module is always assumed
+   // to be the full bit mask.
+diff --git a/rtl/prim_ram_1r1w_pkg.sv b/rtl/prim_ram_1r1w_pkg.sv
+new file mode 100644
+index 00000000..416a71d9
+--- /dev/null
++++ b/rtl/prim_ram_1r1w_pkg.sv
+@@ -0,0 +1,20 @@
++// Copyright lowRISC contributors (OpenTitan project).
++// Licensed under the Apache License, Version 2.0, see LICENSE for details.
++// SPDX-License-Identifier: Apache-2.0
++//
++
++package prim_ram_1r1w_pkg;
++
++  // The SPI device can be switched to either use 1r1w or true 2p memories. To ensure
++  // a compatibility between the two choices without increasing the parametrization effort,
++  // derive the 1r1w type from the 2p.
++  parameter int unsigned Ram1r1wReqWidth = prim_ram_2p_pkg::Ram2pReqWidth;
++  parameter int unsigned Ram1r1wRspWidth = prim_ram_2p_pkg::Ram2pRspWidth;
++
++  typedef prim_ram_2p_pkg::ram_2p_cfg_req_t ram_1r1w_cfg_req_t;
++  typedef prim_ram_2p_pkg::ram_2p_cfg_rsp_t ram_1r1w_cfg_rsp_t;
++
++  parameter ram_1r1w_cfg_req_t RAM_1R1W_CFG_REQ_DEFAULT = '0;
++  parameter ram_1r1w_cfg_rsp_t RAM_1R1W_CFG_RSP_DEFAULT = '0;
++
++endpackage // prim_ram_1r1w_pkg
+diff --git a/rtl/prim_ram_2p.sv b/rtl/prim_ram_2p.sv
+index 65f94fe0..442c5dc0 100644
+--- a/rtl/prim_ram_2p.sv
++++ b/rtl/prim_ram_2p.sv
+@@ -32,8 +32,8 @@ module prim_ram_2p import prim_ram_2p_pkg::*; #(
+   input  logic [Width-1:0] b_wmask_i,
+   output logic [Width-1:0] b_rdata_o,
+ 
+-  input  ram_2p_cfg_t      cfg_i,
+-  output ram_2p_cfg_rsp_t  cfg_rsp_o
++  input  ram_2p_cfg_req_t  cfg_i,
++  output ram_2p_cfg_rsp_t  cfg_o
+ );
+ 
+ // For certain synthesis experiments we compile the design with generic models to get an unmapped
+@@ -48,7 +48,7 @@ module prim_ram_2p import prim_ram_2p_pkg::*; #(
+ 
+   logic unused_cfg;
+   assign unused_cfg = ^cfg_i;
+-  assign cfg_rsp_o  = '0;
++  assign cfg_o      = RAM_2P_CFG_RSP_DEFAULT;
+ 
+   // Width of internal write mask. Note *_wmask_i input into the module is always assumed
+   // to be the full bit mask.
+diff --git a/rtl/prim_ram_2p_pkg.sv b/rtl/prim_ram_2p_pkg.sv
+index 87702eeb..c8cb5230 100644
+--- a/rtl/prim_ram_2p_pkg.sv
++++ b/rtl/prim_ram_2p_pkg.sv
+@@ -5,23 +5,18 @@
+ 
+ package prim_ram_2p_pkg;
+ 
+-  typedef struct packed {
+-    logic       test;
+-    logic       cfg_en;
+-    logic [3:0] cfg;
+-  } cfg_t;
++  parameter int unsigned Ram2pReqWidth = 32'd7;
++  parameter int unsigned Ram2pRspWidth = 32'd1;
+ 
+   typedef struct packed {
+-    cfg_t a_ram_fcfg;  // configuration for a port
+-    cfg_t b_ram_fcfg;  // configuration for b port
+-    cfg_t a_ram_lcfg;  // configuration for a port
+-    cfg_t b_ram_lcfg;  // configuration for b port
+-  } ram_2p_cfg_t;
+-
+-  parameter ram_2p_cfg_t RAM_2P_CFG_DEFAULT = '0;
++    logic [Ram2pReqWidth-1:0] req;
++  } ram_2p_cfg_req_t;
+ 
+   typedef struct packed {
+-    logic done;
++    logic [Ram2pRspWidth-1:0] rsp;
+   } ram_2p_cfg_rsp_t;
+ 
++  parameter ram_2p_cfg_req_t RAM_2P_CFG_REQ_DEFAULT = '0;
++  parameter ram_2p_cfg_rsp_t RAM_2P_CFG_RSP_DEFAULT = '0;
++
+ endpackage // prim_ram_2p_pkg

--- a/vendor/patches/lowrisc_ip/prim_xilinx/0001-sram-cfg-interface.patch
+++ b/vendor/patches/lowrisc_ip/prim_xilinx/0001-sram-cfg-interface.patch
@@ -1,0 +1,24 @@
+diff --git a/rtl/prim_ram_1p.sv b/rtl/prim_ram_1p.sv
+index 742d56ba..84a5f09d 100644
+--- a/rtl/prim_ram_1p.sv
++++ b/rtl/prim_ram_1p.sv
+@@ -23,8 +23,8 @@ module prim_ram_1p import prim_ram_1p_pkg::*; #(
+   input  logic [Width-1:0] wdata_i,
+   input  logic [Width-1:0] wmask_i,
+   output logic [Width-1:0] rdata_o, // Read data. Data is returned one cycle after req_i is high.
+-  input ram_1p_cfg_t       cfg_i,
+-  output ram_1p_cfg_rsp_t  cfg_rsp_o
++  input ram_1p_cfg_req_t   cfg_i,
++  output ram_1p_cfg_rsp_t  cfg_o
+ );
+ 
+   localparam int PrimMaxWidth = prim_xilinx_pkg::get_ram_max_width(Width, Depth);
+@@ -70,7 +70,7 @@ module prim_ram_1p import prim_ram_1p_pkg::*; #(
+ 
+     logic unused_signals;
+     assign unused_signals = ^{rst_ni, cfg_i};
+-    assign cfg_rsp_o      = '0;
++    assign cfg_o          = RAM_1P_CFG_RSP_DEFAULT;
+ 
+     for (genvar k = 0; k < Width; k = k + PrimMaxWidth) begin : gen_split
+       localparam int PrimWidth = ((Width - k) > PrimMaxWidth) ? PrimMaxWidth : Width - k;


### PR DESCRIPTION
This PR renames the SRAM cfg ports to align with https://github.com/lowRISC/opentitan/pull/30509. 