### PR TITLE
[rtl] Make fetch FIFO clear dominate updates

### DIFF
--- a/rtl/ibex_fetch_fifo.sv
+++ b/rtl/ibex_fetch_fifo.sv
@@ -239,14 +239,14 @@ module ibex_fetch_fifo #(
         if (!rst_ni) begin
           rdata_q[i] <= '0;
           err_q[i]   <= '0;
-        end else if (entry_en[i]) begin
+        end else if (entry_en[i] && !clear_i) begin
           rdata_q[i] <= rdata_d[i];
           err_q[i]   <= err_d[i];
         end
       end
     end else begin : g_rdata_nr
       always_ff @(posedge clk_i) begin
-        if (entry_en[i]) begin
+        if (entry_en[i] && !clear_i) begin
           rdata_q[i] <= rdata_d[i];
           err_q[i]   <= err_d[i];
         end
@@ -265,5 +265,13 @@ module ibex_fetch_fifo #(
   // Must not push to FIFO when full.
   `ASSERT(IbexFetchFifoPushFull,
       (in_valid_i) |-> (!valid_q[DEPTH-1] || clear_i))
+
+  // A flush invalidates every FIFO entry.
+  `ASSERT(IbexFetchFifoClearInvalidates,
+      clear_i |=> (valid_q == '0))
+
+  // A flush suppresses unnecessary payload/error register updates.
+  `ASSERT(IbexFetchFifoClearPayloadStable,
+      clear_i |=> $stable({rdata_q, err_q}))
 
 endmodule


### PR DESCRIPTION
Local synthesis identifies fetch FIFO payload/error updates on the taken-branch redirect path. Qualifying their enables with !clear_i improves arrival time from 2.89 ns to 2.77 ns at a measured 0.44% area cost.
The change has passed directed clear/push/pop testing, Ibex hello_test, and a standalone SymbiYosys/Z3 proof.
Would this timing/area tradeoff and implementation-level payload stability behavior be considered appropriate for an upstream RTL change?
I have read the CLA Document. By submitting this pull request comment, I am hereby confirming my acceptance of the terms of the CLA Document and my agreement to be legally bound by its terms.