### PR TITLE
[ci] Skip CLA check in the merge queue

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,6 +2,12 @@ name: "CLA Assistant"
 on:
   issue_comment:
     types: [created]
+  # The CLA Assistant action cannot check a merge group, so the job below runs
+  # without steps for this event.  The workflow is nonetheless triggered so that
+  # the required `CLAAssistant` check reports a result instead of blocking the
+  # merge queue.  The CLA is checked on the pull request before it is queued.
+  merge_group:
+    types: [checks_requested]
   pull_request_target:
     types: [opened, closed, synchronize]
 


### PR DESCRIPTION
Prior to this commit, the `CLA Assistant` workflow was not triggered
for merge groups.  The required `CLAAssistant` check therefore never
reported a result for a merge group, which blocked the merge queue
until the check timed out.

The CLA Assistant action cannot check a merge group, because it needs
a pull request to determine the authors and to post its comment on.

This commit adds a `merge_group` trigger to the workflow.  The
condition on the only step of the workflow is false for that event, so
the job completes without running any step and the `CLAAssistant`
check reports success.  The CLA is thus only checked on a pull
request, before that pull request enters the merge queue.
