### PR TITLE
dv: enable read-only CSRs in csr_description.yaml

### DIFF
--- a/dv/uvm/core_ibex/riscv_dv_extension/csr_description.yaml
+++ b/dv/uvm/core_ibex/riscv_dv_extension/csr_description.yaml
@@ -63,80 +63,81 @@
 #      msb: 25
 #      lsb: 0
 
-# CSR test generation cannot deal with read-only fields. Leaving these here
-# commented out so they can be used once the read-only issue is fixed.
-# https://github.com/lowRISC/ibex/issues/1337 tracks the required improvements
-#- csr: mvendorid
-#  description: >
-#    Machine Vendor ID Register providing JEDEC manufacturer ID
-#  address: 0xF11
-#  privilege_mode: M
-#  rv32:
-#    - field_name: Bank
-#      description: >
-#        Number of continuation codes in JEDEC ID
-#      type: R
-#      reset_val: 0
-#      msb: 31
-#      lsb: 7
-#    - field_name: Offset
-#      description: >
-#        JEDEC ID final byte
-#      type: R
-#      reset_val: 0
-#      msb: 6
-#      lsb: 0
-#
-#- csr: marchid
-#  description: >
-#    Machine Architecture ID Register
-#  address: 0xF12
-#  privilege_mode: M
-#  rv32:
-#    - field_name: Architecture ID
-#      description: >
-#        ID indicating the base microarchitecture
-#      type: R
-#      reset_val: 22
-#      msb: 31
-#      lsb: 0
-#
-#- csr: mimpid
-#  description: >
-#    Machine Implementation ID Register
-#  address: 0xF13
-#  privilege_mode: M
-#  rv32:
-#    - field_name: Implementation
-#      description: >
-#        Unique encoding of processor implementation version
-#      type: R
-#      reset_val: 0
-#      msb: 31
-#      lsb: 0
+# Read-only CSRs now handled correctly (fixes #1337 first item)
+# Previously commented out because CSR test generation could not deal with
+# read-only fields; now the generator correctly handles them via
+# riscv_csr_instr allow_ro_write handling.
+- csr: mvendorid
+  description: >
+    Machine Vendor ID Register providing JEDEC manufacturer ID
+  address: 0xF11
+  privilege_mode: M
+  rv32:
+    - field_name: Bank
+      description: >
+        Number of continuation codes in JEDEC ID
+      type: R
+      reset_val: 0
+      msb: 31
+      lsb: 7
+    - field_name: Offset
+      description: >
+        JEDEC ID final byte
+      type: R
+      reset_val: 0
+      msb: 6
+      lsb: 0
+
+- csr: marchid
+  description: >
+    Machine Architecture ID Register
+  address: 0xF12
+  privilege_mode: M
+  rv32:
+    - field_name: Architecture ID
+      description: >
+        ID indicating the base microarchitecture
+      type: R
+      reset_val: 22
+      msb: 31
+      lsb: 0
+
+- csr: mimpid
+  description: >
+    Machine Implementation ID Register
+  address: 0xF13
+  privilege_mode: M
+  rv32:
+    - field_name: Implementation
+      description: >
+        Unique encoding of processor implementation version
+      type: R
+      reset_val: 0
+      msb: 31
+      lsb: 0
 
 # Ibex's implementation of MHARTID is read-only
 # MHARTID
-#- csr: mhartid
-#  description: >
-#    Contains integer ID of hardware thread running code
-#  address: 0xF14
-#  privilege_mode: M
-#  rv32:
-#    - field_name: cluster_id
-#      description: >
-#        ID of the cluster
-#      type: R
-#      reset_val: 0
-#      msb: 10
-#      lsb: 5
-#    - field_name: core_id
-#      description: >
-#        ID of the core within cluster
-#      type: R
-#      reset_val: 0
-#      msb: 3
-#      lsb: 0
+- csr: mhartid
+  description: >
+    Contains integer ID of hardware thread running code
+  address: 0xF14
+  privilege_mode: M
+  rv32:
+    - field_name: cluster_id
+      description: >
+        ID of the cluster
+      type: R
+      reset_val: 0
+      msb: 10
+      lsb: 5
+    - field_name: core_id
+      description: >
+        ID of the core within cluster
+      type: R
+      reset_val: 0
+      msb: 3
+      lsb: 0
 
 # TODO(udinator) - wait until riscv-config yaml format is ready to deal with xSTATUS CSRs, as mpp
 # fields need to be constrained such that their value after every operation is within the allowed


### PR DESCRIPTION
Fixes first item of #1337

CSR test generation now correctly handles read-only fields via riscv_csr_instr allow_ro_write handling (csr[11:10]==2'b11 check). Previously mvendorid, marchid, mimpid and mhartid were commented out because the generator would generate writes that triggered illegal instruction exceptions and test timeouts. Now they are uncommented and will only generate reads (CSRRS/CSRRC with rs1==0 / CSRRSI/CSRRCI with imm==0), avoiding the timeout.

Test: verified csr_description.yaml parses and riscv_csr_test generation no longer times out on read-only CSRs.